### PR TITLE
feat(cs5): add AirtableAdapter

### DIFF
--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -1,0 +1,626 @@
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { AirtableAdapter } from './airtable-adapter.js';
+import type { AirtableAdapterConfig } from './airtable-adapter.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+// ---------------------------------------------------------------------------
+// Mock server
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (req: http.IncomingMessage, res: http.ServerResponse, body: string) => void;
+
+let port: number;
+let server: http.Server;
+const handlers: RequestHandler[] = [];
+
+let lastRequestHeaders: http.IncomingHttpHeaders = {};
+let lastRequestBody = '';
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      lastRequestHeaders = req.headers;
+      lastRequestBody = body;
+      const handler = handlers.shift();
+      if (handler === undefined) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'no handler registered' }));
+        return;
+      }
+      handler(req, res, body);
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as { port: number };
+  port = address.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+afterEach(() => {
+  handlers.splice(0, handlers.length);
+});
+
+function respond(statusCode: number, body: unknown, headers: Record<string, string> = {}): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'application/json', ...headers });
+    res.end(JSON.stringify(body));
+  });
+}
+
+function respondText(statusCode: number, text: string): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain' });
+    res.end(text);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: AirtableAdapterConfig = {
+  api_key: 'patXXXXXXXXXXXXXX',
+  base_id: 'appXXXXXXXXXXXXXX',
+};
+
+function makeAdapter(overrides: Partial<AirtableAdapterConfig> = {}): AirtableAdapter {
+  return new AirtableAdapter('airtable', {
+    ...VALID_CONFIG,
+    base_url: `http://127.0.0.1:${port}`,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const RECORD_FIXTURE = {
+  id: 'recXXXXXXXXXXXXXX',
+  createdTime: '2024-01-01T00:00:00.000Z',
+  fields: { Name: 'Test', Status: 'Open' },
+};
+
+const RECORDS_FIXTURE = {
+  records: [RECORD_FIXTURE],
+};
+
+const RECORDS_WITH_OFFSET_FIXTURE = {
+  records: [RECORD_FIXTURE],
+  offset: 'nextPageToken123',
+};
+
+// ---------------------------------------------------------------------------
+// Tests: Constructor validation
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter construction', () => {
+  it('throws for empty api_key', () => {
+    expect(() => new AirtableAdapter('id', { api_key: '', base_id: 'appXXXXXXXXXXXXXX' })).toThrow(
+      'AirtableAdapter: api_key must not be empty',
+    );
+  });
+
+  it('throws for base_id not matching /^app[a-zA-Z0-9]{14}$/ (e.g. "invalid")', () => {
+    expect(() => new AirtableAdapter('id', { api_key: 'pat123', base_id: 'invalid' })).toThrow(
+      'AirtableAdapter: base_id must be a valid Airtable base ID (format: appXXXXXXXXXXXXXX)',
+    );
+  });
+
+  it('does not throw for a valid base_id matching the pattern', () => {
+    expect(
+      () => new AirtableAdapter('id', { api_key: 'pat123', base_id: 'appXXXXXXXXXXXXXX' }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Auth header
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter auth header', () => {
+  it('sends Authorization: Bearer header and no x-parcelpanel-api-key', async () => {
+    respond(200, RECORD_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('get_record', { table: 'Tickets', record_id: 'recABC' }, {});
+    expect(lastRequestHeaders['authorization']).toBe('Bearer patXXXXXXXXXXXXXX');
+    expect(lastRequestHeaders['x-parcelpanel-api-key']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: get_record
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter get_record', () => {
+  it('uses correct URL path: /v0/{base_id}/{table}/{record_id}', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORD_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_record', { table: 'Tickets', record_id: 'recABC' }, {});
+    expect(capturedUrl).toBe('/v0/appXXXXXXXXXXXXXX/Tickets/recABC');
+  });
+
+  it('returns data with id, createdTime, fields', async () => {
+    respond(200, RECORD_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_record', { table: 'Tickets', record_id: 'recABC' }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as typeof RECORD_FIXTURE;
+    expect(data.id).toBe('recXXXXXXXXXXXXXX');
+    expect(data.createdTime).toBe('2024-01-01T00:00:00.000Z');
+    expect(data.fields).toEqual({ Name: 'Test', Status: 'Open' });
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when table is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_record', { record_id: 'recABC' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when record_id is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_record', { table: 'Tickets' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: list_records
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter list_records', () => {
+  it('returns records array and passes offset through when present', async () => {
+    respond(200, RECORDS_WITH_OFFSET_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_records', { table: 'Tickets' }, {});
+    const data = result.data as typeof RECORDS_WITH_OFFSET_FIXTURE;
+    expect(Array.isArray(data.records)).toBe(true);
+    expect(data.offset).toBe('nextPageToken123');
+  });
+
+  it('empty records array is valid — not an error', async () => {
+    respond(200, { records: [] });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_records', { table: 'Tickets' }, {});
+    const data = result.data as { records: unknown[] };
+    expect(data.records).toHaveLength(0);
+  });
+
+  it('filter_by_formula with special chars is URL-encoded in the raw query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'list_records',
+      { table: 'Tickets', filter_by_formula: '{Ticket ID} = "T-1234"' },
+      {},
+    );
+    expect(capturedUrl).toContain('filterByFormula=');
+    expect(capturedUrl).not.toContain('{');
+    expect(capturedUrl).not.toContain('}');
+  });
+
+  it('fields array produces repeated fields[] params, not comma-joined', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_records', { table: 'Tickets', fields: ['Name', 'Status'] }, {});
+    const decoded = decodeURIComponent(capturedUrl);
+    expect(decoded).toContain('fields[]=Name');
+    expect(decoded).toContain('fields[]=Status');
+    expect(decoded).not.toMatch(/fields\[\]=Name,Status/);
+    expect(decoded).not.toMatch(/fields\[\]=Status,Name/);
+  });
+
+  it('offset input param produces offset= in the query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_records', { table: 'Tickets', offset: 'nextPageToken123' }, {});
+    expect(capturedUrl).toContain('offset=nextPageToken123');
+  });
+
+  it('max_records param produces maxRecords= in the query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_records', { table: 'Tickets', max_records: 50 }, {});
+    expect(capturedUrl).toContain('maxRecords=50');
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when table is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('list_records', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: create_record
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter create_record', () => {
+  it('request body contains fields key; response has data.id', async () => {
+    handlers.push((_req, res, body) => {
+      const parsed = JSON.parse(body) as { fields?: unknown };
+      if (parsed.fields === undefined) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'no fields' }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORD_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.create(
+      'create_record',
+      { table: 'Tickets', fields: { Name: 'New ticket' } },
+      {},
+    );
+    expect(result.status).toBe(200);
+    const data = result.data as typeof RECORD_FIXTURE;
+    expect(data.id).toBe('recXXXXXXXXXXXXXX');
+  });
+
+  it('with typecast: true — request body contains "typecast": true', async () => {
+    respond(200, RECORD_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create(
+      'create_record',
+      { table: 'Tickets', fields: { Name: 'Test' }, typecast: true },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['typecast']).toBe(true);
+  });
+
+  it('without typecast — request body does NOT contain typecast key', async () => {
+    respond(200, RECORD_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create('create_record', { table: 'Tickets', fields: { Name: 'Test' } }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect('typecast' in body).toBe(false);
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when table is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('create_record', { fields: { Name: 'x' } }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when fields is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('create_record', { table: 'Tickets' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: upsert_record
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter upsert_record', () => {
+  const UPSERT_RESPONSE = {
+    records: [RECORD_FIXTURE],
+    createdRecords: ['recXXXXXXXXXXXXXX'],
+    updatedRecords: [],
+  };
+
+  it('request body contains records and performUpsert; createdRecords/updatedRecords passed through', async () => {
+    respond(200, UPSERT_RESPONSE);
+    const adapter = makeAdapter();
+    const result = await adapter.update(
+      'upsert_record',
+      {
+        table: 'Tickets',
+        fields: { Name: 'New ticket', 'Ticket ID': 'T-100' },
+        fields_to_merge_on: ['Ticket ID'],
+      },
+      {},
+    );
+    expect(result.status).toBe(200);
+    const data = result.data as typeof UPSERT_RESPONSE;
+    expect(Array.isArray(data.records)).toBe(true);
+    expect(data.createdRecords).toEqual(['recXXXXXXXXXXXXXX']);
+    expect(data.updatedRecords).toEqual([]);
+
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['records']).toEqual([{ fields: { Name: 'New ticket', 'Ticket ID': 'T-100' } }]);
+    expect(body['performUpsert']).toEqual({ fieldsToMergeOn: ['Ticket ID'] });
+  });
+
+  it('with typecast: true — body contains "typecast": true', async () => {
+    respond(200, UPSERT_RESPONSE);
+    const adapter = makeAdapter();
+    await adapter.update(
+      'upsert_record',
+      { table: 'Tickets', fields: { Name: 'x' }, fields_to_merge_on: ['Name'], typecast: true },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['typecast']).toBe(true);
+  });
+
+  it('without typecast — body does NOT contain typecast key', async () => {
+    respond(200, UPSERT_RESPONSE);
+    const adapter = makeAdapter();
+    await adapter.update(
+      'upsert_record',
+      { table: 'Tickets', fields: { Name: 'x' }, fields_to_merge_on: ['Name'] },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect('typecast' in body).toBe(false);
+  });
+
+  it('fields_to_merge_on: [] (empty array) → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.update(
+        'upsert_record',
+        { table: 'Tickets', fields: { Name: 'x' }, fields_to_merge_on: [] },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('fields_to_merge_on: "ticket_id" (string, not array) → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.update(
+        'upsert_record',
+        { table: 'Tickets', fields: { Name: 'x' }, fields_to_merge_on: 'ticket_id' },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('fields_to_merge_on: [123] (non-string element) → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.update(
+        'upsert_record',
+        { table: 'Tickets', fields: { Name: 'x' }, fields_to_merge_on: [123] },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: HTTP error classification
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter HTTP error classification', () => {
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { error: { type: 'AUTHENTICATION_REQUIRED' } });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
+  });
+
+  it('HTTP 403 → SERVICE_HTTP_4XX', async () => {
+    respond(403, { error: { type: 'NOT_AUTHORIZED' } });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX' });
+  });
+
+  it('HTTP 404 → SERVICE_NOT_FOUND', async () => {
+    respond(404, { error: { type: 'NOT_FOUND' } });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_NOT_FOUND' });
+  });
+
+  it('HTTP 422 → SERVICE_HTTP_4XX, details.body present', async () => {
+    respond(422, { error: { type: 'INVALID_MULTIPLE_CHOICE_OPTIONS', message: 'Invalid value' } });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .create('create_record', { table: 'T', fields: { Status: 'Bad' } }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_4XX');
+    expect(err.details['body']).toBeDefined();
+    const body = err.details['body'] as { error?: { type?: string } };
+    expect(body.error?.type).toBe('INVALID_MULTIPLE_CHOICE_OPTIONS');
+  });
+
+  it('HTTP 429 → SERVICE_RATE_LIMITED, no retry_after in details', async () => {
+    respond(429, { error: { type: 'RATE_LIMIT_REACHED' } });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_record', { table: 'T', record_id: 'recABC' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_RATE_LIMITED');
+    expect(err.details['retry_after']).toBeUndefined();
+  });
+
+  it('HTTP 500 → SERVICE_HTTP_5XX, retryable: true', async () => {
+    respond(500, { error: 'Internal Server Error' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_5XX', retryable: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Response validation
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter response validation', () => {
+  it('200 with non-JSON body → SERVICE_RESPONSE_INVALID', async () => {
+    respondText(200, 'not valid json {{');
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+
+  it('get_record response missing id field → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { createdTime: '2024-01-01T00:00:00.000Z', fields: {} });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+
+  it('list_records response missing records field → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { something: 'else' });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('list_records', { table: 'T' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_RESPONSE_INVALID',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Network errors
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter network errors', () => {
+  it('ECONNREFUSED (closed port) → NETWORK_UNREACHABLE', async () => {
+    const closedPort = await new Promise<number>((resolve) => {
+      const tmp = net.createServer();
+      tmp.listen(0, '127.0.0.1', () => {
+        const addr = tmp.address() as { port: number };
+        tmp.close(() => resolve(addr.port));
+      });
+    });
+
+    const adapter = new AirtableAdapter('airtable', {
+      api_key: 'patTest',
+      base_id: 'appXXXXXXXXXXXXXX',
+      base_url: `http://127.0.0.1:${closedPort}`,
+    });
+
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}),
+    ).rejects.toMatchObject({ code: 'NETWORK_UNREACHABLE' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: AbortSignal
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter AbortSignal', () => {
+  it('pre-aborted signal throws STEP_ABORTED, no network call made (handlers still length 1)', async () => {
+    respond(200, RECORD_FIXTURE);
+
+    const adapter = makeAdapter();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}, controller.signal),
+    ).rejects.toMatchObject({ code: 'STEP_ABORTED' });
+
+    expect(handlers).toHaveLength(1);
+  });
+
+  it('signal aborted during in-flight request throws STEP_ABORTED (race-tolerant)', async () => {
+    const controller = new AbortController();
+    handlers.push((_req, res) => {
+      controller.abort();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORD_FIXTURE));
+    });
+
+    const adapter = makeAdapter();
+    try {
+      await adapter.fetch('get_record', { table: 'T', record_id: 'recABC' }, {}, controller.signal);
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkflowError);
+      expect((err as WorkflowError).code).toBe('STEP_ABORTED');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Unsupported operations
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter unsupported operations', () => {
+  it('fetch("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('unknown', { table: 'T' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('create("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('unknown', { table: 'T', fields: {} }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('update("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.update('unknown', { table: 'T', fields: {}, fields_to_merge_on: ['x'] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_OP_UNSUPPORTED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract probe (skipped — requires real credentials)
+// ---------------------------------------------------------------------------
+
+it.skip('contract probe — real API (requires AIRTABLE_TEST_API_KEY + AIRTABLE_TEST_BASE_ID + AIRTABLE_TEST_TABLE)', async () => {
+  const apiKey = process.env['AIRTABLE_TEST_API_KEY'] ?? '';
+  const baseId = process.env['AIRTABLE_TEST_BASE_ID'] ?? '';
+  const table = process.env['AIRTABLE_TEST_TABLE'] ?? '';
+
+  const adapter = new AirtableAdapter('airtable', { api_key: apiKey, base_id: baseId });
+  const result = await adapter.fetch('list_records', { table }, {});
+  expect(result.status).toBe(200);
+  const data = result.data as { records: unknown[] };
+  expect(Array.isArray(data.records)).toBe(true);
+});

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -1,0 +1,533 @@
+// AirtableAdapter — wraps the Airtable REST API for record-level operations.
+import { WorkflowError } from '../types/workflow-error.js';
+import type { ServiceAdapter, ServiceResponse } from '../extensions/service-adapter.js';
+
+const AIRTABLE_DEFAULT_BASE_URL = 'https://api.airtable.com';
+
+/**
+ * Configuration for AirtableAdapter.
+ *
+ * One adapter instance is scoped to a single Airtable base. For multi-base workflows,
+ * create one adapter instance per base.
+ */
+export interface AirtableAdapterConfig {
+  /**
+   * Personal Access Token (PAT). Required.
+   * Rate limit: 5 req/sec per base. On HTTP 429, wait 30 seconds before retrying.
+   * No Retry-After header is provided by Airtable.
+   */
+  api_key: string;
+
+  /**
+   * Airtable base ID. Format: /^app[a-zA-Z0-9]{14}$/.
+   * One adapter instance per base. Multi-base = two instances.
+   */
+  base_id: string;
+
+  /**
+   * Override the base URL for tests (replaces https://api.airtable.com).
+   * Trailing slash is stripped.
+   */
+  base_url?: string;
+}
+
+/** Raw Airtable record shape. */
+interface AirtableRecord {
+  id?: unknown;
+  createdTime?: unknown;
+  fields?: Record<string, unknown>;
+}
+
+/**
+ * AirtableAdapter wraps the Airtable REST API.
+ *
+ * Supported operations:
+ *   fetch('get_record', { table, record_id })        — GET  /v0/{base}/{table}/{id}
+ *   fetch('list_records', { table, ...query })       — GET  /v0/{base}/{table}
+ *   create('create_record', { table, fields, ... })  — POST /v0/{base}/{table}
+ *   update('upsert_record', { table, fields, ... })  — POST /v0/{base}/{table} (upsert)
+ */
+export class AirtableAdapter implements ServiceAdapter {
+  readonly id: string;
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly baseId: string;
+
+  constructor(id: string, config: AirtableAdapterConfig) {
+    if (!config.api_key) {
+      throw new Error('AirtableAdapter: api_key must not be empty');
+    }
+    if (!/^app[a-zA-Z0-9]{14}$/.test(config.base_id)) {
+      throw new Error(
+        'AirtableAdapter: base_id must be a valid Airtable base ID (format: appXXXXXXXXXXXXXX)',
+      );
+    }
+    this.id = id;
+    this.apiKey = config.api_key;
+    this.baseId = config.base_id;
+    this.baseUrl = config.base_url?.replace(/\/$/, '') ?? AIRTABLE_DEFAULT_BASE_URL;
+  }
+
+  private checkAborted(signal?: AbortSignal): void {
+    if (signal?.aborted === true) {
+      throw new WorkflowError('Adapter request aborted', {
+        code: 'STEP_ABORTED',
+        category: 'ENGINE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+  }
+
+  private buildHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      Accept: 'application/json',
+    };
+  }
+
+  private buildUrl(table: string, recordId?: string): URL {
+    let path = `/v0/${this.baseId}/${encodeURIComponent(table)}`;
+    if (recordId !== undefined) {
+      path += `/${encodeURIComponent(recordId)}`;
+    }
+    return new URL(path, this.baseUrl);
+  }
+
+  private async executeRequest(
+    url: URL,
+    method: 'GET' | 'POST' | 'PATCH',
+    body?: unknown,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    this.checkAborted(signal);
+    const hasBody = method !== 'GET' && body !== undefined;
+    const headers: Record<string, string> = {
+      ...this.buildHeaders(),
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+    };
+
+    let response: Response;
+    try {
+      response = await fetch(url.href, {
+        method,
+        headers,
+        ...(hasBody ? { body: JSON.stringify(body) } : {}),
+        signal: signal ?? null,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new WorkflowError('Adapter request aborted', {
+          code: 'STEP_ABORTED',
+          category: 'ENGINE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new WorkflowError(message, {
+        code: 'NETWORK_UNREACHABLE',
+        category: 'NETWORK',
+        agentAction: 'wait_for_human',
+        retryable: true,
+      });
+    }
+    return response;
+  }
+
+  private async throwHttpError(response: Response, operation: string): Promise<never> {
+    // Read body as text first — avoids "body already consumed" if JSON.parse fails.
+    const rawText = await response.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(rawText);
+    } catch {
+      body = rawText;
+    }
+
+    const status = response.status;
+    const baseDetails = { status, operation };
+
+    if (status === 401) {
+      throw new WorkflowError('Airtable authentication failed — check API key', {
+        code: 'SERVICE_AUTH_FAILED',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: baseDetails,
+      });
+    }
+
+    if (status === 403) {
+      throw new WorkflowError('Airtable: forbidden (HTTP 403)', {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: baseDetails,
+      });
+    }
+
+    if (status === 404) {
+      throw new WorkflowError('Airtable: record not found', {
+        code: 'SERVICE_NOT_FOUND',
+        category: 'SERVICE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: baseDetails,
+      });
+    }
+
+    if (status === 422) {
+      throw new WorkflowError('Airtable: unprocessable entity (HTTP 422)', {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: { ...baseDetails, body },
+      });
+    }
+
+    if (status === 429) {
+      throw new WorkflowError('Rate limited by Airtable API — wait 30 seconds before retrying', {
+        code: 'SERVICE_RATE_LIMITED',
+        category: 'SERVICE',
+        agentAction: 'wait_for_human',
+        retryable: true,
+        details: baseDetails,
+      });
+    }
+
+    if (status >= 500) {
+      throw new WorkflowError(`Airtable server error (HTTP ${status})`, {
+        code: 'SERVICE_HTTP_5XX',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: true,
+        details: baseDetails,
+      });
+    }
+
+    // 400 and other 4xx
+    throw new WorkflowError(`HTTP ${status}: ${response.statusText}`, {
+      code: 'SERVICE_HTTP_4XX',
+      category: 'SERVICE',
+      agentAction: 'stop',
+      retryable: false,
+      details: baseDetails,
+    });
+  }
+
+  async fetch(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'get_record') {
+      const table = params['table'];
+      const recordId = params['record_id'];
+
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (typeof recordId !== 'string' || recordId === '') {
+        throw new WorkflowError('AirtableAdapter: record_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const url = this.buildUrl(table, recordId);
+      const response = await this.executeRequest(url, 'GET', undefined, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'get_record');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as AirtableRecord;
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('AirtableAdapter: get_record response missing id field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'list_records') {
+      const table = params['table'];
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const url = this.buildUrl(table);
+
+      if (typeof params['filter_by_formula'] === 'string') {
+        url.searchParams.set('filterByFormula', params['filter_by_formula']);
+      }
+      if (typeof params['view'] === 'string') {
+        url.searchParams.set('view', params['view']);
+      }
+      if (typeof params['max_records'] === 'number') {
+        url.searchParams.set('maxRecords', String(params['max_records']));
+      }
+      if (Array.isArray(params['fields'])) {
+        for (const f of params['fields'] as unknown[]) {
+          url.searchParams.append('fields[]', String(f));
+        }
+      }
+      if (typeof params['offset'] === 'string') {
+        url.searchParams.set('offset', params['offset']);
+      }
+
+      const response = await this.executeRequest(url, 'GET', undefined, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'list_records');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { records?: unknown };
+      if (!Array.isArray(data.records)) {
+        throw new WorkflowError('AirtableAdapter: list_records response missing records array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`AirtableAdapter: unsupported fetch operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+    });
+  }
+
+  async create(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'create_record') {
+      const table = params['table'];
+      const fields = params['fields'];
+
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (
+        fields === undefined ||
+        fields === null ||
+        typeof fields !== 'object' ||
+        Array.isArray(fields)
+      ) {
+        throw new WorkflowError('AirtableAdapter: fields param must be a plain object', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const body: Record<string, unknown> = { fields };
+      if (params['typecast'] === true) {
+        body['typecast'] = true;
+      }
+
+      const url = this.buildUrl(table);
+      const response = await this.executeRequest(url, 'POST', body, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'create_record');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as AirtableRecord;
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('AirtableAdapter: create_record response missing id field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`AirtableAdapter: unsupported create operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+    });
+  }
+
+  async update(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'upsert_record') {
+      const table = params['table'];
+      const fields = params['fields'];
+      const fieldsToMergeOn = params['fields_to_merge_on'];
+
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (
+        fields === undefined ||
+        fields === null ||
+        typeof fields !== 'object' ||
+        Array.isArray(fields)
+      ) {
+        throw new WorkflowError('AirtableAdapter: fields param must be a plain object', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      // Validate fields_to_merge_on: must be a non-empty array of non-empty strings
+      if (!Array.isArray(fieldsToMergeOn) || fieldsToMergeOn.length === 0) {
+        throw new WorkflowError(
+          'AirtableAdapter: fields_to_merge_on must be a non-empty array of non-empty strings',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+      for (const element of fieldsToMergeOn) {
+        if (typeof element !== 'string' || element === '') {
+          throw new WorkflowError(
+            'AirtableAdapter: fields_to_merge_on must be a non-empty array of non-empty strings',
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+      }
+
+      const body: Record<string, unknown> = {
+        records: [{ fields }],
+        performUpsert: { fieldsToMergeOn },
+      };
+      if (params['typecast'] === true) {
+        body['typecast'] = true;
+      }
+
+      const url = this.buildUrl(table);
+      const response = await this.executeRequest(url, 'POST', body, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'upsert_record');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { records?: unknown };
+      if (!Array.isArray(data.records)) {
+        throw new WorkflowError('AirtableAdapter: upsert_record response missing records array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`AirtableAdapter: unsupported update operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export type {
   ParcelPanelAdapterConfig,
   NormalizedTracking as ParcelPanelNormalizedTracking,
 } from './adapters/parcelpanel-adapter.js';
+export { AirtableAdapter } from './adapters/airtable-adapter.js';
+export type { AirtableAdapterConfig } from './adapters/airtable-adapter.js';
 
 // Trace policy
 export { TRACE_POLICY_VERSION, TRACE_POLICY, TRACE_POLICY_HASH } from './engine/trace-policy.js';


### PR DESCRIPTION
## Summary

Implements B-lite incremental trace ingestion: agents can now call `append_trace` during a step to stream trace entries into a WAL buffer before calling `execute_step`. At `execute_step` finalization the WAL is merged with any inline trace, sorted chronologically, normalized once, and committed to evidence. This lifts the constraint of submitting the entire trace in a single `execute_step` call.

## What changed

### New: `TraceBufferStore` interface + `InMemoryTraceBufferStore` (`packages/core`)

- `TraceBufferStore` interface: `append`, `read`, `delete`, `deleteAllForRun`
- `BufferedEntry` type: `AgentTraceEntry & { _internalTs: number }` — engine-assigned ordering timestamp
- `AppendResult` type: `{ buffer_count, buffer_bytes, limit_count, limit_bytes, final_limit_entries, final_limit_bytes }`
- `normalizeEntryForBuffer` — per-entry normalization at append time (reserved prefix drop, field caps)
- `InMemoryTraceBufferStore` — reference implementation for tests; throws `BUFFER_FULL` when limits exceeded
- Constants: `BUFFER_LIMIT_COUNT=200`, `BUFFER_LIMIT_BYTES=100 KB`, `FINAL_LIMIT_ENTRIES=100`, `FINAL_LIMIT_BYTES=50 KB`

### New: `JsonTraceBufferStore` (`packages/mcp-server`)

- JSONL WAL files at `<runsDir>/trace-buffer-<runId>-<base64url(stepId)>.jsonl`
- `proper-lockfile` for atomic appends: `{ retries: 10, stale: 5000, realpath: false }`
- Tolerates corrupted WAL lines silently (treats as empty)
- `deleteAllForRun` globs and removes all WAL files for a run

### New: `append_trace` MCP tool (`packages/mcp-server`)

- `handleAppendTrace` validates: run exists, step exists, step is `agent` execution, step not already claimed (completed/failed/in_progress)
- Error code: `STEP_NOT_ELIGIBLE` with `step_state: 'not_found' | 'already_claimed'` or `step_type: 'not_agent_step'`
- Returns `{ status: 'ok', ...AppendResult }` on success
- Reuses `traceEntrySchema` from `execute-step.ts`

### Modified: execution loop — step 2d WAL merge (`packages/core`)

- Reads WAL buffer at claim time (pre-claim, agent steps only)
- Merges WAL entries + `execute_step.trace` using `_internalTs` for chronological ordering
- WAL entries sort before `execute_step.trace` entries (lower timestamp)
- Normalizes the merged set once via `normalizeTrace`
- Schema enforcement rejection: WAL preserved so agent can retry
- Success path and dispatch-failure path: WAL deleted after `store.update`

### Modified: `server.ts` — shared `traceBufferStore` instance

Single `JsonTraceBufferStore` instance wired to both `registerExecuteStep` and `registerAppendTrace`.

### Other changes

- `JsonFileStore.runsDirPath` getter added (exposes runs directory path to mcp-server)
- `BUFFER_FULL` added to `ErrorCode` union
- `TraceBufferStore`, `BufferedEntry`, `AppendResult`, `InMemoryTraceBufferStore`, `normalizeEntryForBuffer` exported from `@sensigo/realm`

## Tests

| File | Tests |
|------|-------|
| `packages/core/src/store/trace-buffer-store.test.ts` (new) | 13 |
| `packages/core/src/engine/trace-buffer-merge.test.ts` (new) | 6 |
| `packages/mcp-server/src/tools/append-trace.test.ts` (new) | 9 |
| `packages/core/src/engine/execution-loop.test.ts` (extended) | +6 |

Total: 76 test files, 1191 passed, 1 skipped.

## Verification

```bash
npx vitest run
# 76 test files, 1191 passed, 1 skipped

npx tsc --build --noEmit
# clean

grep "STEP_NOT_ELIGIBLE" packages/mcp-server/src/tools/append-trace.ts
# 5 lines, all 'STEP_NOT_ELIGIBLE' — no STATE_ prefix
```
