### PR TITLE
fix(core): correct agentAction on ADAPTER_OP_UNSUPPORTED + MCP step5 tests

### DIFF
--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -342,7 +342,7 @@ export class AirtableAdapter implements ServiceAdapter {
     throw new WorkflowError(`AirtableAdapter: unsupported fetch operation "${operation}"`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
-      agentAction: 'provide_input',
+      agentAction: 'report_to_user',
       retryable: false,
     });
   }
@@ -419,7 +419,7 @@ export class AirtableAdapter implements ServiceAdapter {
     throw new WorkflowError(`AirtableAdapter: unsupported create operation "${operation}"`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
-      agentAction: 'provide_input',
+      agentAction: 'report_to_user',
       retryable: false,
     });
   }
@@ -526,7 +526,7 @@ export class AirtableAdapter implements ServiceAdapter {
     throw new WorkflowError(`AirtableAdapter: unsupported update operation "${operation}"`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
-      agentAction: 'provide_input',
+      agentAction: 'report_to_user',
       retryable: false,
     });
   }

--- a/packages/core/src/adapters/parcelpanel-adapter.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.ts
@@ -324,7 +324,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
-      agentAction: 'provide_input',
+      agentAction: 'report_to_user',
       retryable: false,
     });
   }
@@ -338,7 +338,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
-      agentAction: 'provide_input',
+      agentAction: 'report_to_user',
       retryable: false,
     });
   }
@@ -352,7 +352,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
-      agentAction: 'provide_input',
+      agentAction: 'report_to_user',
       retryable: false,
     });
   }

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -241,7 +241,7 @@ async function callAdapter(
       {
         code: 'ADAPTER_OP_UNSUPPORTED',
         category: 'ENGINE',
-        agentAction: 'provide_input',
+        agentAction: 'report_to_user',
         retryable: false,
       },
     );

--- a/packages/mcp-server/src/tools/mcp-tools.test.ts
+++ b/packages/mcp-server/src/tools/mcp-tools.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { JsonFileStore, JsonWorkflowStore } from '@sensigo/realm';
-import type { WorkflowDefinition } from '@sensigo/realm';
+import { JsonFileStore, JsonWorkflowStore, WorkflowError, ExtensionRegistry } from '@sensigo/realm';
+import type { WorkflowDefinition, ServiceAdapter } from '@sensigo/realm';
 import { CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
 import { handleListWorkflows } from './list-workflows.js';
 import { handleGetWorkflowProtocol } from './get-workflow-protocol.js';
@@ -442,5 +442,169 @@ describe('mcp tool handlers', () => {
 
     const run = await runStore.get(result.run_id);
     expect(run.run_phase).toBe('completed');
+  });
+
+  // ---
+  // Step 5 dispatch-failure integration tests — verify agent_action in the serialised
+  // MCP JSON response when a service adapter throws during auto-step execution.
+  // ---
+
+  /** Single-step service workflow — run becomes terminal on failure (no recovery step). */
+  function makeSingleServiceDef(): WorkflowDefinition {
+    return {
+      id: 'single-service-wf',
+      name: 'Single Service Workflow',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      services: { svc: { adapter: 'mock_throwing' } },
+      steps: {
+        call_api: {
+          description: 'Service call',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+        },
+      },
+    };
+  }
+
+  /**
+   * Two-step service workflow: auto service step + agent recovery step.
+   * When `call_api` fails, `recover` becomes eligible via `trigger_rule: 'one_failed'`.
+   * The run is therefore non-terminal after the failure.
+   */
+  function makeTwoStepServiceDef(): WorkflowDefinition {
+    return {
+      id: 'two-step-service-wf',
+      name: 'Two Step Service Workflow',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      services: { svc: { adapter: 'mock_throwing' } },
+      steps: {
+        call_api: {
+          description: 'Service call',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+        },
+        recover: {
+          description: 'Recovery step — runs when call_api fails',
+          execution: 'agent',
+          depends_on: ['call_api'],
+          trigger_rule: 'one_failed',
+        },
+      },
+    };
+  }
+
+  /** Returns a ServiceAdapter whose fetch/create/update all throw the given WorkflowError. */
+  function makeThrowingAdapter(err: WorkflowError): ServiceAdapter {
+    return {
+      id: 'mock_throwing',
+      fetch: async () => {
+        throw err;
+      },
+      create: async () => {
+        throw err;
+      },
+      update: async () => {
+        throw err;
+      },
+    };
+  }
+
+  it('Step 5 dispatch failure: terminal run → agent_action: stop in MCP response', async () => {
+    const adapterErr = new WorkflowError('Mock adapter failure', {
+      code: 'SERVICE_UNAVAILABLE',
+      category: 'SERVICE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock_throwing', makeThrowingAdapter(adapterErr));
+
+    const workflowStore = new JsonWorkflowStore(workflowDir);
+    await workflowStore.register(makeSingleServiceDef());
+    const runStore = new JsonFileStore(runDir);
+    const run = await runStore.create({
+      workflowId: 'single-service-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const result = await handleExecuteStepTool(
+      { run_id: run.id, command: 'call_api' },
+      { runStore, workflowStore, registry },
+    );
+
+    const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    // Terminal run: resolvePostDispatchAgentAction always returns 'stop'.
+    expect(parsed['agent_action']).toBe('stop');
+    expect(Array.isArray(parsed['next_actions'])).toBe(true);
+    expect((parsed['next_actions'] as unknown[]).length).toBe(0);
+  });
+
+  it('Step 5 dispatch failure: non-terminal run, report_to_user error → agent_action: report_to_user with next_actions', async () => {
+    const adapterErr = new WorkflowError('Mock adapter failure', {
+      code: 'SERVICE_UNAVAILABLE',
+      category: 'SERVICE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock_throwing', makeThrowingAdapter(adapterErr));
+
+    const workflowStore = new JsonWorkflowStore(workflowDir);
+    await workflowStore.register(makeTwoStepServiceDef());
+    const runStore = new JsonFileStore(runDir);
+    const run = await runStore.create({
+      workflowId: 'two-step-service-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const result = await handleExecuteStepTool(
+      { run_id: run.id, command: 'call_api' },
+      { runStore, workflowStore, registry },
+    );
+
+    const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    // Non-terminal run, report_to_user passes through.
+    expect(parsed['agent_action']).toBe('report_to_user');
+    // Recovery step is eligible — next_actions must be non-empty.
+    expect(Array.isArray(parsed['next_actions'])).toBe(true);
+    expect((parsed['next_actions'] as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('Step 5 dispatch failure: non-terminal run, wait_for_human error → agent_action: wait_for_human', async () => {
+    const adapterErr = new WorkflowError('Mock adapter temporarily unavailable', {
+      code: 'SERVICE_UNAVAILABLE',
+      category: 'SERVICE',
+      agentAction: 'wait_for_human',
+      retryable: true,
+    });
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock_throwing', makeThrowingAdapter(adapterErr));
+
+    const workflowStore = new JsonWorkflowStore(workflowDir);
+    await workflowStore.register(makeTwoStepServiceDef());
+    const runStore = new JsonFileStore(runDir);
+    const run = await runStore.create({
+      workflowId: 'two-step-service-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const result = await handleExecuteStepTool(
+      { run_id: run.id, command: 'call_api' },
+      { runStore, workflowStore, registry },
+    );
+
+    const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    // Non-terminal run, wait_for_human passes through.
+    expect(parsed['agent_action']).toBe('wait_for_human');
   });
 });


### PR DESCRIPTION
## Context

Follow-up to PRs #19–21 which established the error resolution contract and fixed MCP outer catch handlers. Two gaps remained:

1. `ADAPTER_OP_UNSUPPORTED` was constructed with `agentAction: 'provide_input'` in three files — an incorrect signal that tells agents to retry with corrected arguments. Unsupported adapter operations are workflow authoring errors; there are no arguments an agent can change at runtime to fix a missing adapter method or an unrecognised operation string.

2. The Step 5 dispatch-failure path was only tested at the `executeStep` unit level (`execution-loop.test.ts`). No tests exercised the path from a real `handleExecuteStepTool` call through to the serialised MCP JSON response, meaning regressions in `agent_action` serialisation or `next_actions` population would go undetected.

## Root Cause

**Change 1:** Construction sites were authored with `provide_input` without considering the semantics of the error context. `ADAPTER_OP_UNSUPPORTED` surfaces when a workflow definition references a `service_method` or operation that the adapter does not implement — this is fixed by correcting the workflow YAML, not by the agent retrying with different arguments.

**Change 2:** The MCP-layer integration gap: `execution-loop.test.ts` confirms that `resolvePostDispatchAgentAction` translates action values correctly at the envelope level, but does not call `handleExecuteStepTool` and therefore does not cover the JSON serialisation, the `next_actions` builder, or the response envelope shape at the MCP boundary.

## Changes

### `packages/core/src/engine/execution-loop.ts`

One site: the guard that surfaces `ADAPTER_OP_UNSUPPORTED` when an adapter is missing a requested method. Changed `agentAction: 'provide_input'` → `agentAction: 'report_to_user'`.

### `packages/core/src/adapters/airtable-adapter.ts`

Three sites: fallthrough throws in `fetch`, `create`, and `update`. Changed `agentAction: 'provide_input'` → `agentAction: 'report_to_user'` at each.

### `packages/core/src/adapters/parcelpanel-adapter.ts`

Three sites: fallthrough throws in `fetch`, `create`, and `update`. Same change.

### `packages/mcp-server/src/tools/mcp-tools.test.ts`

Added three integration tests using a real `JsonWorkflowStore`, real `JsonFileStore`, and a mock `ServiceAdapter` that throws a `WorkflowError`. Tests call `handleExecuteStepTool` and assert the parsed MCP JSON:

| Test | Workflow shape | Adapter agentAction | Expected MCP agent_action | next_actions |
|---|---|---|---|---|
| Terminal run | Single service step (no recovery) | `report_to_user` | `stop` | `[]` |
| Non-terminal, report_to_user | Two steps, recovery via `trigger_rule: 'one_failed'` | `report_to_user` | `report_to_user` | non-empty |
| Non-terminal, wait_for_human | Two steps, recovery via `trigger_rule: 'one_failed'` | `wait_for_human` | `wait_for_human` | (not asserted) |

## Verification

```bash
# TypeScript
npx tsc --noEmit -p packages/core/tsconfig.json
npx tsc --noEmit -p packages/mcp-server/tsconfig.json

# Full test suite (78 files, 1262 passed, 2 skipped)
npx vitest run

# Target file only
npx vitest run packages/mcp-server/src/tools/mcp-tools.test.ts
```

Expected output:
```
Test Files  78 passed (78)
     Tests  1262 passed | 2 skipped (1264)
```

## Rollback

```bash
git revert HEAD
```

No data mutations, no external API calls. Safe to revert with a single commit.

## Related

- PR #19: fix(core): propagate dispatch error semantics in Step 5 failure envelope
- PR #20: fix(mcp): propagate WorkflowError.agentAction in outer catch handlers
- PR #21: fix(core): formalise error resolution contract
