### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] — 2026-06-03
+
 ### Added
 
+- **`execution: guard` step type** — a new step kind that evaluates `abort_unless` conditions against resolved run state. If any condition is not met the run transitions to `run_phase: aborted` and no further steps execute. Guard steps appear in `chained_auto_steps` and always run as auto steps. See the [YAML schema reference](docs/reference/yaml-schema.md) for the full condition syntax.
+- `abort_context` on `get_run_state` — when `run_phase` is `aborted`, the response now includes the guard step ID, each evaluated condition with its resolved value, and the optional `abort_message` authored in the workflow YAML.
+- **`config_schema`** field on service adapter definitions — a JSON Schema that validates the `config` object passed from a step's `config` field before the adapter is invoked. Invalid configs produce a structured validation error without reaching the adapter.
+- `config` pass-through on steps — workflow step definitions now accept an optional `config` object forwarded verbatim to service adapters that declare `config_schema`.
 - **`start_run_batch` MCP tool** — atomically enqueues multiple child workflow runs in a single call. All items are validated before any run is created (all-or-nothing semantics). Each item accepts `workflow_id`, `params`, and an optional `idempotency_key` for safe re-runs.
 - `parent_run_id` field on `RunRecord` — links child runs to their originating parent run for lineage tracking.
 - `idempotency_key` field on `RunRecord` — deduplication key for `start_run` and `start_run_batch` calls. The `JsonFileStore` deduplicates by key within a workflow: a second create with the same key returns the existing run.
@@ -16,10 +24,21 @@ All notable changes to this project are documented here.
 - New error codes `VALIDATION_BATCH_TOO_LARGE` and `VALIDATION_BATCH_ITEMS` in `ErrorCode` union.
 - New exported type `InputMapNode` — a recursive union type (`string | { [key: string]: InputMapNode }`) representing a leaf source-path string or a nested map used for nested object construction in `input_map`.
 - `input_map` now supports nested object construction. Object nodes assemble a plain nested object by recursively resolving their children as source paths. Maximum depth is 10. Empty object nodes and non-string leaves are rejected at workflow registration time with a clear error message.
+- **Agent profile runtime injection** — `agent_profile_instructions` from the MCP protocol step response is now prepended to the LLM system prompt at runtime by the Anthropic and OpenAI providers. Previously the field was present in the protocol but not consumed by the agent loop.
 
 ### Changed
 
 - `WorkflowDefinition.input_map` value type changed from `string` to `InputMapNode` (`string | { [key: string]: InputMapNode }`). Runtime behaviour is unchanged for all-string `input_map` blocks.
+- `@sensigo/realm-mcp`: individual MCP tool modules are now accessible as subpath exports (`@sensigo/realm-mcp/tools/<name>`).
+
+### Fixed
+
+- MCP server: version assertion now uses a semver pattern regex instead of a hardcoded string, so it no longer needs updating on each release.
+
+### Security
+
+- **ReDoS in `render-template`**: removed `\s*` anchors and excluded `{` from the template variable capture group (`[^}]+?` → `[^{}]+`) to eliminate polynomial backtracking on adversarial inputs containing repeated `{` characters or trailing spaces.
+- **CodeQL alerts**: patched Gorgias adapter tag-stripping loop to handle nested-tag bypass patterns (e.g. `<scr<x>ipt>`); replaced sequential entity-escape calls with a single-pass regex to prevent double-unescaping; tightened precondition literal capture group (`(.+)` → `(\S.*)`) to remove leading-whitespace backtracking ambiguity.
 
 ### Breaking Changes
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.1.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.2.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.1.0',
+    version: '0.2.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.0';


### PR DESCRIPTION
## Context

Cutting v0.2.0. All milestone PRs (#43, #44, #45, #47, #48) have merged to `main`. The `[Unreleased]` section of the CHANGELOG contained entries for `start_run_batch`, `input_map` widening, and `InputMapNode` — plus several post-v0.1.0 features that were missing from the changelog (guard steps, config_schema, ReDoS fixes, CodeQL fixes, agent profile runtime injection, semver fix, subpath exports). All entries have been consolidated into `[0.2.0]`.

## Motivation

v0.2.0 introduces fan-out orchestration (`start_run_batch`), conditional workflow abort (`execution: guard`), structured adapter configuration (`config_schema`), nested `input_map` object construction, agent profile runtime injection, and two security patches. The `StepDefinition.input_map` value type widening is a breaking TypeScript API change, warranting a minor version bump (pre-1.0 semver).

## Changes

- `CHANGELOG.md`: renamed `[Unreleased]` to `[0.2.0] — 2026-06-03`; added missing post-v0.1.0 changelog entries (guard, config_schema, subpath exports, agent profile injection, ReDoS, CodeQL, semver fix); added fresh empty `[Unreleased]` section.
- All four `package.json` files bumped from `0.1.x` to `0.2.0`.
- Five `VERSION` constants in source files bumped to `0.2.0`.

## Verification

```bash
# After merge, verify versions are bumped:
grep '"version"' packages/core/package.json packages/mcp-server/package.json packages/cli/package.json packages/testing/package.json
# Expected: "version": "0.2.0" in all four

# Verify tag exists:
git tag | grep v0.2.0
# Expected: v0.2.0
```

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. npm publish has NOT been triggered yet — that requires `git push --tags` after this PR merges (see step 5 of the pre-publication checklist).

## Related

Closes no issues. Follows the Part B release process in `.github/instructions/pre-publication.instructions.md`.

> **IMPORTANT — merge strategy**: use `gh pr merge --merge` (merge commit), NOT rebase or squash. The release script tagged commit `0e9aef1` on this branch. A rebase would rewrite that SHA, making `v0.2.0` a dangling reference and breaking `publish.yml`.
