### PR TITLE
feat(core): trace A1 — contract hardening and canonical evidence rules (phase-63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project are documented here.
   `EvidenceSnapshot`. `evidence_hash` is unaffected — it covers `output_summary` only. Trace is
   silently dropped for non-agent steps. `realm run inspect` shows a compact summary line and a
   yellow warning when the trace was truncated.
+  - _Correction 1_: reserved-prefix check now runs on the normalized event (post-trim), so
+    whitespace-padded variants like `"  trace.internal"` are correctly dropped. Byte limit now
+    uses `Buffer.byteLength(…, 'utf8')` instead of JS string length, giving accurate enforcement
+    for multi-byte Unicode payloads. `realm run inspect` truncation warning now reports total
+    `discarded_entries` (reserved + overflow) rather than overflow-only.
 
 - `output_schema` field on `StepDefinition` — an optional JSON Schema that
   validates the params an agent submits to `execute_step` before the engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- **Step Trace A1 — contract hardening**: `execute_step` now accepts an optional top-level
+  `trace` array of `{ event, timestamp?, data? }` entries alongside `params`. The engine
+  canonicalizes submissions in a single pass (deterministic seq assignment, 100-char event cap,
+  500-char string-value cap, 20-key data cap, 100-entry / 50 KB hard limits, reserved `trace.`
+  prefix drop) and persists the result as `trace`, `trace_digest`, and `trace_summary` on the
+  `EvidenceSnapshot`. `evidence_hash` is unaffected — it covers `output_summary` only. Trace is
+  silently dropped for non-agent steps. `realm run inspect` shows a compact summary line and a
+  yellow warning when the trace was truncated.
+
 - `output_schema` field on `StepDefinition` — an optional JSON Schema that
   validates the params an agent submits to `execute_step` before the engine
   claims the step. Symmetric to `input_schema`. Only valid on

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -226,4 +226,46 @@ describe('inspectRun', () => {
     expect(result).not.toContain('Tools declared');
     expect(result).toContain('research');
   });
+
+  it('renders trace summary line when trace is present on evidence snapshot', async () => {
+    const snap = makeSnapshot('research', {
+      trace: [
+        { seq: 1, event: 'search_called', data: { query: 'hello' } },
+        { seq: 2, event: 'search_returned', data: { count: 3 } },
+      ],
+      trace_digest: 'abc123',
+      trace_summary: {
+        submitted_entries: 2,
+        stored_entries: 2,
+        discarded_entries: 0,
+        discarded_reserved_event_entries: 0,
+        discarded_overflow_entries: 0,
+        truncated: false,
+      },
+    });
+    const run = makeRun([snap]);
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Trace:  2 entries (not hashed).');
+    expect(result).not.toContain('⚠ Trace truncated');
+  });
+
+  it('renders truncation warning when trace_summary.truncated is true', async () => {
+    const snap = makeSnapshot('research', {
+      trace: Array.from({ length: 101 }, (_, i) => ({ seq: i + 1, event: `ev_${i}` })),
+      trace_digest: 'def456',
+      trace_summary: {
+        submitted_entries: 105,
+        stored_entries: 101,
+        discarded_entries: 5,
+        discarded_reserved_event_entries: 0,
+        discarded_overflow_entries: 5,
+        truncated: true,
+        truncation_reason: 'count_limit' as const,
+      },
+    });
+    const run = makeRun([snap]);
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Trace:  101 entries (not hashed).');
+    expect(result).toContain('⚠ Trace truncated (count_limit): 101 stored, 5 discarded.');
+  });
 });

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -254,10 +254,10 @@ describe('inspectRun', () => {
       trace: Array.from({ length: 101 }, (_, i) => ({ seq: i + 1, event: `ev_${i}` })),
       trace_digest: 'def456',
       trace_summary: {
-        submitted_entries: 105,
+        submitted_entries: 107,
         stored_entries: 101,
-        discarded_entries: 5,
-        discarded_reserved_event_entries: 0,
+        discarded_entries: 7, // 2 reserved + 5 overflow
+        discarded_reserved_event_entries: 2,
         discarded_overflow_entries: 5,
         truncated: true,
         truncation_reason: 'count_limit' as const,
@@ -266,6 +266,8 @@ describe('inspectRun', () => {
     const run = makeRun([snap]);
     const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
     expect(result).toContain('Trace:  101 entries (not hashed).');
-    expect(result).toContain('⚠ Trace truncated (count_limit): 101 stored, 5 discarded.');
+    // Warning must report total discarded (7), not overflow-only (5).
+    expect(result).toContain('⚠ Trace truncated (count_limit): 101 stored, 7 discarded.');
+    expect(result).not.toContain('5 discarded');
   });
 });

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -127,6 +127,17 @@ export async function inspectRun(
         lines.push(`     Resolved: ${formatSummary(lastSnap.resolved_params)}`);
       }
       lines.push(`     Output: ${formatSummary(lastSnap.output_summary)}`);
+      if (lastSnap.trace !== undefined) {
+        lines.push(`     Trace:  ${lastSnap.trace.length} entries (not hashed).`);
+        if (lastSnap.trace_summary?.truncated) {
+          const s = lastSnap.trace_summary;
+          lines.push(
+            chalk.yellow(
+              `     ⚠ Trace truncated (${s.truncation_reason ?? 'unknown'}): ${s.stored_entries} stored, ${s.discarded_overflow_entries} discarded.`,
+            ),
+          );
+        }
+      }
       if (lastSnap.diagnostics !== undefined) {
         lines.push(chalk.dim(`     Diagnostics: ${formatDiagnostics(lastSnap.diagnostics)}`));
       }
@@ -155,6 +166,17 @@ export async function inspectRun(
           lines.push(`     Resolved: ${formatSummary(snap.resolved_params)}`);
         }
         lines.push(`     Output: ${formatSummary(snap.output_summary)}`);
+        if (snap.trace !== undefined) {
+          lines.push(`     Trace:  ${snap.trace.length} entries (not hashed).`);
+          if (snap.trace_summary?.truncated) {
+            const s = snap.trace_summary;
+            lines.push(
+              chalk.yellow(
+                `     ⚠ Trace truncated (${s.truncation_reason ?? 'unknown'}): ${s.stored_entries} stored, ${s.discarded_overflow_entries} discarded.`,
+              ),
+            );
+          }
+        }
         if (snap.tool_calls === undefined) {
           // callStep path — print nothing
         } else if (snap.tool_calls.length === 0) {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -133,7 +133,7 @@ export async function inspectRun(
           const s = lastSnap.trace_summary;
           lines.push(
             chalk.yellow(
-              `     ⚠ Trace truncated (${s.truncation_reason ?? 'unknown'}): ${s.stored_entries} stored, ${s.discarded_overflow_entries} discarded.`,
+              `     ⚠ Trace truncated (${s.truncation_reason ?? 'unknown'}): ${s.stored_entries} stored, ${s.discarded_entries} discarded.`,
             ),
           );
         }
@@ -172,7 +172,7 @@ export async function inspectRun(
             const s = snap.trace_summary;
             lines.push(
               chalk.yellow(
-                `     ⚠ Trace truncated (${s.truncation_reason ?? 'unknown'}): ${s.stored_entries} stored, ${s.discarded_overflow_entries} discarded.`,
+                `     ⚠ Trace truncated (${s.truncation_reason ?? 'unknown'}): ${s.stored_entries} stored, ${s.discarded_entries} discarded.`,
               ),
             );
           }

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -1605,4 +1605,213 @@ describe('executeStep', () => {
       expect(envelope.gate?.display).not.toContain('step.prompt');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // trace — A1 contract hardening
+  // ---------------------------------------------------------------------------
+
+  describe('trace', () => {
+    it('agent step stores canonical trace with seq numbers in evidence', async () => {
+      const agentDefinition: WorkflowDefinition = {
+        ...definition,
+        id: 'trace-agent-wf',
+        steps: {
+          ...definition.steps,
+          'step-one': { ...definition.steps['step-one']!, execution: 'agent', depends_on: [] },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'trace-agent-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const envelope = await executeStep(store, agentDefinition, {
+        runId: run.id,
+        command: 'step-one',
+        input: { result: 'done' },
+        dispatcher: echoDispatcher,
+        trace: [
+          { event: 'tool_called', data: { name: 'read_file' } },
+          { event: 'tool_result', data: { status: 'ok' } },
+        ],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace).toBeDefined();
+      expect(snap?.trace).toHaveLength(2);
+      expect(snap?.trace![0]!.seq).toBe(1);
+      expect(snap?.trace![0]!.event).toBe('tool_called');
+      expect(snap?.trace![1]!.seq).toBe(2);
+      expect(snap?.trace_digest).toMatch(/^[0-9a-f]{64}$/);
+      expect(snap?.trace_summary?.stored_entries).toBe(2);
+      expect(snap?.trace_summary?.truncated).toBe(false);
+    });
+
+    it('non-agent step silently drops provided trace', async () => {
+      // step-one is execution: 'auto' in the default definition
+      const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+      const envelope = await executeStep(store, definition, {
+        runId: run.id,
+        command: 'step-one',
+        input: {},
+        dispatcher: echoDispatcher,
+        trace: [{ event: 'should_be_dropped' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace).toBeUndefined();
+      expect(snap?.trace_digest).toBeUndefined();
+      expect(snap?.trace_summary).toBeUndefined();
+    });
+
+    it('reserved "trace." prefix entries are dropped from agent trace', async () => {
+      const agentDefinition: WorkflowDefinition = {
+        ...definition,
+        id: 'trace-reserved-wf',
+        steps: {
+          ...definition.steps,
+          'step-one': { ...definition.steps['step-one']!, execution: 'agent', depends_on: [] },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'trace-reserved-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const envelope = await executeStep(store, agentDefinition, {
+        runId: run.id,
+        command: 'step-one',
+        input: { r: 1 },
+        dispatcher: echoDispatcher,
+        trace: [
+          { event: 'trace.internal_engine_event' },
+          { event: 'trace.another_reserved' },
+          { event: 'user_event' },
+        ],
+      });
+
+      const snap = envelope.evidence[0];
+      expect(snap?.trace).toHaveLength(1);
+      expect(snap?.trace![0]!.event).toBe('user_event');
+      expect(snap?.trace_summary?.discarded_reserved_event_entries).toBe(2);
+    });
+
+    it('count limit produces single sentinel with accurate summary', async () => {
+      const agentDefinition: WorkflowDefinition = {
+        ...definition,
+        id: 'trace-count-wf',
+        steps: {
+          ...definition.steps,
+          'step-one': { ...definition.steps['step-one']!, execution: 'agent', depends_on: [] },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'trace-count-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const manyEntries = Array.from({ length: 105 }, (_, i) => ({ event: `ev_${i}` }));
+      const envelope = await executeStep(store, agentDefinition, {
+        runId: run.id,
+        command: 'step-one',
+        input: { r: 1 },
+        dispatcher: echoDispatcher,
+        trace: manyEntries,
+      });
+
+      const snap = envelope.evidence[0];
+      // 100 real entries + 1 sentinel
+      expect(snap?.trace).toHaveLength(101);
+      expect(snap?.trace![100]!.event).toBe('trace.truncated');
+      expect(snap?.trace_summary?.truncated).toBe(true);
+      expect(snap?.trace_summary?.truncation_reason).toBe('count_limit');
+      expect(snap?.trace_summary?.discarded_overflow_entries).toBe(5);
+    });
+
+    it('evidence_hash is unchanged when trace changes but output is identical', async () => {
+      const agentDefinition: WorkflowDefinition = {
+        ...definition,
+        id: 'trace-hash-stable-wf',
+        steps: {
+          ...definition.steps,
+          'step-one': { ...definition.steps['step-one']!, execution: 'agent', depends_on: [] },
+        },
+      };
+
+      const run1 = await store.create({
+        workflowId: 'trace-hash-stable-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const e1 = await executeStep(store, agentDefinition, {
+        runId: run1.id,
+        command: 'step-one',
+        input: { result: 'same_output' },
+        dispatcher: echoDispatcher,
+        trace: [{ event: 'trace_a' }],
+      });
+
+      const run2 = await store.create({
+        workflowId: 'trace-hash-stable-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const e2 = await executeStep(store, agentDefinition, {
+        runId: run2.id,
+        command: 'step-one',
+        input: { result: 'same_output' },
+        dispatcher: echoDispatcher,
+        trace: [{ event: 'trace_b' }],
+      });
+
+      expect(e1.evidence[0]?.evidence_hash).toBe(e2.evidence[0]?.evidence_hash);
+      expect(e1.evidence[0]?.trace_digest).not.toBe(e2.evidence[0]?.trace_digest);
+    });
+
+    it('trace_digest differs when canonical trace differs', async () => {
+      const agentDefinition: WorkflowDefinition = {
+        ...definition,
+        id: 'trace-digest-diff-wf',
+        steps: {
+          ...definition.steps,
+          'step-one': { ...definition.steps['step-one']!, execution: 'agent', depends_on: [] },
+        },
+      };
+
+      const run1 = await store.create({
+        workflowId: 'trace-digest-diff-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const e1 = await executeStep(store, agentDefinition, {
+        runId: run1.id,
+        command: 'step-one',
+        input: { r: 1 },
+        dispatcher: echoDispatcher,
+        trace: [{ event: 'alpha' }],
+      });
+
+      const run2 = await store.create({
+        workflowId: 'trace-digest-diff-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const e2 = await executeStep(store, agentDefinition, {
+        runId: run2.id,
+        command: 'step-one',
+        input: { r: 1 },
+        dispatcher: echoDispatcher,
+        trace: [{ event: 'beta' }],
+      });
+
+      expect(e1.evidence[0]?.trace_digest).toBeDefined();
+      expect(e2.evidence[0]?.trace_digest).toBeDefined();
+      expect(e1.evidence[0]?.trace_digest).not.toBe(e2.evidence[0]?.trace_digest);
+    });
+  });
 });

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -2,7 +2,12 @@
 // run state update, and ResponseEnvelope construction for the DAG execution model.
 // Includes: step claiming, step-level retry, step timeouts, human gate mechanics,
 // auto-chaining with fan-out, and registry-based dispatch for adapter and handler steps.
-import type { RunRecord, EvidenceSnapshot, WorkflowContextSnapshot } from '../types/run-record.js';
+import type {
+  RunRecord,
+  EvidenceSnapshot,
+  WorkflowContextSnapshot,
+  AgentTraceEntry,
+} from '../types/run-record.js';
 import type { ToolCallRecord } from '../types/mcp-types.js';
 import type { ResponseEnvelope, NextAction } from '../types/response-envelope.js';
 import { WorkflowError } from '../types/workflow-error.js';
@@ -56,6 +61,12 @@ export interface ExecuteStepOptions {
    * Present (possibly []) when tools were declared — threads through to captureEvidence.
    */
   stepMeta?: { toolCalls?: ToolCallRecord[] };
+  /**
+   * Optional agent-submitted trace entries for this step.
+   * Silently dropped for non-agent steps. When present on agent steps, the
+   * normalizer canonicalizes and persists them in the EvidenceSnapshot.
+   */
+  trace?: AgentTraceEntry[];
 }
 
 export interface SubmitGateOptions {
@@ -79,6 +90,8 @@ export interface ExecuteChainOptions {
    * Present (possibly []) when tools were declared — threads through to captureEvidence.
    */
   stepMeta?: { toolCalls?: ToolCallRecord[] };
+  /** @see ExecuteStepOptions.trace */
+  trace?: AgentTraceEntry[];
 }
 
 function delayMs(ms: number): Promise<void> {
@@ -635,6 +648,10 @@ export async function executeStep(
       ...(resolvedParams !== undefined ? { resolvedParams } : {}),
       ...(options.stepMeta?.toolCalls !== undefined
         ? { toolCalls: options.stepMeta.toolCalls }
+        : {}),
+      // Gate trace to agent steps only — drop silently for auto/adapter/handler steps.
+      ...(stepDef?.execution === 'agent' && options.trace !== undefined
+        ? { trace: options.trace }
         : {}),
     });
     const snap: EvidenceSnapshot =

--- a/packages/core/src/engine/trace-normalizer.test.ts
+++ b/packages/core/src/engine/trace-normalizer.test.ts
@@ -168,6 +168,13 @@ describe('normalizeTrace', () => {
 
   // ─── byte-budget boundary correctness ────────────────────────────────────
   //
+  // Guardrail note:
+  // These tests codify the invariant that incremental byte accounting is exact
+  // under current JSON array serialization behavior and object construction
+  // order used by the normalizer. If serialization strategy changes later,
+  // parity tests in this section are expected to fail and should trigger
+  // a review of byte-budget logic rather than a blind threshold update.
+  //
   // Fixtures are engineered to exact known byte sizes.
   //
   // 96 entries with event='x' and data={k:'A'.repeat(490)} — all ASCII:

--- a/packages/core/src/engine/trace-normalizer.test.ts
+++ b/packages/core/src/engine/trace-normalizer.test.ts
@@ -217,4 +217,39 @@ describe('normalizeTrace', () => {
     const { digest: d2 } = normalizeTrace([{ event: 'beta' }]);
     expect(d1).not.toBe(d2);
   });
+
+  // ─── correction 1: normalize-before-prefix-check ─────────────────────────
+
+  it('drops whitespace-padded reserved-prefix event after normalization', () => {
+    // "  trace.internal  " normalizes to "trace.internal" → reserved → dropped.
+    const { entries, summary } = normalizeTrace([
+      { event: '  trace.internal  ' },
+      { event: '  trace.engine_event' },
+      { event: '\ttrace.tab_padded\t' },
+      { event: 'legit' },
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.event).toBe('legit');
+    expect(summary.discarded_reserved_event_entries).toBe(3);
+  });
+
+  // ─── correction 2: UTF-8 byte limit ──────────────────────────────────────
+
+  it('byte limit is enforced using UTF-8 byte count, not JS string length', () => {
+    // U+1F600 (😀) is 1 JS char in some representations but takes 4 UTF-8 bytes.
+    // A string of 200 emoji repeated 5 times per entry should trigger byte_limit
+    // well before count_limit (100 entries) because UTF-8 size > JS string length.
+    const emojiPayload = '😀'.repeat(200); // 200 * 4 bytes = 800 bytes per entry (UTF-8)
+    const input = Array.from({ length: 80 }, (_, i) => ({
+      event: `ev_${i}`,
+      data: { payload: emojiPayload },
+    }));
+    const { summary } = normalizeTrace(input);
+    // Should hit byte_limit before count_limit (count_limit = 100 > 80 entries).
+    expect(summary.truncation_reason).toBe('byte_limit');
+    expect(summary.truncated).toBe(true);
+    // Fewer entries should be stored when measured by UTF-8 bytes vs JS length.
+    // With UTF-8, 800+ bytes per entry, max is ~62 entries before 50KB is hit.
+    expect(summary.stored_entries).toBeLessThan(80);
+  });
 });

--- a/packages/core/src/engine/trace-normalizer.test.ts
+++ b/packages/core/src/engine/trace-normalizer.test.ts
@@ -1,0 +1,220 @@
+// Unit tests for the trace normalizer — deterministic canonicalization of agent trace entries.
+import { describe, it, expect } from 'vitest';
+import { normalizeTrace } from './trace-normalizer.js';
+
+describe('normalizeTrace', () => {
+  // ─── basic operation ──────────────────────────────────────────────────────
+
+  it('assigns seq numbers starting from 1', () => {
+    const { entries } = normalizeTrace([{ event: 'alpha' }, { event: 'beta' }, { event: 'gamma' }]);
+    expect(entries.map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+
+  it('passes through timestamp and data when present', () => {
+    const { entries } = normalizeTrace([
+      { event: 'step', timestamp: '2024-01-01T00:00:00Z', data: { key: 'val' } },
+    ]);
+    expect(entries[0]).toMatchObject({
+      seq: 1,
+      event: 'step',
+      timestamp: '2024-01-01T00:00:00Z',
+      data: { key: 'val' },
+    });
+  });
+
+  it('omits timestamp and data when absent', () => {
+    const { entries } = normalizeTrace([{ event: 'bare' }]);
+    expect(entries[0]).not.toHaveProperty('timestamp');
+    expect(entries[0]).not.toHaveProperty('data');
+  });
+
+  it('returns empty entries and undefined digest for empty input', () => {
+    const { entries, digest, summary } = normalizeTrace([]);
+    expect(entries).toHaveLength(0);
+    expect(digest).toBeUndefined();
+    expect(summary.submitted_entries).toBe(0);
+    expect(summary.stored_entries).toBe(0);
+  });
+
+  // ─── event normalization ──────────────────────────────────────────────────
+
+  it('trims whitespace from event strings', () => {
+    const { entries } = normalizeTrace([{ event: '  leading_space  ' }]);
+    expect(entries[0]!.event).toBe('leading_space');
+  });
+
+  it('replaces empty (post-trim) event with "unknown_event"', () => {
+    const { entries } = normalizeTrace([{ event: '' }, { event: '   ' }]);
+    expect(entries[0]!.event).toBe('unknown_event');
+    expect(entries[1]!.event).toBe('unknown_event');
+  });
+
+  it('caps event length to 100 characters', () => {
+    const long = 'x'.repeat(200);
+    const { entries } = normalizeTrace([{ event: long }]);
+    expect(entries[0]!.event).toHaveLength(100);
+  });
+
+  // ─── data normalization ───────────────────────────────────────────────────
+
+  it('keeps string, number, boolean, null values', () => {
+    const { entries } = normalizeTrace([
+      { event: 'types', data: { s: 'hello', n: 42, b: true, nil: null } },
+    ]);
+    expect(entries[0]!.data).toEqual({ s: 'hello', n: 42, b: true, nil: null });
+  });
+
+  it('drops object and array values silently', () => {
+    const { entries } = normalizeTrace([
+      // Cast to any to bypass TS type since we test runtime robustness
+      { event: 'mixed', data: { good: 'ok', bad: { nested: true } as unknown as string } },
+    ]);
+    expect(entries[0]!.data).toEqual({ good: 'ok' });
+  });
+
+  it('caps string values to 500 characters', () => {
+    const long = 'y'.repeat(600);
+    const { entries } = normalizeTrace([{ event: 'ev', data: { long } }]);
+    expect(entries[0]!.data!['long']).toHaveLength(500);
+  });
+
+  it('caps data keys to the first 20', () => {
+    const data: Record<string, string> = {};
+    for (let i = 0; i < 30; i++) data[`key${i}`] = 'v';
+    const { entries } = normalizeTrace([{ event: 'many_keys', data }]);
+    expect(Object.keys(entries[0]!.data!)).toHaveLength(20);
+  });
+
+  it('omits data field when all values are dropped', () => {
+    const { entries } = normalizeTrace([
+      { event: 'ev', data: { bad: { obj: 1 } as unknown as string } },
+    ]);
+    expect(entries[0]).not.toHaveProperty('data');
+  });
+
+  it('omits data field when data is undefined', () => {
+    const { entries } = normalizeTrace([{ event: 'ev' }]);
+    expect(entries[0]).not.toHaveProperty('data');
+  });
+
+  // ─── reserved prefix ──────────────────────────────────────────────────────
+
+  it('drops entries whose event starts with "trace."', () => {
+    const { entries, summary } = normalizeTrace([
+      { event: 'trace.internal' },
+      { event: 'trace.other' },
+      { event: 'legit' },
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.event).toBe('legit');
+    expect(summary.discarded_reserved_event_entries).toBe(2);
+    expect(summary.discarded_entries).toBe(2);
+  });
+
+  it('does not drop entries whose event merely contains "trace." in the middle', () => {
+    const { entries } = normalizeTrace([{ event: 'my.trace.info' }]);
+    expect(entries[0]!.event).toBe('my.trace.info');
+  });
+
+  // ─── count limit ──────────────────────────────────────────────────────────
+
+  it('stores at most 100 entries, then appends sentinel', () => {
+    const input = Array.from({ length: 101 }, (_, i) => ({ event: `ev${i}` }));
+    const { entries, summary } = normalizeTrace(input);
+    // 100 real entries + 1 sentinel
+    expect(entries).toHaveLength(101);
+    expect(entries[100]!.event).toBe('trace.truncated');
+    expect(entries[100]!.seq).toBe(101);
+    expect(summary.truncated).toBe(true);
+    expect(summary.truncation_reason).toBe('count_limit');
+    expect(summary.discarded_overflow_entries).toBe(1);
+    expect(summary.stored_entries).toBe(101);
+  });
+
+  it('sets sentinel data accurately on count limit', () => {
+    const input = Array.from({ length: 105 }, (_, i) => ({ event: `ev${i}` }));
+    const { entries } = normalizeTrace(input);
+    const sentinel = entries[entries.length - 1]!;
+    expect(sentinel.data!['submitted']).toBe(105);
+    expect(sentinel.data!['stored_before_sentinel']).toBe(100);
+    expect(sentinel.data!['discarded']).toBe(5);
+    expect(sentinel.data!['reason']).toBe('count_limit');
+  });
+
+  it('entries after count limit count as discarded_overflow, not discarded_reserved', () => {
+    const input = Array.from({ length: 103 }, (_, i) => ({ event: `ev${i}` }));
+    const { summary } = normalizeTrace(input);
+    expect(summary.discarded_overflow_entries).toBe(3);
+    expect(summary.discarded_reserved_event_entries).toBe(0);
+  });
+
+  // ─── byte limit ───────────────────────────────────────────────────────────
+
+  it('triggers byte_limit when serialized trace exceeds 50 KB', () => {
+    // Each entry: event + 500-char data value. Around 65-70 entries will hit 50 KB.
+    const bigVal = 'z'.repeat(500);
+    const input = Array.from({ length: 120 }, (_, i) => ({
+      event: `event_${i}`,
+      data: { payload: bigVal },
+    }));
+    const { entries, summary } = normalizeTrace(input);
+    const sentinel = entries[entries.length - 1]!;
+    expect(sentinel.event).toBe('trace.truncated');
+    expect(summary.truncation_reason).toBe('byte_limit');
+    expect(summary.truncated).toBe(true);
+    // Sentinel is always appended even if that pushes slightly over 50 KB
+    expect(entries.length).toBeLessThan(120);
+  });
+
+  // ─── first-trigger semantics ──────────────────────────────────────────────
+
+  it('count_limit fires before byte_limit when entry count reaches 100 first', () => {
+    // Small entries: will hit count limit before byte limit.
+    const input = Array.from({ length: 120 }, (_, i) => ({ event: `s${i}` }));
+    const { summary } = normalizeTrace(input);
+    expect(summary.truncation_reason).toBe('count_limit');
+  });
+
+  // ─── summary fields ───────────────────────────────────────────────────────
+
+  it('summary reflects submitted, stored, discarded counts when no truncation', () => {
+    const { summary } = normalizeTrace([
+      { event: 'trace.dropped' }, // reserved — dropped
+      { event: 'good1' },
+      { event: 'good2' },
+    ]);
+    expect(summary.submitted_entries).toBe(3);
+    expect(summary.stored_entries).toBe(2);
+    expect(summary.discarded_entries).toBe(1);
+    expect(summary.discarded_reserved_event_entries).toBe(1);
+    expect(summary.discarded_overflow_entries).toBe(0);
+    expect(summary.truncated).toBe(false);
+    expect(summary.truncation_reason).toBeUndefined();
+  });
+
+  // ─── digest ───────────────────────────────────────────────────────────────
+
+  it('returns a 64-char hex digest for non-empty stored trace', () => {
+    const { digest } = normalizeTrace([{ event: 'ev' }]);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns undefined digest for empty stored trace', () => {
+    const { digest } = normalizeTrace([{ event: 'trace.only_reserved' }]);
+    expect(digest).toBeUndefined();
+  });
+
+  it('digest is deterministic for identical input', () => {
+    const input = [{ event: 'alpha', data: { k: 'v' } }];
+    const { digest: d1 } = normalizeTrace(input);
+    const { digest: d2 } = normalizeTrace(input);
+    expect(d1).toBe(d2);
+    expect(d1).toBeDefined();
+  });
+
+  it('digest differs when trace content differs', () => {
+    const { digest: d1 } = normalizeTrace([{ event: 'alpha' }]);
+    const { digest: d2 } = normalizeTrace([{ event: 'beta' }]);
+    expect(d1).not.toBe(d2);
+  });
+});

--- a/packages/core/src/engine/trace-normalizer.test.ts
+++ b/packages/core/src/engine/trace-normalizer.test.ts
@@ -166,6 +166,70 @@ describe('normalizeTrace', () => {
     expect(entries.length).toBeLessThan(120);
   });
 
+  // ─── byte-budget boundary correctness ────────────────────────────────────
+  //
+  // Fixtures are engineered to exact known byte sizes.
+  //
+  // 96 entries with event='x' and data={k:'A'.repeat(490)} — all ASCII:
+  //   seq 1-9  → {"seq":N,"event":"x","data":{"k":"..."}} = 527 bytes each
+  //   seq 10-96 → 528 bytes each
+  //   Array total: 2 + 9×527 + 87×528 + 95 commas = 50776 bytes
+  //
+  // Entry 97 (seq=97, 2-digit): fixed overhead = {"seq":97,"event":"x","data":{"k":""}} + value
+  //   prefix ("{"seq":97,"event":"x","data":{"k":"") = 35 bytes
+  //   suffix ("}}") = 3 bytes
+  //   fixed overhead = 38 bytes
+  //
+  //   With 385-char value: 423 bytes → prospective = 50776 + 1 + 423 = 51200 = MAX_BYTES → fits
+  //   With 386-char value: 424 bytes → prospective = 50776 + 1 + 424 = 51201 > MAX_BYTES → rejected
+
+  it('boundary: candidate that exactly fills the byte budget is stored (no truncation)', () => {
+    const PRELUDE_VAL = 'A'.repeat(490);
+    const prelude = Array.from({ length: 96 }, () => ({ event: 'x', data: { k: PRELUDE_VAL } }));
+    // Entry 97 sized to exactly fill remaining budget.
+    const exactFit = { event: 'x', data: { k: 'B'.repeat(385) } };
+
+    const { entries, summary } = normalizeTrace([...prelude, exactFit]);
+
+    expect(summary.truncated).toBe(false);
+    expect(entries).toHaveLength(97);
+    expect(entries[96]!.data!['k']).toHaveLength(385);
+    // Parity: the stored array serializes to exactly MAX_BYTES.
+    expect(Buffer.byteLength(JSON.stringify(entries), 'utf8')).toBe(50 * 1024);
+  });
+
+  it('boundary: candidate that exceeds byte budget by 1 byte triggers byte_limit', () => {
+    const PRELUDE_VAL = 'A'.repeat(490);
+    const prelude = Array.from({ length: 96 }, () => ({ event: 'x', data: { k: PRELUDE_VAL } }));
+    // Entry 97 sized to exceed by exactly 1 byte.
+    const overBy1 = { event: 'x', data: { k: 'B'.repeat(386) } };
+
+    const { entries, summary } = normalizeTrace([...prelude, overBy1]);
+
+    expect(summary.truncated).toBe(true);
+    expect(summary.truncation_reason).toBe('byte_limit');
+    // 96 prelude entries stored + 1 sentinel = 97 total; entry 97 was rejected.
+    expect(entries).toHaveLength(97);
+    expect(entries[96]!.event).toBe('trace.truncated');
+    expect(summary.discarded_overflow_entries).toBe(1);
+    // The stored payload (without sentinel) is within budget.
+    const payload = entries.slice(0, 96);
+    expect(Buffer.byteLength(JSON.stringify(payload), 'utf8')).toBe(50776);
+  });
+
+  it('parity: stored payload entries are within budget after byte_limit truncation', () => {
+    const bigVal = 'A'.repeat(490);
+    const input = Array.from({ length: 100 }, () => ({ event: 'x', data: { k: bigVal } }));
+    const { entries, summary } = normalizeTrace(input);
+
+    expect(summary.truncated).toBe(true);
+    expect(summary.truncation_reason).toBe('byte_limit');
+
+    // All stored entries excluding the sentinel must fit within 50 KB.
+    const payload = entries.filter((e) => e.event !== 'trace.truncated');
+    expect(Buffer.byteLength(JSON.stringify(payload), 'utf8')).toBeLessThanOrEqual(50 * 1024);
+  });
+
   // ─── first-trigger semantics ──────────────────────────────────────────────
 
   it('count_limit fires before byte_limit when entry count reaches 100 first', () => {

--- a/packages/core/src/engine/trace-normalizer.ts
+++ b/packages/core/src/engine/trace-normalizer.ts
@@ -69,6 +69,11 @@ export interface NormalizeTraceResult {
  * This is exact because JSON array serialization is the concatenation of independently
  * serialized element strings separated by commas and wrapped in brackets.
  *
+ * Invariant note: this exactness relies on current JSON serialization behavior and
+ * object construction order in this module. If serialization strategy changes,
+ * parity tests in trace-normalizer.test.ts are expected to fail and should trigger
+ * a review of the incremental byte-budget logic.
+ *
  * Sentinel entries are exempt from the reserved-prefix drop rule.
  * The sentinel data contains submitted, stored_before_sentinel, discarded, and reason fields.
  */

--- a/packages/core/src/engine/trace-normalizer.ts
+++ b/packages/core/src/engine/trace-normalizer.ts
@@ -62,7 +62,12 @@ export interface NormalizeTraceResult {
  *
  * Normalization precedes the reserved-prefix check so that whitespace-padded variants
  * like "  trace.internal" are caught and dropped correctly.
- * Byte limit uses UTF-8 byte count (Buffer.byteLength) rather than JS string length.
+ * Byte limit uses incremental UTF-8 byte accounting: the serialized array size is
+ * maintained as a running counter rather than re-serializing the full array each
+ * iteration. The counter starts at 2 (empty JSON array `[]`) and grows by
+ * Buffer.byteLength(JSON.stringify(candidate)) + comma overhead per accepted entry.
+ * This is exact because JSON array serialization is the concatenation of independently
+ * serialized element strings separated by commas and wrapped in brackets.
  *
  * Sentinel entries are exempt from the reserved-prefix drop rule.
  * The sentinel data contains submitted, stored_before_sentinel, discarded, and reason fields.
@@ -75,6 +80,9 @@ export function normalizeTrace(input: AgentTraceEntry[]): NormalizeTraceResult {
   let truncationReason: 'count_limit' | 'byte_limit' | undefined;
 
   const stored: TraceEntry[] = [];
+  // Incremental UTF-8 byte accounting for the serialized array form.
+  // Starts at 2 for the empty array (`[]`); grows by candidateBytes + commaBytes on each accept.
+  let currentArrayBytes = 2;
 
   for (const entry of input) {
     // Normalize event first so whitespace-padded reserved-prefix events are caught below.
@@ -109,14 +117,20 @@ export function normalizeTrace(input: AgentTraceEntry[]): NormalizeTraceResult {
       continue;
     }
 
-    // Byte limit check: measure UTF-8 byte size including seq-assigned candidate.
-    if (Buffer.byteLength(JSON.stringify([...stored, candidate]), 'utf8') > MAX_BYTES) {
+    // Byte limit check: compute candidate bytes once and check the prospective array total.
+    // Incrementally tracking the array byte count is exact because JSON.stringify on an array
+    // equals '[' + elements.join(',') + ']' — element serializations are independent of context.
+    const candidateStr = JSON.stringify(candidate);
+    const candidateBytes = Buffer.byteLength(candidateStr, 'utf8');
+    const commaBytes = stored.length > 0 ? 1 : 0;
+    if (currentArrayBytes + commaBytes + candidateBytes > MAX_BYTES) {
       truncated = true;
       truncationReason = 'byte_limit';
       discardedOverflow++;
       continue;
     }
 
+    currentArrayBytes += commaBytes + candidateBytes;
     stored.push(candidate);
   }
 

--- a/packages/core/src/engine/trace-normalizer.ts
+++ b/packages/core/src/engine/trace-normalizer.ts
@@ -1,0 +1,150 @@
+// trace-normalizer.ts — Deterministic single-pass canonicalization for agent-submitted trace entries.
+import { createHash } from 'node:crypto';
+import type {
+  AgentTraceEntry,
+  TraceEntry,
+  TraceNormalizationSummary,
+} from '../types/run-record.js';
+
+const MAX_ENTRIES = 100;
+const MAX_BYTES = 50 * 1024; // 50 KB
+const MAX_EVENT_LENGTH = 100;
+const MAX_DATA_KEYS = 20;
+const MAX_STRING_VALUE = 500;
+const RESERVED_PREFIX = 'trace.';
+const SENTINEL_EVENT = 'trace.truncated';
+
+function normalizeEvent(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.length === 0 ? 'unknown_event' : trimmed.slice(0, MAX_EVENT_LENGTH);
+}
+
+type AllowedValue = string | number | boolean | null;
+
+function normalizeData(
+  raw: Record<string, unknown> | undefined,
+): Record<string, AllowedValue> | undefined {
+  if (raw === undefined) return undefined;
+  const keys = Object.keys(raw).slice(0, MAX_DATA_KEYS);
+  const result: Record<string, AllowedValue> = {};
+  for (const key of keys) {
+    const v = raw[key];
+    if (v === null) {
+      result[key] = null;
+    } else if (typeof v === 'boolean') {
+      result[key] = v;
+    } else if (typeof v === 'number') {
+      result[key] = v;
+    } else if (typeof v === 'string') {
+      result[key] = v.slice(0, MAX_STRING_VALUE);
+    }
+    // Other types (object, array, undefined) are dropped silently.
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export interface NormalizeTraceResult {
+  entries: TraceEntry[];
+  digest: string | undefined;
+  summary: TraceNormalizationSummary;
+}
+
+/**
+ * Canonicalizes agent-submitted trace entries in a single pass.
+ *
+ * Rules applied in order:
+ *   1. Drop entries whose event starts with "trace." (reserved engine namespace).
+ *   2. Normalize event: trim whitespace; replace empty with "unknown_event"; cap to 100 chars.
+ *   3. Normalize data: keep first 20 keys; cap string values to 500 chars; drop non-primitive values.
+ *   4. Apply hard limits (first-trigger wins): max 100 entries, max 50 KB serialized.
+ *   5. Assign seq numbers (1-based, monotonically increasing) after filtering.
+ *   6. Append a sentinel entry if truncation occurred.
+ *
+ * Sentinel entries are exempt from the reserved-prefix drop rule.
+ * The sentinel data contains submitted, stored_before_sentinel, discarded, and reason fields.
+ */
+export function normalizeTrace(input: AgentTraceEntry[]): NormalizeTraceResult {
+  const submittedEntries = input.length;
+  let discardedReserved = 0;
+  let discardedOverflow = 0;
+  let truncated = false;
+  let truncationReason: 'count_limit' | 'byte_limit' | undefined;
+
+  const stored: TraceEntry[] = [];
+
+  for (const entry of input) {
+    // Drop reserved-prefix entries (engine namespace).
+    if (entry.event.startsWith(RESERVED_PREFIX)) {
+      discardedReserved++;
+      continue;
+    }
+
+    // First-trigger: once truncated, all remaining valid entries count as overflow.
+    if (truncated) {
+      discardedOverflow++;
+      continue;
+    }
+
+    const event = normalizeEvent(entry.event);
+    const data = normalizeData(entry.data as Record<string, unknown> | undefined);
+
+    const candidate: TraceEntry = {
+      seq: stored.length + 1,
+      event,
+      ...(entry.timestamp !== undefined ? { timestamp: entry.timestamp } : {}),
+      ...(data !== undefined ? { data } : {}),
+    };
+
+    // Count limit check (evaluated before byte limit — first-trigger wins).
+    if (stored.length >= MAX_ENTRIES) {
+      truncated = true;
+      truncationReason = 'count_limit';
+      discardedOverflow++;
+      continue;
+    }
+
+    // Byte limit check: measure serialized size including seq-assigned candidate.
+    if (JSON.stringify([...stored, candidate]).length > MAX_BYTES) {
+      truncated = true;
+      truncationReason = 'byte_limit';
+      discardedOverflow++;
+      continue;
+    }
+
+    stored.push(candidate);
+  }
+
+  // Append engine sentinel if truncation occurred. Sentinel is exempt from reserved-prefix drop.
+  if (truncated) {
+    const sentinel: TraceEntry = {
+      seq: stored.length + 1,
+      event: SENTINEL_EVENT,
+      data: {
+        submitted: submittedEntries,
+        stored_before_sentinel: stored.length,
+        discarded: discardedReserved + discardedOverflow,
+        reason: truncationReason!,
+      },
+    };
+    stored.push(sentinel);
+  }
+
+  const discardedEntries = discardedReserved + discardedOverflow;
+
+  const summary: TraceNormalizationSummary = {
+    submitted_entries: submittedEntries,
+    stored_entries: stored.length,
+    discarded_entries: discardedEntries,
+    discarded_reserved_event_entries: discardedReserved,
+    discarded_overflow_entries: discardedOverflow,
+    truncated,
+    ...(truncationReason !== undefined ? { truncation_reason: truncationReason } : {}),
+  };
+
+  const digest =
+    stored.length > 0
+      ? createHash('sha256').update(JSON.stringify(stored)).digest('hex')
+      : undefined;
+
+  return { entries: stored, digest, summary };
+}

--- a/packages/core/src/engine/trace-normalizer.ts
+++ b/packages/core/src/engine/trace-normalizer.ts
@@ -53,12 +53,16 @@ export interface NormalizeTraceResult {
  * Canonicalizes agent-submitted trace entries in a single pass.
  *
  * Rules applied in order:
- *   1. Drop entries whose event starts with "trace." (reserved engine namespace).
- *   2. Normalize event: trim whitespace; replace empty with "unknown_event"; cap to 100 chars.
+ *   1. Normalize event: trim whitespace; replace empty with "unknown_event"; cap to 100 chars.
+ *   2. Drop entries whose normalized event starts with "trace." (reserved engine namespace).
  *   3. Normalize data: keep first 20 keys; cap string values to 500 chars; drop non-primitive values.
- *   4. Apply hard limits (first-trigger wins): max 100 entries, max 50 KB serialized.
+ *   4. Apply hard limits (first-trigger wins): max 100 entries, max 50 KB UTF-8 bytes.
  *   5. Assign seq numbers (1-based, monotonically increasing) after filtering.
  *   6. Append a sentinel entry if truncation occurred.
+ *
+ * Normalization precedes the reserved-prefix check so that whitespace-padded variants
+ * like "  trace.internal" are caught and dropped correctly.
+ * Byte limit uses UTF-8 byte count (Buffer.byteLength) rather than JS string length.
  *
  * Sentinel entries are exempt from the reserved-prefix drop rule.
  * The sentinel data contains submitted, stored_before_sentinel, discarded, and reason fields.
@@ -73,8 +77,11 @@ export function normalizeTrace(input: AgentTraceEntry[]): NormalizeTraceResult {
   const stored: TraceEntry[] = [];
 
   for (const entry of input) {
-    // Drop reserved-prefix entries (engine namespace).
-    if (entry.event.startsWith(RESERVED_PREFIX)) {
+    // Normalize event first so whitespace-padded reserved-prefix events are caught below.
+    const event = normalizeEvent(entry.event);
+
+    // Drop entries whose normalized event starts with the reserved engine prefix.
+    if (event.startsWith(RESERVED_PREFIX)) {
       discardedReserved++;
       continue;
     }
@@ -85,7 +92,6 @@ export function normalizeTrace(input: AgentTraceEntry[]): NormalizeTraceResult {
       continue;
     }
 
-    const event = normalizeEvent(entry.event);
     const data = normalizeData(entry.data as Record<string, unknown> | undefined);
 
     const candidate: TraceEntry = {
@@ -103,8 +109,8 @@ export function normalizeTrace(input: AgentTraceEntry[]): NormalizeTraceResult {
       continue;
     }
 
-    // Byte limit check: measure serialized size including seq-assigned candidate.
-    if (JSON.stringify([...stored, candidate]).length > MAX_BYTES) {
+    // Byte limit check: measure UTF-8 byte size including seq-assigned candidate.
+    if (Buffer.byteLength(JSON.stringify([...stored, candidate]), 'utf8') > MAX_BYTES) {
       truncated = true;
       truncationReason = 'byte_limit';
       discardedOverflow++;

--- a/packages/core/src/evidence/snapshot.ts
+++ b/packages/core/src/evidence/snapshot.ts
@@ -1,7 +1,8 @@
 // Standalone evidence capture utility — builds an EvidenceSnapshot from step execution data.
 import { createHash } from 'node:crypto';
-import type { EvidenceSnapshot, StepDiagnostics } from '../types/run-record.js';
+import type { EvidenceSnapshot, StepDiagnostics, AgentTraceEntry } from '../types/run-record.js';
 import type { ToolCallRecord } from '../types/mcp-types.js';
+import { normalizeTrace } from '../engine/trace-normalizer.js';
 
 export interface CaptureEvidenceParams {
   stepId: string;
@@ -16,11 +17,34 @@ export interface CaptureEvidenceParams {
   resolvedParams?: Record<string, unknown>;
   /** MCP tool calls made during this step. Absent = callStep path; present = callStepWithTools path. */
   toolCalls?: ToolCallRecord[];
+  /**
+   * Agent-submitted trace entries. When present (even empty array), the normalizer runs
+   * and trace_summary is always recorded. Entries surviving normalization are stored as trace.
+   * evidence_hash is unaffected — it covers output_summary only.
+   */
+  trace?: AgentTraceEntry[];
 }
 
-/** Builds an EvidenceSnapshot from step execution parameters, including a SHA-256 content hash. */
+/** Builds an EvidenceSnapshot from step execution parameters, including a SHA-256 content hash.
+ *
+ * evidence_hash is computed from output_summary only and is unaffected by trace.
+ * trace_digest (when present) covers the canonical trace array separately.
+ */
 export function captureEvidence(params: CaptureEvidenceParams): EvidenceSnapshot {
+  // evidence_hash: hash of output only — behavior unchanged.
   const evidenceHash = createHash('sha256').update(JSON.stringify(params.output)).digest('hex');
+
+  // Trace normalization: only when trace input is provided.
+  let traceEntry: Pick<EvidenceSnapshot, 'trace' | 'trace_digest' | 'trace_summary'> = {};
+  if (params.trace !== undefined) {
+    const { entries, digest, summary } = normalizeTrace(params.trace);
+    if (entries.length > 0 && digest !== undefined) {
+      traceEntry = { trace: entries, trace_digest: digest, trace_summary: summary };
+    } else {
+      traceEntry = { trace_summary: summary };
+    }
+  }
+
   return {
     step_id: params.stepId,
     started_at: params.startedAt.toISOString(),
@@ -38,5 +62,6 @@ export function captureEvidence(params: CaptureEvidenceParams): EvidenceSnapshot
       : {}),
     ...(params.resolvedParams !== undefined ? { resolved_params: params.resolvedParams } : {}),
     ...(params.toolCalls !== undefined ? { tool_calls: params.toolCalls } : {}),
+    ...traceEntry,
   };
 }

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -1,6 +1,38 @@
 // Types for an active or historical workflow run record stored on disk.
 import type { ToolCallRecord } from './mcp-types.js';
 
+/**
+ * A single trace entry submitted by the agent. Submitted as-is; the engine
+ * canonicalizes and assigns seq before persisting.
+ */
+export interface AgentTraceEntry {
+  event: string;
+  timestamp?: string | undefined;
+  data?: Record<string, string | number | boolean | null> | undefined;
+}
+
+/**
+ * A single stored trace entry after canonicalization.
+ * seq is engine-assigned: 1-based, monotonically increasing in stored order.
+ */
+export interface TraceEntry {
+  seq: number;
+  event: string;
+  timestamp?: string;
+  data?: Record<string, string | number | boolean | null>;
+}
+
+/** Discard and truncation accounting produced by the trace normalizer. */
+export interface TraceNormalizationSummary {
+  submitted_entries: number;
+  stored_entries: number;
+  discarded_entries: number;
+  discarded_reserved_event_entries: number;
+  discarded_overflow_entries: number;
+  truncated: boolean;
+  truncation_reason?: 'count_limit' | 'byte_limit';
+}
+
 /** Diagnostic metadata captured during step execution. Written once; read by inspect. */
 export interface StepDiagnostics {
   /** Rough token count estimate: Math.ceil(JSON.stringify(input).length / 4) */
@@ -45,6 +77,23 @@ export interface EvidenceSnapshot {
    * derived from run state and passed to the service adapter. Absent for all other step types.
    */
   resolved_params?: Record<string, unknown>;
+  /**
+   * Canonical stored trace entries for this step. Present only on agent execution steps
+   * when the agent submitted a non-empty trace that survived normalization.
+   * Excludes evidence_hash computation — integrity is tracked separately via trace_digest.
+   */
+  trace?: TraceEntry[];
+  /**
+   * SHA-256 hex digest of JSON.stringify(trace). Present when trace is non-empty.
+   * Separate from evidence_hash, which covers output_summary only.
+   */
+  trace_digest?: string;
+  /**
+   * Discard and truncation accounting from the trace normalizer.
+   * Present whenever the agent submitted a trace (even if all entries were dropped).
+   * Absent when no trace was submitted.
+   */
+  trace_summary?: TraceNormalizationSummary;
 }
 
 export interface PendingGate {

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -7,8 +7,16 @@ import {
   executeChain,
   type StepDispatcher,
   type ResponseEnvelope,
+  type AgentTraceEntry,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
+
+/** Zod schema for a single agent trace entry submitted to execute_step. */
+const traceEntrySchema = z.object({
+  event: z.string(),
+  timestamp: z.string().optional(),
+  data: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+});
 
 // For agent steps, the agent's params represent their work output. The dispatcher
 // passes them through as the step output recorded in evidence.
@@ -22,7 +30,12 @@ const makeParamsDispatcher =
  * Validates eligibility, claims the step, and records the agent's params as step output.
  */
 export async function handleExecuteStep(
-  args: { run_id: string; command: string; params?: Record<string, unknown> },
+  args: {
+    run_id: string;
+    command: string;
+    params?: Record<string, unknown>;
+    trace?: AgentTraceEntry[] | undefined;
+  },
   stores?: HandleRunStores,
 ): Promise<ResponseEnvelope> {
   const workflowStore = stores?.workflowStore ?? new JsonWorkflowStore();
@@ -38,6 +51,8 @@ export async function handleExecuteStep(
     dispatcher: makeParamsDispatcher(params),
     ...(stores?.registry !== undefined ? { registry: stores.registry } : {}),
     ...(stores?.secrets !== undefined ? { secrets: stores.secrets } : {}),
+    // trace is a top-level execute_step field — never embedded in params.
+    ...(args.trace !== undefined ? { trace: args.trace } : {}),
   });
 }
 
@@ -47,7 +62,12 @@ export async function handleExecuteStep(
  * Exported for direct testing of the MCP response shape.
  */
 export async function handleExecuteStepTool(
-  args: { run_id: string; command: string; params?: Record<string, unknown> },
+  args: {
+    run_id: string;
+    command: string;
+    params?: Record<string, unknown>;
+    trace?: AgentTraceEntry[] | undefined;
+  },
   stores?: HandleRunStores,
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   try {
@@ -104,6 +124,7 @@ export function registerExecuteStep(
       run_id: z.string(),
       command: z.string(),
       params: z.record(z.unknown()).optional().default({}),
+      trace: z.array(traceEntrySchema).optional(),
     },
     async (args) => {
       return handleExecuteStepTool(args, opts);

--- a/packages/mcp-server/src/tools/mcp-tools.test.ts
+++ b/packages/mcp-server/src/tools/mcp-tools.test.ts
@@ -152,6 +152,65 @@ describe('mcp tool handlers', () => {
     expect(finalRun.run_phase).toBe('completed');
   });
 
+  it('handleExecuteStep accepts a top-level trace and persists it in evidence', async () => {
+    const workflowStore = new JsonWorkflowStore(workflowDir);
+    await workflowStore.register(makeAgentDef());
+    const runStore = new JsonFileStore(runDir);
+
+    const startResult = await handleStartRun(
+      { workflow_id: 'agent-wf', params: {} },
+      { runStore, workflowStore },
+    );
+
+    const result = await handleExecuteStep(
+      {
+        run_id: startResult.run_id,
+        command: 'step-agent',
+        params: { result: 'done' },
+        trace: [
+          { event: 'search_called', data: { query: 'hello' } },
+          { event: 'search_returned', data: { count: 3 } },
+        ],
+      },
+      { runStore, workflowStore },
+    );
+
+    expect(result.status).toBe('ok');
+    const snap = result.evidence.find((e) => e.step_id === 'step-agent');
+    expect(snap?.trace).toBeDefined();
+    expect(snap?.trace).toHaveLength(2);
+    expect(snap?.trace![0]!.event).toBe('search_called');
+    expect(snap?.trace_digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('trace is not merged into params — trace content does not appear in output_summary', async () => {
+    const workflowStore = new JsonWorkflowStore(workflowDir);
+    await workflowStore.register(makeAgentDef());
+    const runStore = new JsonFileStore(runDir);
+
+    const startResult = await handleStartRun(
+      { workflow_id: 'agent-wf', params: {} },
+      { runStore, workflowStore },
+    );
+
+    const result = await handleExecuteStep(
+      {
+        run_id: startResult.run_id,
+        command: 'step-agent',
+        params: { result: 'done' },
+        trace: [{ event: 'should_not_be_in_params', data: { secret: 'leaked?' } }],
+      },
+      { runStore, workflowStore },
+    );
+
+    expect(result.status).toBe('ok');
+    const snap = result.evidence.find((e) => e.step_id === 'step-agent');
+    // output_summary comes from params only — trace fields must not appear in it
+    expect(snap?.output_summary).not.toHaveProperty('trace');
+    expect(snap?.output_summary).not.toHaveProperty('event');
+    expect(snap?.output_summary).toEqual({ result: 'done' });
+  });
+
   it('handleSubmitHumanResponse advances a gate-waiting run', async () => {
     const workflowStore = new JsonWorkflowStore(workflowDir);
     await workflowStore.register(makeGateDef());


### PR DESCRIPTION
## Summary

Implements Step Trace A1 — contract hardening. Adds a first-class `trace` field to `execute_step` that accepts an array of `{ event, timestamp?, data? }` entries alongside `params`. The engine canonicalizes the submission in a single deterministic pass and persists the result (`trace`, `trace_digest`, `trace_summary`) on the `EvidenceSnapshot` without affecting `evidence_hash`.

## Changes

### Source files

| File | Change |
|---|---|
| `packages/core/src/types/run-record.ts` | New types: `AgentTraceEntry`, `TraceEntry`, `TraceNormalizationSummary`; `EvidenceSnapshot` extended with `trace?`, `trace_digest?`, `trace_summary?` |
| `packages/core/src/engine/trace-normalizer.ts` | **New file.** Single-pass canonicalization: reserved `trace.` prefix drop, event normalization (trim, empty→`unknown_event`, 100-char cap), data normalization (20-key cap, 500-char string cap, non-primitive drop), 100-entry and 50 KB hard limits (first-trigger wins), sentinel append on truncation, SHA-256 `trace_digest` |
| `packages/core/src/evidence/snapshot.ts` | `CaptureEvidenceParams` gains `trace?: AgentTraceEntry[]`; `captureEvidence` calls `normalizeTrace` and spreads result into the returned snapshot |
| `packages/core/src/engine/execution-loop.ts` | `ExecuteStepOptions` and `ExecuteChainOptions` gain `trace?: AgentTraceEntry[]`; `captureEvidence` call passes trace only for `execution: agent` steps — auto/handler steps silently drop it |
| `packages/mcp-server/src/tools/execute-step.ts` | Zod schema adds `trace` array; `handleExecuteStep` and `handleExecuteStepTool` accept and pass through `trace`; trace is never merged into `params` |
| `packages/cli/src/commands/inspect.ts` | `realm run inspect` renders `Trace: N entries (not hashed).` and a yellow `⚠ Trace truncated (reason): N stored, M discarded.` warning when applicable (both single-snap and multi-attempt branches) |
| `CHANGELOG.md` | Step Trace A1 entry prepended to `## [Unreleased] ### Added` |

### Test files

| File | Tests added |
|---|---|
| `packages/core/src/engine/trace-normalizer.test.ts` | **25 new tests** — seq assignment, event/data normalization, reserved prefix drop, count/byte limits, sentinel accuracy, digest determinism |
| `packages/core/src/engine/execution-loop.test.ts` | **6 new tests** — agent step persists trace; non-agent drops trace; reserved prefix drop; count limit sentinel; `evidence_hash` stable across trace changes; `trace_digest` differs when trace differs |
| `packages/mcp-server/src/tools/mcp-tools.test.ts` | **2 new tests** — `handleExecuteStep` accepts top-level trace; trace not merged into `output_summary` |
| `packages/cli/src/commands/inspect.test.ts` | **2 new tests** — trace summary line; truncation warning rendering |

## Design Decisions

- **`evidence_hash` is unaffected.** It covers `output_summary` only. `trace_digest` is a separate SHA-256 over the canonical trace array.
- **Sentinel exempt from reserved-prefix drop.** The `trace.truncated` sentinel is engine-appended after normalization — it is never submitted by the agent.
- **First-trigger wins for limits.** Count limit (100 entries) is evaluated before byte limit (50 KB) per loop iteration. Once truncation fires, all remaining valid entries become `discarded_overflow`.
- **Silent drop for non-agent steps.** Auto, handler, and adapter steps silently ignore the `trace` field — this is correct because only agent steps can generate tool-use traces.

## Verification

```bash
# Build
npm run build
# All 4 packages: 0 errors

# Tests
npm test
# @sensigo/realm:       675 tests passed (38 files) — +31 new
# @sensigo/realm-mcp:   35 tests passed  (4 files)  — +2 new
# @sensigo/realm-cli:   272 tests passed (26 files)  — +2 new
# @sensigo/realm-testing: 47 tests passed (1 file)
```

## Related

Closes phase-63 (Step Trace A1 — contract hardening).
