### PR TITLE
fix(cli): provider model limits and routing corrections (phase-57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ plans/
 .github/agents/master-architect.agent.md
 .github/agents/implementation-agent.agent.md
 .github/agents/marketing-god.agent.md
+.github/agents/peer-architect.agent.md
+.github/agents/design-reviewer.agent.md
 .github/instructions/pre-publication.instructions.md
 .github/instructions/project-info-prompt.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,10 +238,24 @@ All notable changes to this project are documented here.
   leaving `hasTransport` false and preventing the bidirectional Slack gate from ever connecting.
   One-way `notify_*` adapter notifications were unaffected because `SlackAdapter` registration
   in the adapter registry is independent of the transport options.
+- `realm agent`: o3/o3-mini/o4-mini misrouted to `OpenAIReasoningProvider` — the `REASONING_MODELS`
+  regex `/^o[1-4](-|$)/i` was too broad, sending o3, o3-mini, and o4-mini through the o1-only path.
+  These models support the standard Chat Completions API including tool calling. Narrowed to
+  `/^o1(-|$)/i`; o3, o3-mini, and o4-mini now route to `OpenAIProvider` and support tool-enabled steps.
+- `realm agent`: missing `max_completion_tokens` on o1-series API calls — `OpenAIReasoningProvider`
+  omitted the field, leaving the model to use an uncontrolled API default. Now sends
+  `max_completion_tokens: 65536` for o1-mini and `32768` for o1/o1-preview.
+- `realm agent`: hardcoded `max_tokens: 4096` in `AnthropicProvider` — all three call sites used a
+  fixed ceiling insufficient for Claude 3.5 and Claude 4 family models (which support 8192 output
+  tokens). Now resolved dynamically: Claude 3.5/Claude 4 → 8192, others → 4096.
+- `realm agent`: `callStepWithTools` suppressed `response_format: json_object` when no input schema
+  was present — the field was gated on `jsonMode && inputSchema !== undefined`. Schema presence and
+  JSON mode are independent concerns; `response_format` now follows `jsonMode` alone, consistent
+  with `callStep`.
 
 ### Tests
 
-962 tests across all packages (639 core, 243 CLI, 33 MCP, 47 testing).
+989 tests across all packages (639 core, 270 CLI, 33 MCP, 47 testing).
 
 ---
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -183,6 +183,12 @@ OPENAI_API_KEY=gsk_... realm agent --workflow ./my-workflow \
   --base-url https://api.groq.com/openai/v1
 ```
 
+**OpenAI reasoning models:** o1-series models (o1, o1-mini, o1-preview) do not support tool
+calling. If your workflow uses MCP tool-enabled steps, `realm agent` exits at startup with an
+error when an o1-series model is selected. Use `--model gpt-4o` (or any non-o1 model) or
+`--provider anthropic` to run tool-enabled workflows. All other OpenAI models — including o3,
+o3-mini, and o4-mini — support tool-enabled steps.
+
 **Custom providers:** use `--provider-module` to supply a fully custom LLM implementation.
 The module must export an instance (not a class) extending `LlmProvider` from
 `@sensigo/realm-cli/agent`:

--- a/packages/cli/src/agent/providers/anthropic-provider.test.ts
+++ b/packages/cli/src/agent/providers/anthropic-provider.test.ts
@@ -84,6 +84,20 @@ describe('AnthropicProvider.callStep', () => {
     await provider.callStep('prompt');
     expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('response_format');
   });
+
+  it('callStep sends max_tokens: 8192 for claude-sonnet-4-5', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    await provider.callStep('prompt');
+    expect(mockCreate.mock.calls[0][0].max_tokens).toBe(8192);
+  });
+
+  it('callStep sends max_tokens: 4096 for claude-3-opus-20240229', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+    const provider = new AnthropicProvider('claude-3-opus-20240229');
+    await provider.callStep('prompt');
+    expect(mockCreate.mock.calls[0][0].max_tokens).toBe(4096);
+  });
 });
 
 // =========================================================================
@@ -91,6 +105,22 @@ describe('AnthropicProvider.callStep', () => {
 // =========================================================================
 describe('AnthropicProvider.callStepWithTools', () => {
   beforeEach(() => mockCreate.mockReset());
+
+  // -----------------------------------------------------------------------
+  // 0. max_tokens is model-aware in the main loop call
+  // -----------------------------------------------------------------------
+  it('callStepWithTools main loop sends max_tokens: 8192 for claude-sonnet-4-5', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"answer":"done"}'));
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    await provider.callStepWithTools('prompt', [], _NOOP_EXECUTOR, {
+      inputSchema: {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+      },
+    });
+    expect(mockCreate.mock.calls[0][0].max_tokens).toBe(8192);
+  });
 
   // -----------------------------------------------------------------------
   // 1. Basic tool call loop

--- a/packages/cli/src/agent/providers/anthropic-provider.ts
+++ b/packages/cli/src/agent/providers/anthropic-provider.ts
@@ -19,6 +19,18 @@ import {
 } from './agent-utils.js';
 
 /**
+ * Returns the maximum output tokens for the given Anthropic model.
+ * The Anthropic Messages API requires max_tokens — this must always produce a valid value.
+ * Source: https://docs.anthropic.com/en/docs/about-claude/models/all-models
+ */
+function resolveMaxTokens(model: string): number {
+  // claude-3.5 and claude-4 families support 8192 output tokens.
+  // Matches: claude-3-5-*, claude-3.5-*, claude-<name>-4-*, etc.
+  if (/claude-(3[-.]5|[a-z]+-4)/i.test(model)) return 8192;
+  return 4096; // safe fallback for claude-3 and any unrecognised model
+}
+
+/**
  * Anthropic LLM provider for realm agent.
  * Uses the Messages API and extracts JSON from the first text content block.
  * Retries once if the model returns non-JSON content.
@@ -57,7 +69,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
       const response = await // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (client.messages.create as (opts: Record<string, unknown>) => Promise<any>)({
         model: this.model,
-        max_tokens: 4096,
+        max_tokens: resolveMaxTokens(this.model),
         system: systemPrompt,
         messages: [{ role: 'user', content: userContent }],
       });
@@ -148,7 +160,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
     const buildMainCallOpts = (): Record<string, unknown> => {
       const opts: Record<string, unknown> = {
         model: this.model,
-        max_tokens: 4096,
+        max_tokens: resolveMaxTokens(this.model),
         system,
         messages: history,
       };
@@ -162,7 +174,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
       const final = await // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (client.messages.create as (opts: Record<string, unknown>) => Promise<any>)({
         model: this.model,
-        max_tokens: 4096,
+        max_tokens: resolveMaxTokens(this.model),
         system,
         messages: history,
         tool_choice: { type: 'none' },

--- a/packages/cli/src/agent/providers/llm-provider.ts
+++ b/packages/cli/src/agent/providers/llm-provider.ts
@@ -86,10 +86,11 @@ export async function resolveProvider(
   }
 
   if (provider === 'openai') {
-    // Match o1, o1-mini, o1-preview, o3, o3-mini, o4-mini, etc. The user has
-    // explicitly declared the model name, so matching on name is the correct
-    // signal here — not an internal allowlist.
-    const REASONING_MODELS = /^o[1-4](-|$)/i;
+    // Match o1, o1-mini, o1-preview — the o1 generation requires the special-case
+    // provider (no tool support, system prompt folded into user message).
+    // o3, o3-mini, and o4-mini support the standard Chat Completions API including
+    // function calling, so they route to OpenAIProvider.
+    const REASONING_MODELS = /^o1(-|$)/i;
     if (modelFlag !== undefined && REASONING_MODELS.test(modelFlag)) {
       const { OpenAIReasoningProvider } = await import('./openai-reasoning-provider.js');
       return new OpenAIReasoningProvider(modelFlag);

--- a/packages/cli/src/agent/providers/openai-provider.test.ts
+++ b/packages/cli/src/agent/providers/openai-provider.test.ts
@@ -88,6 +88,13 @@ describe('OpenAIProvider.callStep', () => {
       response_format: { type: 'json_object' },
     });
   });
+
+  it('callStep with --base-url: response_format is NOT sent to compat endpoints', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+    const provider = new OpenAIProvider('gpt-4o', 'https://compat.endpoint.com');
+    await provider.callStep('prompt');
+    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('response_format');
+  });
 });
 
 // =========================================================================
@@ -371,15 +378,27 @@ describe('OpenAIProvider.callStepWithTools', () => {
   });
 
   // -----------------------------------------------------------------------
-  // 13. inputSchema absent → response_format is not included in the request
+  // 13. compat endpoint (--base-url), inputSchema absent → response_format is NOT present
   // -----------------------------------------------------------------------
-  it('inputSchema absent → response_format is not present in request', async () => {
+  it('compat endpoint (--base-url), inputSchema absent → response_format is NOT present', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+
+    const provider = new OpenAIProvider('gpt-4o', 'https://compat.endpoint.com');
+    await provider.callStepWithTools('prompt', [], NOOP_EXECUTOR, {});
+
+    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('response_format');
+  });
+
+  // -----------------------------------------------------------------------
+  // 13b. native endpoint, inputSchema absent → response_format IS present
+  // -----------------------------------------------------------------------
+  it('native endpoint, inputSchema absent → response_format IS present', async () => {
     mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
 
     const provider = new OpenAIProvider('gpt-4o');
     await provider.callStepWithTools('prompt', [], NOOP_EXECUTOR, {});
 
-    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('response_format');
+    expect(mockCreate.mock.calls[0][0].response_format).toEqual({ type: 'json_object' });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/cli/src/agent/providers/openai-provider.ts
+++ b/packages/cli/src/agent/providers/openai-provider.ts
@@ -138,10 +138,9 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
       ...(this.baseUrl !== undefined ? { baseURL: this.baseUrl } : {}),
     });
 
-    const responseFormat =
-      this.capabilities().jsonMode && options.inputSchema !== undefined
-        ? ({ type: 'json_object' } as const)
-        : undefined;
+    const responseFormat = this.capabilities().jsonMode
+      ? ({ type: 'json_object' } as const)
+      : undefined;
 
     // toolIdMap: bareName → namespaced id, used to recover routing key from LLM responses.
     // Collision guard: two MCP servers may not expose the same bare tool name in the same step.

--- a/packages/cli/src/agent/providers/openai-reasoning-provider.test.ts
+++ b/packages/cli/src/agent/providers/openai-reasoning-provider.test.ts
@@ -74,6 +74,37 @@ describe('OpenAIReasoningProvider.callStep', () => {
   });
 
   // -----------------------------------------------------------------------
+  // 4b. Does NOT send max_tokens (uses max_completion_tokens instead)
+  // -----------------------------------------------------------------------
+  it('callStep does NOT send max_tokens (only max_completion_tokens)', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+    const provider = new OpenAIReasoningProvider('o1-mini');
+    await provider.callStep('prompt');
+    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('max_tokens');
+    expect(mockCreate.mock.calls[0][0]).toHaveProperty('max_completion_tokens');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4c. max_completion_tokens: 65536 for o1-mini
+  // -----------------------------------------------------------------------
+  it('callStep sends max_completion_tokens: 65536 for o1-mini', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+    const provider = new OpenAIReasoningProvider('o1-mini');
+    await provider.callStep('prompt');
+    expect(mockCreate.mock.calls[0][0].max_completion_tokens).toBe(65536);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4d. max_completion_tokens: 32768 for o1
+  // -----------------------------------------------------------------------
+  it('callStep sends max_completion_tokens: 32768 for o1', async () => {
+    mockCreate.mockResolvedValueOnce(makeTextResponse('{"x":1}'));
+    const provider = new OpenAIReasoningProvider('o1');
+    await provider.callStep('prompt');
+    expect(mockCreate.mock.calls[0][0].max_completion_tokens).toBe(32768);
+  });
+
+  // -----------------------------------------------------------------------
   // 5. System prompt folded into user message (no system role)
   // -----------------------------------------------------------------------
   it('callStep folds system prompt into the user message (no system role)', async () => {
@@ -138,16 +169,40 @@ describe('resolveProvider routing for reasoning models', () => {
   });
 
   // -----------------------------------------------------------------------
-  // 9. o3 routes to OpenAIReasoningProvider
+  // 9. o3 routes to OpenAIProvider (NOT OpenAIReasoningProvider)
   // -----------------------------------------------------------------------
-  it('resolveProvider routes o3 to OpenAIReasoningProvider', async () => {
+  it('resolveProvider routes o3 to OpenAIProvider, not OpenAIReasoningProvider', async () => {
+    const { OpenAIProvider } = await import('./openai-provider.js');
     const provider = await resolveProvider('openai', 'o3');
-    expect(provider).toBeInstanceOf(OpenAIReasoningProvider);
-    expect(provider).not.toBeInstanceOf(ToolCapableLlmProvider);
+    expect(provider).not.toBeInstanceOf(OpenAIReasoningProvider);
+    expect(provider).toBeInstanceOf(ToolCapableLlmProvider);
+    expect(provider).toBeInstanceOf(OpenAIProvider);
   });
 
   // -----------------------------------------------------------------------
-  // 10. gpt-4o routes to OpenAIProvider (regression guard)
+  // 10. o3-mini routes to OpenAIProvider
+  // -----------------------------------------------------------------------
+  it('resolveProvider routes o3-mini to OpenAIProvider, not OpenAIReasoningProvider', async () => {
+    const { OpenAIProvider } = await import('./openai-provider.js');
+    const provider = await resolveProvider('openai', 'o3-mini');
+    expect(provider).not.toBeInstanceOf(OpenAIReasoningProvider);
+    expect(provider).toBeInstanceOf(ToolCapableLlmProvider);
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+  });
+
+  // -----------------------------------------------------------------------
+  // 11. o4-mini routes to OpenAIProvider
+  // -----------------------------------------------------------------------
+  it('resolveProvider routes o4-mini to OpenAIProvider, not OpenAIReasoningProvider', async () => {
+    const { OpenAIProvider } = await import('./openai-provider.js');
+    const provider = await resolveProvider('openai', 'o4-mini');
+    expect(provider).not.toBeInstanceOf(OpenAIReasoningProvider);
+    expect(provider).toBeInstanceOf(ToolCapableLlmProvider);
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+  });
+
+  // -----------------------------------------------------------------------
+  // 12. gpt-4o routes to OpenAIProvider (regression guard)
   // -----------------------------------------------------------------------
   it('resolveProvider routes gpt-4o to OpenAIProvider (regression guard)', async () => {
     const { OpenAIProvider } = await import('./openai-provider.js');

--- a/packages/cli/src/agent/providers/openai-reasoning-provider.ts
+++ b/packages/cli/src/agent/providers/openai-reasoning-provider.ts
@@ -1,7 +1,18 @@
-// openai-reasoning-provider.ts — OpenAI reasoning model provider (o1/o3) for realm agent.
-// Extends LlmProvider (not ToolCapableLlmProvider) — reasoning models do not support the tools parameter.
+// openai-reasoning-provider.ts — OpenAI reasoning model provider (o1-series) for realm agent.
+// Extends LlmProvider (not ToolCapableLlmProvider) — o1-series models do not support the tools parameter.
 import { LlmProvider } from './llm-provider.js';
 import { buildSystemPrompt } from './agent-utils.js';
+
+/**
+ * Returns the max_completion_tokens for the given OpenAI reasoning model.
+ * For o1-series models this covers both reasoning tokens and visible output.
+ * Source: https://platform.openai.com/docs/models
+ */
+function resolveMaxCompletionTokens(model: string): number {
+  if (/^o1-mini/i.test(model)) return 65536;
+  // o1, o1-preview, and any other o1 variant default to 32768.
+  return 32768;
+}
 
 /**
  * OpenAI reasoning model provider for realm agent.
@@ -55,6 +66,7 @@ export class OpenAIReasoningProvider extends LlmProvider {
       const response = await // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (client.chat.completions.create as (opts: Record<string, unknown>) => Promise<any>)({
         model: this.model,
+        max_completion_tokens: resolveMaxCompletionTokens(this.model),
         messages: msgs,
       });
       return (response.choices[0]?.message?.content as string | undefined) ?? '';

--- a/packages/cli/src/agent/providers/openai-reasoning-provider.ts
+++ b/packages/cli/src/agent/providers/openai-reasoning-provider.ts
@@ -16,14 +16,15 @@ function resolveMaxCompletionTokens(model: string): number {
 
 /**
  * OpenAI reasoning model provider for realm agent.
- * Handles the o1/o3 model families, which differ from standard chat completions:
+ * Handles the o1-series (o1, o1-mini, o1-preview), which differ from standard chat completions:
  * - No `response_format` parameter (JSON enforced via system prompt + retry).
  * - System prompt content is folded into the first user message — the safe
- *   universal approach for the full o1/o3 lineage. (o1 originally rejected the
+ *   universal approach for the full o1 lineage. (o1 originally rejected the
  *   system role; later versions accept it as a developer role, but prepending
  *   to the user message works uniformly across all revisions.)
  * - Tool calling is not supported — this class extends LlmProvider, not
  *   ToolCapableLlmProvider, so `isToolCapable` returns false for these instances.
+ *   o3 and later support tools and route to OpenAIProvider instead.
  */
 export class OpenAIReasoningProvider extends LlmProvider {
   private readonly model: string;
@@ -55,7 +56,7 @@ export class OpenAIReasoningProvider extends LlmProvider {
       apiKey: process.env['OPENAI_API_KEY'],
     });
 
-    // Fold system prompt into the user message — safe for all o1/o3 API revisions.
+    // Fold system prompt into the user message — safe for all o1-series API revisions.
     const systemPrompt = buildSystemPrompt(inputSchema);
     const userContent = `${systemPrompt}\n\n${prompt}`;
 

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -208,7 +208,7 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
     if (!isToolCapable(deps.provider)) {
       throw new Error(
         'This workflow uses MCP tool-enabled steps, but the configured LLM provider does not support tool calling. ' +
-          'Reasoning models (o1, o3) and custom non-tool providers cannot run tool-enabled steps. ' +
+          'Reasoning models (o1-series) and custom non-tool providers cannot run tool-enabled steps. ' +
           'Use --provider openai with a standard chat model (e.g. gpt-4o), or --provider anthropic.',
       );
     }


### PR DESCRIPTION
## Summary

Four audit findings against the LLM provider layer — one correctness defect, one design deviation, one test gap, and one behaviour asymmetry. All changes are confined to `packages/cli/src/agent/providers/` and one line in `run-agent.ts`.

## Changes

### Finding 1 — Narrow `REASONING_MODELS` regex to o1-series only

`o3`, `o3-mini`, and `o4-mini` support the standard Chat Completions API including function calling. Only the `o1` generation requires `OpenAIReasoningProvider`. The regex is narrowed from `/^o[1-4](-|$)/i` to `/^o1(-|$)/i` so those models route to `OpenAIProvider`.

The error message in `run-agent.ts` is updated from `"Reasoning models (o1, o3)"` to `"Reasoning models (o1-series)"`.

### Finding 2a — `max_completion_tokens` in `OpenAIReasoningProvider` (model-aware)

Added a private `resolveMaxCompletionTokens(model)` helper:
- `o1-mini` → `65536`
- `o1`, `o1-preview`, any other o1 variant → `32768`

### Finding 2b — Model-aware `max_tokens` in `AnthropicProvider`

Replaced three hardcoded `max_tokens: 4096` with `resolveMaxTokens(this.model)`. Claude 3.5 and claude-4 families return `8192`; all others fall back to `4096`.

Regex verified against all five named models from the prompt:
- `claude-3-5-sonnet-20241022` → 8192 ✓
- `claude-3-5-haiku-20241022` → 8192 ✓
- `claude-sonnet-4-5` → 8192 ✓
- `claude-3-opus-20240229` → 4096 ✓
- `claude-3-haiku-20240307` → 4096 ✓

### Finding 3 — Add missing `--base-url` test for `callStep`

Added `'callStep with --base-url: response_format is NOT sent to compat endpoints'` in the `callStep` suite.

### Finding 4 — Remove `inputSchema` gate from `responseFormat` in `callStepWithTools`

The `&& options.inputSchema !== undefined` condition was incorrect. `json_object` mode is wanted whenever the endpoint supports it — not only when a schema is provided. Simplified to:

```typescript
const responseFormat = this.capabilities().jsonMode
  ? ({ type: 'json_object' } as const)
  : undefined;
```

Test 13 updated: renamed from "inputSchema absent → not present" to "compat endpoint (--base-url), inputSchema absent → not present". A new test 13b asserts the native-endpoint positive case.

## Tests

10 new tests added across three files:

| File | New tests |
|------|-----------|
| `openai-reasoning-provider.test.ts` | o3/o3-mini/o4-mini route to `OpenAIProvider`; `max_completion_tokens` values for o1-mini and o1; no `max_tokens` sent |
| `openai-provider.test.ts` | `callStep` base-url suppresses `response_format`; native no-schema path sends `response_format` |
| `anthropic-provider.test.ts` | `max_tokens: 8192` for `claude-sonnet-4-5`; `max_tokens: 4096` for `claude-3-opus-20240229`; `callStepWithTools` main loop uses correct value |

## Verification

```bash
cd packages/cli && npx vitest run
```

```
Test Files  26 passed (26)
Tests       270 passed (270)
```
