### PR TITLE
fix(mcp): propagate WorkflowError.agentAction in outer catch handlers

### DIFF
--- a/packages/mcp-server/src/tools/create-workflow.ts
+++ b/packages/mcp-server/src/tools/create-workflow.ts
@@ -5,6 +5,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   JsonWorkflowStore,
   JsonFileStore,
+  WorkflowError,
   type WorkflowDefinition,
   type ResponseEnvelope,
   type JsonSchema,
@@ -257,6 +258,7 @@ export function registerCreateWorkflow(server: McpServer, opts?: HandleRunStores
           ],
         };
       } catch (err) {
+        const agentAction = err instanceof WorkflowError ? err.agentAction : 'report_to_user';
         const message = err instanceof Error ? err.message : String(err);
         return {
           content: [
@@ -271,9 +273,9 @@ export function registerCreateWorkflow(server: McpServer, opts?: HandleRunStores
                   evidence: [],
                   warnings: [],
                   errors: [message],
-                  agent_action: 'stop',
+                  agent_action: agentAction,
                   context_hint: 'Unexpected error during create_workflow.',
-                  next_action: null,
+                  next_actions: [],
                 },
                 null,
                 2,

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -5,6 +5,7 @@ import {
   JsonWorkflowStore,
   JsonFileStore,
   executeChain,
+  WorkflowError,
   type StepDispatcher,
   type ResponseEnvelope,
   type AgentTraceEntry,
@@ -85,6 +86,7 @@ export async function handleExecuteStepTool(
       ],
     };
   } catch (err) {
+    const agentAction = err instanceof WorkflowError ? err.agentAction : 'report_to_user';
     const message = err instanceof Error ? err.message : String(err);
     return {
       content: [
@@ -100,7 +102,7 @@ export async function handleExecuteStepTool(
               evidence: [],
               warnings: [],
               errors: [message],
-              agent_action: 'stop',
+              agent_action: agentAction,
               context_hint: `Error executing step '${args.command}' for run '${args.run_id}'.`,
               next_actions: [],
             },

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -1,7 +1,7 @@
 // get-run-state tool — returns the current state summary of a run.
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { JsonFileStore, type RunPhase } from '@sensigo/realm';
+import { JsonFileStore, WorkflowError, type RunPhase } from '@sensigo/realm';
 
 export interface HandleRunStateStores {
   runStore?: JsonFileStore;
@@ -64,6 +64,7 @@ export function registerGetRunState(server: McpServer, opts?: HandleRunStateStor
         const result = await handleGetRunState(args, opts);
         return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
+        const agentAction = err instanceof WorkflowError ? err.agentAction : 'report_to_user';
         const message = err instanceof Error ? err.message : String(err);
         return {
           content: [
@@ -78,7 +79,7 @@ export function registerGetRunState(server: McpServer, opts?: HandleRunStateStor
                   evidence: [],
                   warnings: [],
                   errors: [message],
-                  agent_action: 'stop',
+                  agent_action: agentAction,
                   context_hint: `Error retrieving state for run '${args.run_id}'.`,
                   next_actions: [],
                 },

--- a/packages/mcp-server/src/tools/mcp-tools.test.ts
+++ b/packages/mcp-server/src/tools/mcp-tools.test.ts
@@ -287,12 +287,46 @@ describe('mcp tool handlers', () => {
 
     const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
     expect(parsed['status']).toBe('error');
-    expect(parsed['agent_action']).toBe('stop');
+    expect(parsed['agent_action']).toBe('report_to_user');
     expect(Array.isArray(parsed['next_actions'])).toBe(true);
     expect((parsed['next_actions'] as unknown[]).length).toBe(0);
     expect((parsed['errors'] as string[])[0]).toContain('unexpected failure');
     expect(parsed['run_id']).toBe('test-run');
     expect(parsed['command']).toBe('review_security');
+  });
+
+  it('handleExecuteStepTool propagates WorkflowError.agentAction to MCP response', async () => {
+    const { WorkflowError } = await import('@sensigo/realm');
+
+    const throwingOpts = {
+      runStore: {
+        get: async () => {
+          throw new WorkflowError('Run not found: unknown-run', {
+            code: 'STATE_RUN_NOT_FOUND',
+            category: 'STATE',
+            agentAction: 'report_to_user',
+            retryable: false,
+          });
+        },
+        create: async () => {
+          throw new Error('should not be called');
+        },
+        update: async () => {
+          throw new Error('should not be called');
+        },
+        list: async () => [],
+      } as unknown as JsonFileStore,
+    };
+
+    const result = await handleExecuteStepTool(
+      { run_id: 'unknown-run', command: 'some_step' },
+      throwingOpts,
+    );
+
+    const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    expect(parsed['agent_action']).toBe('report_to_user');
+    expect((parsed['errors'] as string[])[0]).toContain('Run not found');
   });
 
   it('handleGetRunState returns run summary', async () => {

--- a/packages/mcp-server/src/tools/start-run.ts
+++ b/packages/mcp-server/src/tools/start-run.ts
@@ -7,6 +7,7 @@ import {
   executeChain,
   buildNextActions,
   findEligibleSteps,
+  WorkflowError,
   type StepDispatcher,
   type ResponseEnvelope,
   type TraceBufferStore,
@@ -105,6 +106,7 @@ export function registerStartRun(
           ],
         };
       } catch (err) {
+        const agentAction = err instanceof WorkflowError ? err.agentAction : 'report_to_user';
         const message = err instanceof Error ? err.message : String(err);
         return {
           content: [
@@ -120,7 +122,7 @@ export function registerStartRun(
                   evidence: [],
                   warnings: [],
                   errors: [message],
-                  agent_action: 'stop',
+                  agent_action: agentAction,
                   context_hint: `Error creating run for workflow '${args.workflow_id}'.`,
                   next_actions: [],
                 },

--- a/packages/mcp-server/src/tools/submit-human-response.ts
+++ b/packages/mcp-server/src/tools/submit-human-response.ts
@@ -5,6 +5,7 @@ import {
   JsonWorkflowStore,
   JsonFileStore,
   submitHumanResponse,
+  WorkflowError,
   type ResponseEnvelope,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
@@ -51,6 +52,7 @@ export function registerSubmitHumanResponse(server: McpServer, opts?: HandleRunS
           ],
         };
       } catch (err) {
+        const agentAction = err instanceof WorkflowError ? err.agentAction : 'report_to_user';
         const message = err instanceof Error ? err.message : String(err);
         return {
           content: [
@@ -66,7 +68,7 @@ export function registerSubmitHumanResponse(server: McpServer, opts?: HandleRunS
                   evidence: [],
                   warnings: [],
                   errors: [message],
-                  agent_action: 'stop',
+                  agent_action: agentAction,
                   context_hint: `Error submitting response for run '${args.run_id}'.`,
                   next_actions: [],
                 },


### PR DESCRIPTION
## Context

Five MCP tool catch handlers — `execute-step.ts`, `submit-human-response.ts`, `start-run.ts`, `get-run-state.ts`, and `create-workflow.ts` — hardcoded `agent_action: 'stop'` for all exceptions thrown by their inner business-logic functions. When the inner function throws a `WorkflowError` carrying a specific `agentAction` (e.g., `'report_to_user'` when a run is not found), that value was silently discarded. The agent received `'stop'` and terminated, when the correct behaviour was to report the error and let the agent decide how to proceed.

Discovered during code review of the MCP server layer while verifying error propagation paths.

## Root Cause

The five catch blocks checked only `err instanceof Error` to extract the message, but never checked `err instanceof WorkflowError` to extract `agentAction`. All five fell through to the hardcoded `'stop'` string.

Additionally, `create-workflow.ts` had a typo in the error envelope: `next_action: null` (singular, missing the `s`) instead of `next_actions: []`.

## Changes

### `packages/mcp-server/src/tools/execute-step.ts`
- Added `WorkflowError` to the `@sensigo/realm` import.
- Catch block: `agent_action` now derived as `err instanceof WorkflowError ? err.agentAction : 'report_to_user'`.

### `packages/mcp-server/src/tools/submit-human-response.ts`
- Added `WorkflowError` to the `@sensigo/realm` import.
- Same catch block fix.

### `packages/mcp-server/src/tools/start-run.ts`
- Added `WorkflowError` to the `@sensigo/realm` import.
- Same catch block fix.

### `packages/mcp-server/src/tools/get-run-state.ts`
- Added `WorkflowError` to the `@sensigo/realm` import.
- Same catch block fix.

### `packages/mcp-server/src/tools/create-workflow.ts`
- Added `WorkflowError` to the `@sensigo/realm` import.
- Same catch block fix.
- Fixed typo: `next_action: null` → `next_actions: []`.

### `packages/mcp-server/src/tools/mcp-tools.test.ts`
- Updated existing `'handleExecuteStepTool returns structured JSON on unexpected catch'` assertion: plain `Error` now falls back to `'report_to_user'`, not `'stop'`.
- Added new test `'handleExecuteStepTool propagates WorkflowError.agentAction to MCP response'`: verifies that when `runStore.get` throws a `WorkflowError` with `agentAction: 'report_to_user'`, that value reaches the MCP response.

## Verification

```bash
cd /home/mihai/code/realm
npx tsc --noEmit -p packages/mcp-server/tsconfig.json
# (no output — clean)

npx vitest run packages/mcp-server 2>&1 | tail -10
# Test Files  5 passed (5)
#      Tests  45 passed (45)

npx vitest run 2>&1 | tail -5
# Test Files  77 passed (77)
#      Tests  1243 passed | 2 skipped (1245)
```

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. A straight revert is sufficient.
