### PR TITLE
docs(yaml-schema): correct when-condition skip propagation behavior

### DIFF
--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -143,6 +143,8 @@ steps:
 
 When a step fails (or is skipped), all downstream steps whose `trigger_rule` can no longer be satisfied are automatically moved to `skipped_steps`. For example, if `extract_fields` fails, any step with `depends_on: [extract_fields]` and the default `trigger_rule: all_success` is skipped immediately. The run terminates cleanly with `run_phase: failed` when no eligible or in-progress steps remain.
 
+`when`-condition branches are skipped the same way: once all of a step's dependencies are settled, if the step's `when` expression evaluates to false, the engine moves it to `skipped_steps` immediately. In a mutual-exclusion pattern (two branches with opposite `when` conditions), the inactive branch is skipped as soon as the shared upstream step completes — the run closes cleanly without any finalizer step.
+
 `skipped_steps` is included in `realm run inspect` and the `get_run_state` MCP response.
 
 ---
@@ -175,7 +177,7 @@ steps:
 
 `when` conditions are evaluated against each step's recorded `output_summary`. Comparison is strict — types must match (`"1"` does not equal `1`).
 
-A step whose `when` condition is permanently false is not automatically moved to `skipped_steps` — it stays ineligible. Only `trigger_rule` impossibility triggers automatic skipping.
+Once all of a step's dependencies are settled, the engine evaluates the `when` condition. If it evaluates to false at that point, the step is moved to `skipped_steps` immediately — it does not remain indefinitely ineligible. In a mutual-exclusion pattern (two branches with opposite `when` conditions), the inactive branch is skipped as soon as the shared upstream step completes. No finalizer step is needed to close the run.
 
 ---
 


### PR DESCRIPTION
## Context

The `## when condition` section in `docs/reference/yaml-schema.md` contained an explicit false statement asserting that `when`-condition steps are never automatically moved to `skipped_steps` and only `trigger_rule` impossibility triggers skip propagation. This is incorrect and was the source of a documented misunderstanding about run termination behaviour in mutual-exclusion patterns.

## Root Cause

The statement was written before (or without awareness of) the `when`-condition branch of `propagateSkips` in `packages/core/src/engine/eligibility.ts`. That function runs a fixed-point algorithm with two skip-triggering paths:

1. `trigger_rule` impossibility — correctly documented.
2. `when`-condition: once all deps are settled and `evaluateWhenCondition` returns false, the step is added to `skipped_steps` immediately. This path was not documented.

Additionally, the "Skip propagation" subsection under `## trigger_rule` was silent on `when`-condition skipping, giving a reader who stopped there an incomplete model.

## Changes

**`docs/reference/yaml-schema.md`**

1. **`## trigger_rule` → Skip propagation subsection** — Added a new paragraph after the existing `trigger_rule` content:

   > `` `when` ``-condition branches are skipped the same way: once all of a step's dependencies are settled, if the step's `when` expression evaluates to false, the engine moves it to `skipped_steps` immediately. In a mutual-exclusion pattern (two branches with opposite `when` conditions), the inactive branch is skipped as soon as the shared upstream step completes — the run closes cleanly without any finalizer step.

2. **`## when condition` section** — Replaced the false closing paragraph with the correct behaviour:

   > Once all of a step's dependencies are settled, the engine evaluates the `when` condition. If it evaluates to false at that point, the step is moved to `skipped_steps` immediately — it does not remain indefinitely ineligible. In a mutual-exclusion pattern (two branches with opposite `when` conditions), the inactive branch is skipped as soon as the shared upstream step completes. No finalizer step is needed to close the run.

No code changes. No other docs files contained claims about this behaviour.

## Verification

```bash
cd /home/mihai/code/realm
grep -n "ineligible\|finalizer\|mutual" docs/reference/yaml-schema.md
```

Expected: `ineligible` appears only in the corrected line (in the positive form "does not remain indefinitely ineligible"), `finalizer` appears in both the propagation section and the `when` section, `mutual` appears in both sections.

```bash
grep -c "stays ineligible" docs/reference/yaml-schema.md
```

Expected: `0` — the false statement is gone.

## Rollback

```bash
git revert HEAD
```

No data mutations. Plain documentation change.
