### PR TITLE
feat(core): add uses_resources to StepHandler with loader validation

### DIFF
--- a/packages/core/src/extensions/step-handler.ts
+++ b/packages/core/src/extensions/step-handler.ts
@@ -37,6 +37,15 @@ export interface StepHandlerResult {
 export interface StepHandler {
   readonly id: string;
   /**
+   * Step IDs this handler reads from `context.resources`.
+   * When declared, the YAML loader verifies that each listed step ID exists in
+   * the workflow definition at registration time.
+   *
+   * Purely informational at runtime — the engine does not enforce or filter
+   * `context.resources` based on this list.
+   */
+  readonly uses_resources?: readonly string[];
+  /**
    * Executes the handler's business logic.
    * Implementors that perform async I/O should check `signal?.aborted` between operations
    * and throw if true, rather than completing work that has already been cancelled.

--- a/packages/core/src/workflow/yaml-loader.test.ts
+++ b/packages/core/src/workflow/yaml-loader.test.ts
@@ -1441,3 +1441,69 @@ steps:
     }
   });
 });
+
+describe('loadWorkflowFromString — uses_resources validation', () => {
+  function makeHandler(id: string, usesResources?: string[]) {
+    return {
+      id,
+      ...(usesResources !== undefined ? { uses_resources: usesResources } : {}),
+      execute: async () => ({ data: {} }),
+    };
+  }
+
+  const BASE_YAML = `
+id: res-test
+name: Resource Test
+version: 1
+steps:
+  step-a:
+    description: First step
+    execution: auto
+    depends_on: []
+    handler: my_handler
+  step-b:
+    description: Second step
+    execution: agent
+    depends_on: [step-a]
+`;
+
+  it('valid reference — handler uses_resources points to existing step loads without error', () => {
+    const registry = new ExtensionRegistry();
+    registry.register('handler', 'my_handler', makeHandler('my_handler', ['step-b']));
+    expect(() => loadWorkflowFromString(BASE_YAML, registry)).not.toThrow();
+  });
+
+  it('missing step ID — handler uses_resources references nonexistent step throws WorkflowError', () => {
+    const registry = new ExtensionRegistry();
+    registry.register('handler', 'my_handler', makeHandler('my_handler', ['nonexistent-step']));
+    try {
+      loadWorkflowFromString(BASE_YAML, registry);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkflowError);
+      expect((err as WorkflowError).message).toContain(
+        "declares uses_resources 'nonexistent-step' but no step with that ID exists in this workflow",
+      );
+    }
+  });
+
+  it('no registry — uses_resources check is silently skipped', () => {
+    // Registry is not passed; validation must not throw even if uses_resources
+    // references a nonexistent step (the handler is not inspectable without a registry).
+    expect(() => loadWorkflowFromString(BASE_YAML)).not.toThrow();
+  });
+
+  it('handler not in registry — skips uses_resources check without error', () => {
+    // The step declares handler: 'unknown-handler' but the registry does not contain it.
+    // The loader must not throw — handler-not-found is a runtime concern, not a loader concern.
+    const registry = new ExtensionRegistry();
+    // Intentionally do not register 'my_handler'.
+    expect(() => loadWorkflowFromString(BASE_YAML, registry)).not.toThrow();
+  });
+
+  it('handler without uses_resources — no regression, loads without error', () => {
+    const registry = new ExtensionRegistry();
+    registry.register('handler', 'my_handler', makeHandler('my_handler'));
+    expect(() => loadWorkflowFromString(BASE_YAML, registry)).not.toThrow();
+  });
+});

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -433,6 +433,22 @@ export function loadWorkflowFromString(
       }
     }
 
+    // Validate uses_resources: each listed step ID must exist in the workflow.
+    if (step['handler'] !== undefined && registry !== undefined) {
+      const handlerName = step['handler'] as string;
+      const handler = registry.getHandler(handlerName);
+      if (handler !== undefined && handler.uses_resources !== undefined) {
+        for (const resourceStepId of handler.uses_resources) {
+          if (!(resourceStepId in stepsRaw)) {
+            errors.push(
+              `Step '${stepName}': handler '${handlerName}' declares uses_resources '${resourceStepId}' ` +
+                `but no step with that ID exists in this workflow`,
+            );
+          }
+        }
+      }
+    }
+
     // Validate trigger_rule.
     if ('trigger_rule' in step) {
       if (!VALID_TRIGGER_RULES.has(step['trigger_rule'] as TriggerRule)) {


### PR DESCRIPTION
## Context

Phase 69: Identified during the CS1 shadow session (June 2026). Handlers silently receive
`undefined` from `context.resources` when a step ID is misspelled or a step is renamed after
the handler was written. The handler then crashes at runtime with a confusing null-dereference
rather than a clear authoring-time error.

## Motivation

Allow a step handler to declare the prior step IDs it reads from `context.resources`. The YAML
loader validates at `realm register` time that every listed step ID actually exists in the
workflow definition. This catches typos and stale names at authoring time — before the workflow
is ever run — rather than silently producing `undefined` at runtime.

## Changes

### `packages/core/src/extensions/step-handler.ts`

Added optional `uses_resources` property to the `StepHandler` interface:

```ts
readonly uses_resources?: readonly string[];
```

Documented as purely informational at runtime — the engine does not enforce or filter
`context.resources` based on this list. The loader consumes it during registration.

### `packages/core/src/workflow/yaml-loader.ts`

Added a validation block inside the per-step validation loop, after the adapter `config_schema`
validation. For any step with a `handler` field, when a `registry` is present, the loader
retrieves the handler and checks each declared `uses_resources` ID against the workflow's step
map. Missing IDs are collected in `errors` with a message that identifies the step, handler,
and missing resource step ID:

```
Step 'fetch-macro': handler 'fetch-macro-handler' declares uses_resources 'nonexistent-step'
but no step with that ID exists in this workflow
```

The check is skipped when `registry` is absent (same gating pattern as `config_schema`
validation today).

### `packages/core/src/workflow/yaml-loader.test.ts`

Five new tests in `describe('loadWorkflowFromString — uses_resources validation')`:

1. Valid reference — handler lists an existing step ID → no error
2. Missing step ID — handler lists a nonexistent step ID → `WorkflowError` with correct message
3. No registry — validation silently skipped, no throw
4. Handler not in registry — `uses_resources` check skipped without error (runtime concern)
5. Handler without `uses_resources` — no regression, loads without error

## Verification

```bash
npx tsc -p packages/core/tsconfig.json --noEmit        # OK
npx tsc -p packages/mcp-server/tsconfig.json --noEmit  # OK
npx tsc -p packages/cli/tsconfig.json --noEmit         # OK
npx vitest run
# Test Files  82 passed (82)
# Tests  1482 passed | 3 skipped (1485)
```

5 new tests, all passing. No regressions.

## Rollback

```bash
git revert HEAD
```

No data mutations. Pure in-process validation change.

## Related

Prompt: `prompts/phase-69-handler-uses-resources.md`
