### PR TITLE
feat(agent): inject agent_profile_instructions into LLM system prompt

### DIFF
--- a/packages/cli/src/agent/providers/agent-utils.test.ts
+++ b/packages/cli/src/agent/providers/agent-utils.test.ts
@@ -15,4 +15,18 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('AI agent executing a step');
     expect(result).toContain(JSON.stringify(schema));
   });
+
+  it('prepends agent profile instructions before the base prompt', () => {
+    const result = buildSystemPrompt(undefined, 'You are a ticket classifier.');
+    expect(result).toMatch(/^You are a ticket classifier\./);
+    expect(result).toContain('AI agent executing a step');
+  });
+
+  it('prepends agent profile and includes schema when both are provided', () => {
+    const schema = { required: ['category'] };
+    const result = buildSystemPrompt(schema, 'You are a ticket classifier.');
+    expect(result).toMatch(/^You are a ticket classifier\./);
+    expect(result).toContain('AI agent executing a step');
+    expect(result).toContain(JSON.stringify(schema));
+  });
 });

--- a/packages/cli/src/agent/providers/agent-utils.ts
+++ b/packages/cli/src/agent/providers/agent-utils.ts
@@ -4,10 +4,17 @@ const SYSTEM_PROMPT_BASE =
   'You are an AI agent executing a step in a structured workflow.\n' +
   'Your task is described below. Respond with a JSON object only — no markdown, no explanation.';
 
-/** Builds the system prompt for an agent step, optionally including the output schema. */
-export function buildSystemPrompt(inputSchema?: Record<string, unknown>): string {
-  if (inputSchema === undefined) return SYSTEM_PROMPT_BASE;
-  return `${SYSTEM_PROMPT_BASE}\nThe JSON must conform to this schema: ${JSON.stringify(inputSchema)}`;
+/** Builds the system prompt for an agent step, optionally prepending an agent profile and/or including the output schema. */
+export function buildSystemPrompt(
+  inputSchema?: Record<string, unknown>,
+  agentProfileInstructions?: string,
+): string {
+  const base =
+    agentProfileInstructions !== undefined
+      ? `${agentProfileInstructions}\n\n${SYSTEM_PROMPT_BASE}`
+      : SYSTEM_PROMPT_BASE;
+  if (inputSchema === undefined) return base;
+  return `${base}\nThe JSON must conform to this schema: ${JSON.stringify(inputSchema)}`;
 }
 
 /**

--- a/packages/cli/src/agent/providers/anthropic-provider.ts
+++ b/packages/cli/src/agent/providers/anthropic-provider.ts
@@ -43,6 +43,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
   async callStep(
     prompt: string,
     inputSchema?: Record<string, unknown>,
+    agentProfileInstructions?: string,
   ): Promise<Record<string, unknown>> {
     // Dynamically import @anthropic-ai/sdk to keep it an optional peer dependency.
     // See openai-provider.ts for an explanation of the 'string' cast technique.
@@ -63,7 +64,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
       apiKey: process.env['ANTHROPIC_API_KEY'],
     });
 
-    const systemPrompt = buildSystemPrompt(inputSchema);
+    const systemPrompt = buildSystemPrompt(inputSchema, agentProfileInstructions);
 
     const makeRequest = async (userContent: string): Promise<string> => {
       const response = await // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,6 +109,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
       inputSchema?: Record<string, unknown>;
       maxToolCalls?: number;
       toolTimeoutMs?: number;
+      agentProfileInstructions?: string;
     },
   ): Promise<StepWithToolsResult> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -152,7 +154,7 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
     const maxCalls = options.maxToolCalls ?? 20;
     let tool_call_count = 0;
     const tool_call_records: ToolCallRecord[] = [];
-    const system = buildSystemPrompt(options.inputSchema);
+    const system = buildSystemPrompt(options.inputSchema, options.agentProfileInstructions);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const history: any[] = [{ role: 'user', content: prompt }];

--- a/packages/cli/src/agent/providers/llm-provider.ts
+++ b/packages/cli/src/agent/providers/llm-provider.ts
@@ -24,6 +24,7 @@ export abstract class LlmProvider {
   abstract callStep(
     prompt: string,
     inputSchema?: Record<string, unknown>,
+    agentProfileInstructions?: string,
   ): Promise<Record<string, unknown>>;
 
   /** Returns the capability set for this provider instance. */
@@ -45,6 +46,7 @@ export abstract class ToolCapableLlmProvider extends LlmProvider {
       inputSchema?: Record<string, unknown>;
       maxToolCalls?: number;
       toolTimeoutMs?: number;
+      agentProfileInstructions?: string;
     },
   ): Promise<StepWithToolsResult>;
 }

--- a/packages/cli/src/agent/providers/openai-provider.ts
+++ b/packages/cli/src/agent/providers/openai-provider.ts
@@ -46,6 +46,7 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
   async callStep(
     prompt: string,
     inputSchema?: Record<string, unknown>,
+    agentProfileInstructions?: string,
   ): Promise<Record<string, unknown>> {
     // Dynamically import openai to keep it an optional peer dependency.
     // Assigning the module specifier to a typed variable via 'string' makes TS
@@ -66,7 +67,7 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
       ...(this.baseUrl !== undefined ? { baseURL: this.baseUrl } : {}),
     });
 
-    const systemPrompt = buildSystemPrompt(inputSchema);
+    const systemPrompt = buildSystemPrompt(inputSchema, agentProfileInstructions);
     type Message = { role: 'system' | 'user' | 'assistant'; content: string };
     const messages: Message[] = [
       { role: 'system', content: systemPrompt },
@@ -120,6 +121,7 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
       inputSchema?: Record<string, unknown>;
       maxToolCalls?: number;
       toolTimeoutMs?: number;
+      agentProfileInstructions?: string;
     },
   ): Promise<StepWithToolsResult> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -172,7 +174,10 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const history: any[] = [
-      { role: 'system', content: buildSystemPrompt(options.inputSchema) },
+      {
+        role: 'system',
+        content: buildSystemPrompt(options.inputSchema, options.agentProfileInstructions),
+      },
       { role: 'user', content: prompt },
     ];
 

--- a/packages/cli/src/agent/providers/openai-reasoning-provider.ts
+++ b/packages/cli/src/agent/providers/openai-reasoning-provider.ts
@@ -37,6 +37,7 @@ export class OpenAIReasoningProvider extends LlmProvider {
   async callStep(
     prompt: string,
     inputSchema?: Record<string, unknown>,
+    agentProfileInstructions?: string,
   ): Promise<Record<string, unknown>> {
     // Dynamically import openai to keep it an optional peer dependency.
     // Assigning the module specifier to a typed variable via 'string' makes TS
@@ -57,7 +58,7 @@ export class OpenAIReasoningProvider extends LlmProvider {
     });
 
     // Fold system prompt into the user message — safe for all o1-series API revisions.
-    const systemPrompt = buildSystemPrompt(inputSchema);
+    const systemPrompt = buildSystemPrompt(inputSchema, agentProfileInstructions);
     const userContent = `${systemPrompt}\n\n${prompt}`;
 
     type Message = { role: 'user' | 'assistant'; content: string };

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -281,6 +281,10 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         const inputSchema =
           (nextAction?.input_schema as Record<string, unknown> | undefined) ??
           (stepDef.input_schema as Record<string, unknown> | undefined);
+        const agentProfileInstructions =
+          stepDef.agent_profile !== undefined
+            ? definition.resolved_profiles?.[stepDef.agent_profile]?.content
+            : undefined;
 
         const descPreview = stepDef.description.slice(0, 80);
         console.log(`\n→ [agent] ${stepName}`);
@@ -359,6 +363,7 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
                 : {}),
               maxToolCalls: stepDef.max_tool_calls ?? 20,
               toolTimeoutMs: (stepDef.tool_timeout ?? 30) * 1000,
+              ...(agentProfileInstructions !== undefined ? { agentProfileInstructions } : {}),
             });
           } catch (err) {
             console.error(
@@ -374,7 +379,11 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
           stepInput = {};
           for (let attempt = 0; attempt < 2; attempt++) {
             try {
-              stepInput = await deps.provider.callStep(prompt, inputSchema);
+              stepInput = await deps.provider.callStep(
+                prompt,
+                inputSchema,
+                agentProfileInstructions,
+              );
               callError = undefined;
               break;
             } catch (err) {


### PR DESCRIPTION
## Context

`realm agent` CLI was not injecting `agent_profile_instructions` into the LLM system prompt. The profile content is resolved and stored on `WorkflowDefinition.resolved_profiles` by the YAML loader, and is included in MCP protocol responses (`agent_profile_instructions` on `ProtocolStep`). However, `run-agent.ts` never read it — the system prompt was always the generic "respond with JSON" baseline regardless of the step's `agent_profile` field.

This meant that when running `realm agent --workflow ...`, steps with `agent_profile` received no persona, no classification rules, no domain-specific instructions — making the LLM's output unreliable for any workflow that depends on a profile.

## Root Cause

`run-agent.ts` derived `prompt` and `inputSchema` from the step definition before calling the provider, but never looked up `definition.resolved_profiles[stepDef.agent_profile]`. All three provider implementations forwarded only `inputSchema` to `buildSystemPrompt`, which built a generic baseline system prompt.

## Changes

- **`agent-utils.ts`** — `buildSystemPrompt` accepts an optional second parameter `agentProfileInstructions`. When present, it is prepended to the base prompt, so the system message reads: `<profile>\n\n<base JSON instruction>\n<schema>`.
- **`llm-provider.ts`** — `callStep` gains an optional `agentProfileInstructions?: string` positional parameter. `callStepWithTools` options bag gains the same field.
- **`anthropic-provider.ts`**, **`openai-provider.ts`**, **`openai-reasoning-provider.ts`** — updated `callStep` and `callStepWithTools` signatures to accept and forward `agentProfileInstructions` to `buildSystemPrompt`.
- **`run-agent.ts`** — after deriving `prompt` and `inputSchema`, resolves the profile content from `definition.resolved_profiles` and passes it to both the tools path (`callStepWithTools` options) and the non-tools path (`callStep`). Steps without `agent_profile` pass `undefined` — no behaviour change for those steps.
- **`agent-utils.test.ts`** — two new test cases: profile-only and profile-with-schema.

## Verification

```bash
cd packages/cli
npx vitest run src/agent/providers/agent-utils.test.ts
```

Expected: 4 tests pass.

```bash
npx tsc -p tsconfig.json --noEmit
```

Expected: no output (clean).

For end-to-end confirmation: run `realm agent` against a workflow with `agent_profile` set and verify `realm run inspect` shows the step's `agent_profile` field, and that the LLM output reflects the profile's classification rules (not a generic response).

## Rollback

```bash
git revert HEAD
```
