### PR TITLE
docs(pre-publication): clarify tag-push trigger and add release cadence rule

### DIFF
--- a/.github/instructions/pre-publication.instructions.md
+++ b/.github/instructions/pre-publication.instructions.md
@@ -74,6 +74,8 @@ Follow this checklist in order before merging any branch into `main`.
 >
 > A package with `"private": true` in its manifest is not published. Part B does not apply to it.
 
+**When to run Part B:** Cut a release when `[Unreleased]` in `CHANGELOG.md` contains at least one `### Added`, `### Changed`, or `### Security` entry and all open PRs for the milestone are merged. Do not let `[Unreleased]` accumulate across multiple sessions without a release — npm will show the previous version until a tag is pushed.
+
 **1. Create a release branch**
 
 ```bash
@@ -113,6 +115,8 @@ git push -u origin release/v<version>
 Open a PR to `main`. Use **merge commit** (`gh pr merge --merge`) — not rebase, not squash. The release script tags the release commit on the branch before the PR is opened; a rebase merge would rewrite that commit's SHA, making the tag a dangling reference unreachable from `main` and breaking the publish workflow. Merge after CI passes.
 
 **5. Push the tag**
+
+> **Hard gate — this is the only action that triggers the automated npm publish pipeline.** `publish.yml` fires on `push: tags: v*` and will not run until this command is executed. Packages remain at the previous version on npm despite CI being green and the PR being merged until this step runs. Do not skip it.
 
 After the PR is merged:
 


### PR DESCRIPTION
## Context

Following a post-mortem on `v0.1.0`, the npm packages were never published despite code shipping to `main` since June 1. Investigation revealed that `git push --tags` (Part B Step 5) was never executed — which is the only step that triggers the automated `publish.yml` workflow. Nothing in the existing instructions called this out as the critical gate, and there was no rule defining when to cut a release.

## Motivation

Two gaps in the instructions caused the missed release:
1. No release cadence / trigger rule — agents and contributors had no signal to act on
2. Step 5 "Push the tag" looked like one step among many, with no indication it is the single trigger for the entire automated publish pipeline

## Changes

**Added: `When to run Part B` cadence rule** (after the Part B preamble)
Defines the trigger condition: cut a release when `[Unreleased]` contains at least one `### Added`, `### Changed`, or `### Security` entry and all milestone PRs are merged. Notes that packages stay at the previous npm version until a tag is pushed.

**Added: Hard-gate callout for Step 5 (Push the tag)**
A blockquote marked _Hard gate_ makes it unmissable: `publish.yml` fires on `push: tags: v*` and will not run until this step executes. Packages stay at the previous version on npm despite CI being green and the PR being merged.

No other changes. No logic, no code, no Part A modifications.

## Verification

```bash
grep -n "When to run Part B\|Hard gate" .github/instructions/pre-publication.instructions.md
```

Expected: two matches — line ~77 for the cadence rule and line ~119 for the hard-gate callout.

## Rollback

```bash
git revert HEAD
```

## Related

Discovered during `v0.2.0` release preparation.
