### PR TITLE
fix(mcp): normalize catch block error envelopes across all MCP tools

### DIFF
--- a/.github/instructions/realm.instructions.md
+++ b/.github/instructions/realm.instructions.md
@@ -141,6 +141,12 @@ If you lose track of a run's current state (e.g. after an error or session gap),
 terminal, the pending gate if any, and how many evidence entries exist. Use it to orient
 yourself before deciding the next tool call — do not guess the state.
 
+`run_version: 0` in an error response is a sentinel meaning the run version was not
+available at the time the error was produced (e.g. the run did not exist, or the error
+occurred before the run could be read). Do not use `0` as a version when constructing a
+retry call — always use the version from `next_actions[0].instruction.call_with`, or call
+`get_run_state` to retrieve the current version before retrying.
+
 ## Error and Blocked Responses
 
 Every `status: 'error'` and `status: 'blocked'` response carries `agent_action` that tells you

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -6,7 +6,7 @@ import {
   JsonFileStore,
   executeChain,
   WorkflowError,
-  resolvePreExecutionAgentAction,
+  buildPreExecutionErrorEnvelope,
   type StepDispatcher,
   type ResponseEnvelope,
   type AgentTraceEntry,
@@ -87,36 +87,33 @@ export async function handleExecuteStepTool(
       ],
     };
   } catch (err) {
-    const agentAction =
-      err instanceof WorkflowError ? resolvePreExecutionAgentAction(err) : 'report_to_user';
-    const message = err instanceof Error ? err.message : String(err);
+    const workflowErr =
+      err instanceof WorkflowError
+        ? err
+        : new WorkflowError(err instanceof Error ? err.message : String(err), {
+            code: 'ENGINE_INTERNAL',
+            category: 'ENGINE',
+            agentAction: 'stop',
+            retryable: false,
+          });
     const contextHint =
-      err instanceof WorkflowError && err.code === 'STATE_WORKFLOW_NOT_FOUND'
+      workflowErr.code === 'STATE_WORKFLOW_NOT_FOUND'
         ? `Workflow definition for run '${args.run_id}' not found.`
-        : err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND'
+        : workflowErr.code === 'STATE_RUN_NOT_FOUND'
           ? `Run '${args.run_id}' not found.`
           : `An error occurred before step '${args.command}' could begin.`;
+    const envelope: ResponseEnvelope = buildPreExecutionErrorEnvelope(
+      args.command,
+      args.run_id,
+      0,
+      workflowErr,
+      contextHint,
+    );
     return {
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify(
-            {
-              command: args.command,
-              run_id: args.run_id,
-              run_version: 0,
-              status: 'error',
-              data: {},
-              evidence: [],
-              warnings: [],
-              errors: [message],
-              agent_action: agentAction,
-              context_hint: contextHint,
-              next_actions: [],
-            },
-            null,
-            2,
-          ),
+          text: JSON.stringify(envelope, null, 2),
         },
       ],
     };

--- a/packages/mcp-server/src/tools/mcp-tools.test.ts
+++ b/packages/mcp-server/src/tools/mcp-tools.test.ts
@@ -8,11 +8,14 @@ import type { WorkflowDefinition, ServiceAdapter } from '@sensigo/realm';
 import { CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
 import { handleListWorkflows } from './list-workflows.js';
 import { handleGetWorkflowProtocol } from './get-workflow-protocol.js';
-import { handleStartRun } from './start-run.js';
+import { handleStartRun, registerStartRun } from './start-run.js';
 import { handleExecuteStep, handleExecuteStepTool } from './execute-step.js';
-import { handleSubmitHumanResponse } from './submit-human-response.js';
+import { handleSubmitHumanResponse, registerSubmitHumanResponse } from './submit-human-response.js';
 import { handleGetRunState } from './get-run-state.js';
 import { createDefaultRegistry } from '../server.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client';
 
 /** Minimal 2-step workflow: auto → completed */
 function makeSimpleDef(): WorkflowDefinition {
@@ -287,12 +290,13 @@ describe('mcp tool handlers', () => {
 
     const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
     expect(parsed['status']).toBe('error');
-    expect(parsed['agent_action']).toBe('report_to_user');
+    expect(parsed['agent_action']).toBe('stop');
     expect(Array.isArray(parsed['next_actions'])).toBe(true);
     expect((parsed['next_actions'] as unknown[]).length).toBe(0);
     expect((parsed['errors'] as string[])[0]).toContain('unexpected failure');
     expect(parsed['run_id']).toBe('test-run');
     expect(parsed['command']).toBe('review_security');
+    expect(parsed['error_code']).toBe('ENGINE_INTERNAL');
   });
 
   it('handleExecuteStepTool propagates WorkflowError.agentAction to MCP response', async () => {
@@ -327,6 +331,7 @@ describe('mcp tool handlers', () => {
     expect(parsed['status']).toBe('error');
     expect(parsed['agent_action']).toBe('report_to_user');
     expect((parsed['errors'] as string[])[0]).toContain('Run not found');
+    expect(parsed['error_code']).toBe('STATE_RUN_NOT_FOUND');
   });
 
   it('handleGetRunState returns run summary', async () => {
@@ -637,5 +642,53 @@ describe('mcp tool handlers', () => {
     expect(parsed['status']).toBe('error');
     expect(parsed['agent_action']).toBe('wait_and_proceed');
     expect(parsed['retry_after']).toBe(30);
+  });
+});
+
+describe('registerStartRun — ResponseEnvelope error shape', () => {
+  it('emits error_code when workflow is not found', async () => {
+    const server = new McpServer({ name: 'test', version: '0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    registerStartRun(server, {});
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test-client', version: '0' });
+    await client.connect(clientTransport);
+    const result = await client.callTool({
+      name: 'start_run',
+      arguments: { workflow_id: 'nonexistent' },
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]!.text;
+    const envelope = JSON.parse(text) as Record<string, unknown>;
+    expect(envelope['status']).toBe('error');
+    expect(envelope['error_code']).toBe('STATE_WORKFLOW_NOT_FOUND');
+    expect(envelope['command']).toBe('start_run');
+    expect(envelope['run_id']).toBe('');
+    expect(envelope['run_version']).toBe(0);
+    expect(Array.isArray(envelope['next_actions'])).toBe(true);
+    await client.close();
+  });
+});
+
+describe('registerSubmitHumanResponse — ResponseEnvelope error shape', () => {
+  it('emits error_code when run is not found', async () => {
+    const server = new McpServer({ name: 'test', version: '0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    registerSubmitHumanResponse(server, {});
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test-client', version: '0' });
+    await client.connect(clientTransport);
+    const result = await client.callTool({
+      name: 'submit_human_response',
+      arguments: { run_id: 'no-such-run', gate_id: 'g1', choice: 'approve' },
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]!.text;
+    const envelope = JSON.parse(text) as Record<string, unknown>;
+    expect(envelope['status']).toBe('error');
+    expect(envelope['error_code']).toBe('STATE_RUN_NOT_FOUND');
+    expect(envelope['command']).toBe('submit_human_response');
+    expect(envelope['run_id']).toBe('no-such-run');
+    expect(envelope['run_version']).toBe(0);
+    expect(Array.isArray(envelope['next_actions'])).toBe(true);
+    await client.close();
   });
 });

--- a/packages/mcp-server/src/tools/start-run.ts
+++ b/packages/mcp-server/src/tools/start-run.ts
@@ -8,7 +8,7 @@ import {
   buildNextActions,
   findEligibleSteps,
   WorkflowError,
-  resolvePreExecutionAgentAction,
+  buildPreExecutionErrorEnvelope,
   type StepDispatcher,
   type ResponseEnvelope,
   type TraceBufferStore,
@@ -107,34 +107,31 @@ export function registerStartRun(
           ],
         };
       } catch (err) {
-        const agentAction =
-          err instanceof WorkflowError ? resolvePreExecutionAgentAction(err) : 'report_to_user';
-        const message = err instanceof Error ? err.message : String(err);
+        const workflowErr =
+          err instanceof WorkflowError
+            ? err
+            : new WorkflowError(err instanceof Error ? err.message : String(err), {
+                code: 'ENGINE_INTERNAL',
+                category: 'ENGINE',
+                agentAction: 'stop',
+                retryable: false,
+              });
         const contextHint =
-          err instanceof WorkflowError && err.code === 'STATE_WORKFLOW_NOT_FOUND'
+          workflowErr.code === 'STATE_WORKFLOW_NOT_FOUND'
             ? `Workflow '${args.workflow_id}' not found.`
             : `An error occurred before the run could be started.`;
+        const envelope: ResponseEnvelope = buildPreExecutionErrorEnvelope(
+          'start_run',
+          '',
+          0,
+          workflowErr,
+          contextHint,
+        );
         return {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  command: 'start_run',
-                  run_id: '',
-                  run_version: 0,
-                  status: 'error',
-                  data: {},
-                  evidence: [],
-                  warnings: [],
-                  errors: [message],
-                  agent_action: agentAction,
-                  context_hint: contextHint,
-                  next_actions: [],
-                },
-                null,
-                2,
-              ),
+              text: JSON.stringify(envelope, null, 2),
             },
           ],
         };

--- a/packages/mcp-server/src/tools/submit-human-response.ts
+++ b/packages/mcp-server/src/tools/submit-human-response.ts
@@ -6,7 +6,7 @@ import {
   JsonFileStore,
   submitHumanResponse,
   WorkflowError,
-  resolvePreExecutionAgentAction,
+  buildPreExecutionErrorEnvelope,
   type ResponseEnvelope,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
@@ -53,36 +53,33 @@ export function registerSubmitHumanResponse(server: McpServer, opts?: HandleRunS
           ],
         };
       } catch (err) {
-        const agentAction =
-          err instanceof WorkflowError ? resolvePreExecutionAgentAction(err) : 'report_to_user';
-        const message = err instanceof Error ? err.message : String(err);
+        const workflowErr =
+          err instanceof WorkflowError
+            ? err
+            : new WorkflowError(err instanceof Error ? err.message : String(err), {
+                code: 'ENGINE_INTERNAL',
+                category: 'ENGINE',
+                agentAction: 'stop',
+                retryable: false,
+              });
         const contextHint =
-          err instanceof WorkflowError && err.code === 'STATE_WORKFLOW_NOT_FOUND'
+          workflowErr.code === 'STATE_WORKFLOW_NOT_FOUND'
             ? `Workflow definition for run '${args.run_id}' not found.`
-            : err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND'
+            : workflowErr.code === 'STATE_RUN_NOT_FOUND'
               ? `Run '${args.run_id}' not found.`
               : `An error occurred before gate response could be submitted.`;
+        const envelope: ResponseEnvelope = buildPreExecutionErrorEnvelope(
+          'submit_human_response',
+          args.run_id,
+          0,
+          workflowErr,
+          contextHint,
+        );
         return {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  command: 'submit_human_response',
-                  run_id: args.run_id,
-                  run_version: 0,
-                  status: 'error',
-                  data: {},
-                  evidence: [],
-                  warnings: [],
-                  errors: [message],
-                  agent_action: agentAction,
-                  context_hint: contextHint,
-                  next_actions: [],
-                },
-                null,
-                2,
-              ),
+              text: JSON.stringify(envelope, null, 2),
             },
           ],
         };


### PR DESCRIPTION
## Context

Follow-up to PR #27 (`fix(mcp): normalize append_trace error responses to ResponseEnvelope`). After that PR, `append-trace` was the only MCP tool whose catch block used `buildPreExecutionErrorEnvelope`. The other three tools (`execute-step`, `submit-human-response`, `start-run`) still constructed `ResponseEnvelope` inline, called `resolvePreExecutionAgentAction` manually, and emitted no `error_code` or `error_details`.

Additionally, the `realm.instructions.md` protocol document did not explain what `run_version: 0` means in an error response, leaving agents without guidance on how to handle it.

## Motivation

All four MCP tools should return consistent error envelopes. Having three tools emit `error_code` and one not is an inconsistency that will cause agent behavior to diverge depending on which tool surfaces the error.

## Changes

**`packages/mcp-server/src/tools/execute-step.ts`**
- Removed `resolvePreExecutionAgentAction` from imports; added `buildPreExecutionErrorEnvelope`.
- Replaced `handleExecuteStepTool` catch block: non-WorkflowErrors wrapped as `ENGINE_INTERNAL`; envelope built via shared helper.

**`packages/mcp-server/src/tools/submit-human-response.ts`**
- Same import swap.
- Replaced `registerSubmitHumanResponse` catch block with the same pattern.

**`packages/mcp-server/src/tools/start-run.ts`**
- Same import swap.
- Replaced `registerStartRun` catch block with the same pattern (`run_id: ''` — correct since the run may not have been created).

**`packages/mcp-server/src/tools/mcp-tools.test.ts`**
- Updated two existing `handleExecuteStepTool` error tests to assert `error_code`.
- Added `describe('registerStartRun — ResponseEnvelope error shape')`: asserts `error_code: 'STATE_WORKFLOW_NOT_FOUND'` through the MCP transport layer.
- Added `describe('registerSubmitHumanResponse — ResponseEnvelope error shape')`: asserts `error_code: 'STATE_RUN_NOT_FOUND'` through the MCP transport layer.

**`.github/instructions/realm.instructions.md`**
- Added two-sentence note to the "Checking Run State" section: `run_version: 0` is a sentinel for "version not available at error time"; agents must not use it as a version value — use `next_actions[0].call_with` or call `get_run_state` instead.

**Behavioral note:** Non-WorkflowErrors now produce `agent_action: 'stop'` instead of the previous `'report_to_user'`. This is intentional: `'stop'` is the correct semantic for a genuinely unexpected failure. `'report_to_user'` implies a specific engine state inconsistency that doesn't apply. This is consistent with the `append-trace` pattern already established in PR #27.

## Verification

```bash
cd /home/mihai/code/realm
npx turbo run test
# Expected: 8 tasks successful
# @sensigo/realm-mcp: 55 passed (was 53 before this PR; +2 new integration tests)
```

## Rollback

```bash
git revert HEAD
```

No external state. Pure code and documentation change.

## Related

Closes the catch-block normalization work begun in PR #27.
