### PR TITLE
fix(core): propagate dispatch error semantics in Step 5 failure envelope

### DIFF
--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -684,6 +684,86 @@ describe('executeStep', () => {
       expect(adapter.fetch).not.toHaveBeenCalled();
     });
 
+    it('calls adapter.delete() when service_method is delete', async () => {
+      const adapter: ServiceAdapter = {
+        id: 'mock_adapter',
+        fetch: vi.fn().mockResolvedValue({ status: 200, data: {} }),
+        create: vi.fn().mockResolvedValue({ status: 201, data: {} }),
+        update: vi.fn().mockResolvedValue({ status: 200, data: {} }),
+        delete: vi.fn().mockResolvedValue({ status: 204, data: {} }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('adapter', 'mock_adapter', adapter);
+
+      const def: WorkflowDefinition = {
+        ...adapterDefinition,
+        steps: {
+          fetch_data: {
+            ...adapterDefinition.steps['fetch_data']!,
+            service_method: 'delete',
+          },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'adapter-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'fetch_data',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(envelope.status).toBe('ok');
+      expect(adapter.delete).toHaveBeenCalledTimes(1);
+      expect(adapter.fetch).not.toHaveBeenCalled();
+    });
+
+    it('throws ADAPTER_OP_UNSUPPORTED when adapter has no delete method', async () => {
+      const adapter: ServiceAdapter = {
+        id: 'mock_adapter',
+        fetch: vi.fn().mockResolvedValue({ status: 200, data: {} }),
+        create: vi.fn().mockResolvedValue({ status: 201, data: {} }),
+        update: vi.fn().mockResolvedValue({ status: 200, data: {} }),
+        // delete is intentionally absent
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('adapter', 'mock_adapter', adapter);
+
+      const def: WorkflowDefinition = {
+        ...adapterDefinition,
+        steps: {
+          fetch_data: {
+            ...adapterDefinition.steps['fetch_data']!,
+            service_method: 'delete',
+          },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'adapter-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'fetch_data',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(envelope.status).toBe('error');
+      expect(envelope.agent_action).toBe('stop');
+      expect(envelope.errors[0]).toContain("does not support service_method 'delete'");
+    });
+
     it('uses step name as operation when operation field is absent', async () => {
       const adapter = makeAdapter({ ok: true });
       const registry = new ExtensionRegistry();

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -2688,18 +2688,8 @@ describe('Step 5 dispatch-failure envelope', () => {
       params: {},
     });
 
-    // Spy after the run is created so claimStep still works; only store.update throws.
-    const originalUpdate = store.update.bind(store);
-    vi.spyOn(store, 'update').mockImplementation(async (record) => {
-      // Allow claimStep's internal update to succeed (it goes through a file lock path),
-      // but reject the explicit store.update call in Step 5.
-      // Since claimStep uses its own internal mechanism, only the Step 5 store.update
-      // call will hit this spy.
-      void record;
-      throw new Error('disk full');
-    });
-    // Restore original for claimStep path — claimStep doesn't call store.update directly.
-    store.update = originalUpdate;
+    // claimStep uses its own atomic file-lock write and does not call store.update,
+    // so spying on store.update only intercepts the Step 5 store.update(failedRun) call.
     vi.spyOn(store, 'update').mockRejectedValue(new Error('disk full'));
 
     const envelope = await executeStep(store, twoStepDef, {
@@ -2717,6 +2707,7 @@ describe('Step 5 dispatch-failure envelope', () => {
     });
 
     expect(envelope.status).toBe('error');
+    expect(envelope.agent_action).toBe('wait_for_human');
     expect(envelope.next_actions).toHaveLength(0);
     expect(envelope.warnings.some((w) => w.toLowerCase().includes('persist'))).toBe(true);
   });

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -2488,3 +2488,285 @@ describe('WAL trace buffer integration (B-lite)', () => {
     expect(snap?.trace?.[0]?.event).toBe('direct_trace');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Step 5 dispatch-failure envelope — agent_action, next_actions, run_version
+// ---------------------------------------------------------------------------
+
+describe('Step 5 dispatch-failure envelope', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-step5-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  // Two-step workflow: step_a (agent) → step_b (agent, trigger_rule: one_failed).
+  const twoStepDef: WorkflowDefinition = {
+    id: 'two-step-wf',
+    name: 'Two Step Workflow',
+    version: 1,
+    steps: {
+      step_a: {
+        description: 'First step',
+        execution: 'agent',
+        depends_on: [],
+      },
+      step_b: {
+        description: 'Recovery step',
+        execution: 'agent',
+        depends_on: ['step_a'],
+        trigger_rule: 'one_failed',
+      },
+    },
+  };
+
+  it('non-terminal failure with wait_for_human exposes recovery branch', async () => {
+    const run = await store.create({
+      workflowId: 'two-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(store, twoStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('Service unavailable', {
+          code: 'SERVICE_HTTP_5XX',
+          category: 'SERVICE',
+          agentAction: 'wait_for_human',
+          retryable: false,
+        });
+      },
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.agent_action).toBe('wait_for_human');
+    expect(envelope.next_actions.length).toBeGreaterThanOrEqual(1);
+    expect(envelope.next_actions[0]?.instruction.call_with.command).toBe('step_b');
+    expect(
+      envelope.context_hint.toLowerCase().includes('service') ||
+        envelope.context_hint.toLowerCase().includes('recovery'),
+    ).toBe(true);
+  });
+
+  it('non-terminal failure with provide_input is translated to report_to_user and exposes recovery branch', async () => {
+    const run = await store.create({
+      workflowId: 'two-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(store, twoStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('Adapter method not supported', {
+          code: 'ADAPTER_OP_UNSUPPORTED',
+          category: 'SERVICE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      },
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.agent_action).toBe('report_to_user');
+    expect(envelope.next_actions.length).toBeGreaterThanOrEqual(1);
+    expect(envelope.next_actions[0]?.instruction.call_with.command).toBe('step_b');
+  });
+
+  it('non-terminal failure with stop is translated to report_to_user and exposes recovery branch', async () => {
+    const run = await store.create({
+      workflowId: 'two-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(store, twoStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('Authentication failed', {
+          code: 'SERVICE_AUTH_FAILED',
+          category: 'SERVICE',
+          agentAction: 'stop',
+          retryable: false,
+        });
+      },
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.agent_action).toBe('report_to_user');
+    expect(envelope.next_actions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('terminal failure always returns stop with empty next_actions', async () => {
+    // Single-step workflow — no recovery branch possible.
+    const singleStepDef: WorkflowDefinition = {
+      id: 'single-step-wf',
+      name: 'Single Step Workflow',
+      version: 1,
+      steps: {
+        step_a: {
+          description: 'Only step',
+          execution: 'agent',
+          depends_on: [],
+        },
+      },
+    };
+
+    const run = await store.create({
+      workflowId: 'single-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(store, singleStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('Service unavailable', {
+          code: 'SERVICE_HTTP_5XX',
+          category: 'SERVICE',
+          agentAction: 'wait_for_human',
+          retryable: false,
+        });
+      },
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.agent_action).toBe('stop');
+    expect(envelope.next_actions).toHaveLength(0);
+  });
+
+  it('WAL deletion failure does NOT suppress next_actions', async () => {
+    const bufferStore = new InMemoryTraceBufferStore();
+    vi.spyOn(bufferStore, 'delete').mockRejectedValue(new Error('disk contention'));
+
+    const run = await store.create({
+      workflowId: 'two-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(store, twoStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('Service unavailable', {
+          code: 'SERVICE_HTTP_5XX',
+          category: 'SERVICE',
+          agentAction: 'wait_for_human',
+          retryable: false,
+        });
+      },
+      traceBufferStore: bufferStore,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.agent_action).toBe('wait_for_human');
+    expect(envelope.next_actions.length).toBeGreaterThanOrEqual(1);
+    expect(
+      envelope.warnings.some(
+        (w) => w.toLowerCase().includes('trace') || w.toLowerCase().includes('buffer'),
+      ),
+    ).toBe(true);
+  });
+
+  it('store.update failure suppresses next_actions', async () => {
+    const run = await store.create({
+      workflowId: 'two-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    // Spy after the run is created so claimStep still works; only store.update throws.
+    const originalUpdate = store.update.bind(store);
+    vi.spyOn(store, 'update').mockImplementation(async (record) => {
+      // Allow claimStep's internal update to succeed (it goes through a file lock path),
+      // but reject the explicit store.update call in Step 5.
+      // Since claimStep uses its own internal mechanism, only the Step 5 store.update
+      // call will hit this spy.
+      void record;
+      throw new Error('disk full');
+    });
+    // Restore original for claimStep path — claimStep doesn't call store.update directly.
+    store.update = originalUpdate;
+    vi.spyOn(store, 'update').mockRejectedValue(new Error('disk full'));
+
+    const envelope = await executeStep(store, twoStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('Service unavailable', {
+          code: 'SERVICE_HTTP_5XX',
+          category: 'SERVICE',
+          agentAction: 'wait_for_human',
+          retryable: false,
+        });
+      },
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.next_actions).toHaveLength(0);
+    expect(envelope.warnings.some((w) => w.toLowerCase().includes('persist'))).toBe(true);
+  });
+
+  it('run_version reflects persisted version not stale pre-persist version', async () => {
+    const run = await store.create({
+      workflowId: 'single-step-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    // Track the version returned by store.update in Step 5.
+    const originalUpdate = store.update.bind(store);
+    let persistedVersion: number | undefined;
+    vi.spyOn(store, 'update').mockImplementation(async (record) => {
+      const result = await originalUpdate(record);
+      persistedVersion = result.version;
+      return result;
+    });
+
+    const singleStepDef: WorkflowDefinition = {
+      id: 'single-step-wf',
+      name: 'Single Step Workflow',
+      version: 1,
+      steps: {
+        step_a: {
+          description: 'Only step',
+          execution: 'agent',
+          depends_on: [],
+        },
+      },
+    };
+
+    const envelope = await executeStep(store, singleStepDef, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => {
+        throw new WorkflowError('failure', {
+          code: 'ENGINE_HANDLER_FAILED',
+          category: 'ENGINE',
+          agentAction: 'stop',
+          retryable: false,
+        });
+      },
+    });
+
+    expect(envelope.status).toBe('error');
+    // run_version must equal what store.update returned, not the stale pendingRun.version.
+    expect(persistedVersion).toBeDefined();
+    expect(envelope.run_version).toBe(persistedVersion);
+  });
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -11,6 +11,7 @@ import type {
 import type { ToolCallRecord } from '../types/mcp-types.js';
 import type { ResponseEnvelope, NextAction } from '../types/response-envelope.js';
 import { WorkflowError } from '../types/workflow-error.js';
+import type { AgentAction } from '../types/workflow-error.js';
 import type {
   WorkflowDefinition,
   StepDefinition,
@@ -823,51 +824,99 @@ export async function executeStep(
 
   // Step 5: Handle dispatch failure — move step to failed_steps.
   if (dispatchError !== null) {
-    let cleanupWarning: string | undefined;
+    // Pure in-memory derivations — no I/O, no try required.
+    const afterFail: RunRecord = {
+      ...pendingRun,
+      in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
+      failed_steps: [...pendingRun.failed_steps, options.command],
+    };
+    // Propagate skips: mark steps whose trigger_rule can never be satisfied after this failure.
+    const withSkippedFail: RunRecord = {
+      ...afterFail,
+      skipped_steps: propagateSkips(afterFail, definition),
+    };
+    // A run is terminal when all steps are settled OR when no step will ever become
+    // eligible again (safety net for when-condition edge cases not covered by propagateSkips).
+    const isComplete =
+      isWorkflowComplete(withSkippedFail, definition) ||
+      (withSkippedFail.in_progress_steps.length === 0 &&
+        findEligibleSteps(definition, withSkippedFail).length === 0);
+    const failedRun: RunRecord = {
+      ...withSkippedFail,
+      evidence: [...pendingRun.evidence, ...allEvidence],
+      terminal_state: isComplete,
+      ...(isComplete
+        ? { terminal_reason: `Step '${options.command}' failed: ${dispatchError.message}` }
+        : {}),
+    };
+
+    // Persist run state and WAL cleanup in separate try/catch blocks so a WAL deletion
+    // failure does not mask a successful store.update.
+    let persistedRun: RunRecord | undefined;
+    let storeCleanupWarning: string | undefined;
     try {
-      // Build the hypothetical run state after marking this step as failed.
-      const afterFail: RunRecord = {
-        ...pendingRun,
-        in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
-        failed_steps: [...pendingRun.failed_steps, options.command],
-      };
-      // Propagate skips: mark steps whose trigger_rule can never be satisfied after this failure.
-      const withSkippedFail: RunRecord = {
-        ...afterFail,
-        skipped_steps: propagateSkips(afterFail, definition),
-      };
-      // A run is terminal when all steps are settled OR when no step will ever become
-      // eligible again (safety net for when-condition edge cases not covered by propagateSkips).
-      const isComplete =
-        isWorkflowComplete(withSkippedFail, definition) ||
-        (withSkippedFail.in_progress_steps.length === 0 &&
-          findEligibleSteps(definition, withSkippedFail).length === 0);
-      const failedRun: RunRecord = {
-        ...withSkippedFail,
-        evidence: [...pendingRun.evidence, ...allEvidence],
-        terminal_state: isComplete,
-        ...(isComplete
-          ? { terminal_reason: `Step '${options.command}' failed: ${dispatchError.message}` }
-          : {}),
-      };
-      await store.update(failedRun);
+      persistedRun = await store.update(failedRun);
+    } catch (storeErr) {
+      storeCleanupWarning = `Failed to persist step failure: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
+    }
+    let walCleanupWarning: string | undefined;
+    try {
       // Delete WAL after run state is written for failure — entries are now in evidence.
       await options.traceBufferStore?.delete(options.runId, options.command);
-    } catch (cleanupErr) {
-      cleanupWarning = `Failed to persist step failure: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`;
+    } catch (walErr) {
+      walCleanupWarning = `Failed to clean up trace buffer after step failure: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
     }
+
+    // Derive the agent_action from the error semantics and run termination state.
+    //
+    // Non-terminal 'stop' errors (e.g. auth failure with a recovery branch) are surfaced
+    // as 'report_to_user' so the agent knows recovery steps are available. Terminal runs
+    // stay 'stop' — no further progress is possible.
+    //
+    // 'provide_input' and 'resolve_precondition' both imply "retry the same command" which
+    // is impossible once a step is in failed_steps; translate both to 'report_to_user'.
+    const rawAction: AgentAction = isComplete
+      ? 'stop'
+      : dispatchError.agentAction === 'stop'
+        ? 'report_to_user'
+        : dispatchError.agentAction;
+    const effectiveAction: AgentAction =
+      rawAction === 'provide_input'
+        ? 'report_to_user'
+        : rawAction === 'resolve_precondition'
+          ? 'report_to_user'
+          : rawAction;
+
+    // Mirror makeErrorEnvelope: populate next_actions for any action other than 'stop',
+    // but only when store.update succeeded (inconsistent state → no reliable next_actions).
+    let nextActions: NextAction[] = [];
+    if (effectiveAction !== 'stop' && storeCleanupWarning === undefined) {
+      try {
+        nextActions = buildNextActions(definition, persistedRun ?? failedRun);
+      } catch {
+        // buildNextActions can throw for unresolvable template references; fall back to [].
+      }
+    }
+
+    const contextHint =
+      effectiveAction === 'stop'
+        ? `Step '${options.command}' failed. Run is terminated.`
+        : effectiveAction === 'wait_for_human'
+          ? `Step '${options.command}' failed due to external service unavailability. Wait for service recovery, then proceed with the steps in next_actions.`
+          : `Step '${options.command}' failed. ${isComplete ? 'Run is terminated.' : 'Recovery steps are available in next_actions.'}`;
+
     return {
       command: options.command,
       run_id: options.runId,
-      run_version: pendingRun.version,
+      run_version: (persistedRun ?? failedRun).version,
       status: 'error',
       data: {},
       evidence: allEvidence,
-      warnings: mergeWarnings(traceWarnings, cleanupWarning),
+      warnings: mergeWarnings(traceWarnings, storeCleanupWarning ?? walCleanupWarning),
       errors: [dispatchError.message],
-      agent_action: 'stop' as const,
-      context_hint: `Step '${options.command}' failed.`,
-      next_actions: [],
+      agent_action: effectiveAction,
+      context_hint: contextHint,
+      next_actions: nextActions,
     };
   }
 

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -31,7 +31,7 @@ import { TERMINAL_PHASES } from './lifecycle.js';
 import { checkPreconditions, evaluateAllPreconditions } from './precondition.js';
 import { ExtensionRegistry } from '../extensions/registry.js';
 import { createDefaultRegistry } from '../extensions/default-registry.js';
-import type { ServiceResponse } from '../extensions/service-adapter.js';
+import type { ServiceAdapter, ServiceResponse } from '../extensions/service-adapter.js';
 import { resolveSecret } from '../config/secrets.js';
 import { renderTemplate, resolvePath, UnknownFilterError } from './render-template.js';
 import { generateSchemaSkeleton } from '../utils/schema-skeleton.js';
@@ -227,9 +227,31 @@ async function callAdapter(
   const operation = stepDef.operation ?? options.command;
 
   const adapterParams = resolveInputMap(stepDef.input_map, options, pendingRun);
+
+  // Guard: `delete` is optional on ServiceAdapter. If the adapter omits it, surface
+  // ADAPTER_OP_UNSUPPORTED rather than allowing a TypeError from an undefined call.
+  const adapterMethod = adapter[method as keyof ServiceAdapter];
+  if (typeof adapterMethod !== 'function') {
+    throw new WorkflowError(
+      `Adapter '${serviceDef.adapter}' does not support service_method '${method}'`,
+      {
+        code: 'ADAPTER_OP_UNSUPPORTED',
+        category: 'ENGINE',
+        agentAction: 'provide_input',
+        retryable: false,
+      },
+    );
+  }
+
   let response: ServiceResponse;
   try {
-    response = await adapter[method](operation, adapterParams, config, signal);
+    response = await (adapterMethod as ServiceAdapter['fetch']).call(
+      adapter,
+      operation,
+      adapterParams,
+      config,
+      signal,
+    );
   } catch (err) {
     if (err instanceof WorkflowError) throw err;
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/extensions/service-adapter.ts
+++ b/packages/core/src/extensions/service-adapter.ts
@@ -11,6 +11,14 @@ export interface ServiceResponse {
  * Implementors that perform multi-step operations (paginated fetch, multi-part upload,
  * sequential writes) must check `signal?.aborted` between steps and throw if true.
  * Passing the signal to native `fetch()` handles single-request cancellation automatically.
+ *
+ * Method semantics:
+ * - `fetch`  — read or query; must be safe and idempotent.
+ * - `create` — write a new resource; may be non-idempotent.
+ * - `update` — mutate an existing resource; typically idempotent when addressed by ID.
+ * - `delete` — remove an existing resource. Optional: only implement when the adapter
+ *              supports deletion. The engine throws `ADAPTER_OP_UNSUPPORTED` if a workflow
+ *              step requests `service_method: delete` but the adapter omits this method.
  */
 export interface ServiceAdapter {
   readonly id: string;
@@ -27,6 +35,12 @@ export interface ServiceAdapter {
     signal?: AbortSignal,
   ): Promise<ServiceResponse>;
   update(
+    operation: string,
+    params: Record<string, unknown>,
+    config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse>;
+  delete?(
     operation: string,
     params: Record<string, unknown>,
     config: Record<string, unknown>,

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -85,7 +85,7 @@ export interface StepDefinition {
    * Which adapter method to invoke for this service step.
    * Defaults to 'fetch' if omitted.
    */
-  service_method?: 'fetch' | 'create' | 'update';
+  service_method?: 'fetch' | 'create' | 'update' | 'delete';
   /**
    * Operation name passed as the first argument to the adapter method.
    * Defaults to the step name if omitted.

--- a/packages/core/src/workflow/yaml-loader.test.ts
+++ b/packages/core/src/workflow/yaml-loader.test.ts
@@ -69,6 +69,14 @@ describe('loadWorkflowFromString', () => {
     }
   });
 
+  it('accepts service_method: delete without throwing', () => {
+    const content = VALID_YAML.replace(
+      'depends_on: []',
+      'depends_on: []\n    service_method: delete',
+    );
+    expect(() => loadWorkflowFromString(content)).not.toThrow();
+  });
+
   it('preserves step config block in parsed definition', () => {
     const yaml = `
 id: cfg-test

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -15,7 +15,7 @@ import { resolveTemplates } from './template-resolver.js';
 export const CURRENT_WORKFLOW_SCHEMA_VERSION = 1;
 
 const VALID_EXECUTIONS = new Set(['auto', 'agent']);
-const VALID_SERVICE_METHODS = new Set(['fetch', 'create', 'update']);
+const VALID_SERVICE_METHODS = new Set(['fetch', 'create', 'update', 'delete']);
 const VALID_TRIGGER_RULES = new Set<TriggerRule>([
   'all_success',
   'all_failed',
@@ -296,7 +296,7 @@ export function loadWorkflowFromString(content: string): WorkflowDefinition {
 
     if ('service_method' in step && !VALID_SERVICE_METHODS.has(step['service_method'] as string)) {
       errors.push(
-        `Step '${stepName}': invalid service_method '${String(step['service_method'])}'; must be 'fetch', 'create', or 'update'`,
+        `Step '${stepName}': invalid service_method '${String(step['service_method'])}'; must be 'fetch', 'create', 'update', or 'delete'`,
       );
     }
 


### PR DESCRIPTION
## Context

Raised as a design question in the `feat(core): add optional delete method to ServiceAdapter` task (report: `reports/feat-core-service-adapter-delete.md`). The Step 5 dispatch-failure path in `executeStep` hardcoded `agent_action: 'stop'` and `next_actions: []` regardless of the error's `agentAction` or whether recovery branches were available. This made the engine unable to guide the agent to recovery steps after a non-terminal adapter failure (e.g. a `trigger_rule: one_failed` branch that should become available after a service auth failure).

## Root Cause

In `packages/core/src/engine/execution-loop.ts`, the Step 5 block (lines ~824–873) had three correctness issues and one structural issue:

1. `agent_action: 'stop' as const` was hardcoded — the actual `dispatchError.agentAction` was ignored.
2. `next_actions: []` was hardcoded — `buildNextActions` was never called, so recovery branches never appeared.
3. `run_version: pendingRun.version` used the stale pre-persist version instead of the version returned by `store.update`.
4. All derivations (pure in-memory) and both I/O operations (`store.update` + `traceBufferStore.delete`) were in a single try/catch, meaning a WAL deletion failure would incorrectly set `cleanupWarning` and suppress `next_actions`.

## Changes

### `packages/core/src/engine/execution-loop.ts`

- Added `import type { AgentAction }` from `workflow-error.ts` (needed for explicit type annotations on `rawAction`/`effectiveAction`).
- Replaced the Step 5 block with a corrected version:
  - Pure in-memory derivations (`afterFail`, `withSkippedFail`, `isComplete`, `failedRun`) moved outside the try block.
  - `store.update` and `traceBufferStore.delete` placed in separate try/catch blocks (`storeCleanupWarning` vs `walCleanupWarning`).
  - `persistedRun = await store.update(failedRun)` captures the returned record for its updated version.
  - `agent_action` derived from `dispatchError.agentAction` with two translation rules:
    - Terminal run → always `'stop'`.
    - Non-terminal `'stop'` → `'report_to_user'` (recovery steps are available but the original command cannot be retried).
    - `'provide_input'` / `'resolve_precondition'` → `'report_to_user'` (both imply retrying the failed step, which is in `failed_steps` and cannot be reclaimed).
  - `next_actions` populated via `buildNextActions` when `effectiveAction !== 'stop'` and `storeCleanupWarning === undefined` (store failure → inconsistent state → no reliable recovery guidance).
  - `run_version` uses `(persistedRun ?? failedRun).version` — the persisted version when available, in-memory fallback on store error.
  - `context_hint` is now action-appropriate (three variants: terminal stop, wait_for_human, general recovery).

### `packages/core/src/engine/execution-loop.test.ts`

New `describe('Step 5 dispatch-failure envelope', ...)` block with 7 tests:

1. `wait_for_human` non-terminal failure → `agent_action: 'wait_for_human'`, `next_actions` contains `step_b`.
2. `provide_input` non-terminal failure → translated to `agent_action: 'report_to_user'`, `next_actions` populated.
3. `stop` non-terminal failure → translated to `agent_action: 'report_to_user'`, `next_actions` populated.
4. Terminal failure (single-step) → `agent_action: 'stop'`, `next_actions: []`.
5. WAL deletion failure → `next_actions` still populated; warning contains 'trace'/'buffer'.
6. `store.update` failure → `next_actions: []`; warning contains 'persist'.
7. `run_version` correctness → `envelope.run_version` equals the version returned by `store.update`.

## Verification

```bash
cd /home/mihai/code/realm
npx tsc --noEmit -p packages/core/tsconfig.json  # zero output (clean)
npx vitest run                                     # 77 files, 1242 passed, 2 skipped
```

Baseline before this PR: 1235 tests. After: 1242 tests (+7 new).

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. Pure logic change in `execution-loop.ts`.

## Related

- Design question from `reports/feat-core-service-adapter-delete.md`
- Precedes this commit: `feat(core): add optional delete method to ServiceAdapter` (same branch)
