### PR TITLE
docs: document deterministic workflow ID semantics in create_workflow instructions

### DIFF
--- a/.github/instructions/realm-create-workflow.instructions.md
+++ b/.github/instructions/realm-create-workflow.instructions.md
@@ -208,6 +208,17 @@ already started — check `next_actions` immediately and proceed to `execute_ste
 }
 ```
 
+**`data.workflow_id` is deterministic.** The ID is derived from a SHA-256 hash of the
+workflow definition content (steps, schemas, metadata). Calling `create_workflow` twice with
+identical arguments produces the same `workflow_id` and overwrites the previously registered
+definition — the file store is idempotent by overwrite. This means retrying a failed
+`create_workflow` call is safe: you will get back the same workflow ID.
+
+However, any change to the definition — including a corrected typo in a step description —
+produces a different hash and therefore a different `workflow_id`. This is intentional: a
+different definition is a different workflow. Do not rely on the ID being stable across
+definition changes.
+
 Call `execute_step` using `instruction.call_with` as the template — fill in your step output
 in `params` (shaped to `next_actions[0].input_schema` if present). The engine does not require
 a `run_version` argument — it reads the current version from the store automatically.


### PR DESCRIPTION
## Context

Design debate and review of `fix/core/error-resolution-contract` (PR #21) surfaced a
documentation gap: the `create_workflow` instructions file did not explain that workflow IDs
are deterministic (content-hash-based). An agent encountering the same `workflow_id` on retry
would not know whether to expect the same ID or a new one.

## Motivation

`create_workflow` now derives its `workflow_id` from a SHA-256 hash of the definition content.
This makes retries safe and idempotent — the same arguments always produce the same ID. But it
also means any change to the definition (including a typo correction) produces a new ID and a
new registered workflow. Agents reading the instructions had no way to know either of these
properties.

## Changes

Added a `data.workflow_id` is deterministic paragraph to the "After Calling create_workflow"
section of `realm-create-workflow.instructions.md`, immediately after the response code block
where `workflow_id` first appears. Covers:

- Retry safety: same args → same ID → file-store overwrite is idempotent
- Mutation sensitivity: any definition change → different hash → different workflow ID
- Explicit guidance not to rely on ID stability across definition changes

## Verification

Read `realm-create-workflow.instructions.md` — the new paragraph appears between the JSON
response example and the `Call execute_step...` sentence.

```bash
grep -A12 "data.workflow_id.*is deterministic" \
  .github/instructions/realm-create-workflow.instructions.md
```

## Rollback

```bash
git revert HEAD
```

No runtime changes — documentation only.
