### PR TITLE
docs(git-workflow): set rebase merge as default; merge commit for release PRs only

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -100,10 +100,10 @@ type(scope): short imperative description
 
 ## PR Merge Strategy
 
-- **Merge commit** is the default. It preserves the full branch history honestly — individual commits remain reachable for `git bisect` and archaeology. Use `git log --first-parent main` for a linear view when needed.
+- **Rebase merge is the default.** Individual commits are replayed onto `main` with their original messages and a linear history is preserved. Use `gh pr merge --rebase`.
+- **Merge commit is required for `release/v*` branches.** The release script tags the release commit on the branch before the PR is opened. A rebase merge would rewrite that commit's SHA, making the tag a dangling reference unreachable from `main` and breaking the publish workflow. Use `gh pr merge --merge` for release PRs only.
 - **Squash merge** is permitted when a branch has a noisy commit history that adds no value to the record (e.g. many "wip" or "fix" commits with no meaningful structure).
-- **Rebase merge** is permitted for clean, well-structured commit sequences where linear history and individual commit preservation are both desired.
-- Do not mix strategies across a project without a documented reason.
+- Do not mix strategies beyond the above rules without a documented reason.
 
 ---
 

--- a/.github/instructions/pre-publication.instructions.md
+++ b/.github/instructions/pre-publication.instructions.md
@@ -110,7 +110,7 @@ The script: checks the working tree is clean, bumps `version` in all four `packa
 git push -u origin release/v<version>
 ```
 
-Open a PR to `main`. Select **merge commit** (not squash) — the release commit must exist as an ancestor of `main` for the tag to be reachable from `main`'s history. Merge after CI passes.
+Open a PR to `main`. Use **merge commit** (`gh pr merge --merge`) — not rebase, not squash. The release script tags the release commit on the branch before the PR is opened; a rebase merge would rewrite that commit's SHA, making the tag a dangling reference unreachable from `main` and breaking the publish workflow. Merge after CI passes.
 
 **5. Push the tag**
 


### PR DESCRIPTION
## Context

Policy inconsistency identified during branch protection audit: the `required_linear_history` setting on GitHub blocks merge commits, but the policy had just been updated to use merge commit as the default. Release PRs require merge commit to preserve tag reachability (the release script tags the commit on the branch before the PR is opened; a rebase would rewrite the SHA and orphan the tag).

## Motivation

Establish a consistent, well-reasoned merge strategy:
- Rebase merge for all feature/fix/chore/docs branches — linear history, individual commits preserved, no fabricated SHA
- Merge commit for `release/v*` branches only — required because the release script tags the release commit before the PR is merged; rebase would break tag reachability and the publish workflow

## Changes

- `git-workflow.instructions.md`: set rebase merge as the default; document merge commit exception for release branches with the technical reason
- `pre-publication.instructions.md`: update release PR merge instruction to use `gh pr merge --merge` with the explicit rationale

## Verification

Read the updated sections in both files and confirm the strategy and rationale are clear.

## Rollback

```bash
git revert HEAD
```
