### PR TITLE
feat(core): add $literal sentinel support to input_map

### DIFF
--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -17,6 +17,7 @@ import type {
   RetryConfig,
   ContextWrapperFormat,
   InputMapNode,
+  LiteralNode,
 } from '../types/workflow-definition.js';
 import type { RunStore } from '../store/store-interface.js';
 import type { TraceBufferStore, BufferedEntry } from '../store/trace-buffer-store.js';
@@ -203,9 +204,16 @@ function resolveInputMapNode(
   if (typeof node === 'string') {
     return resolvePath(node, root);
   }
+
+  // Literal node — return the value directly without path resolution.
+  if ('$literal' in node && Object.keys(node).length === 1) {
+    return (node as LiteralNode).$literal;
+  }
+
+  // Nested object — recurse.
   const result: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(node)) {
-    result[key] = resolveInputMapNode(child, root, `${keyChain}.${key}`, depth + 1);
+    result[key] = resolveInputMapNode(child as InputMapNode, root, `${keyChain}.${key}`, depth + 1);
   }
   return result;
 }

--- a/packages/core/src/engine/input-map.test.ts
+++ b/packages/core/src/engine/input-map.test.ts
@@ -442,4 +442,249 @@ describe('input_map', () => {
     expect(snap).toBeDefined();
     expect(snap!.resolved_params).toEqual({ fields: { name: 'Bob' } });
   });
+
+  it('input_map — $literal string value resolves without path lookup', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-wf',
+      name: 'InputMap Workflow',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        insert: {
+          description: 'Adapter step with literal table name',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+          input_map: { table: { $literal: 'CS_Macros' } },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { insert: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'insert',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'insert',
+      { table: 'CS_Macros' },
+      expect.any(Object),
+      undefined,
+    );
+  });
+
+  it('input_map — $literal boolean false resolves to false', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-wf',
+      name: 'InputMap Workflow',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        query: {
+          description: 'Adapter step with boolean literal',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+          input_map: { include_archived: { $literal: false } },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { query: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'query',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'query',
+      { include_archived: false },
+      expect.any(Object),
+      undefined,
+    );
+  });
+
+  it('input_map — $literal number resolves to number', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-wf',
+      name: 'InputMap Workflow',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        list: {
+          description: 'Adapter step with number literal',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+          input_map: { max_results: { $literal: 100 } },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { list: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'list',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'list',
+      { max_results: 100 },
+      expect.any(Object),
+      undefined,
+    );
+  });
+
+  it('input_map — $literal null resolves to null', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-wf',
+      name: 'InputMap Workflow',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        clear: {
+          description: 'Adapter step with null literal',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+          input_map: { owner: { $literal: null } },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { clear: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'clear',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith('clear', { owner: null }, expect.any(Object), undefined);
+  });
+
+  it('input_map — mixed path leaf and literal leaf produces correct merged object', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-wf',
+      name: 'InputMap Workflow',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        upsert2: {
+          description: 'Adapter step with mixed path and literal',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+          input_map: {
+            table: { $literal: 'CS_Macros' },
+            record_id: 'run.params.id',
+          },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { upsert2: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const run = await store.create({
+      workflowId: 'imap-wf',
+      workflowVersion: 1,
+      params: { id: 'rec123' },
+    });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'upsert2',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'upsert2',
+      { table: 'CS_Macros', record_id: 'rec123' },
+      expect.any(Object),
+      undefined,
+    );
+  });
+
+  it('input_map — $literal nested inside object node resolves correctly', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-wf',
+      name: 'InputMap Workflow',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        nested: {
+          description: 'Adapter step with literal inside nested object',
+          execution: 'auto',
+          depends_on: [],
+          uses_service: 'svc',
+          input_map: {
+            config: {
+              table: { $literal: 'CS_Macros' },
+              id: 'run.params.id',
+            },
+          },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { nested: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const run = await store.create({
+      workflowId: 'imap-wf',
+      workflowVersion: 1,
+      params: { id: 'rec456' },
+    });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'nested',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'nested',
+      { config: { table: 'CS_Macros', id: 'rec456' } },
+      expect.any(Object),
+      undefined,
+    );
+  });
 });

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -82,11 +82,15 @@ export type TriggerRule =
   | 'none_failed';
 
 /**
- * A node in an input_map tree. Either a dot-path string leaf or a nested object
- * whose values are themselves InputMapNodes. Enables building nested param objects
- * for adapter steps without flattening the structure.
+ * A node in an input_map tree. One of:
+ * - string: a dot-path reference resolved against run state
+ * - { $literal: scalar }: a static constant value
+ * - { [key: string]: InputMapNode }: a nested object (recursive)
+ *
+ * The $literal sentinel must appear alone — no sibling keys are permitted.
  */
-export type InputMapNode = string | { [key: string]: InputMapNode };
+export type LiteralNode = { $literal: string | number | boolean | null };
+export type InputMapNode = string | LiteralNode | { [key: string]: InputMapNode };
 
 export interface StepDefinition {
   description: string;

--- a/packages/core/src/workflow/yaml-loader.test.ts
+++ b/packages/core/src/workflow/yaml-loader.test.ts
@@ -338,6 +338,110 @@ steps:
       expect((err as WorkflowError).message).toContain('input_map');
     }
   });
+
+  it('input_map with valid $literal string loads without error', () => {
+    const yaml = `
+id: wf
+name: WF
+version: 1
+services:
+  svc:
+    adapter: mock
+    trust: engine_delivered
+steps:
+  step1:
+    description: step
+    execution: auto
+    uses_service: svc
+    input_map:
+      table:
+        $literal: CS_Macros
+`;
+    expect(() => loadWorkflowFromString(yaml)).not.toThrow();
+    const def = loadWorkflowFromString(yaml);
+    expect((def.steps['step1']?.input_map?.['table'] as { $literal: unknown }).$literal).toBe(
+      'CS_Macros',
+    );
+  });
+
+  it('input_map with $literal having sibling key is rejected', () => {
+    const yaml = `
+id: wf
+name: WF
+version: 1
+services:
+  svc:
+    adapter: mock
+    trust: engine_delivered
+steps:
+  step1:
+    description: step
+    execution: auto
+    uses_service: svc
+    input_map:
+      table:
+        $literal: CS_Macros
+        extra: should_fail
+`;
+    expect(() => loadWorkflowFromString(yaml)).toThrow(WorkflowError);
+    try {
+      loadWorkflowFromString(yaml);
+    } catch (err) {
+      expect((err as WorkflowError).message).toContain('$literal');
+      expect((err as WorkflowError).message).toContain('sibling keys');
+    }
+  });
+
+  it('input_map with $literal array value is rejected', () => {
+    const yaml = `
+id: wf
+name: WF
+version: 1
+services:
+  svc:
+    adapter: mock
+    trust: engine_delivered
+steps:
+  step1:
+    description: step
+    execution: auto
+    uses_service: svc
+    input_map:
+      ids:
+        $literal:
+          - one
+          - two
+`;
+    expect(() => loadWorkflowFromString(yaml)).toThrow(WorkflowError);
+    try {
+      loadWorkflowFromString(yaml);
+    } catch (err) {
+      expect((err as WorkflowError).message).toContain('$literal value must be');
+    }
+  });
+
+  it('input_map with $literal nested inside object validates correctly', () => {
+    const yaml = `
+id: wf
+name: WF
+version: 1
+services:
+  svc:
+    adapter: mock
+    trust: engine_delivered
+steps:
+  step1:
+    description: step
+    execution: auto
+    uses_service: svc
+    input_map:
+      config:
+        table:
+          $literal: CS_Macros
+        id: run.params.id
+`;
+    expect(() => loadWorkflowFromString(yaml)).not.toThrow();
+  });
 });
 
 describe('loadWorkflowFromFile', () => {

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -648,7 +648,26 @@ function validateInputMapNode(
     return;
   }
   if (typeof node === 'object' && node !== null && !Array.isArray(node)) {
-    const entries = Object.entries(node as Record<string, unknown>);
+    const obj = node as Record<string, unknown>;
+
+    // Literal sentinel node.
+    if ('$literal' in obj) {
+      if (Object.keys(obj).length !== 1) {
+        errors.push(
+          `${pathDesc}: $literal node must have exactly one key ($literal); found sibling keys`,
+        );
+        return;
+      }
+      const val = obj['$literal'];
+      const allowed = ['string', 'number', 'boolean'];
+      if (val !== null && !allowed.includes(typeof val)) {
+        errors.push(`${pathDesc}: $literal value must be a string, number, boolean, or null`);
+      }
+      return;
+    }
+
+    // Nested object — recurse.
+    const entries = Object.entries(obj);
     if (entries.length === 0) {
       errors.push(`${pathDesc}: object nodes must have at least one key`);
       return;


### PR DESCRIPTION
## Context

Identified during CS1 shadow session (June 2026). Handler authors were writing full custom API clients solely because `input_map` couldn't express static string constants such as `table: "CS_Macros"`. The `registry.ts` comment in the Bradley workspace stated the problem directly at line 84.

## Motivation

Every `input_map` string leaf was interpreted as a dot-path reference. There was no way to inject a static value (e.g. an Airtable table name, a boolean flag, a numeric constant) without writing a full custom handler. This phase adds a `$literal` sentinel that marks an object node as a direct value rather than a path.

## Changes

### `packages/core/src/types/workflow-definition.ts`
- Added `LiteralNode = { $literal: string | number | boolean | null }` export
- Extended `InputMapNode` to a three-way union: `string | LiteralNode | { [key: string]: InputMapNode }`

### `packages/core/src/engine/execution-loop.ts`
- Imported `LiteralNode` from `workflow-definition.ts`
- Added literal branch in `resolveInputMapNode` before the recursive object case: when `'$literal' in node && Object.keys(node).length === 1`, returns `node.$literal` directly

### `packages/core/src/workflow/yaml-loader.ts`
- Added `$literal` branch in `validateInputMapNode`:
  - Rejects nodes where `Object.keys(obj).length !== 1` (sibling key guard)
  - Rejects values that are not `string | number | boolean | null` (array/object guard)
  - Valid literals return without further recursion

### `packages/core/src/index.ts`
- Added `export type { LiteralNode }` from `./types/workflow-definition.js`

### Tests
- `packages/core/src/engine/input-map.test.ts`: 6 new tests — string literal, boolean literal, number literal, null literal, mixed path+literal map, literal nested inside object node
- `packages/core/src/workflow/yaml-loader.test.ts`: 4 new tests — valid literal string loads, sibling key rejection, array value rejection, nested literal validates correctly

## Verification

```bash
# Type-check all packages
npx tsc -p packages/core/tsconfig.json --noEmit        # OK
npx tsc -p packages/mcp-server/tsconfig.json --noEmit  # OK
npx tsc -p packages/cli/tsconfig.json --noEmit         # OK

# Full test suite
npx vitest run
# Test Files  82 passed (82)
#       Tests  1471 passed | 3 skipped (1474)
```

## Rollback

```bash
git revert HEAD~1 HEAD
```

No out-of-band mutations. Code-only change.
