### PR TITLE
docs: update protocol docs for execution: guard and run_phase: aborted

### DIFF
--- a/.github/instructions/realm-create-workflow.instructions.md
+++ b/.github/instructions/realm-create-workflow.instructions.md
@@ -239,8 +239,9 @@ them as described in `realm.instructions.md`.
 - `depends_on` accepts at most one step ID per step — dynamic workflows are always linear.
   Submitting more than one dependency causes `agent_action: 'provide_input'`.
 - All steps in a dynamic workflow are `execution: agent` — the engine always returns them to
-  you for execution. `handler:` and `uses_service:` are not available on dynamic steps; use
-  a YAML-registered workflow if you need auto steps, service adapters, or handlers.
+  you for execution. `handler:`, `uses_service:`, and `execution: guard` are not available on
+  dynamic steps; use a YAML-registered workflow if you need auto steps, service adapters,
+  handlers, or guard conditions.
 - `depends_on` references must point to steps earlier in the `steps` array. Forward references
   cause a `provide_input` error at `create_workflow` call time.
 - `trigger_rule` is not supported on dynamically-created workflows. Step sequencing is always

--- a/.github/instructions/realm.instructions.md
+++ b/.github/instructions/realm.instructions.md
@@ -97,6 +97,11 @@ Repeat from step 4 until:
 - `status` is `confirm_required` — a human gate is open; handle it in step 6, then continue.
 - `status` is `ok` and `next_actions` is empty — the workflow has finished. No further steps exist.
 
+**Guard abort:** When a workflow contains an `execution: guard` step and its `abort_unless` conditions
+are not met, the engine aborts the run cleanly. This also produces `status: ok` with `next_actions: []`.
+`context_hint` will state that a guard step aborted the run. Call `get_run_state` if you need the full
+condition evaluation — the response will include `abort_context` when `run_phase` is `aborted`.
+
 ### 5a. Reading `chained_auto_steps`
 
 When `start_run`, `execute_step`, or `submit_human_response` triggers auto steps before returning,
@@ -112,6 +117,9 @@ ran — only present when the array would be non-empty:
 
 `branched_via` is present when a DAG transition fired (e.g. the engine selected a particular
 trigger-rule branch). Use it to understand which path the engine took before returning to you.
+
+Guard steps (`execution: guard`) also appear in `chained_auto_steps`. When a guard passes, its
+`run_phase` is `running`. When a guard fires and aborts the run, its `run_phase` is `aborted`.
 
 ### 5b. `status: ok` with warnings — recovery step executed
 
@@ -140,6 +148,10 @@ If you lose track of a run's current state (e.g. after an error or session gap),
 `get_run_state` with the `run_id`. It returns the current state name, whether the run is
 terminal, the pending gate if any, and how many evidence entries exist. Use it to orient
 yourself before deciding the next tool call — do not guess the state.
+
+When `run_phase` is `aborted`, the response also includes `abort_context`: the guard step ID,
+the evaluated conditions with their resolved values, and an optional `abort_message` authored
+in the workflow YAML. `aborted` is a terminal phase — the run will not execute any further steps.
 
 `run_version: 0` in an error response is a sentinel meaning the run version was not
 available at the time the error was produced (e.g. the run did not exist, or the error

--- a/docs/reference/mcp-protocol.md
+++ b/docs/reference/mcp-protocol.md
@@ -6,15 +6,15 @@ Realm exposes 7 MCP tools. This document covers the full protocol: tool call pat
 
 ## Tools
 
-| Tool                    | Description                                                                                                                                   |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list_workflows`        | Returns all registered workflow IDs and names. Call this first to discover what is available.                                                 |
-| `get_workflow_protocol` | Returns the full agent briefing for a workflow: step list, input schemas, instructions, rules, and quick_start. Read this before `start_run`. |
-| `start_run`             | Starts a new run for a workflow. Accepts `workflow_id` and optional `params`.                                                                 |
-| `execute_step`          | Submits agent output for the current step. Accepts `run_id`, `command` (step name), and `params`.                                             |
-| `submit_human_response` | Submits a human gate response. Accepts `run_id`, `gate_id`, and `choice`.                                                                     |
-| `get_run_state`         | Returns the current state, evidence chain, and terminal status of a run.                                                                      |
-| `create_workflow`       | Registers a dynamic workflow from a `steps` array and immediately starts a run. No YAML file or `realm register` required.                    |
+| Tool                    | Description                                                                                                                                                                                         |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_workflows`        | Returns all registered workflow IDs and names. Call this first to discover what is available.                                                                                                       |
+| `get_workflow_protocol` | Returns the full agent briefing for a workflow: step list, input schemas, instructions, rules, and quick_start. Read this before `start_run`.                                                       |
+| `start_run`             | Starts a new run for a workflow. Accepts `workflow_id` and optional `params`.                                                                                                                       |
+| `execute_step`          | Submits agent output for the current step. Accepts `run_id`, `command` (step name), and `params`.                                                                                                   |
+| `submit_human_response` | Submits a human gate response. Accepts `run_id`, `gate_id`, and `choice`.                                                                                                                           |
+| `get_run_state`         | Returns the current state, evidence chain, and terminal status of a run. When `run_phase` is `aborted`, also returns `abort_context` (guard step ID, evaluated conditions, optional abort message). |
+| `create_workflow`       | Registers a dynamic workflow from a `steps` array and immediately starts a run. No YAML file or `realm register` required.                                                                          |
 
 ---
 
@@ -78,6 +78,8 @@ When `start_run` or `execute_step` chains through auto steps before returning, `
 ```
 
 `branched_via` is present when a DAG branch was taken (e.g. a `trigger_rule: one_failed` recovery step was auto-executed).
+
+Guard steps (`execution: guard`) also appear in `chained_auto_steps`. A passing guard has `run_phase: running`; a guard that fires and aborts the run has `run_phase: aborted`, and the outer response will have `next_actions: []`.
 
 ---
 


### PR DESCRIPTION
## Context

Phases 18A and 18B introduced `execution: guard`, `run_phase: aborted`, and `abort_context` on `get_run_state`. Three documentation files were not updated during those phases and need patching now.

## Changes

**`.github/instructions/realm.instructions.md`**
- Section 5 (Repeat until done): added a "Guard abort" paragraph explaining that a guard firing also produces `status: ok` with `next_actions: []`, and pointing agents to `abort_context` in `get_run_state`.
- Section 5a (`chained_auto_steps`): added two lines explaining that guard steps appear in `chained_auto_steps` with `run_phase: running` (pass) or `run_phase: aborted` (fire).
- "Checking Run State": added a paragraph explaining that `run_phase: aborted` is terminal and that `abort_context` is present in `get_run_state` when it occurs.

**`.github/instructions/realm-create-workflow.instructions.md`**
- Constraints list: added `execution: guard` to the list of step types unavailable on dynamic workflows (alongside `handler:` and `uses_service:`).

**`docs/reference/mcp-protocol.md`**
- `get_run_state` tool table entry: added `abort_context` mention.
- `chained_auto_steps` section: added sentence about guard steps appearing there with `aborted` phase when they fire.

## Verification

No code changes — documentation only. Build and tests unchanged.

```bash
cd /home/mihai/code/realm && npm run build && npx vitest run
# 81 test files, 1435 passed
```

## Rollback

```bash
git revert HEAD
```

## Related

Closes no issue. Follows PR #35 (Phase 18A) and PR #36 (Phase 18B).
