### PR TITLE
feat(core): add min_retry_seconds floor to RateLimitConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- `min_retry_seconds` on service `rate_limit` config — enforces a minimum retry-after floor
+  for HTTP 429 responses, overriding short `Retry-After` header values.
+
+---
+
 ## [0.5.0] — 2026-06-13
 
 ### Added

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -3267,6 +3267,253 @@ describe('retry_after on ResponseEnvelope', () => {
 });
 
 // ---------------------------------------------------------------------------
+// min_retry_seconds floor
+// ---------------------------------------------------------------------------
+
+describe('min_retry_seconds floor', () => {
+  let store: JsonFileStore;
+
+  beforeEach(async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-min-retry-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  it('floors a short Retry-After header to min_retry_seconds', async () => {
+    const capturedDelays: number[] = [];
+    const origSetTimeout = globalThis.setTimeout;
+    (globalThis as Record<string, unknown>)['setTimeout'] = (
+      fn: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      capturedDelays.push(delay ?? 0);
+      return origSetTimeout(fn, 0);
+    };
+
+    try {
+      let attempt = 0;
+      const adapter: ServiceAdapter = {
+        id: 'rl_floor_adapter',
+        fetch: vi.fn().mockImplementation(async () => {
+          attempt++;
+          if (attempt === 1) {
+            throw new WorkflowError('Rate limited', {
+              code: 'SERVICE_RATE_LIMITED',
+              category: 'SERVICE',
+              agentAction: 'wait_and_proceed',
+              retryable: true,
+              retry_after: 1,
+            });
+          }
+          return { status: 200, data: { ok: true } };
+        }),
+        create: vi.fn(),
+        update: vi.fn(),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('adapter', 'rl_floor_adapter', adapter);
+
+      const def: WorkflowDefinition = {
+        id: 'min-retry-floor-wf',
+        name: 'Min Retry Floor Workflow',
+        version: 1,
+        services: {
+          svc: {
+            adapter: 'rl_floor_adapter',
+            trust: 'engine_delivered',
+            rate_limit: { min_retry_seconds: 30 },
+          },
+        },
+        steps: {
+          step_a: {
+            description: 'Step using rate-limited service',
+            execution: 'auto',
+            depends_on: [],
+            uses_service: 'svc',
+            retry: { max_attempts: 2, backoff: 'fixed', base_delay_ms: 500 },
+          },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'min-retry-floor-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(result.status).toBe('ok');
+      expect(attempt).toBe(2);
+      // min_retry_seconds=30 floors retry_after: 1 → 30; Math.max(500, 30000) = 30000
+      expect(capturedDelays).toContain(30000);
+    } finally {
+      (globalThis as Record<string, unknown>)['setTimeout'] = origSetTimeout;
+    }
+  });
+
+  it('acts as fallback when no Retry-After header', async () => {
+    const capturedDelays: number[] = [];
+    const origSetTimeout = globalThis.setTimeout;
+    (globalThis as Record<string, unknown>)['setTimeout'] = (
+      fn: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      capturedDelays.push(delay ?? 0);
+      return origSetTimeout(fn, 0);
+    };
+
+    try {
+      let attempt = 0;
+      const adapter: ServiceAdapter = {
+        id: 'rl_fallback_adapter',
+        fetch: vi.fn().mockImplementation(async () => {
+          attempt++;
+          if (attempt === 1) {
+            throw new WorkflowError('Rate limited', {
+              code: 'SERVICE_RATE_LIMITED',
+              category: 'SERVICE',
+              agentAction: 'wait_and_proceed',
+              retryable: true,
+              // no retry_after — min_retry_seconds acts as floor
+            });
+          }
+          return { status: 200, data: { ok: true } };
+        }),
+        create: vi.fn(),
+        update: vi.fn(),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('adapter', 'rl_fallback_adapter', adapter);
+
+      const def: WorkflowDefinition = {
+        id: 'min-retry-fallback-wf',
+        name: 'Min Retry Fallback Workflow',
+        version: 1,
+        services: {
+          svc: {
+            adapter: 'rl_fallback_adapter',
+            trust: 'engine_delivered',
+            rate_limit: { min_retry_seconds: 30 },
+          },
+        },
+        steps: {
+          step_a: {
+            description: 'Step using rate-limited service',
+            execution: 'auto',
+            depends_on: [],
+            uses_service: 'svc',
+            retry: { max_attempts: 2, backoff: 'fixed', base_delay_ms: 500 },
+          },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'min-retry-fallback-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(result.status).toBe('ok');
+      expect(attempt).toBe(2);
+      // no header → rawRetryAfter=undefined; min_retry_seconds=30 → Math.max(500, 30000) = 30000
+      expect(capturedDelays).toContain(30000);
+    } finally {
+      (globalThis as Record<string, unknown>)['setTimeout'] = origSetTimeout;
+    }
+  });
+
+  it('regression: no min_retry_seconds, short Retry-After header honoured as-is', async () => {
+    const capturedDelays: number[] = [];
+    const origSetTimeout = globalThis.setTimeout;
+    (globalThis as Record<string, unknown>)['setTimeout'] = (
+      fn: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      capturedDelays.push(delay ?? 0);
+      return origSetTimeout(fn, 0);
+    };
+
+    try {
+      let attempt = 0;
+      const adapter: ServiceAdapter = {
+        id: 'rl_regression_adapter',
+        fetch: vi.fn().mockImplementation(async () => {
+          attempt++;
+          if (attempt === 1) {
+            throw new WorkflowError('Rate limited', {
+              code: 'SERVICE_RATE_LIMITED',
+              category: 'SERVICE',
+              agentAction: 'wait_and_proceed',
+              retryable: true,
+              retry_after: 1,
+            });
+          }
+          return { status: 200, data: { ok: true } };
+        }),
+        create: vi.fn(),
+        update: vi.fn(),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('adapter', 'rl_regression_adapter', adapter);
+
+      const def: WorkflowDefinition = {
+        id: 'min-retry-regression-wf',
+        name: 'Min Retry Regression Workflow',
+        version: 1,
+        services: {
+          svc: {
+            adapter: 'rl_regression_adapter',
+            trust: 'engine_delivered',
+            // no rate_limit — min_retry_seconds absent
+          },
+        },
+        steps: {
+          step_a: {
+            description: 'Step using rate-limited service',
+            execution: 'auto',
+            depends_on: [],
+            uses_service: 'svc',
+            retry: { max_attempts: 2, backoff: 'fixed', base_delay_ms: 500 },
+          },
+        },
+      };
+
+      const run = await store.create({
+        workflowId: 'min-retry-regression-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      expect(result.status).toBe('ok');
+      expect(attempt).toBe(2);
+      // no min_retry_seconds; retry_after=1 honoured; Math.max(500, 1000) = 1000
+      expect(capturedDelays).toContain(1000);
+    } finally {
+      (globalThis as Record<string, unknown>)['setTimeout'] = origSetTimeout;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // execution: guard — inline guard step execution via executeChain
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -336,10 +336,14 @@ async function callAdapter(
         //   1. Header value (already on err.retry_after from the adapter)
         //   2. rate_limit.fallback_retry_seconds from YAML
         //   3. adapter.defaultRetryAfterSeconds constant
-        const resolvedRetryAfter =
+        // Apply min_retry_seconds as a floor — overrides short Retry-After header values.
+        const rawRetryAfter =
           err.retry_after ??
           serviceDef.rate_limit?.fallback_retry_seconds ??
           adapter?.defaultRetryAfterSeconds;
+        const minRetry = serviceDef.rate_limit?.min_retry_seconds;
+        const resolvedRetryAfter =
+          minRetry !== undefined ? Math.max(rawRetryAfter ?? 0, minRetry) : rawRetryAfter;
 
         // Pause the token bucket for the resolved retry window.
         // The cap (Math.min with max_retry_seconds) is applied before calling pause() so

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -36,6 +36,12 @@ export interface RateLimitConfig {
    */
   fallback_retry_seconds?: number;
   /**
+   * Minimum retry-after floor (seconds). When set, the resolved retry_after is
+   * Math.max(header_or_fallback, min_retry_seconds) — prevents short Retry-After
+   * header values from causing retries before the rate limit window has cleared.
+   */
+  min_retry_seconds?: number;
+  /**
    * Maximum retry-after window (seconds). When the resolved retry_after exceeds this value,
    * the step fails immediately with agentAction: 'report_to_user' instead of waiting.
    */

--- a/packages/core/src/workflow/yaml-loader.test.ts
+++ b/packages/core/src/workflow/yaml-loader.test.ts
@@ -1074,6 +1074,31 @@ describe('loadWorkflowFromString — rate_limit validation', () => {
     );
     expect(() => loadWorkflowFromString(content)).toThrow(WorkflowError);
   });
+
+  it('accepts min_retry_seconds on rate_limit without requests_per_second', () => {
+    const content = VALID_YAML_WITH_SERVICE.replace(
+      'trust: engine_delivered',
+      'trust: engine_delivered\n    rate_limit:\n      min_retry_seconds: 30',
+    );
+    const def = loadWorkflowFromString(content);
+    expect(def.services?.['my-service'].rate_limit?.min_retry_seconds).toBe(30);
+  });
+
+  // min_retry_seconds = 0 is invalid (must be > 0)
+  it('rejects min_retry_seconds ≤ 0', () => {
+    const content = VALID_YAML_WITH_SERVICE.replace(
+      'trust: engine_delivered',
+      'trust: engine_delivered\n    rate_limit:\n      min_retry_seconds: 0',
+    );
+    expect(() => loadWorkflowFromString(content)).toThrow(WorkflowError);
+    try {
+      loadWorkflowFromString(content);
+    } catch (err) {
+      expect((err as WorkflowError).message).toContain(
+        "'rate_limit.min_retry_seconds' must be a positive number",
+      );
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -610,6 +610,14 @@ export function loadWorkflowFromString(
         );
       }
       if (
+        'min_retry_seconds' in rl &&
+        (typeof rl['min_retry_seconds'] !== 'number' || (rl['min_retry_seconds'] as number) <= 0)
+      ) {
+        errors.push(
+          `Service '${serviceName}': 'rate_limit.min_retry_seconds' must be a positive number (> 0)`,
+        );
+      }
+      if (
         'max_retry_seconds' in rl &&
         (!Number.isInteger(rl['max_retry_seconds']) || (rl['max_retry_seconds'] as number) < 1)
       ) {


### PR DESCRIPTION
## Context

Shadow batch testing on 200 Gorgias tickets (2026-06-14) revealed that `fetch_customer_thread`
exhausted all 3 retry attempts on rate-limited tickets within ~3 seconds total. Run evidence
(`a44b5b0f`, ticket 66343635) showed attempt-to-attempt gaps of ~1001ms — exactly
`Math.max(base_delay_ms=1000, retry_after_ms=1000)` — meaning Gorgias was sending
`Retry-After: 1` (one second), which the engine correctly honoured, but one second is
insufficient to clear Gorgias's actual rate limit window.

## Motivation

The engine's three-tier retry-after resolution (`Retry-After` header → `fallback_retry_seconds`
→ `adapter.defaultRetryAfterSeconds`) only applies fallback and adapter defaults when the header
is **absent**. When a service sends a short `Retry-After` header value that doesn't reflect its
actual rate limit window, there is no mechanism to enforce a minimum wait. `min_retry_seconds`
closes this gap.

## Changes

**`packages/core/src/types/workflow-definition.ts`**  
Added `min_retry_seconds?: number` to `RateLimitConfig` (after `fallback_retry_seconds`, before
`max_retry_seconds`) with JSDoc explaining the floor semantics.

**`packages/core/src/workflow/yaml-loader.ts`**  
Added validation: `min_retry_seconds` must be a positive number (> 0). Placed between the
`fallback_retry_seconds` and `max_retry_seconds` validation blocks.

**`packages/core/src/engine/execution-loop.ts` — `callAdapter`**  
Replaced the single `resolvedRetryAfter` constant with a two-step resolution:

```typescript
// Before
const resolvedRetryAfter =
  err.retry_after ??
  serviceDef.rate_limit?.fallback_retry_seconds ??
  adapter?.defaultRetryAfterSeconds;

// After
const rawRetryAfter =
  err.retry_after ??
  serviceDef.rate_limit?.fallback_retry_seconds ??
  adapter?.defaultRetryAfterSeconds;
const minRetry = serviceDef.rate_limit?.min_retry_seconds;
const resolvedRetryAfter =
  minRetry !== undefined
    ? Math.max(rawRetryAfter ?? 0, minRetry)
    : rawRetryAfter;
```

When `min_retry_seconds` is not set, `resolvedRetryAfter = rawRetryAfter` — existing behaviour
is unchanged. The rest of the rate-limit path (token bucket pause, fail-fast, re-throw) already
uses `resolvedRetryAfter` and requires no modification.

**5 new tests** (2 in yaml-loader, 3 in execution-loop): valid value accepted, invalid value
rejected, short header floored, no-header fallback, regression guard with no `min_retry_seconds`.

## Verification

```bash
npm run build
# 4 tasks successful, exit 0

npm run test --workspace=packages/core
# Tests 1143 passed (1143), 0 skipped

npm run lint
# 4 tasks successful, exit 0
```

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations. Pure additive change — existing workflows without `min_retry_seconds`
are unaffected.
