### PR TITLE
docs: generalise workflow, PR, and issue standards for any repo

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -1,0 +1,128 @@
+---
+applyTo: '**'
+---
+
+# Git Workflow Policy
+
+This policy applies to all agents and human contributors working across all repositories.
+
+## The Rule
+
+All changes flow through branches. **Direct commits to `main` are not permitted on any repo.**
+
+```
+git switch main
+git pull
+git switch -c feat/scope/description
+# make changes
+git add .
+git commit -m "feat(scope): add thing"
+git push -u origin feat/scope/description
+# open PR into main
+```
+
+## Repos
+
+This rule applies to every repository without exception. The reviewer for any given repo is whoever owns that project. When in doubt, ask the human to confirm the reviewer before opening a PR.
+
+The reviewer and the branch author may be the same person — the PR still exists as a record.
+
+---
+
+## Branch Naming Convention
+
+| Type            | Pattern                          | Example                                |
+| --------------- | -------------------------------- | -------------------------------------- |
+| Feature         | `feat/{scope}/{description}`     | `feat/api/add-klaviyo-flow`            |
+| Bug fix         | `fix/{scope}/{description}`      | `fix/auth/shopify-token-refresh`       |
+| Hotfix          | `hotfix/{description}`           | `hotfix/critical-null-pointer`         |
+| Chore / deps    | `chore/{description}`            | `chore/update-env-docs`                |
+| Docs            | `docs/{description}`             | `docs/update-readme`                   |
+| Refactor        | `refactor/{scope}/{description}` | `refactor/core/simplify-state-machine` |
+| Performance     | `perf/{scope}/{description}`     | `perf/db/optimise-query`               |
+| Tests           | `test/{scope}/{description}`     | `test/core/add-edge-cases`             |
+| CI / infra      | `ci/{description}`               | `ci/add-lint-step`                     |
+| Security        | `security/{description}`         | `security/patch-cve-2024-1234`         |
+| Revert          | `revert/{description}`           | `revert/feat-klaviyo-flow`             |
+| AI agent branch | `agent/{branch-name}`            | `agent/setup-dev-workspace`            |
+
+**Rules:**
+
+- Use lowercase and hyphens. No spaces. No uppercase.
+- `{scope}` is optional for single-scope repos but preferred when the change is localised to a package, service, or feature area.
+- For client-services work, `{scope}` is the client name (e.g. `fix/maxim/shopify-token-refresh`).
+
+---
+
+## Commit Messages
+
+Follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+type(scope): short imperative description
+
+[optional body]
+
+[optional footer(s)]
+```
+
+| Type       | When to use                               |
+| ---------- | ----------------------------------------- |
+| `feat`     | New feature or capability                 |
+| `fix`      | Bug fix                                   |
+| `chore`    | Maintenance, dependencies, config         |
+| `docs`     | Documentation only                        |
+| `refactor` | Code restructure with no behaviour change |
+| `perf`     | Performance improvement                   |
+| `test`     | Test additions or changes                 |
+| `ci`       | CI/CD configuration                       |
+| `security` | Security fix or vulnerability patch       |
+| `revert`   | Reverting a prior commit                  |
+
+**Rules:**
+
+- Lowercase throughout.
+- Imperative mood: "add X", "fix Y" — not "added X" or "fixes Y".
+- No period at the end of the description.
+- Subject line ≤ 50 characters. Wrap the body at 72 characters.
+- Scope is optional but preferred when the change is localised.
+- Breaking changes: append `!` after the type/scope (e.g. `feat!: drop Node 18 support`) and add a `BREAKING CHANGE:` footer.
+
+---
+
+## Branch Lifecycle
+
+- Delete the branch after merge. Never leave stale branches on remote.
+- **Never force-push** (`--force` / `-f`) to any branch that has an open PR or has been shared with others. Force-pushing rewrites history and breaks reviewer workflows.
+- `git push --force-with-lease` is permitted on your own branch to clean up commits **before** review has started — never after.
+
+---
+
+## PR Merge Strategy
+
+- **Squash merge** is the default for feature and fix branches — keeps `main` history linear and readable.
+- **Merge commit** is permitted when preserving the full branch history is explicitly required.
+- **Rebase merge** is permitted for clean, well-structured commit sequences that add value to the linear history.
+- Do not mix strategies across a project without a documented reason.
+
+---
+
+## Draft PRs
+
+Open a draft PR when:
+
+- The branch is ready for early feedback but not yet ready to merge.
+- CI must run but the work is incomplete.
+- You want to signal work is in progress without triggering a review request.
+
+Convert to ready-for-review only when all checklist items are satisfied and CI passes.
+
+---
+
+## Enforcement for Agents
+
+- **Never push directly to `main`** on any repo.
+- Always create a branch before making any changes.
+- After pushing a branch, open a PR. Do not merge it yourself unless explicitly authorised by the human.
+- If a task prompt does not specify a branch name, generate one following the naming convention above and state it in your report.
+- Never use `--force` on any branch. `--force-with-lease` is only permitted before review has started.

--- a/.github/instructions/issue-standards.instructions.md
+++ b/.github/instructions/issue-standards.instructions.md
@@ -4,7 +4,7 @@ applyTo: '**'
 
 # GitHub Issue Standards
 
-This policy applies to all agents and human contributors across all 187n repositories.
+This policy applies to all agents and human contributors across all repositories.
 
 ---
 
@@ -44,10 +44,10 @@ Use a concise, descriptive imperative phrase prefixed with a type label:
 
 **Rules:**
 
-- Imperative mood: "lock bot to owner" not "bot should be locked" or "locking bot"
+- Imperative mood: "restrict access to authenticated users" not "should restrict access" or "restricting access"
 - Lowercase after the type prefix
 - No period at the end
-- Be specific: `[security] telegram bot responds to any user` not `[security] bot issue`
+- Be specific: `[security] API returns data for unauthenticated requests` not `[security] auth issue`
 
 ---
 
@@ -104,9 +104,9 @@ What the solution should be. Keep it at the approach level — implementation de
 A numbered list of conditions that must be true for this issue to be considered resolved. Each item must be verifiable.
 
 ```
-1. New users completing setup must have TELEGRAM_ALLOWED_USERS set to their ID
-2. Existing deployed containers can have the value updated without full re-provisioning
-3. Unit tests cover the new field in buildCustomerRow
+1. Unauthenticated requests to all protected endpoints return 403
+2. Existing integrations continue to work without configuration changes
+3. Unit tests cover the new validation logic
 ```
 
 ### `## Severity` _(bugs and security only)_
@@ -120,7 +120,7 @@ A numbered list of conditions that must be true for this issue to be considered 
 
 ### `## Related` _(optional)_
 
-Links to relevant PRs, issues, Supabase rows, Whop dashboard entries, or external references.
+Links to relevant PRs, issues, external service records, or supporting documentation.
 
 ---
 

--- a/.github/instructions/pr-standards.instructions.md
+++ b/.github/instructions/pr-standards.instructions.md
@@ -1,0 +1,128 @@
+---
+applyTo: '**'
+---
+
+# Pull Request Standards
+
+This policy applies to all agents and human contributors across all repositories.
+
+---
+
+## PR Title
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+type(scope): short imperative description
+```
+
+| Type       | When to use                               |
+| ---------- | ----------------------------------------- |
+| `feat`     | New feature or capability                 |
+| `fix`      | Bug fix                                   |
+| `chore`    | Maintenance, dependencies, config         |
+| `refactor` | Code restructure with no behaviour change |
+| `docs`     | Documentation only                        |
+| `test`     | Test additions or changes                 |
+| `perf`     | Performance improvement                   |
+| `ci`       | CI/CD configuration                       |
+| `security` | Security fix or vulnerability patch       |
+| `revert`   | Reverting a prior commit                  |
+
+**Rules:**
+
+- Lowercase throughout
+- Imperative mood: "add X", "fix Y", not "added X" or "fixes Y"
+- No period at the end
+- Scope is optional but preferred when the change is localised (e.g. `fix(auth): …`)
+
+---
+
+## PR Body
+
+Always write the body to a temp file and pass it with `--body-file`:
+
+```bash
+cat > /tmp/pr-body.md << 'BODY'
+<content>
+BODY
+
+gh pr create \
+  --title "type(scope): description" \
+  --body-file /tmp/pr-body.md \
+  --base main \
+  --head branch-name
+```
+
+**Never** use `--body "..."` inline — multiline content becomes unreadable and escaping errors are common.
+
+---
+
+## Required Sections
+
+Every PR body must contain these sections in this order. Omit only `## Root Cause` when there is no bug (feature PRs replace it with `## Motivation`).
+
+### `## Context`
+
+What prompted this change. Include:
+
+- Who reported it / what triggered the work (ticket ID, issue number, date)
+- What was observed (the symptom, not the cause)
+- Any relevant quoted communication or linked discussion
+
+### `## Root Cause` _(bugs)_ / `## Motivation` _(features)_
+
+**For bugs:** The confirmed root cause. State what the code was doing and why it was wrong. Do not conflate symptom with cause.
+
+**For features:** Why this capability is needed. What problem it solves and for whom.
+
+### `## Changes`
+
+What changed and why each change was made. For non-trivial logic, include before/after code snippets. If the change has multiple distinct parts (e.g. a data fix + a code fix), use sub-sections.
+
+### `## Verification`
+
+Concrete, copy-pasteable commands the reviewer can run to confirm the change works. Include expected output where meaningful. Do not write "I tested it locally" — write the commands.
+
+### `## Rollback`
+
+How to revert this change if it causes a production incident. At minimum:
+
+```bash
+git revert HEAD
+```
+
+If the change includes out-of-band data mutations (e.g. external API calls, database writes) that cannot be reverted with `git revert`, state this explicitly and describe the manual revert steps.
+
+### `## Related` _(optional)_
+
+Links to tickets, issues, other PRs, or external references. Use when relevant.
+
+To auto-close a linked issue when this PR merges, place a closing keyword on its own line in the PR body:
+
+```
+Closes #123
+```
+
+Supported keywords: `Closes`, `Fixes`, `Resolves` (case-insensitive). GitHub will close the referenced issue automatically on merge.
+
+---
+
+## Commit Messages
+
+Individual commit messages (not the PR title) follow the same Conventional Commits format.
+
+Keep commit messages focused: one logical change per commit. Avoid bundling unrelated changes into a single commit.
+
+---
+
+## Branch Hygiene
+
+- Delete the branch after merge (use `--delete-branch` with `gh pr merge`)
+- Do not leave stale branches on remote
+
+---
+
+## Enforcement for Agents
+
+Before running `gh pr create`, verify the draft PR body satisfies every required section above. A PR body that is missing sections, uses vague language, or omits verification commands is not acceptable.

--- a/.github/instructions/pre-publication.instructions.md
+++ b/.github/instructions/pre-publication.instructions.md
@@ -1,0 +1,184 @@
+---
+applyTo: '**'
+---
+
+# Pre-Publication Checklist
+
+## Part A — Every PR Merge
+
+Follow this checklist in order before merging any branch into `main`.
+
+### 1. Remove Dead Code
+
+- Delete commented-out code blocks (not explanatory comments — actual dead code)
+- Remove unused variables, imports, and functions
+- Remove TODO/FIXME/HACK comments that reference incomplete work — either finish the work or delete the comment and its stub
+- Remove development logging (debug prints, console.log, etc.) unless it is intentional production logging
+- Remove broken or irrelevant test files
+
+### 2. Automated Checks _(hard gate — must pass before merge)_
+
+- Run linter; zero errors and zero warnings
+- Run type-checker (if applicable); clean output
+- Run dependency vulnerability audit (`npm audit --audit-level=high` or equivalent) — scope to production dependencies; no high or critical findings
+- All CI pipeline checks are green on the PR before merging
+
+### 3. Comments and Documentation
+
+- Every exported function, class, or module has at least a one-sentence description
+- Parameters and return values are documented for all public functions
+- Comments explain **why**, not **what** — remove comments that just restate the code
+- Non-obvious decisions, edge cases, and performance choices are explained inline
+- Each file has a brief top-level comment stating what it contains
+
+### 4. Public API Review _(hard gate for breaking changes)_
+
+- Every publicly exported symbol is intentionally public — internals are clearly marked or unexported
+- Similar operations have consistent signatures (options object vs positional args — pick one pattern)
+- All documented configuration options are implemented and functional
+- Default values are sensible and documented
+- **If any exported symbol's signature or behaviour changes in a non-backwards-compatible way:** this is a breaking change — flag it explicitly. Do not merge without a CHANGELOG entry planned, a major version bump in the version plan, and a migration guide committed or linked.
+
+### 5. Test Coverage
+
+- Every public function or module has at least one test
+- No skipped, pending, or commented-out tests — either implement them or delete them
+- Edge cases flagged in comments are covered
+
+### 6. README
+
+- README accurately reflects the current state of the code
+- Includes: what the project is, how to install/run it, a minimal working example, configuration reference, and how to run tests
+- No references to features that don't exist or were removed
+
+### 7. Repository Hygiene _(hard gate — no secrets)_
+
+- `.gitignore` covers all build artifacts, dependency directories, IDE files, OS files, local config, and secrets
+- `package.json` / project manifest has accurate name, version, description, and entry points. Version follows Semantic Versioning: patch for bug fixes, minor for new backwards-compatible features, major for breaking changes.
+- No files that shouldn't be public: credentials, local config, database files, logs, build output
+- **No hardcoded secrets, API keys, tokens, or environment-specific paths in source code**
+- License file is present if this is an open-source release
+
+### 8. Final Verification
+
+1. Re-read every file modified in this session. Verify each is coherent, complete, and consistent with adjacent code.
+2. Confirm nothing private, internal, or unfinished is exposed in the public surface.
+
+---
+
+## Part B — Release Publication
+
+> Run Part B after the Part A PR has been merged and your local `main` is up to date (`git switch main && git pull`).
+>
+> This repository uses a coordinated release script (`scripts/release.mjs`) that bumps all four packages atomically — `@sensigo/realm`, `@sensigo/realm-mcp`, `@sensigo/realm-testing`, `@sensigo/realm-cli` — and publishes them in dependency order. Do not attempt manual per-package releases; the script is the authoritative release mechanism.
+>
+> A package with `"private": true` in its manifest is not published. Part B does not apply to it.
+
+**1. Create a release branch**
+
+```bash
+git switch main && git pull
+git switch -c release/v<version>
+```
+
+**2. Update CHANGELOG.md**
+
+Rename `## [Unreleased]` to `## [<version>] — YYYY-MM-DD`. Use [keepachangelog.com](https://keepachangelog.com/en/1.1.0/) sections: `## Added`, `## Changed`, `## Fixed`, `## Removed`, `## Deprecated`, `## Security`. Rules:
+
+- Security entries must link to a CVE or advisory if applicable.
+- Breaking changes: include a note referencing the migration guide.
+- If using automated CHANGELOG tooling (changesets, git-cliff), run the tool and verify its output before committing.
+
+Commit:
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update changelog for v<version>"
+```
+
+**3. Run the release script**
+
+```bash
+npm run release -- --version <version>
+```
+
+The script: checks the working tree is clean, bumps `version` in all four `package.json` files and five source-file `VERSION` constants, pins inter-package dependency ranges, runs `npm run build`, publishes each package with `npm publish --access public` in dependency order, restores workspace dependency ranges, stages the changed files, commits with `chore: release v<version>`, and creates the git tag `v<version>`. If any step fails, the script exits without creating the commit or tag — fix the issue and re-run.
+
+**4. Push and open a PR**
+
+```bash
+git push -u origin release/v<version>
+```
+
+Open a PR to `main`. Select **merge commit** (not squash) — the release commit must exist as an ancestor of `main` for the tag to be reachable from `main`'s history. Merge after CI passes.
+
+**5. Push the tag**
+
+After the PR is merged:
+
+```bash
+git switch main && git pull
+git push --tags
+```
+
+**6. Verify the published artifact**
+
+Install the package in a clean environment and confirm the minimal working example from the README runs correctly:
+
+```bash
+mkdir /tmp/test-install && cd /tmp/test-install
+npm init -y
+npm install @sensigo/realm@<version>
+node -e "<minimal working example from README>"
+```
+
+If `publishConfig.registry` is set on the package, add `--registry <registry-url>` to the install command.
+
+**7. Rollback note**
+
+If step 3 (`npm run release`) fails before completing, no commit or tag has been created. Fix the issue and re-run from step 3.
+
+If a publish error occurs after some packages are already published but before all four complete: the script exits. Identify which packages were published, fix the issue (credentials, registry, network), and re-run `npm run release` — `npm publish` will skip packages already at the target version with a `409 conflict` or `EPUBLISHCONFLICT` error. Confirm all four packages appear on the registry before proceeding.
+
+If the tag was pushed but verification (step 6) reveals a broken artifact: publish a patch release following this entire Part B sequence with an incremented patch version.
+
+---
+
+## Naming Consistency
+
+_(Review these before running the build in Part B step 3. For projects with fully configured linting, passing Automated Checks §2 satisfies most of these items.)_
+
+- File names follow a single consistent convention throughout the project (pick one: camelCase, kebab-case, snake_case)
+- Types and classes are PascalCase
+- Functions and variables are camelCase or snake_case — consistently, not mixed
+- Constants are UPPER_SNAKE_CASE
+- No single-letter variable names outside of loop indices and obvious lambda shorthand
+- Equivalent concepts use the same name everywhere — no `opts` vs `options`, `handler` vs `callback` for the same pattern
+
+## Code Consistency
+
+_(Review these before running the build in Part B step 3. For projects with fully configured linting, passing Automated Checks §2 satisfies most of these items.)_
+
+- Consistent quote style (single or double — pick one)
+- Consistent semicolons (all or none)
+- Consistent indentation and spacing
+- Consistent brace and bracket style
+- Same patterns used for the same operations — no mixing paradigms without a documented reason
+- Error handling follows a uniform pattern across all similar components
+
+---
+
+## Agent Instructions
+
+**Part A**
+
+- Do not refactor architecture during a publication pass. Structure is intentional. This is a cleanup pass.
+- Do not add new features. If you find something worth improving, note it but do not implement it.
+- Do not change public API signatures without explicit instruction.
+- If you find a genuine bug, fix it and document what you fixed and why.
+
+**Part B**
+
+- Treat each numbered step as a hard gate. Do not proceed to the next step until the current step has completed successfully.
+- Do not run `npm run release` directly on `main`. Always use a `release/v<version>` branch.
+- Do not create git tags manually. The release script creates the tag after a successful publish.

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ plans/
 .github/agents/marketing-god.agent.md
 .github/agents/peer-architect.agent.md
 .github/agents/design-reviewer.agent.md
-.github/instructions/pre-publication.instructions.md
 .github/instructions/project-info-prompt.md
 
 # Dependencies


### PR DESCRIPTION
## Context

The workflow instruction files in `.github/instructions/` contained hardcoded references to a previous organisation (`187n`) and project-specific examples that made them unsuitable for general use. `pre-publication.instructions.md` was also unnecessarily gitignored, preventing it from being shared as workspace context.

## Motivation

These files serve as the authoritative policy for every agent and contributor working in this repo. They are picked up automatically by GitHub Copilot as workspace instructions. They must be repo-agnostic so they apply correctly regardless of context and can be published alongside the codebase.

## Changes

### `git-workflow.instructions.md` (new file)
- Removed hardcoded 187n repo/reviewer table; replaced with a general rule covering every repository
- Renamed `{client}` segment to `{scope}` with a note that scope = client name in client-services work
- Expanded branch naming table with all standard types: `hotfix/`, `docs/`, `refactor/`, `perf/`, `test/`, `ci/`, `security/`, `revert/`
- Renamed AI agent branch prefix from `claude/` to `agent/` (vendor-neutral)
- Added full **Commit Messages** section (Conventional Commits v1.0.0) — was completely absent
- Added **Branch Lifecycle** section: branch deletion policy and force-push prohibition
- Added **PR Merge Strategy** section: squash default, conditions for merge/rebase
- Added **Draft PRs** section: when to open draft vs ready-for-review
- Tightened Enforcement for Agents: explicit `--force` prohibition

### `issue-standards.instructions.md` (modified)
- Removed "187n" from the opening scope line
- Replaced Telegram-specific title examples with generic ones
- Replaced project-specific acceptance criteria examples (TELEGRAM_ALLOWED_USERS, buildCustomerRow) with generic verifiable examples
- Replaced "Supabase rows, Whop dashboard entries" in Related section with generic link guidance

### `pr-standards.instructions.md` (new file)
- Removed "187n" from the opening scope line
- Added `ci` and `security` types to the PR title type table (were in git-workflow but absent here)
- Replaced `fix(cs3_runner)` scope example with generic `fix(auth)`
- Replaced "client name / quoted client communication" in Context section with generic equivalents
- Replaced "Airtable API calls" in Rollback section with "external API calls"

### `pre-publication.instructions.md` (new file — previously gitignored)
- Removed from `.gitignore`; no content changes (was already fully generic)

## Verification

```bash
# Confirm no org-specific strings remain
grep -rn "187n\|cs3_runner\|Airtable\|Whop\|Supabase\|telegram\|TELEGRAM\|buildCustomerRow\|paw-parent\|claude/" .github/instructions/
# Expected: no output

# Confirm pre-publication is no longer gitignored
git check-ignore -v .github/instructions/pre-publication.instructions.md
# Expected: no output (file is tracked)
```

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. Full rollback via git revert.
