### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.3.0] — 2026-06-04
+
+### Added
+
+- **`$literal` sentinel in `input_map`** — workflow YAML authors can now write `{ $literal: <value> }` as a leaf node in `input_map` to inject a static scalar value (string, number, boolean, or null) directly, without any dot-path resolution. Validated at registration time: sibling keys alongside `$literal` and non-scalar values are rejected with a clear error message.
+- **Handler graceful abort via `result.abort`** — handlers can now return `{ abort: { message: "..." } }` to cleanly stop a run with `run_phase: 'aborted'` instead of throwing an `Error` (which produces `run_phase: 'failed'`). Mirrors the `execution: guard` abort path. The aborting step is recorded in evidence with `status: 'skipped'`; all downstream steps are skipped; `aborted_at.abort_message` is set on the run record.
+- **`uses_resources` on `StepHandler`** — handlers can declare `readonly uses_resources?: readonly string[]` listing the step IDs they read from `context.resources`. When declared, the YAML loader validates at `realm register` time that every listed ID exists in the workflow definition. Missing IDs produce a clear error identifying the step, handler, and the missing resource step ID. Purely informational at runtime — the engine does not filter `context.resources`.
+
+### Changed
+
+- `StepHandlerResult.data` is now optional. Handlers that return only `abort` or `state_update` no longer need to include an empty `data: {}`.
+- `RunRecord.aborted_at.conditions` is now optional. Guard aborts continue to populate it; handler aborts set `aborted_at` without a conditions array.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.2.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.3.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.2.0';
+export const VERSION = '0.3.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.2.0';
+export const VERSION = '0.3.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.2.0',
+    version: '0.3.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.2.0';
+export const VERSION = '0.3.0';


### PR DESCRIPTION
## Context

Three feature phases completed on `main` since v0.2.0 (phases 67, 68, 69 — all merged today):
- PR #50: `$literal` sentinel in `input_map`
- PR #52: handler graceful abort via `result.abort`
- PR #53: `uses_resources` on `StepHandler`

## Motivation

Publishing these as v0.3.0 to make the new capabilities available on npm. No breaking changes.

## Changes

### `$literal` sentinel in `input_map`
Workflow YAML can now write `{ $literal: <value> }` as a leaf node to inject a static scalar directly, without dot-path resolution.

### Handler graceful abort (`result.abort`)
Handlers can return `{ abort: { message: "..." } }` to cleanly stop a run with `run_phase: 'aborted'` instead of throwing. Mirrors the guard abort path.

### `uses_resources` on `StepHandler`
Optional declaration of step IDs the handler reads from `context.resources`. Validated at `realm register` time.

### Supporting type changes
- `StepHandlerResult.data` is now optional
- `RunRecord.aborted_at.conditions` is now optional
- `RunStateSummary.abort_context.conditions` is now optional

## Verification

```bash
npm run build    # all 4 packages build clean
npm run test     # 1485 passed, 3 skipped, 0 failed
```

## Rollback

```bash
git revert HEAD
```

No out-of-band data mutations. npm packages at v0.2.0 remain on the registry until this PR merges and the tag is pushed.

## Related

- Closes via merge: #50, #52, #53
