### PR TITLE
feat(core): add ParcelPanelAdapter — ParcelWILL tracking API v2 (phase-cs4)

### DIFF
--- a/packages/core/src/adapters/parcelpanel-adapter.test.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.test.ts
@@ -1,0 +1,537 @@
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { ParcelPanelAdapter } from './parcelpanel-adapter.js';
+import type { ParcelPanelAdapterConfig, NormalizedTracking } from './parcelpanel-adapter.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+// ---------------------------------------------------------------------------
+// Mock server
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (req: http.IncomingMessage, res: http.ServerResponse, body: string) => void;
+
+let port: number;
+let server: http.Server;
+const handlers: RequestHandler[] = [];
+
+// Last received request details for assertions
+let lastRequestHeaders: http.IncomingHttpHeaders = {};
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      lastRequestHeaders = req.headers;
+      const handler = handlers.shift();
+      if (handler === undefined) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'no handler registered' }));
+        return;
+      }
+      handler(req, res, body);
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as { port: number };
+  port = address.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+afterEach(() => {
+  handlers.splice(0, handlers.length);
+});
+
+/** Register a static JSON response. */
+function respond(statusCode: number, body: unknown, headers: Record<string, string> = {}): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'application/json', ...headers });
+    res.end(JSON.stringify(body));
+  });
+}
+
+/** Respond with non-JSON text. */
+function respondText(statusCode: number, text: string): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain' });
+    res.end(text);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: ParcelPanelAdapterConfig = {
+  stores: {
+    mystore: 'pp_test_api_key',
+  },
+};
+
+function makeAdapter(overrides: Partial<ParcelPanelAdapterConfig> = {}): ParcelPanelAdapter {
+  return new ParcelPanelAdapter('parcelpanel', {
+    ...VALID_CONFIG,
+    base_url: `http://127.0.0.1:${port}`,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tracking response fixtures
+// ---------------------------------------------------------------------------
+
+function fulfilledOrderBody(
+  overrides: Partial<{
+    tracking_link: string;
+    shipments: unknown[];
+  }> = {},
+) {
+  return {
+    order: {
+      order_id: 6140516335690,
+      order_number: '#1030',
+      tracking_link:
+        overrides.tracking_link ?? 'https://example.myshopify.com/apps/parcelpanel?order=1030',
+      shipments: overrides.shipments ?? [
+        {
+          status: 'IN_TRANSIT',
+          status_label: 'In transit',
+          tracking_number: 'YT2436021211003147',
+          carrier: {
+            name: 'YunExpress',
+            code: 'yunexpress',
+          },
+        },
+      ],
+    },
+  };
+}
+
+function unfulfilledOrderBody() {
+  return {
+    order: {
+      order_id: 6140516335690,
+      order_number: '#1030',
+      tracking_link: 'https://example.myshopify.com/apps/parcelpanel?order=1030',
+      shipments: [],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Constructor validation
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter construction', () => {
+  it('throws for empty stores map', () => {
+    expect(() => new ParcelPanelAdapter('id', { stores: {} })).toThrow(
+      'ParcelPanelAdapter: stores must not be empty',
+    );
+  });
+
+  it('throws for empty store key', () => {
+    expect(() => new ParcelPanelAdapter('id', { stores: { '': 'apikey' } })).toThrow(
+      'ParcelPanelAdapter: store key must not be an empty string',
+    );
+  });
+
+  it('throws for empty API key value', () => {
+    expect(() => new ParcelPanelAdapter('id', { stores: { mystore: '' } })).toThrow(
+      'ParcelPanelAdapter: api_key must not be empty for store "mystore"',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Auth header
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter auth header', () => {
+  it('sends x-parcelpanel-api-key header (not Authorization: Bearer)', async () => {
+    respond(200, fulfilledOrderBody());
+    const adapter = makeAdapter();
+    await adapter.fetch('get_tracking', { store: 'mystore', order_number: '1030' }, {});
+    expect(lastRequestHeaders['x-parcelpanel-api-key']).toBe('pp_test_api_key');
+    expect(lastRequestHeaders['authorization']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Store routing
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter store routing', () => {
+  it('uses correct API key per store in a two-store config', async () => {
+    const adapter = new ParcelPanelAdapter('parcelpanel', {
+      stores: {
+        'store-a': 'key_for_a',
+        'store-b': 'key_for_b',
+      },
+      base_url: `http://127.0.0.1:${port}`,
+    });
+
+    respond(200, fulfilledOrderBody());
+    await adapter.fetch('get_tracking', { store: 'store-a', order_number: '100' }, {});
+    expect(lastRequestHeaders['x-parcelpanel-api-key']).toBe('key_for_a');
+
+    respond(200, fulfilledOrderBody());
+    await adapter.fetch('get_tracking', { store: 'store-b', order_number: '200' }, {});
+    expect(lastRequestHeaders['x-parcelpanel-api-key']).toBe('key_for_b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Param validation
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter param validation', () => {
+  it('throws ADAPTER_VALIDATION_FAILED when store param is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_tracking', { order_number: '1234' }, {})).rejects.toMatchObject(
+      { code: 'ADAPTER_VALIDATION_FAILED' },
+    );
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED with details.store for unknown store', async () => {
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_tracking', { store: 'unknown', order_number: '1234' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.details['store']).toBe('unknown');
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when order_number is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_tracking', { store: 'mystore' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: order_number normalization
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter order_number normalization', () => {
+  it('"#1234" → sends order_number=1234 in query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(fulfilledOrderBody()));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_tracking', { store: 'mystore', order_number: '#1234' }, {});
+    expect(capturedUrl).toContain('order_number=1234');
+    expect(capturedUrl).not.toContain('order_number=%231234');
+  });
+
+  it('"  #1234  " → sends order_number=1234 (trimmed and hash stripped)', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(fulfilledOrderBody()));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_tracking', { store: 'mystore', order_number: '  #1234  ' }, {});
+    expect(capturedUrl).toContain('order_number=1234');
+  });
+
+  it('"1234" → sends order_number=1234 (no hash to strip)', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(fulfilledOrderBody()));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {});
+    expect(capturedUrl).toContain('order_number=1234');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: HTTP error classification
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter HTTP error classification', () => {
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { errors: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
+  });
+
+  it('HTTP 404 → SERVICE_NOT_FOUND', async () => {
+    respond(404, { errors: 'Order not found' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '9999' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_NOT_FOUND' });
+  });
+
+  it('HTTP 403 → SERVICE_HTTP_4XX', async () => {
+    respond(403, { errors: 'Forbidden' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX' });
+  });
+
+  it('HTTP 422 → SERVICE_HTTP_4XX', async () => {
+    respond(422, { errors: 'Unprocessable Entity' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX' });
+  });
+
+  it('HTTP 429 → SERVICE_RATE_LIMITED with retry_after in details', async () => {
+    respond(429, { errors: 'Too Many Requests' }, { 'Retry-After': '30' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_RATE_LIMITED');
+    expect(err.details['retry_after']).toBe('30');
+  });
+
+  it('HTTP 500 → SERVICE_HTTP_5XX', async () => {
+    respond(500, { errors: 'Internal Server Error' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_5XX', retryable: true });
+  });
+
+  it('non-JSON response body → SERVICE_RESPONSE_INVALID', async () => {
+    respondText(200, 'not valid json {{');
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Network errors
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter network errors', () => {
+  it('fetch() throws ECONNREFUSED → NETWORK_UNREACHABLE', async () => {
+    // Find a port with no server listening
+    const closedPort = await new Promise<number>((resolve) => {
+      const tmp = net.createServer();
+      tmp.listen(0, '127.0.0.1', () => {
+        const addr = tmp.address() as { port: number };
+        tmp.close(() => resolve(addr.port));
+      });
+    });
+
+    const adapter = new ParcelPanelAdapter('parcelpanel', {
+      stores: { mystore: 'key' },
+      base_url: `http://127.0.0.1:${closedPort}`,
+    });
+
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'NETWORK_UNREACHABLE' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: AbortSignal
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter AbortSignal', () => {
+  it('pre-aborted signal throws STEP_ABORTED before making a network call', async () => {
+    const adapter = makeAdapter();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      adapter.fetch(
+        'get_tracking',
+        { store: 'mystore', order_number: '1234' },
+        {},
+        controller.signal,
+      ),
+    ).rejects.toMatchObject({ code: 'STEP_ABORTED' });
+    // Confirm no handler was consumed (no network call made)
+    expect(handlers).toHaveLength(0);
+  });
+
+  it('signal aborted during in-flight request throws STEP_ABORTED', async () => {
+    const controller = new AbortController();
+    handlers.push((_req, res) => {
+      // Abort the signal before writing the response
+      controller.abort();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(fulfilledOrderBody()));
+    });
+    const adapter = makeAdapter();
+    // The AbortController is aborted server-side but signal was active at call time;
+    // the in-flight request may either succeed or abort depending on timing.
+    // We verify that if STEP_ABORTED is thrown, it has the correct code.
+    try {
+      await adapter.fetch(
+        'get_tracking',
+        { store: 'mystore', order_number: '1234' },
+        {},
+        controller.signal,
+      );
+      // If it succeeded (race), that's also acceptable — abort arrived after response
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkflowError);
+      expect((err as WorkflowError).code).toBe('STEP_ABORTED');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Normalization — fulfilled order
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter normalization', () => {
+  it('fulfilled order: all four NormalizedTracking fields populated', async () => {
+    respond(200, fulfilledOrderBody());
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'get_tracking',
+      { store: 'mystore', order_number: '1030' },
+      {},
+    );
+    expect(result.status).toBe(200);
+    const data = result.data as NormalizedTracking;
+    expect(data.tracking_url).toBe('https://example.myshopify.com/apps/parcelpanel?order=1030');
+    expect(data.carrier).toBe('YunExpress');
+    expect(data.tracking_number).toBe('YT2436021211003147');
+    expect(data.status).toBe('IN_TRANSIT');
+  });
+
+  it('unfulfilled order: tracking_url set, carrier/tracking_number/status all null', async () => {
+    respond(200, unfulfilledOrderBody());
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'get_tracking',
+      { store: 'mystore', order_number: '1030' },
+      {},
+    );
+    const data = result.data as NormalizedTracking;
+    expect(data.tracking_url).toBe('https://example.myshopify.com/apps/parcelpanel?order=1030');
+    expect(data.carrier).toBeNull();
+    expect(data.tracking_number).toBeNull();
+    expect(data.status).toBeNull();
+  });
+
+  it('split fulfillment: uses shipments[0], second shipment silently ignored', async () => {
+    respond(
+      200,
+      fulfilledOrderBody({
+        shipments: [
+          {
+            status: 'DELIVERED',
+            tracking_number: 'TN_FIRST',
+            carrier: { name: 'FedEx' },
+          },
+          {
+            status: 'IN_TRANSIT',
+            tracking_number: 'TN_SECOND',
+            carrier: { name: 'UPS' },
+          },
+        ],
+      }),
+    );
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'get_tracking',
+      { store: 'mystore', order_number: '1030' },
+      {},
+    );
+    const data = result.data as NormalizedTracking;
+    expect(data.carrier).toBe('FedEx');
+    expect(data.tracking_number).toBe('TN_FIRST');
+    expect(data.status).toBe('DELIVERED');
+  });
+
+  it('200 with missing order key → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { something: 'else' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+
+  it('200 with order.tracking_link not a string → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { order: { tracking_link: 12345, shipments: [] } });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Unsupported operations
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter unsupported operations', () => {
+  it('fetch("unknown_operation") throws ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('unknown_operation', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_OP_UNSUPPORTED' });
+    await expect(
+      adapter.fetch('unknown_operation', { store: 'mystore', order_number: '1234' }, {}),
+    ).rejects.toBeInstanceOf(WorkflowError);
+  });
+
+  it('create throws ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('anything', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('update throws ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('anything', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract probe (skipped — requires real credentials)
+// ---------------------------------------------------------------------------
+
+it.skip('contract probe — real API (requires PARCELPANEL_TEST_API_KEY and PARCELPANEL_TEST_STORE)', async () => {
+  const apiKey = process.env['PARCELPANEL_TEST_API_KEY'] ?? '';
+  const store = process.env['PARCELPANEL_TEST_STORE'] ?? '';
+  const orderNumber = process.env['PARCELPANEL_TEST_ORDER_NUMBER'] ?? '';
+
+  const adapter = new ParcelPanelAdapter('parcelpanel', {
+    stores: { [store]: apiKey },
+  });
+
+  const result = await adapter.fetch('get_tracking', { store, order_number: orderNumber }, {});
+  expect(result.status).toBe(200);
+  const data = result.data as NormalizedTracking;
+  expect(typeof data.tracking_url).toBe('string');
+  expect(data.tracking_url.length).toBeGreaterThan(0);
+});

--- a/packages/core/src/adapters/parcelpanel-adapter.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.ts
@@ -1,0 +1,359 @@
+// ParcelPanelAdapter — communicates with the ParcelPanel / ParcelWILL Shopify tracking API v2.
+import { WorkflowError } from '../types/workflow-error.js';
+import type { ServiceAdapter, ServiceResponse } from '../extensions/service-adapter.js';
+
+const PARCELPANEL_DEFAULT_BASE_URL = 'https://open.parcelwill.com';
+// Previous domain https://open.parcelpanel.com deprecated as of 2026-02-11.
+// Override base_url in ParcelPanelAdapterConfig for tests.
+
+/**
+ * Configuration for ParcelPanelAdapter.
+ *
+ * Uses a flat Record<string, string> for the stores map (unlike ShopifyAdapter's nested
+ * object) because ParcelPanel has exactly one credential per store — an API key. The shape
+ * intentionally diverges from ShopifyAdapter's nested form; do not "fix" this to match.
+ */
+export interface ParcelPanelAdapterConfig {
+  /**
+   * Per-store routing map. Keys are store identifiers (e.g. 'ellegems', 'fleur').
+   * Values are the ParcelPanel API keys for those stores. At least one entry required.
+   */
+  stores: Record<string, string>;
+  /**
+   * Override the base URL for tests (replaces https://open.parcelwill.com).
+   * Trailing slash is stripped.
+   */
+  base_url?: string;
+}
+
+/**
+ * Normalized tracking data returned by ParcelPanelAdapter.
+ *
+ * tracking_url is always present when the order exists (sourced from order.tracking_link,
+ * documented as non-null in the ParcelPanel API).
+ *
+ * carrier, tracking_number, and status are all null in tandem when order.shipments is empty
+ * (order exists but has not yet been fulfilled).
+ */
+export interface NormalizedTracking {
+  /** ParcelPanel-hosted tracking page URL. Always a non-empty string when the order exists. */
+  tracking_url: string;
+  /** Primary carrier name, e.g. "YunExpress". Null if order has no shipments yet. */
+  carrier: string | null;
+  /** Primary carrier tracking number. Null if order has no shipments yet. */
+  tracking_number: string | null;
+  /** Primary shipment status code, e.g. "IN_TRANSIT". Null if order has no shipments yet. */
+  status: string | null;
+}
+
+/** Raw shipment shape from the ParcelPanel API. */
+interface ParcelPanelShipment {
+  status?: string;
+  tracking_number?: string;
+  carrier?: { name?: string } | null;
+}
+
+/** Raw order body shape from the ParcelPanel API. */
+interface ParcelPanelOrderBody {
+  order?: {
+    tracking_link?: unknown;
+    shipments?: ParcelPanelShipment[];
+  };
+}
+
+/**
+ * ParcelPanelAdapter communicates with the ParcelPanel / ParcelWILL tracking API v2.
+ *
+ * Supported operations:
+ *   fetch('get_tracking', { store, order_number })   — GET /api/v2/tracking/order?order_number={n}
+ */
+export class ParcelPanelAdapter implements ServiceAdapter {
+  readonly id: string;
+  private readonly baseUrl: string;
+  private readonly storesMap: Map<string, string>;
+
+  constructor(id: string, config: ParcelPanelAdapterConfig) {
+    const entries = Object.entries(config.stores);
+
+    if (entries.length === 0) {
+      throw new Error('ParcelPanelAdapter: stores must not be empty');
+    }
+
+    for (const [key, apiKey] of entries) {
+      if (key === '') {
+        throw new Error('ParcelPanelAdapter: store key must not be an empty string');
+      }
+      if (apiKey === '') {
+        throw new Error(`ParcelPanelAdapter: api_key must not be empty for store "${key}"`);
+      }
+    }
+
+    this.id = id;
+    this.baseUrl = config.base_url?.replace(/\/$/, '') ?? PARCELPANEL_DEFAULT_BASE_URL;
+    this.storesMap = new Map(entries);
+  }
+
+  private checkAborted(signal?: AbortSignal): void {
+    if (signal?.aborted === true) {
+      throw new WorkflowError('Adapter request aborted', {
+        code: 'STEP_ABORTED',
+        category: 'ENGINE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+  }
+
+  private buildHeaders(apiKey: string): Record<string, string> {
+    return {
+      'x-parcelpanel-api-key': apiKey,
+      Accept: 'application/json',
+    };
+  }
+
+  private async executeRequest(
+    url: string,
+    apiKey: string,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    this.checkAborted(signal);
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: this.buildHeaders(apiKey),
+        signal: signal ?? null,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new WorkflowError('Adapter request aborted', {
+          code: 'STEP_ABORTED',
+          category: 'ENGINE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new WorkflowError(message, {
+        code: 'NETWORK_UNREACHABLE',
+        category: 'NETWORK',
+        agentAction: 'wait_for_human',
+        retryable: true,
+      });
+    }
+    return response;
+  }
+
+  private async throwHttpError(response: Response, operation: string): Promise<never> {
+    // Read body as text first — avoids "body already consumed" if JSON.parse fails.
+    const rawText = await response.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(rawText);
+    } catch {
+      body = rawText;
+    }
+
+    const status = response.status;
+    const details = { status, operation, body };
+
+    if (status === 429) {
+      throw new WorkflowError('Rate limited by ParcelPanel API', {
+        code: 'SERVICE_RATE_LIMITED',
+        category: 'SERVICE',
+        agentAction: 'wait_for_human',
+        retryable: true,
+        details: { ...details, retry_after: response.headers.get('Retry-After') ?? undefined },
+      });
+    }
+
+    if (status === 401) {
+      throw new WorkflowError('ParcelPanel authentication failed — check API key', {
+        code: 'SERVICE_AUTH_FAILED',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details,
+      });
+    }
+
+    if (status === 404) {
+      throw new WorkflowError('ParcelPanel: order not found', {
+        code: 'SERVICE_NOT_FOUND',
+        category: 'SERVICE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details,
+      });
+    }
+
+    if (status >= 500) {
+      throw new WorkflowError(`ParcelPanel server error (HTTP ${status})`, {
+        code: 'SERVICE_HTTP_5XX',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: true,
+        details,
+      });
+    }
+
+    // Any other 4xx (400, 403, 422, etc.)
+    throw new WorkflowError(`HTTP ${status}: ${response.statusText}`, {
+      code: 'SERVICE_HTTP_4XX',
+      category: 'SERVICE',
+      agentAction: 'stop',
+      retryable: false,
+      details,
+    });
+  }
+
+  async fetch(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'get_tracking') {
+      // Validate store param
+      const store = params['store'];
+      if (typeof store !== 'string' || store === '') {
+        throw new WorkflowError('ParcelPanelAdapter: store param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      const apiKey = this.storesMap.get(store);
+      if (apiKey === undefined) {
+        throw new WorkflowError(`ParcelPanelAdapter: unknown store "${store}"`, {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+          details: { store },
+        });
+      }
+
+      // Validate order_number param
+      const rawOrderNumber = params['order_number'];
+      if (typeof rawOrderNumber !== 'string' || rawOrderNumber === '') {
+        throw new WorkflowError(
+          'ParcelPanelAdapter: order_number param must be a non-empty string',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      // Normalize order_number: trim whitespace then strip leading '#'
+      let normalizedOrderNumber = rawOrderNumber.trim();
+      if (normalizedOrderNumber.startsWith('#')) {
+        normalizedOrderNumber = normalizedOrderNumber.slice(1);
+      }
+
+      const url = `${this.baseUrl}/api/v2/tracking/order?order_number=${encodeURIComponent(normalizedOrderNumber)}`;
+
+      const response = await this.executeRequest(url, apiKey, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'get_tracking');
+      }
+
+      // Parse response body
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('ParcelPanelAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const body = parsed as ParcelPanelOrderBody;
+
+      // Validate shape
+      if (body.order === undefined || body.order === null) {
+        throw new WorkflowError('ParcelPanelAdapter: response missing order field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      if (typeof body.order.tracking_link !== 'string') {
+        throw new WorkflowError(
+          'ParcelPanelAdapter: response missing or invalid order.tracking_link',
+          {
+            code: 'SERVICE_RESPONSE_INVALID',
+            category: 'SERVICE',
+            agentAction: 'report_to_user',
+            retryable: false,
+          },
+        );
+      }
+
+      const shipments = body.order.shipments ?? [];
+      const firstShipment = shipments[0];
+
+      const normalized: NormalizedTracking =
+        firstShipment !== undefined
+          ? {
+              tracking_url: body.order.tracking_link,
+              carrier: firstShipment.carrier?.name ?? null,
+              tracking_number: firstShipment.tracking_number ?? null,
+              status: firstShipment.status ?? null,
+            }
+          : {
+              tracking_url: body.order.tracking_link,
+              carrier: null,
+              tracking_number: null,
+              status: null,
+            };
+
+      return { status: 200, data: normalized };
+    }
+
+    throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+    });
+  }
+
+  async create(
+    operation: string,
+    _params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    _signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+    });
+  }
+
+  async update(
+    operation: string,
+    _params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    _signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,11 @@ export type {
   ShopifyAdapterConfig,
   NormalizedOrder as ShopifyNormalizedOrder,
 } from './adapters/shopify-adapter.js';
+export { ParcelPanelAdapter } from './adapters/parcelpanel-adapter.js';
+export type {
+  ParcelPanelAdapterConfig,
+  NormalizedTracking as ParcelPanelNormalizedTracking,
+} from './adapters/parcelpanel-adapter.js';
 
 // Trace policy
 export { TRACE_POLICY_VERSION, TRACE_POLICY, TRACE_POLICY_HASH } from './engine/trace-policy.js';


### PR DESCRIPTION
## Summary

Adds `ParcelPanelAdapter`, a `ServiceAdapter` implementation that wraps the ParcelPanel / ParcelWILL Shopify tracking API v2. This is the third service adapter in the CS integration stack, following `GorgiasAdapter` (#12) and `ShopifyAdapter` (#13).

## Changes

### `packages/core/src/adapters/parcelpanel-adapter.ts`

New adapter. Key design decisions:

- **Auth**: `x-parcelpanel-api-key` header per store (the architecture plan incorrectly documented `Authorization: Bearer` — corrected against live API docs)
- **Base URL**: `https://open.parcelwill.com` (deprecated `parcelpanel.com` domain noted in a comment)
- **Config**: flat `stores: Record<string, string>` (store slug → API key), stored internally as `Map<string, string>` for O(1) lookup
- **Operation**: `fetch('get_tracking', { store, order_number })` → `NormalizedTracking`
- **Endpoint**: `GET /api/v2/tracking/order?order_number=<encoded>` — single-object response `{ order: { tracking_link, shipments: [...] } }`
- **order_number normalization**: `.trim()` then strip leading `#`
- **Empty shipments[]**: returns partial `NormalizedTracking` (tracking_url populated, rest null) — not an error
- **Multi-shipment**: uses `shipments[0]` silently
- **Error taxonomy**: 401 → `SERVICE_AUTH_FAILED`, 404 → `SERVICE_NOT_FOUND`, 429 → `SERVICE_RATE_LIMITED` + `Retry-After` captured, 5xx → `SERVICE_HTTP_5XX` (retryable), other 4xx (400, 403, 422) → `SERVICE_HTTP_4XX`
- **Network errors**: `NETWORK_UNREACHABLE` with `category: 'NETWORK'` — consistent with all existing adapters
- **AbortSignal**: `checkAborted` guard called before every `fetch()` call

### `packages/core/src/adapters/parcelpanel-adapter.test.ts`

30 tests (29 active + 1 skipped contract probe):

- Constructor validation (empty stores, empty key, empty API key value)
- Auth header verified (`x-parcelpanel-api-key` sent, `Authorization` absent)
- Store routing (two-store config, correct key routed per store)
- Param validation (missing store, unknown store with `details.store`, missing order_number)
- order_number normalization (`#1234`, `  #1234  `, `1234`)
- HTTP error classification (401, 403, 404, 422, 429 with retry_after, 500, non-JSON body)
- Network error (ECONNREFUSED → NETWORK_UNREACHABLE)
- AbortSignal (pre-aborted, in-flight abort)
- Normalization (fulfilled, unfulfilled, split fulfillment, missing order key, non-string tracking_link)
- Unsupported operations (unknown fetch, create, update)
- Contract probe (`it.skip`, gated on `PARCELPANEL_TEST_API_KEY` / `PARCELPANEL_TEST_STORE` / `PARCELPANEL_TEST_ORDER_NUMBER`)

### `packages/core/src/index.ts`

Three new exports added after the ShopifyAdapter exports:

```ts
export { ParcelPanelAdapter } from './adapters/parcelpanel-adapter.js';
export type {
  ParcelPanelAdapterConfig,
  NormalizedTracking as ParcelPanelNormalizedTracking,
} from './adapters/parcelpanel-adapter.js';
```

## Verification

```
npm run build --workspace=packages/core
# → tsc --build, clean, no errors

npx vitest run packages/core/src/adapters/parcelpanel-adapter.test.ts
# → 29 passed | 1 skipped (30)

npx vitest run
# → 73 test files, 1157 passed | 1 skipped (1158 total), no regressions
```

## Related

- #12 GorgiasAdapter
- #13 ShopifyAdapter
- `prompts/phase-cs4-parcelpanel-adapter.md`
