### PR TITLE
chore(mcp-server): expose dist/tools/*.js as public subpath exports

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -27,6 +27,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./dist/tools/*.js": {
+      "import": "./dist/tools/*.js",
+      "types": "./dist/tools/*.d.ts"
     }
   },
   "engines": {


### PR DESCRIPTION
## Context

`@sensigo/realm-mcp` is installed as a `file:` dependency in `bradley-max/realm-workspace`. Node.js enforces the `exports` map strictly for `file:` symlinks — unlisted subpaths throw `ERR_PACKAGE_PATH_NOT_EXPORTED` at runtime. TypeScript's `NodeNext` resolution catches the same gap at compile time with `TS2307` errors.

The E2E test (`test-e2e.ts`) in `bradley-max/realm-workspace` imports the Engine API tool handlers directly from the package subpaths:

```typescript
import { handleStartRun } from '@sensigo/realm-mcp/dist/tools/start-run.js';
import { handleExecuteStep } from '@sensigo/realm-mcp/dist/tools/execute-step.js';
import { handleSubmitHumanResponse } from '@sensigo/realm-mcp/dist/tools/submit-human-response.js';
import { handleGetRunState } from '@sensigo/realm-mcp/dist/tools/get-run-state.js';
```

Without the subpath export, these imports fail at both compile time and runtime.

## Changes

Added a wildcard subpath export entry to `packages/mcp-server/package.json`:

```json
"./dist/tools/*.js": {
  "import": "./dist/tools/*.js",
  "types": "./dist/tools/*.d.ts"
}
```

This allows consumers to import individual tool handler modules directly without going through the barrel `index.js` export.

## Verification

```bash
# TypeScript: 0 errors
cd /home/mihai/code/187n/bradley-max/realm-workspace
npx tsc --noEmit
# (produces no output)

# E2E test: passes
node dist/test-e2e.js 63990455
# ✅ E2E test PASSED
# Run ID: 9113b4e7-e65b-4f88-b66b-1fb651d170c3
```

## Rollback

```bash
git revert HEAD
```
