### PR TITLE
chore: pin vitest devDependency range to ^4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4543,7 +4543,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4562,7 +4562,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "typescript": "*",
-        "vitest": "*"
+        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -4594,7 +4594,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -4609,7 +4609,7 @@
         "@types/proper-lockfile": "^4.1.4",
         "@types/uuid": "^10.0.0",
         "typescript": "*",
-        "vitest": "*"
+        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -4639,7 +4639,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4652,7 +4652,7 @@
       "devDependencies": {
         "@types/node": "^25.5.0",
         "typescript": "*",
-        "vitest": "*"
+        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -4660,7 +4660,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",
@@ -4670,7 +4670,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "typescript": "*",
-        "vitest": "*"
+        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.0",
     "typescript": "*",
-    "vitest": "*"
+    "vitest": "^4.1.0"
   },
   "dependencies": {
     "@sensigo/realm": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "@types/proper-lockfile": "^4.1.4",
     "@types/uuid": "^10.0.0",
     "typescript": "*",
-    "vitest": "*"
+    "vitest": "^4.1.0"
   },
   "dependencies": {
     "ajv": "^8.18.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "typescript": "*",
-    "vitest": "*"
+    "vitest": "^4.1.0"
   },
   "files": [
     "dist",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -45,7 +45,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.0",
     "typescript": "*",
-    "vitest": "*"
+    "vitest": "^4.1.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Context

The v0.4.0 pre-publication review left 4 critical Dependabot alerts open on the default branch, all for GHSA-5xrq-8626-4rwp in `vitest`. The installed version is vitest 4.1.8, which is **not** vulnerable — the alerts are manifest-range false positives: the four workspace manifests declare `"vitest": "*"`, and Dependabot evaluates the declared range, which includes vulnerable versions `< 3.2.6`.

## Motivation

Clear the 4 standing Dependabot alerts without changing any installed dependency. The root `package.json` already pins `^4.1.0`; only the workspace manifests use the wildcard.

## Changes

Replaced `"vitest": "*"` with `"vitest": "^4.1.0"` in the devDependencies of:

- `packages/core/package.json`
- `packages/mcp-server/package.json`
- `packages/testing/package.json`
- `packages/cli/package.json`

Then refreshed `package-lock.json` via `npm install`. No other dependency was touched; the resolved vitest version is unchanged (4.1.8).

## Verification

```bash
npm ls vitest | head -8
# all four workspaces resolve vitest@4.1.8 (deduped)

npm run build
# 4 tasks successful

npm test
# core: 1109 passed | 3 skipped (1112); cli: 284; mcp: 67; testing: 47 — unchanged

git diff --stat main
# only the 4 manifests + package-lock.json
```

## Rollback

```bash
git revert HEAD
npm install
```

No out-of-band mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
