### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.4.0] — 2026-06-11
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.3.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.4.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.3.0';
+export const VERSION = '0.4.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.3.0';
+export const VERSION = '0.4.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.3.0',
+    version: '0.4.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.3.0';
+export const VERSION = '0.4.0';


### PR DESCRIPTION
## Context

PR #63 (merged 2026-06-11) completed the engine gap remediation: handler `warn` results, `run.params` in `when:` conditions, `input_map` on handler steps, shadow mode documentation, and `_debug` capture. The `[Unreleased]` changelog section now contains five `### Added` entries and one `### Changed` entry, which per `.github/instructions/pre-publication.instructions.md` Part B means a release is due.

## Motivation

Publish the new backwards-compatible engine capabilities to npm so workflow authors can use them. All changes are additive (optional fields, optional parameter with default, loosened loader restriction); the only behavioral tightening — reserved step names `run`/`context` — is flagged in the changelog with a migration note. Minor version bump per SemVer: 0.3.0 → 0.4.0.

## Changes

- `CHANGELOG.md`: renamed `[Unreleased]` to `[0.4.0] — 2026-06-11`
- `chore: release v0.4.0` (via `npm run release -- --version 0.4.0`): bumped `version` to 0.4.0 in all four `package.json` files and the source `VERSION` constants; tag `v0.4.0` created on the release commit

## Verification

```bash
npm run build          # 4 tasks successful
npm run lint           # 4 tasks successful, zero warnings
npm test               # core 1109 passed | 3 skipped; mcp 67; testing 47; cli 284
npm audit --omit=dev --audit-level=high   # found 0 vulnerabilities
node scripts/check-versions.mjs           # all versions consistent at 0.4.0
```

CI must be green on this PR before merge.

## Rollback

Before the tag is pushed: `git revert -m 1 <merge-commit>` on main and delete the local/remote tag (`git tag -d v0.4.0 && git push origin :refs/tags/v0.4.0`).

After the tag is pushed and the publish workflow has run, npm packages cannot be unpublished safely — publish a patch release (0.4.1) following Part B of the pre-publication checklist instead.

## Related

- PR #63 — the feature delta in this release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
