### PR TITLE
test(core): extract live-API contract probes into on-demand suite

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "build": "tsc --build",
     "test": "vitest run",
+    "test:contract": "vitest run --config vitest.contract.config.ts",
     "lint": "eslint src"
   },
   "devDependencies": {

--- a/packages/core/src/adapters/airtable-adapter.probe.ts
+++ b/packages/core/src/adapters/airtable-adapter.probe.ts
@@ -1,0 +1,24 @@
+// Contract probe for AirtableAdapter — hits the real Airtable API.
+// Requires AIRTABLE_TEST_API_KEY, AIRTABLE_TEST_BASE_ID, and AIRTABLE_TEST_TABLE.
+// Run via `npm run test:contract --workspace=packages/core`.
+import { it, expect } from 'vitest';
+import { AirtableAdapter } from './airtable-adapter.js';
+
+it.skipIf(
+  !process.env['AIRTABLE_TEST_API_KEY'] ||
+    !process.env['AIRTABLE_TEST_BASE_ID'] ||
+    !process.env['AIRTABLE_TEST_TABLE'],
+)(
+  'contract probe — real API (requires AIRTABLE_TEST_API_KEY + AIRTABLE_TEST_BASE_ID + AIRTABLE_TEST_TABLE)',
+  async () => {
+    const apiKey = process.env['AIRTABLE_TEST_API_KEY'] ?? '';
+    const baseId = process.env['AIRTABLE_TEST_BASE_ID'] ?? '';
+    const table = process.env['AIRTABLE_TEST_TABLE'] ?? '';
+
+    const adapter = new AirtableAdapter('airtable', { api_key: apiKey, base_id: baseId });
+    const result = await adapter.fetch('list_records', { table }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as { records: unknown[] };
+    expect(Array.isArray(data.records)).toBe(true);
+  },
+);

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -611,19 +611,3 @@ describe('AirtableAdapter unsupported operations', () => {
     ).rejects.toMatchObject({ code: 'ADAPTER_OP_UNSUPPORTED' });
   });
 });
-
-// ---------------------------------------------------------------------------
-// Contract probe (skipped — requires real credentials)
-// ---------------------------------------------------------------------------
-
-it.skip('contract probe — real API (requires AIRTABLE_TEST_API_KEY + AIRTABLE_TEST_BASE_ID + AIRTABLE_TEST_TABLE)', async () => {
-  const apiKey = process.env['AIRTABLE_TEST_API_KEY'] ?? '';
-  const baseId = process.env['AIRTABLE_TEST_BASE_ID'] ?? '';
-  const table = process.env['AIRTABLE_TEST_TABLE'] ?? '';
-
-  const adapter = new AirtableAdapter('airtable', { api_key: apiKey, base_id: baseId });
-  const result = await adapter.fetch('list_records', { table }, {});
-  expect(result.status).toBe(200);
-  const data = result.data as { records: unknown[] };
-  expect(Array.isArray(data.records)).toBe(true);
-});

--- a/packages/core/src/adapters/notion-adapter.probe.ts
+++ b/packages/core/src/adapters/notion-adapter.probe.ts
@@ -1,0 +1,16 @@
+// Contract probe for NotionAdapter — hits the real Notion API.
+// Requires NOTION_TEST_API_KEY. Run via `npm run test:contract --workspace=packages/core`.
+import { it, expect } from 'vitest';
+import { NotionAdapter } from './notion-adapter.js';
+
+it.skipIf(!process.env['NOTION_TEST_API_KEY'])(
+  'contract probe — real API (requires NOTION_TEST_API_KEY)',
+  async () => {
+    const apiKey = process.env['NOTION_TEST_API_KEY'] ?? '';
+    const adapter = new NotionAdapter('notion', { api_key: apiKey });
+    const result = await adapter.fetch('search', {}, {});
+    expect(result.status).toBe(200);
+    const data = result.data as { results: unknown[] };
+    expect(Array.isArray(data.results)).toBe(true);
+  },
+);

--- a/packages/core/src/adapters/notion-adapter.test.ts
+++ b/packages/core/src/adapters/notion-adapter.test.ts
@@ -1029,16 +1029,3 @@ describe('NotionAdapter unsupported operations', () => {
     });
   });
 });
-
-// ---------------------------------------------------------------------------
-// Contract probe (skipped — requires real credentials)
-// ---------------------------------------------------------------------------
-
-it.skip('contract probe — real API (requires NOTION_TEST_API_KEY)', async () => {
-  const apiKey = process.env['NOTION_TEST_API_KEY'] ?? '';
-  const adapter = new NotionAdapter('notion', { api_key: apiKey });
-  const result = await adapter.fetch('search', {}, {});
-  expect(result.status).toBe(200);
-  const data = result.data as { results: unknown[] };
-  expect(Array.isArray(data.results)).toBe(true);
-});

--- a/packages/core/src/adapters/parcelpanel-adapter.probe.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.probe.ts
@@ -1,0 +1,25 @@
+// Contract probe for ParcelPanelAdapter — hits the real ParcelPanel API.
+// Requires PARCELPANEL_TEST_API_KEY and PARCELPANEL_TEST_STORE (optionally
+// PARCELPANEL_TEST_ORDER_NUMBER). Run via `npm run test:contract --workspace=packages/core`.
+import { it, expect } from 'vitest';
+import { ParcelPanelAdapter } from './parcelpanel-adapter.js';
+import type { NormalizedTracking } from './parcelpanel-adapter.js';
+
+it.skipIf(!process.env['PARCELPANEL_TEST_API_KEY'] || !process.env['PARCELPANEL_TEST_STORE'])(
+  'contract probe — real API (requires PARCELPANEL_TEST_API_KEY and PARCELPANEL_TEST_STORE)',
+  async () => {
+    const apiKey = process.env['PARCELPANEL_TEST_API_KEY'] ?? '';
+    const store = process.env['PARCELPANEL_TEST_STORE'] ?? '';
+    const orderNumber = process.env['PARCELPANEL_TEST_ORDER_NUMBER'] ?? '';
+
+    const adapter = new ParcelPanelAdapter('parcelpanel', {
+      stores: { [store]: apiKey },
+    });
+
+    const result = await adapter.fetch('get_tracking', { store, order_number: orderNumber }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as NormalizedTracking;
+    expect(typeof data.tracking_url).toBe('string');
+    expect(data.tracking_url.length).toBeGreaterThan(0);
+  },
+);

--- a/packages/core/src/adapters/parcelpanel-adapter.test.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.test.ts
@@ -530,23 +530,3 @@ describe('ParcelPanelAdapter unsupported operations', () => {
     });
   });
 });
-
-// ---------------------------------------------------------------------------
-// Contract probe (skipped — requires real credentials)
-// ---------------------------------------------------------------------------
-
-it.skip('contract probe — real API (requires PARCELPANEL_TEST_API_KEY and PARCELPANEL_TEST_STORE)', async () => {
-  const apiKey = process.env['PARCELPANEL_TEST_API_KEY'] ?? '';
-  const store = process.env['PARCELPANEL_TEST_STORE'] ?? '';
-  const orderNumber = process.env['PARCELPANEL_TEST_ORDER_NUMBER'] ?? '';
-
-  const adapter = new ParcelPanelAdapter('parcelpanel', {
-    stores: { [store]: apiKey },
-  });
-
-  const result = await adapter.fetch('get_tracking', { store, order_number: orderNumber }, {});
-  expect(result.status).toBe(200);
-  const data = result.data as NormalizedTracking;
-  expect(typeof data.tracking_url).toBe('string');
-  expect(data.tracking_url.length).toBeGreaterThan(0);
-});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,5 +7,5 @@
     "types": ["node"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "**/*.probe.ts"]
 }

--- a/packages/core/vitest.contract.config.ts
+++ b/packages/core/vitest.contract.config.ts
@@ -1,0 +1,10 @@
+// Contract probe suite — live third-party API tests requiring real credentials.
+// Run via `npm run test:contract --workspace=packages/core`. Excluded from the
+// default `vitest run`, whose include pattern does not match *.probe.ts.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.probe.ts'],
+  },
+});


### PR DESCRIPTION
## Context

The v0.4.0 pre-publication review noted 3 pre-existing skipped tests in core. They are live-API contract probes (Notion, Airtable, ParcelPanel) written as `it.skip` at the end of their adapter test files. As written they can never run — un-skipping requires editing source — and they permanently pollute every default test run with "3 skipped". They are deliberate probes, not unfinished work.

## Motivation

Two goals: the default suite reports zero skipped (so a future skip is a real signal, not noise), and the probes become actually runnable via an explicit entry point instead of requiring source edits.

## Changes

- **New `packages/core/vitest.contract.config.ts`** — dedicated config including only `src/**/*.probe.ts`. The `*.probe.ts` suffix is outside vitest's default include pattern (`**/*.{test,spec}.?(c|m)[jt]s?(x)`), so the default `vitest run` never picks probes up. There are no other vitest config files in the repo, so the default suite needs no config change.
- **New `test:contract` script** in `packages/core/package.json`: `vitest run --config vitest.contract.config.ts`.
- **Three new probe files** (`notion-adapter.probe.ts`, `airtable-adapter.probe.ts`, `parcelpanel-adapter.probe.ts`) — probe bodies moved verbatim from the test files. Each is guarded with `it.skipIf(<missing env vars>)`, so the contract suite runs with partial credentials: probes with credentials run, the rest skip with a name stating what they need.
- **Probe blocks removed** from the three `.test.ts` files (the section comment + trailing `it.skip` block only; nothing else touched). `NormalizedTracking` remains imported in `parcelpanel-adapter.test.ts` because it is still used by other tests there.

## Verification

```bash
npm run test --workspace=packages/core 2>&1 | grep "Tests"
# Tests  1109 passed (1109) — zero skipped

npm run test:contract --workspace=packages/core 2>&1 | grep "Tests"
# without credentials: Tests  3 skipped (3) — zero failures

npm run build && npm run lint
# clean
```

The default-suite count dropping from 1112 to 1109 (skips from 3 to 0) is the intended outcome.

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
