### PR TITLE
feat(core): add NotionAdapter

### DIFF
--- a/packages/core/src/adapters/notion-adapter.test.ts
+++ b/packages/core/src/adapters/notion-adapter.test.ts
@@ -1,0 +1,1044 @@
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { NotionAdapter } from './notion-adapter.js';
+import type { NotionAdapterConfig } from './notion-adapter.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+// ---------------------------------------------------------------------------
+// Mock server
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (req: http.IncomingMessage, res: http.ServerResponse, body: string) => void;
+
+let port: number;
+let server: http.Server;
+const handlers: RequestHandler[] = [];
+
+let lastRequestHeaders: http.IncomingHttpHeaders = {};
+let lastRequestBody = '';
+let lastRequestMethod = '';
+let lastRequestUrl = '';
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      lastRequestHeaders = req.headers;
+      lastRequestBody = body;
+      lastRequestMethod = req.method ?? '';
+      lastRequestUrl = req.url ?? '';
+      const handler = handlers.shift();
+      if (handler === undefined) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'no handler registered' }));
+        return;
+      }
+      handler(req, res, body);
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as { port: number };
+  port = address.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+afterEach(() => {
+  handlers.splice(0, handlers.length);
+});
+
+function respond(statusCode: number, body: unknown, headers: Record<string, string> = {}): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'application/json', ...headers });
+    res.end(JSON.stringify(body));
+  });
+}
+
+function respondText(statusCode: number, text: string): void {
+  handlers.push((_req, res) => {
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain' });
+    res.end(text);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG: NotionAdapterConfig = {
+  api_key: 'secret_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+};
+
+function makeAdapter(overrides: Partial<NotionAdapterConfig> = {}): NotionAdapter {
+  return new NotionAdapter('notion', {
+    ...VALID_CONFIG,
+    base_url: `http://127.0.0.1:${port}`,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PAGE_FIXTURE = {
+  id: 'page-uuid-1234',
+  object: 'page',
+  properties: {},
+};
+
+const LIST_FIXTURE = {
+  object: 'list',
+  results: [{ id: 'block-1', type: 'paragraph' }],
+  has_more: false,
+  next_cursor: null,
+};
+
+// ---------------------------------------------------------------------------
+// Tests: Constructor validation
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter construction', () => {
+  it('throws for empty api_key', () => {
+    expect(() => new NotionAdapter('id', { api_key: '' })).toThrow(
+      'NotionAdapter: api_key must not be empty',
+    );
+  });
+
+  it('does not throw for a valid config', () => {
+    expect(() => new NotionAdapter('id', { api_key: 'secret_xxx' })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Auth headers
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter auth headers', () => {
+  it('sends Authorization: Bearer header and Notion-Version header', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('get_page', { page_id: 'page-123' }, {});
+    expect(lastRequestHeaders['authorization']).toBe(
+      'Bearer secret_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    );
+    expect(lastRequestHeaders['notion-version']).toBe('2026-03-11');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: get_page
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter get_page', () => {
+  it('uses correct URL path: /v1/pages/{page_id}', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('get_page', { page_id: 'page-abc' }, {});
+    expect(lastRequestUrl).toBe('/v1/pages/page-abc');
+    expect(lastRequestMethod).toBe('GET');
+  });
+
+  it('returns data with id', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_page', { page_id: 'page-abc' }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as typeof PAGE_FIXTURE;
+    expect(data.id).toBe('page-uuid-1234');
+  });
+
+  it('filter_properties produces repeated filter_properties params', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('get_page', { page_id: 'p1', filter_properties: ['title', 'status'] }, {});
+    const decoded = decodeURIComponent(lastRequestUrl);
+    expect(decoded).toContain('filter_properties=title');
+    expect(decoded).toContain('filter_properties=status');
+  });
+
+  it('missing page_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_page', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_AUTH_FAILED',
+    });
+  });
+
+  it('HTTP 404 → SERVICE_NOT_FOUND', async () => {
+    respond(404, { message: 'Not found' });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_NOT_FOUND',
+    });
+  });
+
+  it('HTTP 429 → SERVICE_RATE_LIMITED, agentAction: wait_for_human', async () => {
+    respond(429, { message: 'Rate limited' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_page', { page_id: 'p1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_RATE_LIMITED');
+    expect(err.agentAction).toBe('wait_for_human');
+  });
+
+  it('HTTP 429 with Retry-After header → retryAfterSeconds in details', async () => {
+    respond(429, { message: 'Rate limited' }, { 'Retry-After': '60' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_page', { page_id: 'p1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_RATE_LIMITED');
+    expect(err.details['retryAfterSeconds']).toBe(60);
+  });
+
+  it('HTTP 503 → SERVICE_HTTP_5XX, agentAction: wait_for_human', async () => {
+    respond(503, { message: 'unavailable' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_page', { page_id: 'p1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_5XX');
+    expect(err.agentAction).toBe('wait_for_human');
+  });
+
+  it('HTTP 503 with additional_data → additionalData in details', async () => {
+    respond(503, { message: 'timeout', additional_data: { retry_after: 30 } });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_page', { page_id: 'p1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_5XX');
+    expect(err.details['additionalData']).toEqual({ retry_after: 30 });
+  });
+
+  it('HTTP 500 → SERVICE_HTTP_5XX, agentAction: report_to_user', async () => {
+    respond(500, { message: 'Internal Server Error' });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_HTTP_5XX',
+      agentAction: 'report_to_user',
+    });
+  });
+
+  it('HTTP 400 → SERVICE_HTTP_4XX, message from body', async () => {
+    respond(400, { message: 'path.field is invalid' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_page', { page_id: 'p1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_4XX');
+    expect(err.message).toContain('path.field is invalid');
+    expect(err.details['body']).toBeDefined();
+  });
+
+  it('x-notion-request-id header is included in error details', async () => {
+    respond(404, { message: 'Not found' }, { 'x-notion-request-id': 'req-id-xyz' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_page', { page_id: 'p1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.details['notionRequestId']).toBe('req-id-xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: list_block_children
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter list_block_children', () => {
+  it('uses correct URL path: /v1/blocks/{block_id}/children', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('list_block_children', { block_id: 'block-abc' }, {});
+    expect(lastRequestUrl).toMatch(/^\/v1\/blocks\/block-abc\/children/);
+    expect(lastRequestMethod).toBe('GET');
+  });
+
+  it('start_cursor and page_size produce query params', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'list_block_children',
+      { block_id: 'b1', start_cursor: 'cursor-xyz', page_size: 25 },
+      {},
+    );
+    expect(lastRequestUrl).toContain('start_cursor=cursor-xyz');
+    expect(lastRequestUrl).toContain('page_size=25');
+  });
+
+  it('returns results array', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_block_children', { block_id: 'b1' }, {});
+    const data = result.data as typeof LIST_FIXTURE;
+    expect(Array.isArray(data.results)).toBe(true);
+    expect(data.has_more).toBe(false);
+  });
+
+  it('missing block_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('list_block_children', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_block_children', { block_id: 'b1' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
+  });
+
+  it('HTTP 404 → SERVICE_NOT_FOUND', async () => {
+    respond(404, { message: 'Not found' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_block_children', { block_id: 'b1' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_NOT_FOUND' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: query_data_source
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter query_data_source', () => {
+  it('uses correct URL path and method: POST /v1/data_sources/{id}/query', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('query_data_source', { data_source_id: 'ds-abc' }, {});
+    expect(lastRequestUrl).toMatch(/^\/v1\/data_sources\/ds-abc\/query/);
+    expect(lastRequestMethod).toBe('POST');
+  });
+
+  it('body includes only present optional fields', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'query_data_source',
+      { data_source_id: 'ds-1', filter: { property: 'Status', equals: 'Done' }, page_size: 10 },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['filter']).toEqual({ property: 'Status', equals: 'Done' });
+    expect(body['page_size']).toBe(10);
+    expect('sorts' in body).toBe(false);
+    expect('start_cursor' in body).toBe(false);
+  });
+
+  it('filter_properties produces repeated query params', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'query_data_source',
+      { data_source_id: 'ds-1', filter_properties: ['Name', 'Status'] },
+      {},
+    );
+    const decoded = decodeURIComponent(lastRequestUrl);
+    expect(decoded).toContain('filter_properties=Name');
+    expect(decoded).toContain('filter_properties=Status');
+  });
+
+  it('missing data_source_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('query_data_source', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('HTTP 403 → SERVICE_HTTP_4XX', async () => {
+    respond(403, { message: 'Forbidden' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('query_data_source', { data_source_id: 'ds-1' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX' });
+  });
+
+  it('HTTP 503 → SERVICE_HTTP_5XX, agentAction: wait_for_human', async () => {
+    respond(503, { message: 'Backend timeout' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('query_data_source', { data_source_id: 'ds-1' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_5XX');
+    expect(err.agentAction).toBe('wait_for_human');
+  });
+
+  it('returns results array', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('query_data_source', { data_source_id: 'ds-1' }, {});
+    const data = result.data as typeof LIST_FIXTURE;
+    expect(Array.isArray(data.results)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: search
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter search', () => {
+  it('uses correct URL and method: POST /v1/search', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('search', {}, {});
+    expect(lastRequestUrl).toBe('/v1/search');
+    expect(lastRequestMethod).toBe('POST');
+  });
+
+  it('body includes only present params', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('search', { query: 'hello', page_size: 5 }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['query']).toBe('hello');
+    expect(body['page_size']).toBe(5);
+    expect('filter' in body).toBe(false);
+  });
+
+  it('valid filter passes through to body', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.fetch('search', { filter: { property: 'object', value: 'page' } }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['filter']).toEqual({ property: 'object', value: 'page' });
+  });
+
+  it('filter with invalid value → ADAPTER_VALIDATION_FAILED (bad value)', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('search', { filter: { property: 'object', value: 'invalid' } }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('filter with wrong property → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('search', { filter: { property: 'type', value: 'page' } }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('filter as array → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('search', { filter: [{ property: 'object', value: 'page' }] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('filter: data_source is a valid value', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('search', { filter: { property: 'object', value: 'data_source' } }, {}),
+    ).resolves.toBeDefined();
+  });
+
+  it('returns results array', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('search', {}, {});
+    const data = result.data as typeof LIST_FIXTURE;
+    expect(Array.isArray(data.results)).toBe(true);
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('search', {}, {})).rejects.toMatchObject({
+      code: 'SERVICE_AUTH_FAILED',
+    });
+  });
+
+  it('HTTP 500 → SERVICE_HTTP_5XX, agentAction: report_to_user', async () => {
+    respond(500, { message: 'Internal error' });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('search', {}, {})).rejects.toMatchObject({
+      code: 'SERVICE_HTTP_5XX',
+      agentAction: 'report_to_user',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: create_page
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter create_page', () => {
+  it('uses correct URL and method: POST /v1/pages', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create('create_page', { parent: { page_id: 'p-parent' } }, {});
+    expect(lastRequestUrl).toBe('/v1/pages');
+    expect(lastRequestMethod).toBe('POST');
+  });
+
+  it('parent { page_id } normalised to wire format', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create('create_page', { parent: { page_id: 'p-abc' } }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['parent']).toEqual({ type: 'page_id', page_id: 'p-abc' });
+  });
+
+  it('parent { data_source_id } normalised to wire format', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create('create_page', { parent: { data_source_id: 'ds-abc' } }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['parent']).toEqual({ type: 'data_source_id', data_source_id: 'ds-abc' });
+  });
+
+  it('parent { workspace: true } normalised to wire format', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create('create_page', { parent: { workspace: true } }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['parent']).toEqual({ type: 'workspace', workspace: true });
+  });
+
+  it('invalid parent → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('create_page', { parent: { unknown_key: 'x' } }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('missing parent → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('create_page', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('children and markdown both present → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create(
+        'create_page',
+        {
+          parent: { page_id: 'p1' },
+          children: [{ type: 'paragraph' }],
+          markdown: '# Hello',
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('children > 100 → ADAPTER_VALIDATION_FAILED with count in message', async () => {
+    const adapter = makeAdapter();
+    const children = Array.from({ length: 101 }, () => ({ type: 'paragraph' }));
+    const err = await adapter
+      .create('create_page', { parent: { page_id: 'p1' }, children }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.message).toContain('101');
+  });
+
+  it('children exactly 100 is allowed', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    const children = Array.from({ length: 100 }, () => ({ type: 'paragraph' }));
+    await expect(
+      adapter.create('create_page', { parent: { page_id: 'p1' }, children }, {}),
+    ).resolves.toBeDefined();
+  });
+
+  it('optional fields are included only when present', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create(
+      'create_page',
+      { parent: { page_id: 'p1' }, properties: { Title: {} }, icon: { type: 'emoji' } },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['properties']).toEqual({ Title: {} });
+    expect(body['icon']).toEqual({ type: 'emoji' });
+    expect('cover' in body).toBe(false);
+    expect('children' in body).toBe(false);
+  });
+
+  it('returns data with id on success', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.create('create_page', { parent: { page_id: 'p1' } }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as typeof PAGE_FIXTURE;
+    expect(data.id).toBe('page-uuid-1234');
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('create_page', { parent: { page_id: 'p1' } }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
+  });
+
+  it('HTTP 404 → SERVICE_NOT_FOUND', async () => {
+    respond(404, { message: 'Parent not found' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('create_page', { parent: { page_id: 'nonexistent' } }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_NOT_FOUND' });
+  });
+
+  it('HTTP 429 → SERVICE_RATE_LIMITED', async () => {
+    respond(429, { message: 'Rate limited' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('create_page', { parent: { page_id: 'p1' } }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RATE_LIMITED' });
+  });
+
+  it('HTTP 409 → SERVICE_HTTP_4XX with body in details and message from body', async () => {
+    respond(409, { message: 'Conflict with existing page' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .create('create_page', { parent: { page_id: 'p1' } }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_4XX');
+    expect(err.message).toContain('Conflict with existing page');
+    expect(err.details['body']).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: append_block_children
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter append_block_children', () => {
+  it('uses correct URL and HTTP method PATCH /v1/blocks/{id}/children', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create(
+      'append_block_children',
+      { block_id: 'block-abc', children: [{ type: 'paragraph' }] },
+      {},
+    );
+    expect(lastRequestUrl).toBe('/v1/blocks/block-abc/children');
+    expect(lastRequestMethod).toBe('PATCH');
+  });
+
+  it('returns results array on success', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.create(
+      'append_block_children',
+      { block_id: 'b1', children: [{ type: 'paragraph' }] },
+      {},
+    );
+    const data = result.data as typeof LIST_FIXTURE;
+    expect(Array.isArray(data.results)).toBe(true);
+  });
+
+  it('missing block_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('append_block_children', { children: [{ type: 'paragraph' }] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('empty children array → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('append_block_children', { block_id: 'b1', children: [] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('children > 100 → ADAPTER_VALIDATION_FAILED with count in message', async () => {
+    const adapter = makeAdapter();
+    const children = Array.from({ length: 101 }, () => ({ type: 'paragraph' }));
+    const err = await adapter
+      .create('append_block_children', { block_id: 'b1', children }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.message).toContain('101');
+  });
+
+  it('child without type → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create(
+        'append_block_children',
+        { block_id: 'b1', children: [{ not_a_type: 'paragraph' }] },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('child with empty type string → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('append_block_children', { block_id: 'b1', children: [{ type: '' }] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('position: end is valid', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create(
+        'append_block_children',
+        { block_id: 'b1', children: [{ type: 'paragraph' }], position: { type: 'end' } },
+        {},
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('position: invalid type → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create(
+        'append_block_children',
+        { block_id: 'b1', children: [{ type: 'p' }], position: { type: 'middle' } },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('position: after_block without after_block.id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create(
+        'append_block_children',
+        {
+          block_id: 'b1',
+          children: [{ type: 'p' }],
+          position: { type: 'after_block', after_block: {} },
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('position: after_block with valid id is accepted', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create(
+        'append_block_children',
+        {
+          block_id: 'b1',
+          children: [{ type: 'paragraph' }],
+          position: { type: 'after_block', after_block: { id: 'block-ref-id' } },
+        },
+        {},
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('position is included in request body when present', async () => {
+    respond(200, LIST_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.create(
+      'append_block_children',
+      {
+        block_id: 'b1',
+        children: [{ type: 'paragraph' }],
+        position: { type: 'start' },
+      },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['position']).toEqual({ type: 'start' });
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('append_block_children', { block_id: 'b1', children: [{ type: 'p' }] }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: update_page
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter update_page', () => {
+  it('uses correct URL and method: PATCH /v1/pages/{page_id}', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.update('update_page', { page_id: 'p-abc' }, {});
+    expect(lastRequestUrl).toBe('/v1/pages/p-abc');
+    expect(lastRequestMethod).toBe('PATCH');
+  });
+
+  it('returns data with id on success', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    const result = await adapter.update('update_page', { page_id: 'p-abc' }, {});
+    const data = result.data as typeof PAGE_FIXTURE;
+    expect(data.id).toBe('page-uuid-1234');
+  });
+
+  it('optional fields included only when present', async () => {
+    respond(200, PAGE_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.update('update_page', { page_id: 'p1', in_trash: true }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['in_trash']).toBe(true);
+    expect('is_locked' in body).toBe(false);
+    expect('properties' in body).toBe(false);
+  });
+
+  it("'archived' key → ADAPTER_VALIDATION_FAILED with deprecation message", async () => {
+    const adapter = makeAdapter();
+    const err = await adapter
+      .update('update_page', { page_id: 'p1', archived: true }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.message).toContain("'archived' is deprecated");
+    expect(err.message).toContain('in_trash');
+  });
+
+  it('missing page_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_page', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_AUTH_FAILED',
+    });
+  });
+
+  it('HTTP 503 → SERVICE_HTTP_5XX, agentAction: wait_for_human', async () => {
+    respond(503, { message: 'Service unavailable' });
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_HTTP_5XX',
+      agentAction: 'wait_for_human',
+    });
+  });
+
+  it('HTTP 500 → SERVICE_HTTP_5XX, agentAction: report_to_user', async () => {
+    respond(500, { message: 'Server error' });
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_HTTP_5XX',
+      agentAction: 'report_to_user',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: delete_block
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter delete_block', () => {
+  it('uses correct URL and method: DELETE /v1/blocks/{block_id}', async () => {
+    respond(200, { id: 'block-abc', archived: true });
+    const adapter = makeAdapter();
+    await adapter.delete!('delete_block', { block_id: 'block-abc' }, {});
+    expect(lastRequestUrl).toBe('/v1/blocks/block-abc');
+    expect(lastRequestMethod).toBe('DELETE');
+  });
+
+  it('no Content-Type header on DELETE request', async () => {
+    respond(200, { id: 'block-abc', archived: true });
+    const adapter = makeAdapter();
+    await adapter.delete!('delete_block', { block_id: 'block-abc' }, {});
+    expect(lastRequestHeaders['content-type']).toBeUndefined();
+  });
+
+  it('returns data with id on success (archived block object)', async () => {
+    const archived = { id: 'block-xyz', archived: true, type: 'paragraph' };
+    respond(200, archived);
+    const adapter = makeAdapter();
+    const result = await adapter.delete!('delete_block', { block_id: 'block-xyz' }, {});
+    const data = result.data as typeof archived;
+    expect(data.id).toBe('block-xyz');
+    expect(data.archived).toBe(true);
+  });
+
+  it('missing block_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.delete!('delete_block', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('HTTP 404 → SERVICE_NOT_FOUND', async () => {
+    respond(404, { message: 'Block not found' });
+    const adapter = makeAdapter();
+    await expect(adapter.delete!('delete_block', { block_id: 'b1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_NOT_FOUND',
+    });
+  });
+
+  it('HTTP 401 → SERVICE_AUTH_FAILED', async () => {
+    respond(401, { message: 'Unauthorized' });
+    const adapter = makeAdapter();
+    await expect(adapter.delete!('delete_block', { block_id: 'b1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_AUTH_FAILED',
+    });
+  });
+
+  it('HTTP 429 → SERVICE_RATE_LIMITED, agentAction: wait_for_human', async () => {
+    respond(429, { message: 'Rate limited' });
+    const adapter = makeAdapter();
+    await expect(adapter.delete!('delete_block', { block_id: 'b1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_RATE_LIMITED',
+      agentAction: 'wait_for_human',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Response validation
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter response validation', () => {
+  it('get_page: 200 with non-JSON body → SERVICE_RESPONSE_INVALID', async () => {
+    respondText(200, 'not valid json {{');
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_RESPONSE_INVALID',
+    });
+  });
+
+  it('get_page: response missing id field → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { object: 'page', properties: {} });
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'SERVICE_RESPONSE_INVALID',
+    });
+  });
+
+  it('list_block_children: response missing results field → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { object: 'list', has_more: false });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_block_children', { block_id: 'b1' }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Network errors
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter network errors', () => {
+  it('ECONNREFUSED → NETWORK_UNREACHABLE', async () => {
+    const closedPort = await new Promise<number>((resolve) => {
+      const tmp = net.createServer();
+      tmp.listen(0, '127.0.0.1', () => {
+        const addr = tmp.address() as { port: number };
+        tmp.close(() => resolve(addr.port));
+      });
+    });
+
+    const adapter = new NotionAdapter('notion', {
+      api_key: 'secret_test',
+      base_url: `http://127.0.0.1:${closedPort}`,
+    });
+
+    await expect(adapter.fetch('get_page', { page_id: 'p1' }, {})).rejects.toMatchObject({
+      code: 'NETWORK_UNREACHABLE',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: AbortSignal
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter AbortSignal', () => {
+  it('pre-aborted signal throws STEP_ABORTED, no network call made', async () => {
+    respond(200, PAGE_FIXTURE);
+
+    const adapter = makeAdapter();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.fetch('get_page', { page_id: 'p1' }, {}, controller.signal),
+    ).rejects.toMatchObject({ code: 'STEP_ABORTED' });
+
+    expect(handlers).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Unsupported operations
+// ---------------------------------------------------------------------------
+
+describe('NotionAdapter unsupported operations', () => {
+  it('fetch("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('unknown', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('create("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('unknown', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('update("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('unknown', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('update("update_block") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_block', { block_id: 'b1' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+
+  it('delete("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.delete!('unknown', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_OP_UNSUPPORTED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract probe (skipped — requires real credentials)
+// ---------------------------------------------------------------------------
+
+it.skip('contract probe — real API (requires NOTION_TEST_API_KEY)', async () => {
+  const apiKey = process.env['NOTION_TEST_API_KEY'] ?? '';
+  const adapter = new NotionAdapter('notion', { api_key: apiKey });
+  const result = await adapter.fetch('search', {}, {});
+  expect(result.status).toBe(200);
+  const data = result.data as { results: unknown[] };
+  expect(Array.isArray(data.results)).toBe(true);
+});

--- a/packages/core/src/adapters/notion-adapter.ts
+++ b/packages/core/src/adapters/notion-adapter.ts
@@ -1,0 +1,891 @@
+// NotionAdapter — wraps the Notion REST API for page, block, and search operations.
+import { WorkflowError } from '../types/workflow-error.js';
+import type { ServiceAdapter, ServiceResponse } from '../extensions/service-adapter.js';
+import { parseRetryAfterHeader } from './adapter-utils.js';
+
+const NOTION_API_VERSION = '2026-03-11';
+const NOTION_BASE_URL = 'https://api.notion.com';
+
+/**
+ * Configuration for NotionAdapter.
+ */
+export interface NotionAdapterConfig {
+  /**
+   * Notion integration token. Must be a non-empty string.
+   * Obtain from https://www.notion.so/my-integrations
+   */
+  api_key: string;
+
+  /**
+   * Override base URL for tests (replaces https://api.notion.com).
+   * Trailing slash is stripped.
+   */
+  base_url?: string;
+}
+
+/**
+ * NotionAdapter wraps the Notion REST API.
+ *
+ * Supported operations:
+ *   fetch('get_page', { page_id, filter_properties? })                      — GET  /v1/pages/{page_id}
+ *   fetch('list_block_children', { block_id, start_cursor?, page_size? })   — GET  /v1/blocks/{block_id}/children
+ *   fetch('query_data_source', { data_source_id, ...opts })                 — POST /v1/data_sources/{data_source_id}/query
+ *   fetch('search', { query?, filter?, sort?, start_cursor?, page_size? })  — POST /v1/search
+ *   create('create_page', { parent, properties?, children?, icon?, cover? }) — POST /v1/pages
+ *   create('append_block_children', { block_id, children, position? })      — PATCH /v1/blocks/{block_id}/children
+ *   update('update_page', { page_id, properties?, icon?, cover?, ... })     — PATCH /v1/pages/{page_id}
+ *   delete('delete_block', { block_id })                                    — DELETE /v1/blocks/{block_id}
+ */
+export class NotionAdapter implements ServiceAdapter {
+  readonly id: string;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(id: string, config: NotionAdapterConfig) {
+    if (!config.api_key) {
+      throw new Error('NotionAdapter: api_key must not be empty');
+    }
+    this.id = id;
+    this.apiKey = config.api_key;
+    this.baseUrl = config.base_url?.replace(/\/$/, '') ?? NOTION_BASE_URL;
+  }
+
+  private checkAborted(signal?: AbortSignal): void {
+    if (signal?.aborted === true) {
+      throw new WorkflowError('Adapter request aborted', {
+        code: 'STEP_ABORTED',
+        category: 'ENGINE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+  }
+
+  private buildHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Notion-Version': NOTION_API_VERSION,
+      Accept: 'application/json',
+    };
+  }
+
+  private buildUrl(path: string): URL {
+    return new URL(path, this.baseUrl);
+  }
+
+  /**
+   * @param networkRetryable — set to false for non-idempotent write operations
+   *   (create_page, append_block_children) where retrying a failed request may
+   *   create duplicate resources.
+   */
+  private async executeRequest(
+    url: URL,
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+    body?: unknown,
+    signal?: AbortSignal,
+    networkRetryable = true,
+  ): Promise<Response> {
+    this.checkAborted(signal);
+    const hasBody = (method === 'POST' || method === 'PATCH') && body !== undefined;
+    const headers: Record<string, string> = {
+      ...this.buildHeaders(),
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+    };
+
+    let response: Response;
+    try {
+      response = await fetch(url.href, {
+        method,
+        headers,
+        ...(hasBody ? { body: JSON.stringify(body) } : {}),
+        signal: signal ?? null,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new WorkflowError('Adapter request aborted', {
+          code: 'STEP_ABORTED',
+          category: 'ENGINE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new WorkflowError(message, {
+        code: 'NETWORK_UNREACHABLE',
+        category: 'NETWORK',
+        agentAction: 'wait_for_human',
+        retryable: networkRetryable,
+      });
+    }
+    return response;
+  }
+
+  private async throwHttpError(response: Response, operation: string): Promise<never> {
+    // Read body as text first — avoids "body already consumed" if JSON.parse fails.
+    const rawText = await response.text();
+    let parsedBody: unknown;
+    try {
+      parsedBody = JSON.parse(rawText);
+    } catch {
+      parsedBody = rawText;
+    }
+
+    const status = response.status;
+    const notionRequestIdHeader = response.headers.get('x-notion-request-id');
+    const baseDetails: Record<string, unknown> = { status, operation };
+    if (notionRequestIdHeader !== null) {
+      baseDetails['notionRequestId'] = notionRequestIdHeader;
+    }
+
+    if (status === 400) {
+      const parsed = parsedBody as Record<string, unknown> | null;
+      const apiMessage =
+        typeof parsed?.['message'] === 'string' ? parsed['message'] : 'validation error';
+      throw new WorkflowError(`Notion API error (HTTP 400): ${apiMessage}`, {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: { ...baseDetails, body: parsedBody },
+      });
+    }
+
+    if (status === 401) {
+      throw new WorkflowError('Notion authentication failed — check API key', {
+        code: 'SERVICE_AUTH_FAILED',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: baseDetails,
+      });
+    }
+
+    if (status === 403) {
+      throw new WorkflowError('Notion: forbidden (HTTP 403)', {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: baseDetails,
+      });
+    }
+
+    if (status === 404) {
+      throw new WorkflowError('Notion: resource not found', {
+        code: 'SERVICE_NOT_FOUND',
+        category: 'SERVICE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: baseDetails,
+      });
+    }
+
+    if (status === 409) {
+      const parsed = parsedBody as Record<string, unknown> | null;
+      const apiMessage = typeof parsed?.['message'] === 'string' ? parsed['message'] : 'conflict';
+      throw new WorkflowError(`Notion API error (HTTP 409): ${apiMessage}`, {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details: { ...baseDetails, body: parsedBody },
+      });
+    }
+
+    if (status === 429) {
+      const retryAfterSeconds = parseRetryAfterHeader(response.headers.get('Retry-After'));
+      throw new WorkflowError('Rate limited by Notion API', {
+        code: 'SERVICE_RATE_LIMITED',
+        category: 'SERVICE',
+        agentAction: 'wait_for_human',
+        retryable: true,
+        details: {
+          ...baseDetails,
+          ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+        },
+      });
+    }
+
+    if (status === 503) {
+      const parsed = parsedBody as Record<string, unknown> | null;
+      const additionalData = parsed?.['additional_data'];
+      throw new WorkflowError('Notion service temporarily unavailable (HTTP 503)', {
+        code: 'SERVICE_HTTP_5XX',
+        category: 'SERVICE',
+        agentAction: 'wait_for_human',
+        retryable: true,
+        details: {
+          ...baseDetails,
+          ...(additionalData !== undefined ? { additionalData } : {}),
+        },
+      });
+    }
+
+    if (status >= 500) {
+      throw new WorkflowError(`Notion server error (HTTP ${status})`, {
+        code: 'SERVICE_HTTP_5XX',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: true,
+        details: baseDetails,
+      });
+    }
+
+    // other 4xx
+    throw new WorkflowError(`Notion: HTTP ${status}`, {
+      code: 'SERVICE_HTTP_4XX',
+      category: 'SERVICE',
+      agentAction: 'stop',
+      retryable: false,
+      details: baseDetails,
+    });
+  }
+
+  async fetch(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'get_page') {
+      const pageId = params['page_id'];
+      if (typeof pageId !== 'string' || pageId === '') {
+        throw new WorkflowError('NotionAdapter: page_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const url = this.buildUrl(`/v1/pages/${encodeURIComponent(pageId)}`);
+      const filterProperties = params['filter_properties'];
+      if (Array.isArray(filterProperties) && filterProperties.length > 0) {
+        for (const val of filterProperties as unknown[]) {
+          url.searchParams.append('filter_properties', String(val));
+        }
+      }
+
+      const response = await this.executeRequest(url, 'GET', undefined, signal);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { id?: unknown };
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('NotionAdapter: get_page response missing id field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'list_block_children') {
+      // data shape for paginated responses:
+      // { object: 'list', results: unknown[], has_more: boolean, next_cursor: string | null }
+      // Pass next_cursor back as start_cursor on the next call to retrieve subsequent pages.
+      const blockId = params['block_id'];
+      if (typeof blockId !== 'string' || blockId === '') {
+        throw new WorkflowError('NotionAdapter: block_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const url = this.buildUrl(`/v1/blocks/${encodeURIComponent(blockId)}/children`);
+      if (typeof params['start_cursor'] === 'string') {
+        url.searchParams.set('start_cursor', params['start_cursor']);
+      }
+      if (typeof params['page_size'] === 'number') {
+        url.searchParams.set('page_size', String(params['page_size']));
+      }
+
+      const response = await this.executeRequest(url, 'GET', undefined, signal);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { results?: unknown };
+      if (!Array.isArray(data.results)) {
+        throw new WorkflowError(
+          'NotionAdapter: list_block_children response missing results array',
+          {
+            code: 'SERVICE_RESPONSE_INVALID',
+            category: 'SERVICE',
+            agentAction: 'report_to_user',
+            retryable: false,
+          },
+        );
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'query_data_source') {
+      // data shape for paginated responses:
+      // { object: 'list', results: unknown[], has_more: boolean, next_cursor: string | null }
+      // Pass next_cursor back as start_cursor on the next call to retrieve subsequent pages.
+      const dataSourceId = params['data_source_id'];
+      if (typeof dataSourceId !== 'string' || dataSourceId === '') {
+        throw new WorkflowError('NotionAdapter: data_source_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const url = this.buildUrl(`/v1/data_sources/${encodeURIComponent(dataSourceId)}/query`);
+      const filterProperties = params['filter_properties'];
+      if (Array.isArray(filterProperties) && filterProperties.length > 0) {
+        for (const val of filterProperties as unknown[]) {
+          url.searchParams.append('filter_properties', String(val));
+        }
+      }
+
+      const body: Record<string, unknown> = {};
+      if (params['filter'] !== undefined) body['filter'] = params['filter'];
+      if (params['sorts'] !== undefined) body['sorts'] = params['sorts'];
+      if (params['start_cursor'] !== undefined) body['start_cursor'] = params['start_cursor'];
+      if (params['page_size'] !== undefined) body['page_size'] = params['page_size'];
+      if (params['in_trash'] !== undefined) body['in_trash'] = params['in_trash'];
+
+      const response = await this.executeRequest(url, 'POST', body, signal);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { results?: unknown };
+      if (!Array.isArray(data.results)) {
+        throw new WorkflowError('NotionAdapter: query_data_source response missing results array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'search') {
+      // data shape for paginated responses:
+      // { object: 'list', results: unknown[], has_more: boolean, next_cursor: string | null }
+      // Pass next_cursor back as start_cursor on the next call to retrieve subsequent pages.
+
+      // Validate filter structure before sending.
+      const filter = params['filter'];
+      if (filter !== undefined) {
+        if (filter === null || typeof filter !== 'object' || Array.isArray(filter)) {
+          throw new WorkflowError(
+            "NotionAdapter: search — 'filter' must be a plain object with property: 'object' and value: 'page'|'database'|'data_source'",
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+        const f = filter as Record<string, unknown>;
+        if (
+          f['property'] !== 'object' ||
+          !['page', 'database', 'data_source'].includes(f['value'] as string)
+        ) {
+          throw new WorkflowError(
+            "NotionAdapter: search — 'filter' must have property: 'object' and value: 'page'|'database'|'data_source'",
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+      }
+
+      const url = this.buildUrl('/v1/search');
+      const body: Record<string, unknown> = {};
+      if (params['query'] !== undefined) body['query'] = params['query'];
+      if (params['filter'] !== undefined) body['filter'] = params['filter'];
+      if (params['sort'] !== undefined) body['sort'] = params['sort'];
+      if (params['start_cursor'] !== undefined) body['start_cursor'] = params['start_cursor'];
+      if (params['page_size'] !== undefined) body['page_size'] = params['page_size'];
+
+      const response = await this.executeRequest(url, 'POST', body, signal);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { results?: unknown };
+      if (!Array.isArray(data.results)) {
+        throw new WorkflowError('NotionAdapter: search response missing results array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`NotionAdapter: unsupported fetch operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+  }
+
+  /**
+   * NOTE: retryable is false for network errors — retrying a failed create or append
+   * risks creating duplicate content if the server processed the request before the network dropped.
+   */
+  async create(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'create_page') {
+      const parent = params['parent'];
+      if (
+        parent === null ||
+        parent === undefined ||
+        typeof parent !== 'object' ||
+        Array.isArray(parent)
+      ) {
+        throw new WorkflowError('NotionAdapter: create_page — parent must be a plain object', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const p = parent as Record<string, unknown>;
+      let wireParent: Record<string, unknown>;
+      if (typeof p['page_id'] === 'string' && p['page_id'] !== '') {
+        wireParent = { type: 'page_id', page_id: p['page_id'] };
+      } else if (typeof p['data_source_id'] === 'string' && p['data_source_id'] !== '') {
+        wireParent = { type: 'data_source_id', data_source_id: p['data_source_id'] };
+      } else if (p['workspace'] === true) {
+        wireParent = { type: 'workspace', workspace: true };
+      } else {
+        throw new WorkflowError(
+          "NotionAdapter: create_page — 'parent' must be one of: { page_id }, { data_source_id }, or { workspace: true }",
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      const children = params['children'];
+      const markdown = params['markdown'];
+      if (children !== undefined && markdown !== undefined) {
+        throw new WorkflowError(
+          "NotionAdapter: create_page — 'children' and 'markdown' are mutually exclusive",
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      if (Array.isArray(children) && children.length > 100) {
+        throw new WorkflowError(
+          `NotionAdapter: create_page — 'children' array exceeds 100 items (got ${children.length})`,
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      const body: Record<string, unknown> = { parent: wireParent };
+      if (params['properties'] !== undefined) body['properties'] = params['properties'];
+      if (params['children'] !== undefined) body['children'] = params['children'];
+      if (params['markdown'] !== undefined) body['markdown'] = params['markdown'];
+      if (params['icon'] !== undefined) body['icon'] = params['icon'];
+      if (params['cover'] !== undefined) body['cover'] = params['cover'];
+
+      const url = this.buildUrl('/v1/pages');
+      // networkRetryable: false — retrying risks creating a duplicate page.
+      const response = await this.executeRequest(url, 'POST', body, signal, false);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { id?: unknown };
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('NotionAdapter: create_page response missing id field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'append_block_children') {
+      // data shape for paginated responses:
+      // { object: 'list', results: unknown[], has_more: boolean, next_cursor: string | null }
+      // Pass next_cursor back as start_cursor on the next call to retrieve subsequent pages.
+      //
+      // Note: append_block_children lives in create() because it creates new block resources.
+      // The underlying HTTP verb is PATCH — this is expected.
+      const blockId = params['block_id'];
+      if (typeof blockId !== 'string' || blockId === '') {
+        throw new WorkflowError('NotionAdapter: block_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const children = params['children'];
+      if (!Array.isArray(children) || children.length === 0) {
+        throw new WorkflowError(
+          'NotionAdapter: append_block_children — children must be a non-empty array',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      if (children.length > 100) {
+        throw new WorkflowError(
+          `NotionAdapter: append_block_children — 'children' array exceeds 100 items (got ${children.length})`,
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      for (const item of children as unknown[]) {
+        if (
+          item === null ||
+          typeof item !== 'object' ||
+          Array.isArray(item) ||
+          typeof (item as Record<string, unknown>)['type'] !== 'string' ||
+          (item as Record<string, unknown>)['type'] === ''
+        ) {
+          throw new WorkflowError(
+            'NotionAdapter: append_block_children — each child must be a plain object with a non-empty type field',
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+      }
+
+      const position = params['position'];
+      if (position !== undefined) {
+        if (position === null || typeof position !== 'object' || Array.isArray(position)) {
+          throw new WorkflowError(
+            "NotionAdapter: append_block_children — 'position' must be a plain object",
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+        const pos = position as Record<string, unknown>;
+        if (!['end', 'start', 'after_block'].includes(pos['type'] as string)) {
+          throw new WorkflowError(
+            "NotionAdapter: append_block_children — 'position.type' must be one of 'end', 'start', 'after_block'",
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+        if (pos['type'] === 'after_block') {
+          const afterBlock = pos['after_block'];
+          if (
+            afterBlock === null ||
+            typeof afterBlock !== 'object' ||
+            Array.isArray(afterBlock) ||
+            typeof (afterBlock as Record<string, unknown>)['id'] !== 'string' ||
+            (afterBlock as Record<string, unknown>)['id'] === ''
+          ) {
+            throw new WorkflowError(
+              "NotionAdapter: append_block_children — 'position.after_block.id' must be a non-empty string when type is 'after_block'",
+              {
+                code: 'ADAPTER_VALIDATION_FAILED',
+                category: 'ENGINE',
+                agentAction: 'provide_input',
+                retryable: false,
+              },
+            );
+          }
+        }
+      }
+
+      const body: Record<string, unknown> = { children };
+      if (position !== undefined) body['position'] = position;
+
+      const url = this.buildUrl(`/v1/blocks/${encodeURIComponent(blockId)}/children`);
+      // networkRetryable: false — retrying risks appending duplicate blocks.
+      const response = await this.executeRequest(url, 'PATCH', body, signal, false);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { results?: unknown };
+      if (!Array.isArray(data.results)) {
+        throw new WorkflowError(
+          'NotionAdapter: append_block_children response missing results array',
+          {
+            code: 'SERVICE_RESPONSE_INVALID',
+            category: 'SERVICE',
+            agentAction: 'report_to_user',
+            retryable: false,
+          },
+        );
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`NotionAdapter: unsupported create operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+  }
+
+  async update(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'update_page') {
+      const pageId = params['page_id'];
+      if (typeof pageId !== 'string' || pageId === '') {
+        throw new WorkflowError('NotionAdapter: page_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      if ('archived' in params) {
+        throw new WorkflowError(
+          "NotionAdapter: update_page — 'archived' is deprecated; use 'in_trash' instead",
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      const body: Record<string, unknown> = {};
+      if (params['properties'] !== undefined) body['properties'] = params['properties'];
+      if (params['icon'] !== undefined) body['icon'] = params['icon'];
+      if (params['cover'] !== undefined) body['cover'] = params['cover'];
+      if (params['in_trash'] !== undefined) body['in_trash'] = params['in_trash'];
+      if (params['is_locked'] !== undefined) body['is_locked'] = params['is_locked'];
+
+      const url = this.buildUrl(`/v1/pages/${encodeURIComponent(pageId)}`);
+      const response = await this.executeRequest(url, 'PATCH', body, signal);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { id?: unknown };
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('NotionAdapter: update_page response missing id field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`NotionAdapter: unsupported update operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+  }
+
+  async delete(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'delete_block') {
+      const blockId = params['block_id'];
+      if (typeof blockId !== 'string' || blockId === '') {
+        throw new WorkflowError('NotionAdapter: block_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const url = this.buildUrl(`/v1/blocks/${encodeURIComponent(blockId)}`);
+      const response = await this.executeRequest(url, 'DELETE', undefined, signal);
+      if (!response.ok) {
+        await this.throwHttpError(response, operation);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('NotionAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { id?: unknown };
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('NotionAdapter: delete_block response missing id field', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`NotionAdapter: unsupported delete operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,8 @@ export type {
 } from './adapters/parcelpanel-adapter.js';
 export { AirtableAdapter } from './adapters/airtable-adapter.js';
 export type { AirtableAdapterConfig } from './adapters/airtable-adapter.js';
+export { NotionAdapter } from './adapters/notion-adapter.js';
+export type { NotionAdapterConfig } from './adapters/notion-adapter.js';
 
 // Trace policy
 export { TRACE_POLICY_VERSION, TRACE_POLICY, TRACE_POLICY_HASH } from './engine/trace-policy.js';


### PR DESCRIPTION
## Context

Notion adapter was identified as a needed `ServiceAdapter` implementation to bring Notion's REST API into the Realm adapter ecosystem, alongside the existing Airtable and ParcelPanel adapters.

## Motivation

Agents orchestrated by Realm need to read and write Notion pages, blocks, databases, and data sources as part of automated workflows. `NotionAdapter` provides a typed, error-normalised bridge between Realm's `ServiceAdapter` contract and the Notion REST API, so workflow steps can call `fetch`, `create`, `update`, and `delete` without dealing with raw HTTP.

## Changes

**`packages/core/src/adapters/notion-adapter.ts`** — new file
- Implements `NotionAdapter` (class) and `NotionAdapterConfig` (interface)
- 8 operations across 4 methods:
  - `fetch`: `get_page`, `list_block_children`, `query_data_source`, `search`
  - `create`: `create_page`, `append_block_children` (PATCH verb — creates new block resources)
  - `update`: `update_page`
  - `delete`: `delete_block`
- All HTTP errors mapped to `WorkflowError` with correct `code`, `agentAction`, `retryable`, and `details` (including `x-notion-request-id` header when present)
- 400/409: includes `body` and message from Notion API in `details` and error string
- 429: `parseRetryAfterHeader` produces `retryAfterSeconds` in `details`
- 503: `additionalData` from response body included in `details`
- Network errors: `NETWORK_UNREACHABLE`; `retryable: false` for non-idempotent writes (`create_page`, `append_block_children`) to prevent duplicate content on retry
- `Content-Type: application/json` added only for POST/PATCH with a body — DELETE never carries it
- Input validation: parent normalisation (3 shapes), `children`/`markdown` mutual exclusion, 100-item limits, block `type` non-empty check, `position` enum + `after_block.id` sub-check, `search` filter structure, `archived` deprecation guard
- `ADAPTER_OP_UNSUPPORTED` thrown for all unknown operations

**`packages/core/src/adapters/notion-adapter.test.ts`** — new file
- 92 tests (1 skipped: real-API contract probe gated by `NOTION_TEST_API_KEY`)
- Local HTTP server with randomised port and handler queue
- Covers: all 8 operations, all error codes, all validation guards, response shape validation, `Content-Type` on DELETE, AbortSignal, unsupported operations

**`packages/core/src/index.ts`** — exports added
- `export { NotionAdapter } from './adapters/notion-adapter.js'`
- `export type { NotionAdapterConfig } from './adapters/notion-adapter.js'`

## Verification

```bash
# All tests pass
cd /home/mihai/code/realm
npx turbo run test --filter=@sensigo/realm
# Expected: 1020 passed | 3 skipped

# Full build + lint
npx turbo run build lint --filter=@sensigo/realm
# Expected: all tasks successful
```

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. Revert is sufficient.
