### PR TITLE
feat(core): add handler graceful abort via result.abort

### DIFF
--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -1049,6 +1049,204 @@ describe('executeStep', () => {
       expect(ctx.resources).toBeDefined();
       expect(ctx.resources!['fetch_doc']).toBeDefined();
     });
+
+    it('clean abort — handler returning { abort: { message } } produces run_phase: aborted', async () => {
+      const handler: StepHandler = {
+        id: 'my_handler',
+        execute: vi.fn().mockResolvedValue({ abort: { message: 'Ticket is closed' } }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const run = await store.create({
+        workflowId: 'handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, handlerDefinition, {
+        runId: run.id,
+        command: 'validate',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(envelope.status).toBe('ok');
+      expect(envelope.next_actions).toHaveLength(0);
+
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.run_phase).toBe('aborted');
+      expect(updatedRun.terminal_state).toBe(true);
+      expect(updatedRun.aborted_at?.step_id).toBe('validate');
+      expect(updatedRun.aborted_at?.abort_message).toBe('Ticket is closed');
+    });
+
+    it('abort skips downstream steps', async () => {
+      const twoStepHandlerDef: WorkflowDefinition = {
+        id: 'two-step-handler-wf',
+        name: 'Two Step Handler Workflow',
+        version: 1,
+        steps: {
+          check: {
+            description: 'Guard-like check',
+            execution: 'auto',
+            depends_on: [],
+            handler: 'my_handler',
+          },
+          process: {
+            description: 'Downstream processing',
+            execution: 'agent',
+            depends_on: ['check'],
+          },
+        },
+      };
+
+      const handler: StepHandler = {
+        id: 'my_handler',
+        execute: vi.fn().mockResolvedValue({ abort: { message: 'Condition not met' } }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const run = await store.create({
+        workflowId: 'two-step-handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      await executeStep(store, twoStepHandlerDef, {
+        runId: run.id,
+        command: 'check',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.run_phase).toBe('aborted');
+      expect(updatedRun.skipped_steps).toContain('check');
+      expect(updatedRun.skipped_steps).toContain('process');
+      expect(updatedRun.completed_steps).not.toContain('check');
+      expect(updatedRun.failed_steps).not.toContain('check');
+    });
+
+    it('abort evidence entry has status skipped and records the abort message', async () => {
+      const handler: StepHandler = {
+        id: 'my_handler',
+        execute: vi.fn().mockResolvedValue({ abort: { message: 'Ticket is closed' } }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const run = await store.create({
+        workflowId: 'handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      await executeStep(store, handlerDefinition, {
+        runId: run.id,
+        command: 'validate',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      const updatedRun = await store.get(run.id);
+      const abortEntry = updatedRun.evidence.find((e) => e.step_id === 'validate');
+      expect(abortEntry).toBeDefined();
+      expect(abortEntry!.status).toBe('skipped');
+      expect(abortEntry!.error).toBe('Ticket is closed');
+    });
+
+    it('throw still fails — handler that throws produces run_phase: failed', async () => {
+      const handler: StepHandler = {
+        id: 'my_handler',
+        execute: vi.fn().mockRejectedValue(new Error('unexpected crash')),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const run = await store.create({
+        workflowId: 'handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, handlerDefinition, {
+        runId: run.id,
+        command: 'validate',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(envelope.status).toBe('error');
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.run_phase).toBe('failed');
+      expect(updatedRun.failed_steps).toContain('validate');
+    });
+
+    it('data-only result unchanged — handler returning { data } completes normally', async () => {
+      const handler = makeHandler({ processed: true });
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const run = await store.create({
+        workflowId: 'handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, handlerDefinition, {
+        runId: run.id,
+        command: 'validate',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(envelope.status).toBe('ok');
+      expect(envelope.data).toEqual({ processed: true });
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.run_phase).toBe('completed');
+      expect(updatedRun.completed_steps).toContain('validate');
+    });
+
+    it('both abort and data — abort takes precedence and run aborts cleanly', async () => {
+      const handler: StepHandler = {
+        id: 'my_handler',
+        execute: vi
+          .fn()
+          .mockResolvedValue({
+            data: { should_be_ignored: true },
+            abort: { message: 'Abort wins' },
+          }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const run = await store.create({
+        workflowId: 'handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, handlerDefinition, {
+        runId: run.id,
+        command: 'validate',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(envelope.status).toBe('ok');
+      expect(envelope.next_actions).toHaveLength(0);
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.run_phase).toBe('aborted');
+      expect(updatedRun.aborted_at?.abort_message).toBe('Abort wins');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -1217,12 +1217,10 @@ describe('executeStep', () => {
     it('both abort and data — abort takes precedence and run aborts cleanly', async () => {
       const handler: StepHandler = {
         id: 'my_handler',
-        execute: vi
-          .fn()
-          .mockResolvedValue({
-            data: { should_be_ignored: true },
-            abort: { message: 'Abort wins' },
-          }),
+        execute: vi.fn().mockResolvedValue({
+          data: { should_be_ignored: true },
+          abort: { message: 'Abort wins' },
+        }),
       };
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -413,6 +413,10 @@ async function callAdapter(
   };
 }
 
+type HandlerCallResult =
+  | { kind: 'data'; output: Record<string, unknown> }
+  | { kind: 'abort'; message: string };
+
 /**
  * Resolves and calls the step handler for an auto step with a `handler` reference.
  */
@@ -422,7 +426,7 @@ async function callHandler(
   pendingRun: RunRecord,
   evidenceByStep: Record<string, Record<string, unknown>>,
   signal?: AbortSignal,
-): Promise<Record<string, unknown>> {
+): Promise<HandlerCallResult> {
   const handlerName = stepDef.handler!;
   const handler = (options.registry ?? createDefaultRegistry()).getHandler(handlerName);
   if (handler === undefined) {
@@ -459,7 +463,10 @@ async function callHandler(
     });
   }
 
-  return result.data;
+  if (result.abort !== undefined) {
+    return { kind: 'abort', message: result.abort.message };
+  }
+  return { kind: 'data', output: result.data ?? {} };
 }
 
 /**
@@ -903,12 +910,22 @@ export async function executeStep(
       ): Promise<{
         output: Record<string, unknown>;
         resolvedParams: Record<string, unknown> | undefined;
+        handlerAbort?: { message: string };
       }> => {
         if (stepDef?.execution === 'auto' && stepDef.uses_service !== undefined) {
           return callAdapter(stepDef, definition, options, pendingRun, rateLimiterRegistry, signal);
         } else if (stepDef?.execution === 'auto' && stepDef.handler !== undefined) {
           return callHandler(stepDef, options, pendingRun, evidenceByStep, signal).then(
-            (result) => ({ output: result, resolvedParams: undefined }),
+            (result) => {
+              if (result.kind === 'abort') {
+                return {
+                  output: {},
+                  resolvedParams: undefined,
+                  handlerAbort: { message: result.message },
+                };
+              }
+              return { output: result.output, resolvedParams: undefined };
+            },
           );
         } else {
           return options
@@ -920,6 +937,61 @@ export async function executeStep(
         timeoutMs !== undefined
           ? await withTimeout((signal) => makeCall(signal), timeoutMs, options.command)
           : await makeCall();
+
+      // Handle graceful abort from a handler returning { abort: { message } }.
+      if (callResult.handlerAbort !== undefined) {
+        const abortMessage = callResult.handlerAbort.message;
+        const now = new Date();
+        const abortEvidence: EvidenceSnapshot = {
+          ...captureEvidence({
+            stepId: options.command,
+            startedAt: now,
+            completedAt: now,
+            input: options.input,
+            output: { aborted: true, abort_message: abortMessage },
+            error: abortMessage,
+          }),
+          status: 'skipped',
+        };
+        const withHandlerSkipped: RunRecord = {
+          ...pendingRun,
+          in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
+          evidence: [...pendingRun.evidence, abortEvidence],
+          skipped_steps: [...pendingRun.skipped_steps, options.command],
+        };
+        const withAllSkipped: RunRecord = {
+          ...withHandlerSkipped,
+          skipped_steps: propagateSkips(withHandlerSkipped, definition),
+        };
+        const abortedRun: RunRecord = {
+          ...withAllSkipped,
+          terminal_state: true,
+          terminal_reason: `Handler '${options.command}' aborted the run: ${abortMessage}`,
+          aborted_at: {
+            step_id: options.command,
+            abort_message: abortMessage,
+          },
+        };
+        let persistedAbortRun: RunRecord | undefined;
+        try {
+          persistedAbortRun = await store.update(abortedRun);
+        } catch {
+          // Persist failed — return the in-memory run version.
+        }
+        return {
+          command: options.command,
+          run_id: options.runId,
+          run_version: (persistedAbortRun ?? abortedRun).version,
+          status: 'ok',
+          data: {},
+          evidence: [abortEvidence],
+          warnings: [],
+          errors: [],
+          context_hint: `Handler step '${options.command}' aborted the run: ${abortMessage}`,
+          next_actions: [],
+        };
+      }
+
       attemptOutput = callResult.output;
       resolvedParams = callResult.resolvedParams;
       if (resolvedParams !== undefined) {

--- a/packages/core/src/extensions/step-handler.ts
+++ b/packages/core/src/extensions/step-handler.ts
@@ -17,8 +17,21 @@ export interface StepContext {
 }
 
 export interface StepHandlerResult {
-  data: Record<string, unknown>;
+  /**
+   * Output data to record in the evidence chain. Required unless `abort` is set.
+   * When both `abort` and `data` are present, `abort` takes precedence and `data` is ignored.
+   */
+  data?: Record<string, unknown>;
   state_update?: Record<string, unknown>;
+  /**
+   * When set, the engine treats this step as a clean abort rather than a completion.
+   * The run transitions to run_phase: 'aborted' and all downstream steps are skipped.
+   * Use this for expected business conditions (e.g. "ticket is already closed") that
+   * should stop the run cleanly without recording a failure.
+   *
+   * Mutually exclusive with `data` — when both are present, `abort` takes precedence.
+   */
+  abort?: { message: string };
 }
 
 export interface StepHandler {

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -203,7 +203,7 @@ export interface RunRecord {
    */
   aborted_at?: {
     step_id: string;
-    conditions: Array<{ condition: string; resolved_value: unknown; passed: boolean }>;
+    conditions?: Array<{ condition: string; resolved_value: unknown; passed: boolean }>;
     abort_message?: string;
   };
 }

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -29,7 +29,7 @@ export interface RunStateSummary {
   params: Record<string, unknown>;
   abort_context?: {
     step_id: string;
-    conditions: Array<{ condition: string; resolved_value: unknown; passed: boolean }>;
+    conditions?: Array<{ condition: string; resolved_value: unknown; passed: boolean }>;
     abort_message?: string;
   };
 }

--- a/packages/testing/src/mocks/mock-agent.ts
+++ b/packages/testing/src/mocks/mock-agent.ts
@@ -87,7 +87,7 @@ export function createAgentDispatcher(
         { params: input },
         { run_id: run.id, run_params: run.params, config: {} },
       );
-      return result.data;
+      return result.data ?? {};
     }
 
     if (stepDef.uses_service !== undefined) {


### PR DESCRIPTION
## Context

Identified during CS1 shadow session (June 2026). Two Bradley workspace handlers — `assert-ticket-open.ts` and `klant-als-laatste.ts` — both `throw` an `Error` to stop a run when an expected business condition is not met (e.g. "ticket is already closed", "agent spoke last"). This produces `run_phase: 'failed'` and a failure trace, which is semantically wrong. The run did not crash — it reached a clean stop condition.

## Motivation

Handlers need a first-class way to signal a clean, expected early exit without recording a failure. The `run_phase` should be `'aborted'`, mirroring the `execution: guard` path, so callers can distinguish "clean stop" from "handler crashed".

## Changes

### `packages/core/src/extensions/step-handler.ts`
- Made `data` optional on `StepHandlerResult` (was required)
- Added `abort?: { message: string }` field with JSDoc explaining mutual exclusivity with `data`
- When both `abort` and `data` are present, `abort` takes precedence (enforced in the engine)

### `packages/core/src/types/run-record.ts`
- Made `conditions` optional on the `aborted_at` field (`conditions?:` instead of `conditions:`), so handler aborts can set `aborted_at` without a guard-specific conditions array

### `packages/core/src/engine/execution-loop.ts`
- Added `HandlerCallResult` discriminated union type:
  ```ts
  type HandlerCallResult =
    | { kind: 'data'; output: Record<string, unknown> }
    | { kind: 'abort'; message: string };
  ```
- Changed `callHandler` return type from `Promise<Record<string, unknown>>` to `Promise<HandlerCallResult>`; checks `result.abort` before returning
- Extended `makeCall`'s return type to include `handlerAbort?: { message: string }`
- Added abort handling immediately after `await makeCall()`:
  - Builds an `EvidenceSnapshot` with `status: 'skipped'` and `error: abortMessage`
  - Removes the step from `in_progress_steps`, adds it to `skipped_steps`
  - Calls `propagateSkips` to skip all downstream steps
  - Sets `terminal_state: true` and `aborted_at: { step_id, abort_message }`
  - Persists via `store.update()`
  - Returns `{ status: 'ok', next_actions: [], context_hint: "Handler step '...' aborted the run: ..." }`

### `packages/core/src/engine/execution-loop.test.ts`
Six new test cases added inside the `handler dispatch via handler field` describe block:
1. **Clean abort** — `{ abort: { message: "Ticket is closed" } }` → `run_phase: 'aborted'`, `aborted_at.abort_message === "Ticket is closed"`
2. **Abort skips downstream** — downstream `process` step appears in `skipped_steps`
3. **Abort evidence entry** — evidence entry has `status: 'skipped'` and `error` = abort message
4. **Throw still fails** — a throwing handler still produces `run_phase: 'failed'` (regression guard)
5. **Data-only unchanged** — `{ data: { ... } }` without `abort` still completes normally
6. **Both abort and data** — abort takes precedence; run aborts cleanly

## Verification

```bash
npx tsc -p packages/core/tsconfig.json --noEmit     # OK
npx tsc -p packages/mcp-server/tsconfig.json --noEmit  # OK
npx tsc -p packages/cli/tsconfig.json --noEmit       # OK

npx vitest run
# Test Files  82 passed (82)
#       Tests  1477 passed | 3 skipped (1480)
```

6 new tests; all 82 test files pass. No regressions.

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. Change is code-only.
