### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.github/instructions/pre-publication.instructions.md
+++ b/.github/instructions/pre-publication.instructions.md
@@ -70,7 +70,7 @@ Follow this checklist in order before merging any branch into `main`.
 
 > Run Part B after the Part A PR has been merged and your local `main` is up to date (`git switch main && git pull`).
 >
-> This repository uses a coordinated release script (`scripts/release.mjs`) that bumps all four packages atomically — `@sensigo/realm`, `@sensigo/realm-mcp`, `@sensigo/realm-testing`, `@sensigo/realm-cli` — and publishes them in dependency order. Do not attempt manual per-package releases; the script is the authoritative release mechanism.
+> This repository uses a two-part release process. The release script (`scripts/release.mjs`) bumps all four packages atomically and creates the release git commit and tag. Publishing to npm is handled by `.github/workflows/publish.yml`, which is triggered automatically when the tag is pushed after the release PR is merged. Do not attempt manual per-package publishes; the workflow is the authoritative publish mechanism.
 >
 > A package with `"private": true` in its manifest is not published. Part B does not apply to it.
 
@@ -102,7 +102,7 @@ git commit -m "docs: update changelog for v<version>"
 npm run release -- --version <version>
 ```
 
-The script: checks the working tree is clean, bumps `version` in all four `package.json` files and five source-file `VERSION` constants, pins inter-package dependency ranges, runs `npm run build`, publishes each package with `npm publish --access public` in dependency order, restores workspace dependency ranges, stages the changed files, commits with `chore: release v<version>`, and creates the git tag `v<version>`. If any step fails, the script exits without creating the commit or tag — fix the issue and re-run.
+The script: checks the working tree is clean, bumps `version` in all four `package.json` files and five source-file `VERSION` constants, runs `npm run build` as a local sanity check, stages the changed files, commits with `chore: release v<version>`, and creates the git tag `v<version>`. It does **not** publish — publishing is handled by GitHub Actions when the tag is pushed. If any step fails, the script exits without creating the commit or tag — fix the issue and re-run.
 
 **4. Push and open a PR**
 
@@ -121,7 +121,13 @@ git switch main && git pull
 git push --tags
 ```
 
-**6. Verify the published artifact**
+Pushing the tag triggers `.github/workflows/publish.yml`, which builds and publishes all four packages to npm using OIDC Trusted Publishing — no token required.
+
+**6. Verify the publish workflow**
+
+Go to https://github.com/sensigo-hq/realm/actions and confirm the **Publish** workflow triggered and completed successfully on the `v<version>` tag. Each of the four `npm publish` steps should be green.
+
+**7. Verify the published artifact**
 
 Install the package in a clean environment and confirm the minimal working example from the README runs correctly:
 
@@ -129,18 +135,14 @@ Install the package in a clean environment and confirm the minimal working examp
 mkdir /tmp/test-install && cd /tmp/test-install
 npm init -y
 npm install @sensigo/realm@<version>
-node -e "<minimal working example from README>"
+node -e "const { VERSION } = require('@sensigo/realm'); console.log(VERSION);"
 ```
 
-If `publishConfig.registry` is set on the package, add `--registry <registry-url>` to the install command.
+**8. Rollback note**
 
-**7. Rollback note**
+If the publish workflow fails after some packages are published but before all four complete: re-push the tag (delete and re-push, or re-trigger the workflow manually). `npm publish` will skip packages already at the target version with a `EPUBLISHCONFLICT` error. Confirm all four packages appear on the registry before proceeding.
 
-If step 3 (`npm run release`) fails before completing, no commit or tag has been created. Fix the issue and re-run from step 3.
-
-If a publish error occurs after some packages are already published but before all four complete: the script exits. Identify which packages were published, fix the issue (credentials, registry, network), and re-run `npm run release` — `npm publish` will skip packages already at the target version with a `409 conflict` or `EPUBLISHCONFLICT` error. Confirm all four packages appear on the registry before proceeding.
-
-If the tag was pushed but verification (step 6) reveals a broken artifact: publish a patch release following this entire Part B sequence with an incremented patch version.
+If the tag was pushed but verification (step 7) reveals a broken artifact: publish a patch release following this entire Part B sequence with an incremented patch version.
 
 ---
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write # required for OIDC trusted publishing
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # never cache in release builds
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Pin inter-package dependency ranges
+        run: node scripts/pin-deps.mjs
+
+      - name: Publish @sensigo/realm
+        run: npm publish
+        working-directory: packages/core
+
+      - name: Publish @sensigo/realm-mcp
+        run: npm publish
+        working-directory: packages/mcp-server
+
+      - name: Publish @sensigo/realm-testing
+        run: npm publish
+        working-directory: packages/testing
+
+      - name: Publish @sensigo/realm-cli
+        run: npm publish
+        working-directory: packages/cli

--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,9 @@ prompts/
 reports/
 plans/
 
-# Local agent customisation files — personal agents stay private, shared Realm agent is committed
-.github/agents/master-architect.agent.md
-.github/agents/implementation-agent.agent.md
-.github/agents/marketing-god.agent.md
-.github/agents/peer-architect.agent.md
-.github/agents/design-reviewer.agent.md
+# Local agent customisation files — all private by default; only the shared Realm agent is committed
+.github/agents/*.agent.md
+!.github/agents/realm.agent.md
 .github/instructions/project-info-prompt.md
 
 # Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.1.0] — 2026-06-01
 
 ### Added
 
@@ -277,21 +277,4 @@ All notable changes to this project are documented here.
 
 ### Tests
 
-989 tests across all packages (639 core, 270 CLI, 33 MCP, 47 testing).
-
----
-
-## [0.1.0] — 2026-04-03
-
-Initial release.
-
-### Packages
-
-- **`@sensigo/realm` 0.1.0** — Core workflow execution engine: state guard, execution loop, evidence capture with SHA-256 hash chaining, JSON schema validation, human gate support, precondition evaluation, extension registry (adapters, processors, step handlers), built-in `MockAdapter` and `GenericHttpAdapter`, JSON file store, YAML workflow loader.
-- **`@sensigo/realm-cli` 0.1.0** — `realm` CLI with 11 commands: `init`, `validate`, `register`, `run`, `resume`, `respond`, `inspect`, `replay`, `diff`, `cleanup`, `test`.
-- **`@sensigo/realm-mcp` 0.1.0** — `realm-mcp` MCP server exposing 6 tools to AI agents: `list_workflows`, `get_workflow_protocol`, `start_run`, `execute_step`, `submit_human_response`, `get_run_state`.
-- **`@sensigo/realm-testing` 0.1.0** — Testing utilities: `InMemoryStore`, `MockServiceRecorder`, `createAgentDispatcher`, `createGateResponder`, evidence assertions (`assertFinalState`, `assertStepSucceeded`, `assertStepFailed`, `assertStepOutput`, `assertEvidenceHash`), unit test helpers (`testStepHandler`, `testProcessor`, `testAdapter`), fixture-based runner (`runFixtureTests`).
-
-### Test coverage
-
-226 tests across all packages (133 core, 42 CLI, 11 MCP, 40 testing).
+1400 tests across all packages (1020 core, 278 CLI, 55 MCP, 47 testing).

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ When no registered workflow matches the task, the agent calls `create_workflow` 
 | `realm workflow migrate`         | Back-fill provenance fields on local workflow definitions from earlier versions |
 | `realm mcp`                      | Start the MCP server over stdio (for local AI agents)                           |
 | `realm serve`                    | Start the MCP server over HTTP with Bearer token auth (for hosted platforms)    |
+| `realm webhook`                  | Start a webhook server that creates runs from GitHub events                     |
 
 Run `realm <command> --help` for full options on any command.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You define workflows in YAML. The engine enforces step order, validates every ag
 | Package                  | npm                                                                                                                 | Description                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `@sensigo/realm`         | [![npm](https://img.shields.io/npm/v/@sensigo/realm)](https://www.npmjs.com/package/@sensigo/realm)                 | Core engine — state guard, execution loop, evidence capture              |
-| `@sensigo/realm-cli`     | [![npm](https://img.shields.io/npm/v/@sensigo/realm-cli)](https://www.npmjs.com/package/@sensigo/realm-cli)         | `realm` CLI — 17 commands for building, operating, and serving workflows |
+| `@sensigo/realm-cli`     | [![npm](https://img.shields.io/npm/v/@sensigo/realm-cli)](https://www.npmjs.com/package/@sensigo/realm-cli)         | `realm` CLI — 18 commands for building, operating, and serving workflows |
 | `@sensigo/realm-mcp`     | [![npm](https://img.shields.io/npm/v/@sensigo/realm-mcp)](https://www.npmjs.com/package/@sensigo/realm-mcp)         | `realm-mcp` MCP server — 7 tools for AI agent connections                |
 | `@sensigo/realm-testing` | [![npm](https://img.shields.io/npm/v/@sensigo/realm-testing)](https://www.npmjs.com/package/@sensigo/realm-testing) | Testing utilities — fixtures, assertions, in-memory store                |
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sensigo/realm-cli",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Run autonomous agent workflows, host an MCP server over HTTP, and manage workflow definitions and run history from the terminal.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sensigo/realm",
   "version": "0.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Realm workflow execution engine — state machine, evidence capture, and service adapters for agent-driven workflows.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.2.0';
+export const VERSION = '0.1.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sensigo/realm-mcp",
   "version": "0.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "MCP server for Realm — exposes 7 tools for AI agent connections over stdio or HTTP.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.2.0';
+export const VERSION = '0.1.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -57,7 +57,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.2.0',
+    version: '0.1.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sensigo/realm-testing",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Testing utilities for Realm workflows — fixtures, assertions, mocks, and in-memory store.",
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/pin-deps.mjs
+++ b/scripts/pin-deps.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// scripts/pin-deps.mjs — Pins inter-package "*" dep ranges to the current release
+// version before npm publish. Called by .github/workflows/publish.yml in CI.
+// Safe to run multiple times (idempotent: if already ^X.Y.Z, the regex still matches "*").
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// Internal deps each package declares (only dependencies entries, not devDependencies)
+const INTERNAL_DEPS = {
+  'packages/mcp-server': ['@sensigo/realm'],
+  'packages/testing': ['@sensigo/realm'],
+  'packages/cli': ['@sensigo/realm', '@sensigo/realm-mcp', '@sensigo/realm-testing'],
+};
+
+/** Read and parse a package.json. */
+function readPkg(relPath) {
+  const full = join(ROOT, relPath, 'package.json');
+  return { path: full, pkg: JSON.parse(readFileSync(full, 'utf-8')) };
+}
+
+/** Write a package.json object back to disk. */
+function writePkg(fullPath, pkg) {
+  writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
+}
+
+// Derive version from core — it will already be bumped by the release commit.
+const { pkg: corePkg } = readPkg('packages/core');
+const version = corePkg.version;
+
+if (!version || typeof version !== 'string') {
+  console.error('Error: Could not read version from packages/core/package.json');
+  process.exit(1);
+}
+
+console.log(`Pinning inter-package dep ranges to ^${version}...`);
+
+for (const [dir, internalDeps] of Object.entries(INTERNAL_DEPS)) {
+  const { path, pkg } = readPkg(dir);
+  for (const depName of internalDeps) {
+    if (pkg.dependencies !== undefined && pkg.dependencies[depName] !== undefined) {
+      pkg.dependencies[depName] = `^${version}`;
+    }
+  }
+  writePkg(path, pkg);
+  console.log(`  ${dir}/package.json — pinned: ${internalDeps.join(', ')}`);
+}
+
+console.log('Done.');

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-// scripts/release.mjs — Coordinated npm release script for the Realm monorepo.
-// Bumps all four packages to the same version, pins inter-package deps,
-// publishes to npm in dependency order, then restores workspace "*" ranges.
+// scripts/release.mjs — Coordinated release script for the Realm monorepo.
+// Bumps all four packages to the same version, builds, and creates the release
+// git commit and tag. Publishing to npm is handled by .github/workflows/publish.yml
+// which is triggered when the tag is pushed after the release PR is merged.
 //
 // Usage: npm run release -- --version 0.1.0
 
@@ -20,13 +21,6 @@ const PACKAGES = [
   { dir: 'packages/testing', name: '@sensigo/realm-testing' },
   { dir: 'packages/cli', name: '@sensigo/realm-cli' },
 ];
-
-// Internal deps each package declares (only deps entries, not devDependencies)
-const INTERNAL_DEPS = {
-  'packages/mcp-server': ['@sensigo/realm'],
-  'packages/testing': ['@sensigo/realm'],
-  'packages/cli': ['@sensigo/realm', '@sensigo/realm-mcp', '@sensigo/realm-testing'],
-};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -125,69 +119,12 @@ for (const { file, pattern, replacement } of SOURCE_VERSIONS) {
   console.log(`  ${file} → ${version}`);
 }
 
-// ─── Step 4: Pin inter-package dependency ranges ─────────────────────────────
-// Snapshot originals first so step 7 restores exactly what was there,
-// regardless of what the original values were.
-
-const originalDepRanges = {};
-for (const [dir, internalDeps] of Object.entries(INTERNAL_DEPS)) {
-  originalDepRanges[dir] = {};
-  const { pkg } = readPkg(dir);
-  for (const depName of internalDeps) {
-    originalDepRanges[dir][depName] = pkg.dependencies?.[depName];
-  }
-}
-
-console.log('Pinning inter-package dependency ranges...');
-for (const [dir, internalDeps] of Object.entries(INTERNAL_DEPS)) {
-  const { path, pkg } = readPkg(dir);
-  for (const depName of internalDeps) {
-    if (pkg.dependencies !== undefined && pkg.dependencies[depName] !== undefined) {
-      pkg.dependencies[depName] = `^${version}`;
-    }
-  }
-  writePkg(path, pkg);
-  console.log(`  ${dir}/package.json — pinned: ${internalDeps.join(', ')}`);
-}
-
-// ─── Step 5: Build ───────────────────────────────────────────────────────────
+// ─── Step 4: Build ───────────────────────────────────────────────────────────
 
 console.log('Building...');
 execSync('npm run build', { stdio: 'inherit', cwd: ROOT });
 
-// ─── Step 6: Publish in dependency order ─────────────────────────────────────
-
-console.log('Publishing packages...');
-for (const { dir, name } of PACKAGES) {
-  console.log(`  Publishing ${name}...`);
-  try {
-    execSync('npm publish --access public', {
-      stdio: 'inherit',
-      cwd: join(ROOT, dir),
-    });
-  } catch (err) {
-    console.error(`Error: Failed to publish ${name}.`);
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  }
-}
-
-// ─── Step 7: Restore original dep ranges from snapshot ───────────────────────
-
-console.log('Restoring workspace dependency ranges...');
-for (const [dir, internalDeps] of Object.entries(INTERNAL_DEPS)) {
-  const { path, pkg } = readPkg(dir);
-  for (const depName of internalDeps) {
-    const original = originalDepRanges[dir][depName];
-    if (original !== undefined && pkg.dependencies !== undefined) {
-      pkg.dependencies[depName] = original;
-    }
-  }
-  writePkg(path, pkg);
-  console.log(`  ${dir}/package.json — restored: ${internalDeps.join(', ')}`);
-}
-
-// ─── Step 8: Git tag ─────────────────────────────────────────────────────────
+// ─── Step 5: Git tag ─────────────────────────────────────────────────────────
 
 console.log('Creating git commit and tag...');
 execSync(
@@ -197,4 +134,9 @@ execSync(
 execSync(`git commit -m "chore: release v${version}"`, { stdio: 'inherit', cwd: ROOT });
 execSync(`git tag v${version}`, { stdio: 'inherit', cwd: ROOT });
 
-console.log(`\nReleased v${version}. Push with: git push && git push --tags`);
+console.log(`\nRelease commit and tag v${version} created.`);
+console.log('Next steps:');
+console.log('  1. Push branch:  git push -u origin HEAD');
+console.log('  2. Open and merge the release PR (merge commit, not squash)');
+console.log('  3. Push the tag: git switch main && git pull && git push --tags');
+console.log('     The tag push triggers GitHub Actions to publish to npm.');

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -116,11 +116,11 @@ const SOURCE_VERSIONS = [
 for (const { file, pattern, replacement } of SOURCE_VERSIONS) {
   const fullPath = join(ROOT, file);
   const original = readFileSync(fullPath, 'utf-8');
-  const updated = original.replace(pattern, replacement);
-  if (original === updated) {
+  if (!pattern.test(original)) {
     console.error(`Error: Version pattern not found in ${file}. Cannot update version.`);
     process.exit(1);
   }
+  const updated = original.replace(pattern, replacement);
   writeFileSync(fullPath, updated, 'utf-8');
   console.log(`  ${file} → ${version}`);
 }


### PR DESCRIPTION
## Context

This is the v0.1.0 release of the Realm monorepo — the first public release of all four packages (`@sensigo/realm`, `@sensigo/realm-mcp`, `@sensigo/realm-testing`, `@sensigo/realm-cli`).

The release branch carries all work completed since the repository was established, representing the initial stable feature set.

## Motivation

Establish the first versioned, published release of Realm. All packages were developed and tested on `main`; this release branch collects the CHANGELOG, README fix, and CI infrastructure, then creates the release commit and tag atomically.

## Changes

**`docs: update changelog for v0.1.0`**
Collapsed the CHANGELOG from two phantom sections into a single `[0.1.0] — 2026-06-01` section covering all Added features, Fixed items, and test counts (1400 tests across 4 packages).

**`docs(readme): add realm webhook to CLI reference table`**
The CLI reference table was missing `realm webhook`. Table now correctly lists all 18 commands, matching the prose count.

**`fix(release): handle no-op version bump when package already at target version`**
Fixed a bug in `scripts/release.mjs` where the pattern-not-found check used `original === updated` instead of `!pattern.test(original)`, causing false-positive errors when a source file was already at the target version.

**`chore: use wildcard gitignore for agents, exception for realm.agent.md`**
Replaced individual `.gitignore` entries for each agent file with `.github/agents/*.agent.md` + `!.github/agents/realm.agent.md`.

**`ci: migrate npm publish to GitHub Actions OIDC trusted publishing`**
- Created `.github/workflows/publish.yml` — triggered on `v*` tag pushes; uses OIDC trusted publishing; no `NPM_TOKEN` required; provenance generated automatically.
- Created `scripts/pin-deps.mjs` — standalone script that pins inter-package `"*"` dep ranges to `^{version}` before publish; called by CI; ephemeral (no restore step needed).
- Removed publish, pin-deps, and restore-deps steps from `scripts/release.mjs`. Script now only bumps, builds, commits, and tags.
- Added `"publishConfig": { "access": "public" }` to all 4 package manifests.
- Updated `pre-publication.instructions.md` Part B to reflect the new two-part release process.

**`chore: release v0.1.0`**
Version bump commit: all 4 `package.json` files and 5 source-file `VERSION` constants set to `0.1.0`.

## Verification

```bash
# After merge, from local main:
git switch main && git pull

# Confirm all commits are present
git log --oneline origin/main | head -10

# Confirm tag is reachable from main (required — must use merge commit, not squash)
git tag --merged main | grep v0.1.0
```

Publishing is triggered separately by pushing the tag after this PR merges:
```bash
git push --tags
```
The `publish.yml` workflow handles the npm publish via OIDC — no manual publish step.

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations have occurred — nothing has been published to npm yet. The tag exists locally and on remote but has not triggered a publish (the workflow only runs after merge, on tag push from `main`).

## Related

Closes the v0.1.0 release milestone.
