### PR TITLE
feat(core): extend airtable adapter (update, delete, sort, pagination, search, error bodies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`update_record` operation on AirtableAdapter** — PATCH an existing record by `record_id` (`update('update_record', { table, record_id, fields, typecast? })`). Previously the only update path was `upsert_record`, which requires merge fields and can create rows.
+- **`delete_records` operation on AirtableAdapter** — batch delete of 1–10 record IDs in a single API call (`delete('delete_records', { table, record_ids })`, Airtable's per-call limit). No internal chunking — more than 10 IDs is a validation error, keeping each step's evidence atomic. The adapter docs recommend `trust: human_confirmed` on delete steps.
+- **`sort` support on AirtableAdapter `list_records`** — pass `sort: [{ field, direction? }]` to order results server-side; previously ordering required a pre-built Airtable view.
+- **Bounded auto-pagination on AirtableAdapter `list_records`** — opt-in via `fetch_all: true` with two caps, whichever hits first: `max_pages` (default 3, hard cap 10) and `max_bytes` (default 100000 ≈ 25K LLM tokens, hard cap 1000000). On truncation the response carries `truncated: true`, a `truncation_reason` of `page_limit`/`byte_limit`, and the resume `offset`. Unbounded fetch-all is impossible by design.
+- **`search_records` operation on AirtableAdapter** — text search across author-named fields, built as an Airtable `FIND`/`OR` formula with the search term escaped (`"` and `\`) to prevent formula injection. `fields` is required: the adapter has no schema discovery by design.
+- **AirtableAdapter section in `docs/reference/adapters.md`** — full operation reference (params tables, YAML examples, error mapping), including context-budget guidance for `fetch_all` (~4 bytes ≈ 1 token).
+
+### Changed
+
+- **AirtableAdapter 4xx errors now preserve Airtable's error body** — the API's `error.message` is appended to the thrown message and `error.type` is recorded as `details.airtable_error_type` (previously discarded except on 422). 401 errors add a PAT-format hint when the configured key looks malformed (the key itself is never included). Error codes, categories, and agent actions are unchanged.
+
+---
+
 ## [0.4.0] — 2026-06-11
 
 ### Added

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -416,3 +416,150 @@ This calls `GET https://api.example.com/v1/tickets?id={ticket_id}`.
 | Server error (HTTP 5xx)        | `SERVICE_HTTP_5XX`    | `wait_for_human` | Yes       |
 | Network unreachable            | `NETWORK_UNREACHABLE` | `wait_for_human` | Yes       |
 | Request aborted (step timeout) | `STEP_ABORTED`        | `report_to_user` | No        |
+
+---
+
+## AirtableAdapter
+
+Wraps the Airtable REST API for record-level operations. One adapter instance is scoped
+to a single base — for multi-base workflows, register one instance per base. The adapter
+is a deterministic workflow-step executor: schema discovery, schema mutation, comments,
+and attachments are deliberately out of scope.
+
+### YAML declaration
+
+```yaml
+services:
+  airtable:
+    adapter: airtable
+    trust: engine_delivered
+```
+
+### Constructor config
+
+| Key        | Type   | Required | Description                                                            |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `api_key`  | string | Yes      | Personal Access Token (PAT). Rate limit: 5 req/sec per base.           |
+| `base_id`  | string | Yes      | Airtable base ID (`appXXXXXXXXXXXXXX`). One adapter instance per base. |
+| `base_url` | string | No       | Override for tests only — replaces `https://api.airtable.com`.         |
+
+### Operations — fetch (`service_method: fetch`)
+
+#### `get_record`
+
+Fetches a single record by ID. `GET /v0/{base}/{table}/{record_id}`.
+
+| Parameter   | Type   | Required | Description         |
+| ----------- | ------ | -------- | ------------------- |
+| `table`     | string | Yes      | Table name.         |
+| `record_id` | string | Yes      | Record ID (`rec…`). |
+
+**Response:** the raw Airtable record — `id`, `createdTime`, `fields`.
+
+#### `list_records`
+
+Lists records from a table. `GET /v0/{base}/{table}`.
+
+| Parameter           | Type   | Required | Description                                         |
+| ------------------- | ------ | -------- | --------------------------------------------------- |
+| `table`             | string | Yes      | Table name.                                         |
+| `filter_by_formula` | string | No       | Airtable formula, passed as `filterByFormula`.      |
+| `view`              | string | No       | View name or ID.                                    |
+| `max_records`       | number | No       | Passed as `maxRecords`.                             |
+| `fields`            | array  | No       | Field names to return (repeated `fields[]` params). |
+| `offset`            | string | No       | Pagination cursor from a previous response.         |
+
+**Response:** the raw Airtable response — `records` array, plus `offset` when more pages exist.
+
+**YAML step example:**
+
+```yaml
+fetch_open_tickets:
+  description: List open tickets from Airtable.
+  execution: auto
+  uses_service: airtable
+  service_method: fetch
+  operation: list_records
+  input_map:
+    table: { $literal: 'Tickets' }
+    filter_by_formula: { $literal: "{Status} = 'Open'" }
+```
+
+### Operations — create (`service_method: create`)
+
+#### `create_record`
+
+Creates a single record. `POST /v0/{base}/{table}`.
+
+| Parameter  | Type    | Required | Description                                         |
+| ---------- | ------- | -------- | --------------------------------------------------- |
+| `table`    | string  | Yes      | Table name.                                         |
+| `fields`   | object  | Yes      | Field values for the new record.                    |
+| `typecast` | boolean | No       | When `true`, Airtable coerces value types (opt-in). |
+
+**Response:** the created record — `id`, `createdTime`, `fields`.
+
+### Operations — update (`service_method: update`)
+
+#### `upsert_record`
+
+Upserts a record by merge fields. `POST /v0/{base}/{table}` with `performUpsert`.
+
+| Parameter            | Type    | Required | Description                                            |
+| -------------------- | ------- | -------- | ------------------------------------------------------ |
+| `table`              | string  | Yes      | Table name.                                            |
+| `fields`             | object  | Yes      | Field values to write.                                 |
+| `fields_to_merge_on` | array   | Yes      | Non-empty array of field names to match existing rows. |
+| `typecast`           | boolean | No       | Opt-in type coercion.                                  |
+
+**Response:** the raw Airtable upsert response — `records`, `createdRecords`, `updatedRecords`.
+
+#### `update_record`
+
+Updates a single record by ID. `PATCH /v0/{base}/{table}/{record_id}` — a partial
+update: only the fields provided are written, other fields are left untouched.
+
+| Parameter   | Type    | Required | Description            |
+| ----------- | ------- | -------- | ---------------------- |
+| `table`     | string  | Yes      | Table name.            |
+| `record_id` | string  | Yes      | Record ID (`rec…`).    |
+| `fields`    | object  | Yes      | Field values to write. |
+| `typecast`  | boolean | No       | Opt-in type coercion.  |
+
+**Response:** the updated record — `id`, `createdTime`, `fields`.
+
+**YAML step example:**
+
+```yaml
+close_ticket:
+  description: Mark the ticket closed in Airtable.
+  execution: auto
+  uses_service: airtable
+  service_method: update
+  operation: update_record
+  input_map:
+    table: { $literal: 'Tickets' }
+    record_id: context.resources.find_ticket.id
+    fields: { status: { $literal: 'Closed' } }
+```
+
+### Errors
+
+| Condition                      | Error code                  | `agent_action`     | Retryable |
+| ------------------------------ | --------------------------- | ------------------ | --------- |
+| Bad params (pre-request)       | `ADAPTER_VALIDATION_FAILED` | `provide_input`    | No        |
+| Auth failed (HTTP 401)         | `SERVICE_AUTH_FAILED`       | `stop`             | No        |
+| Forbidden (HTTP 403)           | `SERVICE_HTTP_4XX`          | `stop`             | No        |
+| Not found (HTTP 404)           | `SERVICE_NOT_FOUND`         | `provide_input`    | No        |
+| Unprocessable (HTTP 422)       | `SERVICE_HTTP_4XX`          | `stop`             | No        |
+| Rate limited (HTTP 429)        | `SERVICE_RATE_LIMITED`      | `wait_and_proceed` | Yes       |
+| Other client error (HTTP 4xx)  | `SERVICE_HTTP_4XX`          | `stop`             | No        |
+| Server error (HTTP 5xx)        | `SERVICE_HTTP_5XX`          | `report_to_user`   | Yes       |
+| Malformed response body        | `SERVICE_RESPONSE_INVALID`  | `report_to_user`   | No        |
+| Network unreachable            | `NETWORK_UNREACHABLE`       | `wait_for_human`   | Yes       |
+| Request aborted (step timeout) | `STEP_ABORTED`              | `report_to_user`   | No        |
+| Unknown operation              | `ADAPTER_OP_UNSUPPORTED`    | `report_to_user`   | No        |
+
+On HTTP 429 the adapter reads the `Retry-After` header into `retry_after` when present;
+Airtable does not send one, so the engine falls back to the adapter's
+`defaultRetryAfterSeconds` of **30 seconds**.

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -544,6 +544,36 @@ close_ticket:
     fields: { status: { $literal: 'Closed' } }
 ```
 
+### Operations — delete (`service_method: delete`)
+
+#### `delete_records`
+
+Deletes up to 10 records in one call. `DELETE /v0/{base}/{table}?records[]=id1&records[]=id2…`.
+
+| Parameter    | Type   | Required | Description                          |
+| ------------ | ------ | -------- | ------------------------------------ |
+| `table`      | string | Yes      | Table name.                          |
+| `record_ids` | array  | Yes      | 1–10 record IDs (non-empty strings). |
+
+**Response:** the raw Airtable response — `records` array of `{ id, deleted: true }`.
+
+> **Deletion is irreversible. Put delete steps behind a human gate.** The adapter
+> deliberately caps at 10 records per call and performs no internal chunking.
+> Recommended step shape:
+>
+> ```yaml
+> remove_stale_rows:
+>   description: Delete the flagged records after human review
+>   execution: auto
+>   uses_service: airtable
+>   service_method: delete
+>   operation: delete_records
+>   trust: human_confirmed
+>   input_map:
+>     table: { $literal: 'Tasks' }
+>     record_ids: context.resources.flag_stale.record_ids
+> ```
+
 ### Errors
 
 | Condition                      | Error code                  | `agent_action`     | Retryable |

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -460,17 +460,38 @@ Fetches a single record by ID. `GET /v0/{base}/{table}/{record_id}`.
 
 Lists records from a table. `GET /v0/{base}/{table}`.
 
-| Parameter           | Type   | Required | Description                                                                                       |
-| ------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------- |
-| `table`             | string | Yes      | Table name.                                                                                       |
-| `filter_by_formula` | string | No       | Airtable formula, passed as `filterByFormula`.                                                    |
-| `view`              | string | No       | View name or ID.                                                                                  |
-| `max_records`       | number | No       | Passed as `maxRecords`.                                                                           |
-| `fields`            | array  | No       | Field names to return (repeated `fields[]` params).                                               |
-| `offset`            | string | No       | Pagination cursor from a previous response.                                                       |
-| `sort`              | array  | No       | Array of `{ field, direction? }` — `direction` is `asc` or `desc`. Malformed entries are skipped. |
+| Parameter           | Type    | Required | Description                                                                                                                     |
+| ------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `table`             | string  | Yes      | Table name.                                                                                                                     |
+| `filter_by_formula` | string  | No       | Airtable formula, passed as `filterByFormula`.                                                                                  |
+| `view`              | string  | No       | View name or ID.                                                                                                                |
+| `max_records`       | number  | No       | Passed as `maxRecords`.                                                                                                         |
+| `fields`            | array   | No       | Field names to return (repeated `fields[]` params).                                                                             |
+| `offset`            | string  | No       | Pagination cursor from a previous response.                                                                                     |
+| `sort`              | array   | No       | Array of `{ field, direction? }` — `direction` is `asc` or `desc`. Malformed entries are skipped.                               |
+| `fetch_all`         | boolean | No       | Opt-in bounded auto-pagination (see below).                                                                                     |
+| `max_pages`         | number  | No       | With `fetch_all`: page cap. Default 3, hard cap 10 (higher values are clamped).                                                 |
+| `max_bytes`         | number  | No       | With `fetch_all`: accumulated-size cap as `JSON.stringify(records).length`. Default 100000 (~25K LLM tokens), hard cap 1000000. |
 
 **Response:** the raw Airtable response — `records` array, plus `offset` when more pages exist.
+
+**Auto-pagination (`fetch_all: true`):** the adapter follows the response `offset` cursor,
+re-issuing the same query until no pages remain or a cap is hit — whichever comes first.
+Caps are stop conditions, not truncation: the page that crossed a limit is kept. The
+response `data` is constructed (not raw):
+
+| Field               | Type    | Description                                                            |
+| ------------------- | ------- | ---------------------------------------------------------------------- |
+| `records`           | array   | All accumulated records.                                               |
+| `truncated`         | boolean | `true` when a cap stopped the loop with more pages remaining.          |
+| `truncation_reason` | string  | `page_limit` or `byte_limit`. Present only when `truncated` is `true`. |
+| `offset`            | string  | Resume cursor. Present only when `truncated` is `true`.                |
+
+> Results returned by the final step of an auto-chain flow verbatim into the calling
+> LLM's context. Keep `fetch_all` steps in the middle of an auto-chain feeding a
+> handler step (intermediate envelopes are discarded), use `fields` /
+> `filter_by_formula` to shrink records, and treat `max_bytes` as your context
+> budget: ~4 bytes ≈ 1 token.
 
 **YAML step example:**
 

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -507,6 +507,25 @@ fetch_open_tickets:
     filter_by_formula: { $literal: "{Status} = 'Open'" }
 ```
 
+#### `search_records`
+
+Searches records by substring match across named fields, built on `list_records` with a
+generated `filterByFormula`. `GET /v0/{base}/{table}?filterByFormula=…`.
+
+| Parameter     | Type   | Required | Description                                                                                                                                                  |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `table`       | string | Yes      | Table name.                                                                                                                                                  |
+| `search_term` | string | Yes      | Substring to find. `"` and `\` are formula-escaped (injection guard).                                                                                        |
+| `fields`      | array  | Yes      | Non-empty array of field names to search. Required because the adapter has no schema discovery — by design, the workflow author names the searchable fields. |
+| `view`        | string | No       | View name or ID (as in `list_records`).                                                                                                                      |
+| `max_records` | number | No       | Passed as `maxRecords` (as in `list_records`).                                                                                                               |
+
+One field produces `FIND("term", {field})`; multiple fields produce
+`OR(FIND("term", {field1}),FIND("term", {field2}),…)`. The term is escaped before
+interpolation — never embedded raw.
+
+**Response:** the raw Airtable response — `records` array.
+
 ### Operations — create (`service_method: create`)
 
 #### `create_record`

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -460,14 +460,15 @@ Fetches a single record by ID. `GET /v0/{base}/{table}/{record_id}`.
 
 Lists records from a table. `GET /v0/{base}/{table}`.
 
-| Parameter           | Type   | Required | Description                                         |
-| ------------------- | ------ | -------- | --------------------------------------------------- |
-| `table`             | string | Yes      | Table name.                                         |
-| `filter_by_formula` | string | No       | Airtable formula, passed as `filterByFormula`.      |
-| `view`              | string | No       | View name or ID.                                    |
-| `max_records`       | number | No       | Passed as `maxRecords`.                             |
-| `fields`            | array  | No       | Field names to return (repeated `fields[]` params). |
-| `offset`            | string | No       | Pagination cursor from a previous response.         |
+| Parameter           | Type   | Required | Description                                                                                       |
+| ------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------- |
+| `table`             | string | Yes      | Table name.                                                                                       |
+| `filter_by_formula` | string | No       | Airtable formula, passed as `filterByFormula`.                                                    |
+| `view`              | string | No       | View name or ID.                                                                                  |
+| `max_records`       | number | No       | Passed as `maxRecords`.                                                                           |
+| `fields`            | array  | No       | Field names to return (repeated `fields[]` params).                                               |
+| `offset`            | string | No       | Pagination cursor from a previous response.                                                       |
+| `sort`              | array  | No       | Array of `{ field, direction? }` — `direction` is `asc` or `desc`. Malformed entries are skipped. |
 
 **Response:** the raw Airtable response — `records` array, plus `offset` when more pages exist.
 

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -428,6 +428,80 @@ describe('AirtableAdapter upsert_record', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: update_record
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter update_record', () => {
+  it('PATCH to /v0/{base}/{table}/{id} with body { fields }', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      capturedMethod = req.method ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORD_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.update(
+      'update_record',
+      { table: 'Tickets', record_id: 'recABC', fields: { Status: 'Closed' } },
+      {},
+    );
+    expect(capturedUrl).toBe('/v0/appXXXXXXXXXXXXXX/Tickets/recABC');
+    expect(capturedMethod).toBe('PATCH');
+    expect(JSON.parse(lastRequestBody)).toEqual({ fields: { Status: 'Closed' } });
+    expect(result.status).toBe(200);
+    const data = result.data as typeof RECORD_FIXTURE;
+    expect(data.id).toBe('recXXXXXXXXXXXXXX');
+  });
+
+  it('with typecast: true — body contains "typecast": true; without — key absent', async () => {
+    respond(200, RECORD_FIXTURE);
+    const adapter = makeAdapter();
+    await adapter.update(
+      'update_record',
+      { table: 'Tickets', record_id: 'recABC', fields: { Name: 'x' }, typecast: true },
+      {},
+    );
+    expect((JSON.parse(lastRequestBody) as Record<string, unknown>)['typecast']).toBe(true);
+
+    respond(200, RECORD_FIXTURE);
+    await adapter.update(
+      'update_record',
+      { table: 'Tickets', record_id: 'recABC', fields: { Name: 'x' } },
+      {},
+    );
+    expect('typecast' in (JSON.parse(lastRequestBody) as Record<string, unknown>)).toBe(false);
+  });
+
+  it('missing or empty record_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.update('update_record', { table: 'Tickets', fields: { Name: 'x' } }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    await expect(
+      adapter.update(
+        'update_record',
+        { table: 'Tickets', record_id: '', fields: { Name: 'x' } },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('response without id → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { createdTime: '2024-01-01T00:00:00.000Z', fields: {} });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.update(
+        'update_record',
+        { table: 'Tickets', record_id: 'recABC', fields: { Name: 'x' } },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: HTTP error classification
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -318,6 +318,90 @@ describe('AirtableAdapter list_records', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: search_records
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter search_records', () => {
+  function captureQuery(): { get: (key: string) => string | null } {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    return {
+      get: (key: string) => new URLSearchParams(capturedUrl.split('?')[1] ?? '').get(key),
+    };
+  }
+
+  it('single field → filterByFormula is FIND("term", {field})', async () => {
+    const query = captureQuery();
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'search_records',
+      { table: 'Tickets', search_term: 'x', fields: ['Name'] },
+      {},
+    );
+    expect(query.get('filterByFormula')).toBe('FIND("x", {Name})');
+  });
+
+  it('multiple fields → OR(FIND(...),FIND(...))', async () => {
+    const query = captureQuery();
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'search_records',
+      { table: 'Tickets', search_term: 'billing', fields: ['Name', 'Notes'] },
+      {},
+    );
+    expect(query.get('filterByFormula')).toBe(
+      'OR(FIND("billing", {Name}),FIND("billing", {Notes}))',
+    );
+  });
+
+  it('term containing " and \\ is escaped in the formula', async () => {
+    const query = captureQuery();
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'search_records',
+      { table: 'Tickets', search_term: 'say "hi" \\ bye', fields: ['Name'] },
+      {},
+    );
+    const formula = query.get('filterByFormula') ?? '';
+    expect(formula).toBe('FIND("say \\"hi\\" \\\\ bye", {Name})');
+    expect(formula).not.toContain('"hi"'); // no raw unescaped quote from the term
+  });
+
+  it('missing fields → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('search_records', { table: 'Tickets', search_term: 'x' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    await expect(
+      adapter.fetch('search_records', { table: 'Tickets', search_term: 'x', fields: [] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('empty search_term → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('search_records', { table: 'Tickets', search_term: '', fields: ['Name'] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('view and max_records pass through like list_records', async () => {
+    const query = captureQuery();
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'search_records',
+      { table: 'Tickets', search_term: 'x', fields: ['Name'], view: 'Open', max_records: 25 },
+      {},
+    );
+    expect(query.get('view')).toBe('Open');
+    expect(query.get('maxRecords')).toBe('25');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: list_records auto-pagination (fetch_all)
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -271,6 +271,50 @@ describe('AirtableAdapter list_records', () => {
       code: 'ADAPTER_VALIDATION_FAILED',
     });
   });
+
+  it('sort entries produce indexed sort[i][field] / sort[i][direction] params', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'list_records',
+      { table: 'Tickets', sort: [{ field: 'Created', direction: 'desc' }, { field: 'Name' }] },
+      {},
+    );
+    const decoded = decodeURIComponent(capturedUrl);
+    expect(decoded).toContain('sort[0][field]=Created');
+    expect(decoded).toContain('sort[0][direction]=desc');
+    expect(decoded).toContain('sort[1][field]=Name');
+    expect(decoded).not.toContain('sort[1][direction]');
+  });
+
+  it('malformed sort entries (non-object, missing field) are skipped without error', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(RECORDS_FIXTURE));
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'list_records',
+      {
+        table: 'Tickets',
+        sort: ['not-an-object', { direction: 'desc' }, null, { field: 'Name' }],
+      },
+      {},
+    );
+    expect(result.status).toBe(200);
+    const decoded = decodeURIComponent(capturedUrl);
+    expect(decoded).toContain('sort[3][field]=Name');
+    expect(decoded).not.toContain('sort[0]');
+    expect(decoded).not.toContain('sort[1]');
+    expect(decoded).not.toContain('sort[2]');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -611,6 +611,91 @@ describe('AirtableAdapter HTTP error classification', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: delete_records
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter delete_records', () => {
+  const DELETE_RESPONSE = {
+    records: [
+      { id: 'recAAA', deleted: true },
+      { id: 'recBBB', deleted: true },
+    ],
+  };
+
+  it('DELETE with records[] query params; response parsed', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      capturedMethod = req.method ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(DELETE_RESPONSE));
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.delete(
+      'delete_records',
+      { table: 'Tickets', record_ids: ['recAAA', 'recBBB'] },
+      {},
+    );
+    expect(capturedMethod).toBe('DELETE');
+    const decoded = decodeURIComponent(capturedUrl);
+    expect(decoded).toContain('records[]=recAAA');
+    expect(decoded).toContain('records[]=recBBB');
+    expect(result.status).toBe(200);
+    const data = result.data as typeof DELETE_RESPONSE;
+    expect(data.records).toHaveLength(2);
+  });
+
+  it('11 ids → ADAPTER_VALIDATION_FAILED mentioning the 10-id limit', async () => {
+    const adapter = makeAdapter();
+    const ids = Array.from({ length: 11 }, (_, i) => `rec${String(i)}`);
+    const err = await adapter
+      .delete('delete_records', { table: 'Tickets', record_ids: ids }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.message).toContain('at most 10 ids');
+  });
+
+  it('empty array → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.delete('delete_records', { table: 'Tickets', record_ids: [] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('non-array or non-string element → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.delete('delete_records', { table: 'Tickets', record_ids: 'recAAA' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    await expect(
+      adapter.delete('delete_records', { table: 'Tickets', record_ids: ['recAAA', 42] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('response element with deleted: false or missing id → SERVICE_RESPONSE_INVALID', async () => {
+    respond(200, { records: [{ id: 'recAAA', deleted: false }] });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.delete('delete_records', { table: 'Tickets', record_ids: ['recAAA'] }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+
+    respond(200, { records: [{ deleted: true }] });
+    await expect(
+      adapter.delete('delete_records', { table: 'Tickets', record_ids: ['recAAA'] }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+  });
+
+  it('delete("unknown") → ADAPTER_OP_UNSUPPORTED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.delete('unknown', { table: 'Tickets', record_ids: ['recAAA'] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_OP_UNSUPPORTED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: Airtable error body preservation
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -567,6 +567,70 @@ describe('AirtableAdapter HTTP error classification', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: Airtable error body preservation
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter error body preservation', () => {
+  it('400 with error body → message contains Airtable message, details has airtable_error_type', async () => {
+    respond(400, {
+      error: { type: 'INVALID_REQUEST_UNKNOWN', message: 'Unknown field name: "foo"' },
+    });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_record', { table: 'T', record_id: 'recABC' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.message).toContain('Unknown field name');
+    expect(err.details['airtable_error_type']).toBe('INVALID_REQUEST_UNKNOWN');
+  });
+
+  it('403 with error body → message contains the Airtable message', async () => {
+    respond(403, {
+      error: { type: 'NOT_AUTHORIZED', message: 'You are not permitted to perform this operation' },
+    });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_record', { table: 'T', record_id: 'recABC' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_4XX');
+    expect(err.message).toContain('You are not permitted to perform this operation');
+  });
+
+  it('401 with malformed key (no dot) → message contains format hint, key value absent', async () => {
+    respond(401, { error: { type: 'AUTHENTICATION_REQUIRED' } });
+    const adapter = makeAdapter(); // default key 'patXXXXXXXXXXXXXX' has no dot
+    const err = await adapter
+      .fetch('get_record', { table: 'T', record_id: 'recABC' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_AUTH_FAILED');
+    expect(err.message).toContain('API key format looks wrong');
+    expect(err.message).not.toContain('patXXXXXXXXXXXXXX');
+  });
+
+  it('401 with well-formed key (exactly one dot) → no format hint', async () => {
+    respond(401, { error: { type: 'AUTHENTICATION_REQUIRED' } });
+    const adapter = makeAdapter({ api_key: 'patXXXXXXXXXXXXXX.aaaabbbbcccc' });
+    const err = await adapter
+      .fetch('get_record', { table: 'T', record_id: 'recABC' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err.code).toBe('SERVICE_AUTH_FAILED');
+    expect(err.message).not.toContain('API key format looks wrong');
+  });
+
+  it('non-JSON error body → no crash, message has no suffix (regression guard)', async () => {
+    respondText(400, 'Bad Request');
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_record', { table: 'T', record_id: 'recABC' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_4XX');
+    expect(err.message).not.toContain(' — ');
+    expect(err.details['airtable_error_type']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: Response validation
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -318,6 +318,136 @@ describe('AirtableAdapter list_records', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: list_records auto-pagination (fetch_all)
+// ---------------------------------------------------------------------------
+
+describe('AirtableAdapter list_records fetch_all', () => {
+  function pushPage(records: unknown[], offset?: string, onRequest?: (url: string) => void): void {
+    handlers.push((req, res) => {
+      onRequest?.(req.url ?? '');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ records, ...(offset !== undefined ? { offset } : {}) }));
+    });
+  }
+
+  it('2 pages then no offset → records concatenated, truncated: false, offset carried', async () => {
+    const urls: string[] = [];
+    pushPage([{ id: 'rec1' }], 'cursor-1', (u) => urls.push(u));
+    pushPage([{ id: 'rec2' }], undefined, (u) => urls.push(u));
+
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_records', { table: 'Tickets', fetch_all: true }, {});
+
+    expect(urls).toHaveLength(2);
+    expect(decodeURIComponent(urls[1] ?? '')).toContain('offset=cursor-1');
+    const data = result.data as { records: unknown[]; truncated: boolean; offset?: string };
+    expect(data.records).toEqual([{ id: 'rec1' }, { id: 'rec2' }]);
+    expect(data.truncated).toBe(false);
+    expect('truncation_reason' in data).toBe(false);
+    expect('offset' in data).toBe(false);
+  });
+
+  it('max_pages: 2 with 3 pages available → truncated with page_limit and resume offset', async () => {
+    pushPage([{ id: 'rec1' }], 'cursor-1');
+    pushPage([{ id: 'rec2' }], 'cursor-2');
+    pushPage([{ id: 'rec3' }]);
+
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'list_records',
+      { table: 'Tickets', fetch_all: true, max_pages: 2 },
+      {},
+    );
+
+    const data = result.data as {
+      records: unknown[];
+      truncated: boolean;
+      truncation_reason?: string;
+      offset?: string;
+    };
+    expect(data.records).toEqual([{ id: 'rec1' }, { id: 'rec2' }]);
+    expect(data.truncated).toBe(true);
+    expect(data.truncation_reason).toBe('page_limit');
+    expect(data.offset).toBe('cursor-2');
+    expect(handlers).toHaveLength(1); // third page never requested
+  });
+
+  it('tiny max_bytes → stops after first page with byte_limit', async () => {
+    pushPage([{ id: 'rec1', Name: 'a record large enough to exceed ten bytes' }], 'cursor-1');
+    pushPage([{ id: 'rec2' }]);
+
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'list_records',
+      { table: 'Tickets', fetch_all: true, max_bytes: 10 },
+      {},
+    );
+
+    const data = result.data as {
+      records: unknown[];
+      truncated: boolean;
+      truncation_reason?: string;
+      offset?: string;
+    };
+    expect(data.records).toHaveLength(1);
+    expect(data.truncated).toBe(true);
+    expect(data.truncation_reason).toBe('byte_limit');
+    expect(data.offset).toBe('cursor-1');
+    expect(handlers).toHaveLength(1); // second page never requested
+  });
+
+  it('max_pages: 50 is clamped to 10 (11 pages mocked, 10 requests made)', async () => {
+    let requestCount = 0;
+    for (let i = 1; i <= 11; i++) {
+      pushPage([{ id: `rec${String(i)}` }], i < 11 ? `cursor-${String(i)}` : undefined, () => {
+        requestCount += 1;
+      });
+    }
+
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'list_records',
+      { table: 'Tickets', fetch_all: true, max_pages: 50 },
+      {},
+    );
+
+    expect(requestCount).toBe(10);
+    const data = result.data as { records: unknown[]; truncated: boolean };
+    expect(data.records).toHaveLength(10);
+    expect(data.truncated).toBe(true);
+  });
+
+  it('without fetch_all → one request, raw response returned unchanged (regression guard)', async () => {
+    pushPage([{ id: 'rec1' }], 'cursor-1');
+    pushPage([{ id: 'rec2' }]);
+
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_records', { table: 'Tickets' }, {});
+
+    expect(handlers).toHaveLength(1); // only one request consumed
+    const data = result.data as Record<string, unknown>;
+    expect(data['records']).toEqual([{ id: 'rec1' }]);
+    expect(data['offset']).toBe('cursor-1');
+    expect('truncated' in data).toBe(false);
+  });
+
+  it('abort between pages → STEP_ABORTED', async () => {
+    const controller = new AbortController();
+    handlers.push((_req, res) => {
+      controller.abort();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ records: [{ id: 'rec1' }], offset: 'cursor-1' }));
+    });
+    pushPage([{ id: 'rec2' }]);
+
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_records', { table: 'Tickets', fetch_all: true }, {}, controller.signal),
+    ).rejects.toMatchObject({ code: 'STEP_ABORTED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: create_record
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -347,6 +347,95 @@ export class AirtableAdapter implements ServiceAdapter {
         });
       }
 
+      // Bounded auto-pagination — opt-in via fetch_all: true. Two caps, whichever
+      // hits first (mirrors the trace normalizer's count/byte-limit design). Caps
+      // are stop conditions, not truncation: the page that crossed a limit is kept.
+      if (params['fetch_all'] === true) {
+        const rawMaxPages = params['max_pages'];
+        const maxPages =
+          typeof rawMaxPages === 'number' && Number.isFinite(rawMaxPages) && rawMaxPages >= 1
+            ? Math.min(Math.floor(rawMaxPages), 10)
+            : 3;
+        const rawMaxBytes = params['max_bytes'];
+        const maxBytes =
+          typeof rawMaxBytes === 'number' && Number.isFinite(rawMaxBytes) && rawMaxBytes >= 1
+            ? Math.min(Math.floor(rawMaxBytes), 1000000)
+            : 100000;
+
+        const allRecords: unknown[] = [];
+        let pagesFetched = 0;
+        let nextOffset: string | undefined;
+        let truncationReason: 'page_limit' | 'byte_limit' | undefined;
+        let lastStatus = 200;
+
+        for (;;) {
+          this.checkAborted(signal);
+          const pageUrl = new URL(url.href);
+          if (nextOffset !== undefined) {
+            pageUrl.searchParams.set('offset', nextOffset);
+          }
+          const pageResponse = await this.executeRequest(pageUrl, 'GET', undefined, signal);
+
+          if (!pageResponse.ok) {
+            await this.throwHttpError(pageResponse, 'list_records');
+          }
+
+          let pageParsed: unknown;
+          try {
+            pageParsed = await pageResponse.json();
+          } catch {
+            throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+              code: 'SERVICE_RESPONSE_INVALID',
+              category: 'SERVICE',
+              agentAction: 'report_to_user',
+              retryable: false,
+            });
+          }
+
+          const page = pageParsed as { records?: unknown; offset?: unknown };
+          if (!Array.isArray(page.records)) {
+            throw new WorkflowError(
+              'AirtableAdapter: list_records response missing records array',
+              {
+                code: 'SERVICE_RESPONSE_INVALID',
+                category: 'SERVICE',
+                agentAction: 'report_to_user',
+                retryable: false,
+              },
+            );
+          }
+
+          lastStatus = pageResponse.status;
+          allRecords.push(...(page.records as unknown[]));
+          pagesFetched += 1;
+          nextOffset = typeof page.offset === 'string' ? page.offset : undefined;
+
+          // No further pages — the run is complete, not truncated.
+          if (nextOffset === undefined) {
+            break;
+          }
+          if (pagesFetched >= maxPages) {
+            truncationReason = 'page_limit';
+            break;
+          }
+          if (JSON.stringify(allRecords).length > maxBytes) {
+            truncationReason = 'byte_limit';
+            break;
+          }
+        }
+
+        const truncated = truncationReason !== undefined;
+        return {
+          status: lastStatus,
+          data: {
+            records: allRecords,
+            truncated,
+            ...(truncated ? { truncation_reason: truncationReason } : {}),
+            ...(truncated && nextOffset !== undefined ? { offset: nextOffset } : {}),
+          },
+        };
+      }
+
       const response = await this.executeRequest(url, 'GET', undefined, signal);
 
       if (!response.ok) {

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -48,6 +48,7 @@ interface AirtableRecord {
  *   create('create_record', { table, fields, ... })  — POST /v0/{base}/{table}
  *   update('upsert_record', { table, fields, ... })  — POST /v0/{base}/{table} (upsert)
  *   update('update_record', { table, record_id, fields, ... }) — PATCH /v0/{base}/{table}/{id}
+ *   delete('delete_records', { table, record_ids })  — DELETE /v0/{base}/{table}?records[]=…
  */
 export class AirtableAdapter implements ServiceAdapter {
   readonly id: string;
@@ -99,7 +100,7 @@ export class AirtableAdapter implements ServiceAdapter {
 
   private async executeRequest(
     url: URL,
-    method: 'GET' | 'POST' | 'PATCH',
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
     body?: unknown,
     signal?: AbortSignal,
   ): Promise<Response> {
@@ -634,6 +635,119 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     throw new WorkflowError(`AirtableAdapter: unsupported update operation "${operation}"`, {
+      code: 'ADAPTER_OP_UNSUPPORTED',
+      category: 'ENGINE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+  }
+
+  async delete(
+    operation: string,
+    params: Record<string, unknown>,
+    _config: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<ServiceResponse> {
+    if (operation === 'delete_records') {
+      const table = params['table'];
+      const recordIds = params['record_ids'];
+
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (!Array.isArray(recordIds) || recordIds.length === 0) {
+        throw new WorkflowError(
+          'AirtableAdapter: record_ids must be a non-empty array of non-empty strings',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+      if (recordIds.length > 10) {
+        throw new WorkflowError(
+          'AirtableAdapter: record_ids accepts at most 10 ids per call (Airtable API limit) — split into multiple steps',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+      for (const element of recordIds) {
+        if (typeof element !== 'string' || element === '') {
+          throw new WorkflowError(
+            'AirtableAdapter: record_ids must be a non-empty array of non-empty strings',
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+            },
+          );
+        }
+      }
+
+      // One API call only — never chunk internally: partial deletion across
+      // chunks would corrupt evidence semantics.
+      const url = this.buildUrl(table);
+      for (const id of recordIds as string[]) {
+        url.searchParams.append('records[]', id);
+      }
+      const response = await this.executeRequest(url, 'DELETE', undefined, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'delete_records');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { records?: unknown };
+      if (!Array.isArray(data.records)) {
+        throw new WorkflowError('AirtableAdapter: delete_records response missing records array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+      for (const element of data.records) {
+        const record = element as { id?: unknown; deleted?: unknown };
+        if (typeof record.id !== 'string' || record.id === '' || record.deleted !== true) {
+          throw new WorkflowError(
+            'AirtableAdapter: delete_records response element missing id or deleted: true',
+            {
+              code: 'SERVICE_RESPONSE_INVALID',
+              category: 'SERVICE',
+              agentAction: 'report_to_user',
+              retryable: false,
+            },
+          );
+        }
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    throw new WorkflowError(`AirtableAdapter: unsupported delete operation "${operation}"`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
       agentAction: 'report_to_user',

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -45,6 +45,7 @@ interface AirtableRecord {
  * Supported operations:
  *   fetch('get_record', { table, record_id })        — GET  /v0/{base}/{table}/{id}
  *   fetch('list_records', { table, ...query })       — GET  /v0/{base}/{table}
+ *   fetch('search_records', { table, search_term, fields, ... }) — GET via filterByFormula
  *   create('create_record', { table, fields, ... })  — POST /v0/{base}/{table}
  *   update('upsert_record', { table, fields, ... })  — POST /v0/{base}/{table} (upsert)
  *   update('update_record', { table, record_id, fields, ... }) — PATCH /v0/{base}/{table}/{id}
@@ -457,6 +458,90 @@ export class AirtableAdapter implements ServiceAdapter {
       const data = parsed as { records?: unknown };
       if (!Array.isArray(data.records)) {
         throw new WorkflowError('AirtableAdapter: list_records response missing records array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'search_records') {
+      const table = params['table'];
+      const searchTerm = params['search_term'];
+      const fields = params['fields'];
+
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (typeof searchTerm !== 'string' || searchTerm === '') {
+        throw new WorkflowError('AirtableAdapter: search_term param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      // fields is required: the adapter has no schema discovery (by design), so the
+      // workflow author must name the searchable fields.
+      if (
+        !Array.isArray(fields) ||
+        fields.length === 0 ||
+        fields.some((f) => typeof f !== 'string' || f === '')
+      ) {
+        throw new WorkflowError(
+          'AirtableAdapter: fields param must be a non-empty array of non-empty strings — name the fields to search',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+          },
+        );
+      }
+
+      // Injection guard — escape " and \ in the term; never interpolate it raw.
+      const escapedTerm = searchTerm.replace(/["\\]/g, '\\$&');
+      const finds = (fields as string[]).map((f) => `FIND("${escapedTerm}", {${f}})`);
+      const formula = finds.length === 1 ? finds.join('') : `OR(${finds.join(',')})`;
+
+      const url = this.buildUrl(table);
+      url.searchParams.set('filterByFormula', formula);
+      if (typeof params['view'] === 'string') {
+        url.searchParams.set('view', params['view']);
+      }
+      if (typeof params['max_records'] === 'number') {
+        url.searchParams.set('maxRecords', String(params['max_records']));
+      }
+
+      const response = await this.executeRequest(url, 'GET', undefined, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'search_records');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as { records?: unknown };
+      if (!Array.isArray(data.records)) {
+        throw new WorkflowError('AirtableAdapter: search_records response missing records array', {
           code: 'SERVICE_RESPONSE_INVALID',
           category: 'SERVICE',
           agentAction: 'report_to_user',

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -149,10 +149,28 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     const status = response.status;
-    const baseDetails = { status, operation };
+    const airtableError =
+      typeof body === 'object' && body !== null && 'error' in body
+        ? (body as { error?: { type?: unknown; message?: unknown } }).error
+        : undefined;
+    const airtableMessage =
+      typeof airtableError?.message === 'string' ? airtableError.message : undefined;
+    const airtableType = typeof airtableError?.type === 'string' ? airtableError.type : undefined;
+    const detailSuffix = airtableMessage !== undefined ? ` — ${airtableMessage}` : '';
+    const baseDetails = {
+      status,
+      operation,
+      ...(airtableType !== undefined ? { airtable_error_type: airtableType } : {}),
+    };
 
     if (status === 401) {
-      throw new WorkflowError('Airtable authentication failed — check API key', {
+      // PAT format hint (never include any part of the key itself).
+      const dotCount = (this.apiKey.match(/\./g) ?? []).length;
+      const formatHint =
+        dotCount !== 1
+          ? ' (API key format looks wrong: expected one "." in a PAT — check you copied the full token)'
+          : '';
+      throw new WorkflowError(`Airtable authentication failed — check API key${formatHint}`, {
         code: 'SERVICE_AUTH_FAILED',
         category: 'SERVICE',
         agentAction: 'stop',
@@ -162,7 +180,7 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     if (status === 403) {
-      throw new WorkflowError('Airtable: forbidden (HTTP 403)', {
+      throw new WorkflowError(`Airtable: forbidden (HTTP 403)${detailSuffix}`, {
         code: 'SERVICE_HTTP_4XX',
         category: 'SERVICE',
         agentAction: 'stop',
@@ -172,7 +190,7 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     if (status === 404) {
-      throw new WorkflowError('Airtable: record not found', {
+      throw new WorkflowError(`Airtable: record not found${detailSuffix}`, {
         code: 'SERVICE_NOT_FOUND',
         category: 'SERVICE',
         agentAction: 'provide_input',
@@ -182,7 +200,7 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     if (status === 422) {
-      throw new WorkflowError('Airtable: unprocessable entity (HTTP 422)', {
+      throw new WorkflowError(`Airtable: unprocessable entity (HTTP 422)${detailSuffix}`, {
         code: 'SERVICE_HTTP_4XX',
         category: 'SERVICE',
         agentAction: 'stop',
@@ -214,7 +232,7 @@ export class AirtableAdapter implements ServiceAdapter {
     }
 
     // 400 and other 4xx
-    throw new WorkflowError(`HTTP ${status}: ${response.statusText}`, {
+    throw new WorkflowError(`HTTP ${status}: ${response.statusText}${detailSuffix}`, {
       code: 'SERVICE_HTTP_4XX',
       category: 'SERVICE',
       agentAction: 'stop',

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -330,6 +330,21 @@ export class AirtableAdapter implements ServiceAdapter {
       if (typeof params['offset'] === 'string') {
         url.searchParams.set('offset', params['offset']);
       }
+      // Malformed sort entries are skipped silently, consistent with the permissive
+      // param handling in this branch (e.g. non-string view is ignored, not an error).
+      if (Array.isArray(params['sort'])) {
+        (params['sort'] as unknown[]).forEach((entry, i) => {
+          if (typeof entry === 'object' && entry !== null) {
+            const e = entry as { field?: unknown; direction?: unknown };
+            if (typeof e.field === 'string' && e.field !== '') {
+              url.searchParams.set(`sort[${i}][field]`, e.field);
+              if (e.direction === 'asc' || e.direction === 'desc') {
+                url.searchParams.set(`sort[${i}][direction]`, e.direction);
+              }
+            }
+          }
+        });
+      }
 
       const response = await this.executeRequest(url, 'GET', undefined, signal);
 

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -47,6 +47,7 @@ interface AirtableRecord {
  *   fetch('list_records', { table, ...query })       — GET  /v0/{base}/{table}
  *   create('create_record', { table, fields, ... })  — POST /v0/{base}/{table}
  *   update('upsert_record', { table, fields, ... })  — POST /v0/{base}/{table} (upsert)
+ *   update('update_record', { table, record_id, fields, ... }) — PATCH /v0/{base}/{table}/{id}
  */
 export class AirtableAdapter implements ServiceAdapter {
   readonly id: string;
@@ -517,6 +518,78 @@ export class AirtableAdapter implements ServiceAdapter {
       const data = parsed as { records?: unknown };
       if (!Array.isArray(data.records)) {
         throw new WorkflowError('AirtableAdapter: upsert_record response missing records array', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      return { status: response.status, data: parsed };
+    }
+
+    if (operation === 'update_record') {
+      const table = params['table'];
+      const recordId = params['record_id'];
+      const fields = params['fields'];
+
+      if (typeof table !== 'string' || table === '') {
+        throw new WorkflowError('AirtableAdapter: table param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (typeof recordId !== 'string' || recordId === '') {
+        throw new WorkflowError('AirtableAdapter: record_id param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      if (
+        fields === undefined ||
+        fields === null ||
+        typeof fields !== 'object' ||
+        Array.isArray(fields)
+      ) {
+        throw new WorkflowError('AirtableAdapter: fields param must be a plain object', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+
+      const body: Record<string, unknown> = { fields };
+      if (params['typecast'] === true) {
+        body['typecast'] = true;
+      }
+
+      const url = this.buildUrl(table, recordId);
+      const response = await this.executeRequest(url, 'PATCH', body, signal);
+
+      if (!response.ok) {
+        await this.throwHttpError(response, 'update_record');
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new WorkflowError('AirtableAdapter: failed to parse response body', {
+          code: 'SERVICE_RESPONSE_INVALID',
+          category: 'SERVICE',
+          agentAction: 'report_to_user',
+          retryable: false,
+        });
+      }
+
+      const data = parsed as AirtableRecord;
+      if (typeof data.id !== 'string' || data.id === '') {
+        throw new WorkflowError('AirtableAdapter: update_record response missing id field', {
           code: 'SERVICE_RESPONSE_INVALID',
           category: 'SERVICE',
           agentAction: 'report_to_user',


### PR DESCRIPTION
## Context

Comparison against `domdomegg/airtable-mcp-server` identified six improvements for Realm's `AirtableAdapter` (architect prompt, 2026-06-12). The adapter's role is unchanged: a deterministic, single-base, workflow-step executor — not an exploration tool. Schema discovery, schema mutation, comments, attachments, and multi-base support remain explicitly out of scope.

## Motivation

Close the operational gaps that force workflow authors to work around the adapter: no record update by ID, no delete at all, no sort, no pagination beyond manual offset threading, no substring search, and 4xx errors that discard Airtable's diagnostic body.

## Changes

One commit per item, all additive (existing operations are byte-identical for existing params):

### A — `update_record`
New `update()` operation: `PATCH /v0/{base}/{table}/{record_id}` with `{ fields }` body and opt-in `typecast`. Same validation and response-id check patterns as the existing operations. Also creates the `## AirtableAdapter` reference section in `docs/reference/adapters.md` (previously undocumented).

### B — Error body preservation
`throwHttpError` now extracts Airtable's `{ error: { type, message } }` once: the message is appended to 400/403/404/422 error messages, `airtable_error_type` is added to `details`. 401 additionally appends a PAT-format hint when the configured key doesn't contain exactly one `.` (never includes the key itself). 429/5xx messages unchanged. Non-JSON bodies degrade gracefully (no suffix).

### C — `sort` on `list_records`
Accepts `sort: [{ field, direction? }]`, emitting indexed `sort[i][field]` / `sort[i][direction]` query params. Malformed entries are skipped silently, consistent with the branch's permissive param handling.

### D — Batch `delete_records`
Implements the optional `delete` method from `ServiceAdapter`: `DELETE /v0/{base}/{table}?records[]=…`. Validates 1–10 non-empty string ids; more than 10 fails with an explicit Airtable-limit message. One API call only — no internal chunking (partial deletion across chunks would corrupt evidence semantics). Response elements must have `id` and `deleted: true`. `executeRequest`'s method union widened to include `DELETE`. Docs include an irreversibility callout recommending a human gate.

### E — Bounded auto-pagination
Opt-in `fetch_all: true` on `list_records`. Follows the `offset` cursor with two caps, whichever hits first (mirroring the trace normalizer's count/byte design): `max_pages` (default 3, clamped to 10) and `max_bytes` (default 100000, clamped to 1000000). Caps are stop conditions — the crossing page is kept. Constructed response: `{ records, truncated, truncation_reason?, offset? }` with a resume cursor. Loop checks the abort signal before each page. Without `fetch_all`, behavior is byte-identical to before (regression-tested).

### F — `search_records`
New `fetch()` operation building a `FIND`/`OR(FIND…)` formula across caller-named fields (required — no schema discovery by design). `"` and `\` in the search term are escaped before interpolation (injection guard). `view`/`max_records` pass through as in `list_records`.

## Verification

```bash
npm run build --workspace=packages/core
# clean

npm run test --workspace=packages/core 2>&1 | grep "Tests"
# Tests  1138 passed (1138) — baseline 1109 + 29 new, zero skipped

npm run test:contract --workspace=packages/core 2>&1 | grep "Tests"
# Tests  3 skipped (3) — contract probes unaffected

npm run lint
# 4 tasks successful

git diff --stat main
# 3 files, 1100 insertions(+), 7 deletions(-) — no net-negative file
```

## Rollback

```bash
git revert 1996aaf 615c604 e0feb92 419fdc2 bc56ae1 de14e7c
```

or revert the merge commit. No out-of-band mutations — all changes are code and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
