### PR TITLE
fix(core): add parseRetryAfterHeader to Airtable 429 handler

### DIFF
--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -1,6 +1,7 @@
 // AirtableAdapter — wraps the Airtable REST API for record-level operations.
 import { WorkflowError } from '../types/workflow-error.js';
 import type { ServiceAdapter, ServiceResponse } from '../extensions/service-adapter.js';
+import { parseRetryAfterHeader } from './adapter-utils.js';
 
 const AIRTABLE_DEFAULT_BASE_URL = 'https://api.airtable.com';
 
@@ -190,11 +191,13 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     if (status === 429) {
+      const retryAfterFromHeader = parseRetryAfterHeader(response.headers.get('Retry-After'));
       throw new WorkflowError('Rate limited by Airtable API', {
         code: 'SERVICE_RATE_LIMITED',
         category: 'SERVICE',
         agentAction: 'wait_and_proceed',
         retryable: true,
+        ...(retryAfterFromHeader !== undefined ? { retry_after: retryAfterFromHeader } : {}),
         details: baseDetails,
       });
     }


### PR DESCRIPTION
## Context

During the Phase 66 (rate-limit architecture) review, all four service adapters were examined
for consistency with the new `ServiceAdapter.defaultRetryAfterSeconds` contract and the
three-tier `retry_after` resolution chain added in PR #25.

Three adapters — Shopify, Gorgias, ParcelPanel — correctly call `parseRetryAfterHeader` in
their 429 handlers before throwing `SERVICE_RATE_LIMITED`, conditionally including the parsed
header value in the error. Airtable was the only adapter that did not call
`parseRetryAfterHeader`. The comment in `AirtableAdapterConfig.api_key` documents that Airtable
does not currently return a `Retry-After` header, which is why the original implementation
omitted this call.

## Motivation

Airtable's current API does not return a `Retry-After` header. However, Airtable's API has
evolved before (e.g. their REST API migration), and omitting `parseRetryAfterHeader` means
that if Airtable adds the header in a future API version, the engine would silently ignore it
and keep using the 30-second `defaultRetryAfterSeconds` fallback.

Adding the call is a one-line forward-compatibility improvement that makes the Airtable adapter
consistent with the other three adapters. There is no behavioural change today: calling
`parseRetryAfterHeader(response.headers.get('Retry-After'))` when no header is present returns
`undefined`, and the conditional spread `...(undefined !== undefined ? ...)` adds nothing to
the thrown error, leaving the three-tier chain to resolve via `defaultRetryAfterSeconds = 30`
exactly as before.

## Changes

**`packages/core/src/adapters/airtable-adapter.ts`**

- Added `import { parseRetryAfterHeader } from './adapter-utils.js'`
- In the 429 handler inside `throwHttpError()`: added `parseRetryAfterHeader(response.headers.get('Retry-After'))` and the conditional spread, matching the identical pattern used by Gorgias and ParcelPanel adapters

No other files were changed.

## Verification

```bash
cd packages/core
npx vitest run src/adapters/airtable-adapter.test.ts
# Expected: 41 passed | 1 skipped — same as before

npx vitest run src/adapters/ src/engine/reliability.test.ts
# Expected: 200 passed | 2 skipped — all green
```

## Rollback

```bash
git revert HEAD
```

No adapter behaviour changes in the current version. No data mutations.

## Related

Closes no issue. Related: PR #25 (Phase 66 rate-limit architecture, which introduced the three-tier chain and `defaultRetryAfterSeconds` interface property).
