### PR TITLE
feat(core): add ShopifyAdapter — Shopify Admin GraphQL API service adapter (phase-cs2)

### DIFF
--- a/packages/core/src/adapters/shopify-adapter.test.ts
+++ b/packages/core/src/adapters/shopify-adapter.test.ts
@@ -1,0 +1,463 @@
+import * as http from 'node:http';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { ShopifyAdapter } from './shopify-adapter.js';
+import type { ShopifyAdapterConfig, NormalizedOrder } from './shopify-adapter.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+// ---------------------------------------------------------------------------
+// Mock server
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (req: http.IncomingMessage, res: http.ServerResponse, body: string) => void;
+
+let port: number;
+let server: http.Server;
+const handlers: RequestHandler[] = [];
+
+// Last received request details for assertions
+let lastRequestHeaders: http.IncomingHttpHeaders = {};
+let lastRequestBody = '';
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      lastRequestHeaders = req.headers;
+      lastRequestBody = body;
+      const handler = handlers.shift();
+      if (handler === undefined) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'no handler registered' }));
+        return;
+      }
+      handler(req, res, body);
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as { port: number };
+  port = address.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+afterEach(() => {
+  handlers.splice(0, handlers.length);
+});
+
+/** Register a static JSON response. */
+function respondWith(
+  statusCode: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'application/json', ...headers });
+    res.end(JSON.stringify(body));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: ShopifyAdapterConfig = {
+  stores: {
+    mystore: {
+      shop_domain: 'mystore.myshopify.com',
+      access_token: 'shpat_test_token',
+    },
+  },
+  base_url: `http://127.0.0.1:${port}`,
+};
+
+function makeAdapter(overrides: Partial<ShopifyAdapterConfig> = {}): ShopifyAdapter {
+  return new ShopifyAdapter('shopify', {
+    ...VALID_CONFIG,
+    base_url: `http://127.0.0.1:${port}`,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Complete order fixture
+// ---------------------------------------------------------------------------
+
+const FULL_ORDER_NODE = {
+  id: 'gid://shopify/Order/450789469',
+  legacyResourceId: '450789469',
+  number: 1234,
+  name: '#1234',
+  displayFinancialStatus: 'PAID',
+  displayFulfillmentStatus: 'FULFILLED',
+  cancelledAt: null,
+  cancelReason: null,
+  createdAt: '2024-01-15T10:30:00Z',
+  customer: {
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+  },
+  currentTotalPriceSet: { shopMoney: { amount: '99.99', currencyCode: 'EUR' } },
+  currentSubtotalPriceSet: { shopMoney: { amount: '89.99' } },
+  currentShippingPriceSet: { shopMoney: { amount: '5.00' } },
+  discountCodes: ['SUMMER10'],
+  lineItems: {
+    edges: [
+      {
+        node: {
+          name: 'Blue T-Shirt',
+          quantity: 2,
+          originalUnitPriceSet: { shopMoney: { amount: '44.99' } },
+        },
+      },
+    ],
+  },
+};
+
+function gqlSuccess(node: unknown) {
+  return {
+    data: {
+      orders: {
+        edges: [{ node }],
+      },
+    },
+  };
+}
+
+function gqlEmpty() {
+  return { data: { orders: { edges: [] } } };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Constructor validation
+// ---------------------------------------------------------------------------
+
+describe('ShopifyAdapter construction', () => {
+  it('throws when stores is empty', () => {
+    expect(() => new ShopifyAdapter('id', { stores: {}, base_url: 'http://localhost' })).toThrow(
+      'ShopifyAdapter: stores must not be empty',
+    );
+  });
+
+  it('throws for invalid shop_domain', () => {
+    expect(
+      () =>
+        new ShopifyAdapter('id', {
+          stores: { a: { shop_domain: 'not-a-shopify-domain.com', access_token: 'tok' } },
+          base_url: 'http://localhost',
+        }),
+    ).toThrow('ShopifyAdapter: invalid shop_domain for store "a"');
+  });
+
+  it('throws for empty access_token', () => {
+    expect(
+      () =>
+        new ShopifyAdapter('id', {
+          stores: { a: { shop_domain: 'mystore.myshopify.com', access_token: '' } },
+          base_url: 'http://localhost',
+        }),
+    ).toThrow('ShopifyAdapter: access_token must not be empty for store "a"');
+  });
+
+  it('throws for invalid api_version', () => {
+    expect(
+      () =>
+        new ShopifyAdapter('id', {
+          stores: { a: { shop_domain: 'mystore.myshopify.com', access_token: 'tok' } },
+          api_version: 'foobar',
+          base_url: 'http://localhost',
+        }),
+    ).toThrow('ShopifyAdapter: invalid api_version');
+  });
+
+  it('constructs successfully with valid config', () => {
+    const adapter = makeAdapter();
+    expect(adapter.id).toBe('shopify');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fetch('get_order') — param validation
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('get_order') param validation", () => {
+  it('throws ADAPTER_VALIDATION_FAILED when store is a number', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 42, order_name: '#1234' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED with details.store when store not in map', async () => {
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_order', { store: 'unknown', order_name: '#1234' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.details['store']).toBe('unknown');
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when order_name is empty string', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('normalizes "1234" to "#1234" before sending to API', async () => {
+    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+    const adapter = makeAdapter();
+    await adapter.fetch('get_order', { store: 'mystore', order_name: '1234' }, {});
+    const reqBody = JSON.parse(lastRequestBody) as { variables: { query: string } };
+    expect(reqBody.variables.query).toBe('name:#1234');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fetch('get_order') — HTTP errors
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('get_order') HTTP errors", () => {
+  it('throws SERVICE_AUTH_FAILED on HTTP 401', async () => {
+    respondWith(401, { errors: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
+  });
+
+  it('throws SERVICE_RATE_LIMITED on HTTP 429 with retry_after in details', async () => {
+    respondWith(429, { errors: 'Too Many Requests' }, { 'Retry-After': '10' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_order', { store: 'mystore', order_name: '#1234' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_RATE_LIMITED');
+    expect(err.details['retry_after']).toBe('10');
+  });
+
+  it('throws SERVICE_HTTP_4XX on HTTP 422', async () => {
+    respondWith(422, { errors: 'Unprocessable Entity' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX' });
+  });
+
+  it('throws SERVICE_HTTP_5XX on HTTP 503', async () => {
+    respondWith(503, { errors: 'Service Unavailable' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_5XX', retryable: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fetch('get_order') — GraphQL errors
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('get_order') GraphQL errors", () => {
+  it('throws SERVICE_RATE_LIMITED when errors[0].extensions.code === "THROTTLED"', async () => {
+    respondWith(200, {
+      errors: [{ message: 'Throttled', extensions: { code: 'THROTTLED' } }],
+    });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RATE_LIMITED' });
+  });
+
+  it('throws SERVICE_RESPONSE_INVALID for non-throttle GraphQL error', async () => {
+    respondWith(200, {
+      errors: [{ message: 'Field not found', extensions: { code: 'FIELD_ERROR' } }],
+    });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fetch('get_order') — not found
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('get_order') not found", () => {
+  it('throws SERVICE_NOT_FOUND with details when edges is empty', async () => {
+    respondWith(200, gqlEmpty());
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_order', { store: 'mystore', order_name: '#1234' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_NOT_FOUND');
+    expect(err.details['store']).toBe('mystore');
+    expect(err.details['order_name']).toBe('#1234');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fetch('get_order') — successful normalization
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('get_order') normalization", () => {
+  it('returns { status: 200, data: NormalizedOrder } with all fields populated', async () => {
+    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as NormalizedOrder;
+    expect(data.id).toBe('gid://shopify/Order/450789469');
+    expect(data.legacy_id).toBe('450789469');
+    expect(data.order_number).toBe(1234);
+    expect(data.name).toBe('#1234');
+    expect(data.financial_status).toBe('PAID');
+    expect(data.fulfillment_status).toBe('FULFILLED');
+    expect(data.cancelled_at).toBeNull();
+    expect(data.cancel_reason).toBeNull();
+    expect(data.created_at).toBe('2024-01-15T10:30:00Z');
+    expect(data.customer).toEqual({
+      first_name: 'Jane',
+      last_name: 'Doe',
+      email: 'jane@example.com',
+    });
+    expect(data.total_price).toBe('99.99');
+    expect(data.subtotal_price).toBe('89.99');
+    expect(data.shipping_total).toBe('5.00');
+    expect(data.currency).toBe('EUR');
+    expect(data.discount_codes).toEqual(['SUMMER10']);
+    expect(data.line_items).toEqual([{ name: 'Blue T-Shirt', quantity: 2, price: '44.99' }]);
+  });
+
+  it('customer is null for guest checkout (node.customer is null)', async () => {
+    const node = { ...FULL_ORDER_NODE, customer: null };
+    respondWith(200, gqlSuccess(node));
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    expect((result.data as NormalizedOrder).customer).toBeNull();
+  });
+
+  it('customer.email is null when node.customer.email is empty string', async () => {
+    const node = {
+      ...FULL_ORDER_NODE,
+      customer: { firstName: 'Jo', lastName: 'Blank', email: '' },
+    };
+    respondWith(200, gqlSuccess(node));
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    expect((result.data as NormalizedOrder).customer?.email).toBeNull();
+  });
+
+  it('discount_codes is [] when node.discountCodes is []', async () => {
+    const node = { ...FULL_ORDER_NODE, discountCodes: [] };
+    respondWith(200, gqlSuccess(node));
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    expect((result.data as NormalizedOrder).discount_codes).toEqual([]);
+  });
+
+  it('shipping_total is "0.00" when currentShippingPriceSet.shopMoney.amount is "0.00"', async () => {
+    const node = {
+      ...FULL_ORDER_NODE,
+      currentShippingPriceSet: { shopMoney: { amount: '0.00' } },
+    };
+    respondWith(200, gqlSuccess(node));
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    expect((result.data as NormalizedOrder).shipping_total).toBe('0.00');
+  });
+
+  it('uses correct X-Shopify-Access-Token header per store (multi-store)', async () => {
+    const multiAdapter = new ShopifyAdapter('shopify', {
+      stores: {
+        store_a: { shop_domain: 'store-a.myshopify.com', access_token: 'token_a' },
+        store_b: { shop_domain: 'store-b.myshopify.com', access_token: 'token_b' },
+      },
+      base_url: `http://127.0.0.1:${port}`,
+    });
+
+    // First: store_a
+    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+    await multiAdapter.fetch('get_order', { store: 'store_a', order_name: '#1234' }, {});
+    expect(lastRequestHeaders['x-shopify-access-token']).toBe('token_a');
+
+    // Second: store_b
+    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+    await multiAdapter.fetch('get_order', { store: 'store_b', order_name: '#1234' }, {});
+    expect(lastRequestHeaders['x-shopify-access-token']).toBe('token_b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: request construction
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('get_order') request construction", () => {
+  it('request body contains correct variables: { query: "name:#1234" }', async () => {
+    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+    const adapter = makeAdapter();
+    await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    const body = JSON.parse(lastRequestBody) as { variables: { query: string } };
+    expect(body.variables).toEqual({ query: 'name:#1234' });
+  });
+
+  it('request body query field contains "OrderByName"', async () => {
+    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+    const adapter = makeAdapter();
+    await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    const body = JSON.parse(lastRequestBody) as { query: string };
+    expect(body.query).toContain('OrderByName');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: create and update
+// ---------------------------------------------------------------------------
+
+describe('ShopifyAdapter create and update', () => {
+  it('create throws ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('anything', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+    await expect(adapter.create('anything', {}, {})).rejects.toBeInstanceOf(WorkflowError);
+  });
+
+  it('update throws ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('anything', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+    await expect(adapter.update('anything', {}, {})).rejects.toBeInstanceOf(WorkflowError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: AbortSignal
+// ---------------------------------------------------------------------------
+
+describe('ShopifyAdapter AbortSignal', () => {
+  it('pre-aborted signal throws STEP_ABORTED without making a network call', async () => {
+    const adapter = makeAdapter();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}, controller.signal),
+    ).rejects.toMatchObject({ code: 'STEP_ABORTED' });
+    // No handler was consumed — confirms no network call was made
+    expect(handlers).toHaveLength(0);
+  });
+});

--- a/packages/core/src/adapters/shopify-adapter.ts
+++ b/packages/core/src/adapters/shopify-adapter.ts
@@ -1,0 +1,588 @@
+// ShopifyAdapter — communicates with the Shopify Admin GraphQL API.
+import { WorkflowError } from '../types/workflow-error.js';
+import type { ServiceAdapter, ServiceResponse } from '../extensions/service-adapter.js';
+
+const SHOPIFY_DEFAULT_API_VERSION = '2024-04';
+
+const ORDERS_BY_NAME_QUERY = `
+query OrderByName($query: String!) {
+  orders(first: 1, query: $query) {
+    edges {
+      node {
+        id
+        legacyResourceId
+        number
+        name
+        displayFinancialStatus
+        displayFulfillmentStatus
+        cancelledAt
+        cancelReason
+        createdAt
+        customer {
+          firstName
+          lastName
+          email
+        }
+        currentTotalPriceSet {
+          shopMoney { amount currencyCode }
+        }
+        currentSubtotalPriceSet {
+          shopMoney { amount }
+        }
+        currentShippingPriceSet {
+          shopMoney { amount }
+        }
+        discountCodes
+        lineItems(first: 50) {
+          edges {
+            node {
+              name
+              quantity
+              originalUnitPriceSet {
+                shopMoney { amount }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`.trim();
+
+/**
+ * Configuration for ShopifyAdapter.
+ */
+export interface ShopifyAdapterConfig {
+  /**
+   * Per-store routing map. Keys are store identifiers (e.g. 'ellegems', 'fleur').
+   * At least one entry required.
+   */
+  stores: Record<
+    string,
+    {
+      /** Shopify store subdomain — e.g. "my-store" resolves to my-store.myshopify.com */
+      shop_domain: string;
+      /** Private app access token for this store */
+      access_token: string;
+    }
+  >;
+  /**
+   * Shopify Admin API version, e.g. '2024-04'. Default: SHOPIFY_DEFAULT_API_VERSION constant.
+   * Validated against /^\d{4}-\d{2}$/ at construction time.
+   */
+  api_version?: string;
+  /**
+   * Override the base URL for tests (replaces https://{shop_domain} only).
+   * Trailing slash is stripped.
+   */
+  base_url?: string;
+}
+
+/** Normalized order returned by fetch('get_order'). */
+export interface NormalizedOrder {
+  /** Shopify global ID, e.g. "gid://shopify/Order/450789469" */
+  id: string;
+  /** Legacy numeric REST resource ID, e.g. "450789469" */
+  legacy_id: string;
+  /** Sequential order number, e.g. 1234 */
+  order_number: number;
+  /** Order name with store prefix, e.g. "#1234" or "#B1001" */
+  name: string;
+  /** Financial status for display, e.g. "PAID". Null if not available. */
+  financial_status: string | null;
+  /** Fulfillment status for display, e.g. "FULFILLED". Always present. */
+  fulfillment_status: string;
+  /** ISO 8601 datetime when the order was cancelled, or null. */
+  cancelled_at: string | null;
+  /** Cancellation reason, or null. */
+  cancel_reason: string | null;
+  /** ISO 8601 datetime when the order was created. */
+  created_at: string;
+  /** Customer details. Null for guest checkouts. */
+  customer: {
+    first_name: string;
+    last_name: string;
+    /** Customer email. Null for phone-only customers. */
+    email: string | null;
+  } | null;
+  /** Total order price including taxes and discounts, as a decimal string e.g. "99.99". */
+  total_price: string;
+  /** Subtotal price, as a decimal string. */
+  subtotal_price: string;
+  /** Current shipping price after refunds and discounts, as a decimal string. "0.00" if no shipping. */
+  shipping_total: string;
+  /** Currency code for shop money, e.g. "EUR". */
+  currency: string;
+  /** Discount codes applied to the order. */
+  discount_codes: string[];
+  /** Order line items. */
+  line_items: Array<{
+    name: string;
+    quantity: number;
+    price: string;
+  }>;
+}
+
+/** Raw GraphQL node shape from the Shopify API. */
+interface ShopifyOrderNode {
+  id: unknown;
+  legacyResourceId: unknown;
+  number: unknown;
+  name: unknown;
+  displayFinancialStatus: unknown;
+  displayFulfillmentStatus: unknown;
+  cancelledAt: unknown;
+  cancelReason: unknown;
+  createdAt: unknown;
+  customer:
+    | {
+        firstName: string;
+        lastName: string;
+        email: string;
+      }
+    | null
+    | undefined;
+  currentTotalPriceSet:
+    | { shopMoney: { amount: unknown; currencyCode: unknown } }
+    | null
+    | undefined;
+  currentSubtotalPriceSet: { shopMoney: { amount: unknown } } | null | undefined;
+  currentShippingPriceSet: { shopMoney: { amount: unknown } } | null | undefined;
+  discountCodes: unknown;
+  lineItems:
+    | {
+        edges: Array<{
+          node: {
+            name: string;
+            quantity: number;
+            originalUnitPriceSet: { shopMoney: { amount: unknown } } | null | undefined;
+          };
+        }>;
+      }
+    | null
+    | undefined;
+}
+
+/**
+ * ShopifyAdapter communicates with the Shopify Admin GraphQL API.
+ *
+ * Supported operations:
+ *   fetch('get_order', { store, order_name })   — POST /admin/api/{version}/graphql.json
+ */
+export class ShopifyAdapter implements ServiceAdapter {
+  readonly id: string;
+  private readonly apiVersion: string;
+  private readonly baseUrlOverride: string | undefined;
+  private readonly stores: ShopifyAdapterConfig['stores'];
+
+  constructor(id: string, config: ShopifyAdapterConfig) {
+    const storeEntries = Object.entries(config.stores);
+
+    if (storeEntries.length === 0) {
+      throw new Error('ShopifyAdapter: stores must not be empty');
+    }
+
+    for (const [key, store] of storeEntries) {
+      if (key === '') {
+        throw new Error('ShopifyAdapter: store key must not be an empty string');
+      }
+      if (!/^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.com$/.test(store.shop_domain)) {
+        throw new Error(`ShopifyAdapter: invalid shop_domain for store "${key}"`);
+      }
+      if (store.access_token === '') {
+        throw new Error(`ShopifyAdapter: access_token must not be empty for store "${key}"`);
+      }
+    }
+
+    if (config.api_version !== undefined && !/^\d{4}-\d{2}$/.test(config.api_version)) {
+      throw new Error('ShopifyAdapter: invalid api_version');
+    }
+
+    this.id = id;
+    this.stores = config.stores;
+    this.apiVersion = config.api_version ?? SHOPIFY_DEFAULT_API_VERSION;
+    this.baseUrlOverride = config.base_url?.replace(/\/$/, '');
+  }
+
+  private checkAborted(signal?: AbortSignal): void {
+    if (signal?.aborted === true) {
+      throw new WorkflowError('Adapter request aborted', {
+        code: 'STEP_ABORTED',
+        category: 'ENGINE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+  }
+
+  private async executeRequest(
+    url: string,
+    options: RequestInit,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    this.checkAborted(signal);
+    let response: Response;
+    try {
+      response = await fetch(url, { ...options, signal: signal ?? null });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new WorkflowError('Adapter request aborted', {
+          code: 'STEP_ABORTED',
+          category: 'ENGINE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new WorkflowError(message, {
+        code: 'NETWORK_UNREACHABLE',
+        category: 'NETWORK',
+        agentAction: 'wait_for_human',
+        retryable: true,
+      });
+    }
+    return response;
+  }
+
+  private async throwHttpError(response: Response, operation: string): Promise<never> {
+    // Read body as text first — avoids "body already consumed" if JSON.parse fails.
+    const rawText = await response.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(rawText);
+    } catch {
+      body = rawText;
+    }
+
+    const status = response.status;
+    const details = { status, operation, body };
+
+    if (status === 429) {
+      throw new WorkflowError('Rate limited by Shopify API', {
+        code: 'SERVICE_RATE_LIMITED',
+        category: 'SERVICE',
+        agentAction: 'wait_for_human',
+        retryable: true,
+        details: { ...details, retry_after: response.headers.get('Retry-After') ?? undefined },
+      });
+    }
+
+    if (status === 401) {
+      throw new WorkflowError('Shopify authentication failed — check access token', {
+        code: 'SERVICE_AUTH_FAILED',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details,
+      });
+    }
+
+    if (status >= 400 && status < 500) {
+      throw new WorkflowError(`HTTP ${status}: ${response.statusText}`, {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details,
+      });
+    }
+
+    // 5xx
+    throw new WorkflowError(`Shopify server error (HTTP ${status})`, {
+      code: 'SERVICE_HTTP_5XX',
+      category: 'SERVICE',
+      agentAction: 'report_to_user',
+      retryable: true,
+      details,
+    });
+  }
+
+  private normalizeOrder(
+    node: ShopifyOrderNode,
+    store: string,
+    normalizedOrderName: string,
+  ): NormalizedOrder {
+    if (typeof node.id !== 'string' || node.id === '') {
+      throw new WorkflowError('ShopifyAdapter: missing order id in response', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    if (typeof node.number !== 'number') {
+      throw new WorkflowError('ShopifyAdapter: missing order number in response', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    if (typeof node.displayFulfillmentStatus !== 'string' || node.displayFulfillmentStatus === '') {
+      throw new WorkflowError('ShopifyAdapter: missing fulfillment_status in response', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    if (typeof node.createdAt !== 'string') {
+      throw new WorkflowError('ShopifyAdapter: missing created_at in response', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+
+    const totalPrice = node.currentTotalPriceSet?.shopMoney?.amount;
+    if (typeof totalPrice !== 'string') {
+      throw new WorkflowError('ShopifyAdapter: missing total_price in response', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+
+    const subtotalPrice = node.currentSubtotalPriceSet?.shopMoney?.amount;
+    if (typeof subtotalPrice !== 'string') {
+      throw new WorkflowError('ShopifyAdapter: missing subtotal_price in response', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+
+    const customer =
+      node.customer != null
+        ? {
+            first_name: node.customer.firstName,
+            last_name: node.customer.lastName,
+            email: node.customer.email || null,
+          }
+        : null;
+
+    const lineItems = (node.lineItems?.edges ?? []).map((edge) => ({
+      name: edge.node.name,
+      quantity: edge.node.quantity,
+      price: (edge.node.originalUnitPriceSet?.shopMoney?.amount as string | undefined) ?? '0.00',
+    }));
+
+    void store;
+    void normalizedOrderName;
+
+    return {
+      id: node.id,
+      legacy_id: String(node.legacyResourceId ?? ''),
+      order_number: node.number,
+      name: String(node.name ?? ''),
+      financial_status:
+        typeof node.displayFinancialStatus === 'string' ? node.displayFinancialStatus : null,
+      fulfillment_status: node.displayFulfillmentStatus,
+      cancelled_at: typeof node.cancelledAt === 'string' ? node.cancelledAt : null,
+      cancel_reason: typeof node.cancelReason === 'string' ? node.cancelReason : null,
+      created_at: node.createdAt,
+      customer,
+      total_price: totalPrice,
+      subtotal_price: subtotalPrice,
+      shipping_total:
+        (node.currentShippingPriceSet?.shopMoney?.amount as string | undefined) ?? '0.00',
+      currency: (node.currentTotalPriceSet?.shopMoney?.currencyCode as string | undefined) ?? '',
+      discount_codes: Array.isArray(node.discountCodes) ? (node.discountCodes as string[]) : [],
+      line_items: lineItems,
+    };
+  }
+
+  async fetch(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    // config.auth is ignored — auth is set at construction time via stores map
+
+    if (operation === 'get_order') {
+      // Validate store param
+      const store = params['store'];
+      if (typeof store !== 'string') {
+        throw new WorkflowError('ShopifyAdapter: store param must be a string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      const storeConfig = this.stores[store];
+      if (storeConfig === undefined) {
+        throw new WorkflowError(`ShopifyAdapter: unknown store "${store}"`, {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+          details: { store },
+        });
+      }
+
+      // Validate order_name
+      const rawOrderName = params['order_name'];
+      if (typeof rawOrderName !== 'string' || rawOrderName === '') {
+        throw new WorkflowError('ShopifyAdapter: order_name param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      // Normalize order_name
+      let normalizedOrderName = rawOrderName.trim();
+      if (!normalizedOrderName.startsWith('#')) {
+        normalizedOrderName = '#' + normalizedOrderName;
+      }
+      if (!/^#.+$/.test(normalizedOrderName)) {
+        throw new WorkflowError('ShopifyAdapter: order_name is invalid after normalization', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const base = this.baseUrlOverride ?? `https://${storeConfig.shop_domain}`;
+      const url = `${base}/admin/api/${this.apiVersion}/graphql.json`;
+
+      const requestOptions: RequestInit = {
+        method: 'POST',
+        headers: {
+          'X-Shopify-Access-Token': storeConfig.access_token,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          query: ORDERS_BY_NAME_QUERY,
+          variables: { query: `name:${normalizedOrderName}` },
+        }),
+      };
+
+      const response = await this.executeRequest(url, requestOptions, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'get_order');
+      }
+
+      // Parse JSON response
+      let gqlBody: unknown;
+      try {
+        gqlBody = await response.json();
+      } catch {
+        throw new WorkflowError('ShopifyAdapter: failed to parse GraphQL response', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const body = gqlBody as Record<string, unknown>;
+
+      // Check for GraphQL errors
+      if (Array.isArray(body['errors']) && (body['errors'] as unknown[]).length > 0) {
+        const errors = body['errors'] as Array<Record<string, unknown>>;
+        const firstError = errors[0] as Record<string, unknown> | undefined;
+        const extensions = firstError?.['extensions'] as Record<string, unknown> | undefined;
+        if (extensions?.['code'] === 'THROTTLED') {
+          throw new WorkflowError('Shopify GraphQL rate limited', {
+            code: 'SERVICE_RATE_LIMITED',
+            category: 'SERVICE',
+            agentAction: 'wait_for_human',
+            retryable: true,
+          });
+        }
+        throw new WorkflowError('ShopifyAdapter: GraphQL errors in response', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+          details: { errors: body['errors'] },
+        });
+      }
+
+      // Validate edges shape
+      const data = body['data'] as Record<string, unknown> | undefined;
+      const orders = data?.['orders'] as Record<string, unknown> | undefined;
+      const edges = orders?.['edges'];
+      if (!Array.isArray(edges)) {
+        throw new WorkflowError('ShopifyAdapter: unexpected response shape — edges not an array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      if (edges.length === 0) {
+        throw new WorkflowError('ShopifyAdapter: order not found', {
+          code: 'SERVICE_NOT_FOUND',
+          category: 'SERVICE',
+          agentAction: 'provide_input',
+          retryable: false,
+          details: { store, order_name: normalizedOrderName },
+        });
+      }
+
+      if (edges.length > 1) {
+        throw new WorkflowError('ShopifyAdapter: unexpected multiple edges for first:1 query', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const edge = edges[0] as { node: ShopifyOrderNode };
+      const normalizedOrder = this.normalizeOrder(edge.node, store, normalizedOrderName);
+      return { status: 200, data: normalizedOrder };
+    }
+
+    throw new WorkflowError(`ShopifyAdapter: unsupported fetch operation '${operation}'`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+      details: { operation },
+    });
+  }
+
+  async create(
+    operation: string,
+    _params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    _signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    throw new WorkflowError(`ShopifyAdapter: unsupported create operation: ${operation}`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+      details: { operation },
+    });
+  }
+
+  async update(
+    operation: string,
+    _params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    _signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    throw new WorkflowError(`ShopifyAdapter: unsupported update operation: ${operation}`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+      details: { operation },
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,11 @@ export { SlackAdapter } from './adapters/slack-adapter.js';
 export type { SlackAdapterConfig } from './adapters/slack-adapter.js';
 export { GorgiasAdapter } from './adapters/gorgias-adapter.js';
 export type { GorgiasAdapterConfig } from './adapters/gorgias-adapter.js';
+export { ShopifyAdapter } from './adapters/shopify-adapter.js';
+export type {
+  ShopifyAdapterConfig,
+  NormalizedOrder as ShopifyNormalizedOrder,
+} from './adapters/shopify-adapter.js';
 
 // Trace policy
 export { TRACE_POLICY_VERSION, TRACE_POLICY, TRACE_POLICY_HASH } from './engine/trace-policy.js';


### PR DESCRIPTION
## Summary

Adds `ShopifyAdapter`, a `ServiceAdapter` implementation that communicates with the Shopify Admin GraphQL API. Supports per-store token routing from a single adapter instance, enabling multi-store customer service workflows.

## Changes

- `packages/core/src/adapters/shopify-adapter.ts` — implementation
- `packages/core/src/adapters/shopify-adapter.test.ts` — 27-test Vitest suite
- `packages/core/src/index.ts` — exports `ShopifyAdapter`, `ShopifyAdapterConfig`, `ShopifyNormalizedOrder`

## Design

- **Transport**: Shopify Admin GraphQL API (`POST /admin/api/{version}/graphql.json`) — GraphQL-only, no REST fallback.
- **Auth**: `X-Shopify-Access-Token` set at constructor time per store; call-time `config.auth` is ignored.
- **Per-store routing**: `config.stores` is a `Record<storeKey, { shop_domain, access_token }>`. Each `fetch('get_order', { store: 'ellegems', ... })` call uses the matching store's token and domain.
- **Rate limiting**: Shopify returns HTTP 200 with `errors[0].extensions.code === 'THROTTLED'` for GraphQL rate limits (not HTTP 429). Both paths are handled: HTTP 429 → `SERVICE_RATE_LIMITED` (with `retry_after`), GraphQL THROTTLED → `SERVICE_RATE_LIMITED`.
- **Order name normalisation**: `order_name` is trimmed and `#` is prepended if absent. The GraphQL variable uses Shopify search syntax: `{ query: "name:#1234" }`.
- **Not found**: Empty `edges` → `SERVICE_NOT_FOUND` with `details: { store, order_name }`.

## Error Mapping

| Condition | Code | agentAction |
|---|---|---|
| HTTP 401 | `SERVICE_AUTH_FAILED` | `stop` |
| HTTP 429 | `SERVICE_RATE_LIMITED` | `wait_for_human` |
| HTTP 4xx | `SERVICE_HTTP_4XX` | `stop` |
| HTTP 5xx | `SERVICE_HTTP_5XX` | `report_to_user` |
| GraphQL THROTTLED | `SERVICE_RATE_LIMITED` | `wait_for_human` |
| GraphQL other error | `SERVICE_RESPONSE_INVALID` | `report_to_user` |
| Empty edges | `SERVICE_NOT_FOUND` | `provide_input` |
| Invalid params | `ADAPTER_VALIDATION_FAILED` | `provide_input` |
| create / update | `ADAPTER_OP_UNSUPPORTED` | `report_to_user` |

## Tests

27 tests covering: constructor validation (5), param validation (4), HTTP errors (4), GraphQL errors (2), not found (1), normalization edge cases (6), request construction (2), create/update (2), AbortSignal (1).

## Verification

```
npx vitest run packages/core/src/adapters/shopify-adapter.test.ts
→ Tests  27 passed (27)

npx vitest run
→ Tests  1128 passed (1128)

npm run build --workspace=packages/core
→ zero errors
```
