### PR TITLE
fix(mcp): escape SSE line-terminator chars in tool responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **SSE JSON serialization safety** — MCP tool responses now escape U+0085 (NEXT LINE),
+  U+2028 (LINE SEPARATOR), and U+2029 (PARAGRAPH SEPARATOR) as `\uXXXX` sequences in the
+  JSON payload. These three characters are the only ones that `JSON.stringify` leaves
+  unescaped but Python's `str.splitlines()` treats as line terminators, causing SSE `data:`
+  lines to be split mid-JSON and producing `JSONDecodeError` on the client side. Ticket
+  content in multilingual workflows (Dutch, Polish, French) that contains these characters
+  no longer causes truncated responses. All other non-ASCII characters (accented letters,
+  emoji, CJK) pass through unchanged.
+
+---
+
 ## [0.6.0] — 2026-06-15
 
 ### Added

--- a/packages/mcp-server/src/sse-json.test.ts
+++ b/packages/mcp-server/src/sse-json.test.ts
@@ -28,10 +28,13 @@ describe('sseJsonStringify', () => {
     expect(sseJsonStringify(input)).toBe(JSON.stringify(input, null, 2));
   });
 
-  it('round-trips non-ASCII text through JSON.parse', () => {
+  it('leaves regular non-ASCII chars (accented letters) unescaped', () => {
     const input = { t: 'Uw bestelling é ü' };
     const output = sseJsonStringify(input);
-    expect(/[\x80-￿]/g.test(output)).toBe(false);
+    // Targeted approach: only the 3 splitlines() chars are escaped.
+    // Regular non-ASCII (é, ü) must pass through to avoid payload inflation.
+    expect(output).toContain('é');
+    expect(output).toContain('ü');
     expect(JSON.parse(output).t).toBe('Uw bestelling é ü');
   });
 });

--- a/packages/mcp-server/src/sse-json.test.ts
+++ b/packages/mcp-server/src/sse-json.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { sseJsonStringify } from './sse-json.js';
+
+describe('sseJsonStringify', () => {
+  it('escapes U+0085 (NEXT LINE)', () => {
+    const input = { t: '' };
+    const output = sseJsonStringify(input);
+    expect(output).not.toContain('');
+    expect(JSON.parse(output).t).toBe('');
+  });
+
+  it('escapes U+2028 (LINE SEPARATOR)', () => {
+    const input = { t: ' ' };
+    const output = sseJsonStringify(input);
+    expect(output).not.toContain(' ');
+    expect(JSON.parse(output).t).toBe(' ');
+  });
+
+  it('escapes U+2029 (PARAGRAPH SEPARATOR)', () => {
+    const input = { t: ' ' };
+    const output = sseJsonStringify(input);
+    expect(output).not.toContain(' ');
+    expect(JSON.parse(output).t).toBe(' ');
+  });
+
+  it('leaves pure ASCII content unchanged', () => {
+    const input = { msg: 'hello world', n: 42 };
+    expect(sseJsonStringify(input)).toBe(JSON.stringify(input, null, 2));
+  });
+
+  it('round-trips non-ASCII text through JSON.parse', () => {
+    const input = { t: 'Uw bestelling é ü' };
+    const output = sseJsonStringify(input);
+    expect(/[\x80-￿]/g.test(output)).toBe(false);
+    expect(JSON.parse(output).t).toBe('Uw bestelling é ü');
+  });
+});

--- a/packages/mcp-server/src/sse-json.ts
+++ b/packages/mcp-server/src/sse-json.ts
@@ -1,18 +1,19 @@
 /**
- * Serializes a value to JSON, escaping all non-ASCII characters as \uXXXX sequences.
+ * Serializes a value to JSON, escaping the three Unicode characters that Python's
+ * str.splitlines() treats as line terminators but JSON.stringify leaves unescaped:
+ *   U+0085 (NEXT LINE), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR).
  *
- * JavaScript's JSON.stringify leaves characters such as U+0085 (NEXT LINE), U+2028
- * (LINE SEPARATOR), and U+2029 (PARAGRAPH SEPARATOR) unescaped. SSE parsers —
- * including Python's str.splitlines() — treat these as line terminators, splitting
- * the data: line mid-JSON and producing a truncated payload that fails JSON.parse.
+ * When these characters appear in SSE data: lines, splitlines()-based parsers split
+ * the line mid-JSON, producing truncated payloads that fail JSON.parse. All other
+ * non-ASCII characters (accented letters, CJK, emoji surrogate pairs, etc.) are not
+ * splitlines() split points and are left as-is -- preserving human-readable output and
+ * avoiding payload inflation on multilingual ticket content.
  *
- * Escaping ALL characters U+0080–U+FFFF produces pure 7-bit ASCII output: immune to
- * any Unicode-based line-splitting by any SSE client, regardless of language or library.
  * Content round-trips correctly through any standard JSON.parse.
  */
 export function sseJsonStringify(value: unknown): string {
   return JSON.stringify(value, null, 2).replace(
-    /[\x80-￿]/g,
+    /[\u0085\u2028\u2029]/g,
     (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`,
   );
 }

--- a/packages/mcp-server/src/sse-json.ts
+++ b/packages/mcp-server/src/sse-json.ts
@@ -1,0 +1,18 @@
+/**
+ * Serializes a value to JSON, escaping all non-ASCII characters as \uXXXX sequences.
+ *
+ * JavaScript's JSON.stringify leaves characters such as U+0085 (NEXT LINE), U+2028
+ * (LINE SEPARATOR), and U+2029 (PARAGRAPH SEPARATOR) unescaped. SSE parsers —
+ * including Python's str.splitlines() — treat these as line terminators, splitting
+ * the data: line mid-JSON and producing a truncated payload that fails JSON.parse.
+ *
+ * Escaping ALL characters U+0080–U+FFFF produces pure 7-bit ASCII output: immune to
+ * any Unicode-based line-splitting by any SSE client, regardless of language or library.
+ * Content round-trips correctly through any standard JSON.parse.
+ */
+export function sseJsonStringify(value: unknown): string {
+  return JSON.stringify(value, null, 2).replace(
+    /[\x80-￿]/g,
+    (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`,
+  );
+}

--- a/packages/mcp-server/src/tools/append-trace.ts
+++ b/packages/mcp-server/src/tools/append-trace.ts
@@ -12,6 +12,7 @@ import {
   type ResponseEnvelope,
 } from '@sensigo/realm';
 import { traceEntrySchema } from './execute-step.js';
+import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleAppendTraceStores {
   runStore?: JsonFileStore;
@@ -143,7 +144,7 @@ export function registerAppendTrace(
       try {
         const result = await handleAppendTrace(args, opts);
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          content: [{ type: 'text' as const, text: sseJsonStringify(result) }],
         };
       } catch (err) {
         const workflowErr =
@@ -177,7 +178,7 @@ export function registerAppendTrace(
           contextHint,
         );
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(envelope, null, 2) }],
+          content: [{ type: 'text' as const, text: sseJsonStringify(envelope) }],
         };
       }
     },

--- a/packages/mcp-server/src/tools/create-workflow.ts
+++ b/packages/mcp-server/src/tools/create-workflow.ts
@@ -13,6 +13,7 @@ import {
   CURRENT_WORKFLOW_SCHEMA_VERSION,
 } from '@sensigo/realm';
 import { handleStartRun, type HandleRunStores } from './start-run.js';
+import { sseJsonStringify } from '../sse-json.js';
 
 export interface CreateWorkflowStep {
   id: string;
@@ -266,7 +267,7 @@ export function registerCreateWorkflow(server: McpServer, opts?: HandleRunStores
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify({ ...result, command: 'create_workflow' }, null, 2),
+              text: sseJsonStringify({ ...result, command: 'create_workflow' }),
             },
           ],
         };
@@ -278,23 +279,19 @@ export function registerCreateWorkflow(server: McpServer, opts?: HandleRunStores
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  command: 'create_workflow',
-                  run_id: '',
-                  status: 'error',
-                  data: {},
-                  evidence: [],
-                  warnings: [],
-                  errors: [message],
-                  agent_action: agentAction,
-                  context_hint:
-                    'An error occurred before the workflow could be registered or the run could be started.',
-                  next_actions: [],
-                },
-                null,
-                2,
-              ),
+              text: sseJsonStringify({
+                command: 'create_workflow',
+                run_id: '',
+                status: 'error',
+                data: {},
+                evidence: [],
+                warnings: [],
+                errors: [message],
+                agent_action: agentAction,
+                context_hint:
+                  'An error occurred before the workflow could be registered or the run could be started.',
+                next_actions: [],
+              }),
             },
           ],
         };

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -12,6 +12,7 @@ import {
   type AgentTraceEntry,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
+import { sseJsonStringify } from '../sse-json.js';
 
 /** Zod schema for a single agent trace entry submitted to execute_step or append_trace. */
 export const traceEntrySchema = z.object({
@@ -82,7 +83,7 @@ export async function handleExecuteStepTool(
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify({ ...result, data: {}, evidence: [] }, null, 2),
+          text: sseJsonStringify({ ...result, data: {}, evidence: [] }),
         },
       ],
     };
@@ -113,7 +114,7 @@ export async function handleExecuteStepTool(
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify(envelope, null, 2),
+          text: sseJsonStringify(envelope),
         },
       ],
     };

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -7,6 +7,7 @@ import {
   resolvePreExecutionAgentAction,
   type RunPhase,
 } from '@sensigo/realm';
+import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleRunStateStores {
   runStore?: JsonFileStore;
@@ -73,7 +74,7 @@ export function registerGetRunState(server: McpServer, opts?: HandleRunStateStor
     async (args) => {
       try {
         const result = await handleGetRunState(args, opts);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: 'text' as const, text: sseJsonStringify(result) }] };
       } catch (err) {
         const agentAction =
           err instanceof WorkflowError ? resolvePreExecutionAgentAction(err) : 'report_to_user';
@@ -86,22 +87,18 @@ export function registerGetRunState(server: McpServer, opts?: HandleRunStateStor
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  command: 'get_run_state',
-                  run_id: args.run_id,
-                  status: 'error',
-                  data: {},
-                  evidence: [],
-                  warnings: [],
-                  errors: [message],
-                  agent_action: agentAction,
-                  context_hint: contextHint,
-                  next_actions: [],
-                },
-                null,
-                2,
-              ),
+              text: sseJsonStringify({
+                command: 'get_run_state',
+                run_id: args.run_id,
+                status: 'error',
+                data: {},
+                evidence: [],
+                warnings: [],
+                errors: [message],
+                agent_action: agentAction,
+                context_hint: contextHint,
+                next_actions: [],
+              }),
             },
           ],
         };

--- a/packages/mcp-server/src/tools/get-workflow-protocol.ts
+++ b/packages/mcp-server/src/tools/get-workflow-protocol.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { JsonWorkflowStore, WorkflowError } from '@sensigo/realm';
+import { sseJsonStringify } from '../sse-json.js';
 import { generateProtocol, type WorkflowProtocol } from '../protocol/generator.js';
 import type { HandleStores } from './list-workflows.js';
 
@@ -27,7 +28,7 @@ export function registerGetWorkflowProtocol(server: McpServer, opts?: HandleStor
     async (args) => {
       try {
         const result = await handleGetWorkflowProtocol(args, opts);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: 'text' as const, text: sseJsonStringify(result) }] };
       } catch (err) {
         const message = err instanceof WorkflowError ? err.message : String(err);
         return {

--- a/packages/mcp-server/src/tools/list-workflows.ts
+++ b/packages/mcp-server/src/tools/list-workflows.ts
@@ -1,6 +1,7 @@
 // list-workflows tool — returns all registered workflows.
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { JsonWorkflowStore } from '@sensigo/realm';
+import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleStores {
   workflowStore?: JsonWorkflowStore;
@@ -25,6 +26,6 @@ export async function handleListWorkflows(
 export function registerListWorkflows(server: McpServer, opts?: HandleStores): void {
   server.tool('list_workflows', 'List all registered Realm workflows.', async () => {
     const result = await handleListWorkflows(opts);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    return { content: [{ type: 'text' as const, text: sseJsonStringify(result) }] };
   });
 }

--- a/packages/mcp-server/src/tools/start-run-batch.ts
+++ b/packages/mcp-server/src/tools/start-run-batch.ts
@@ -10,6 +10,7 @@ import {
   type ResponseEnvelope,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
+import { sseJsonStringify } from '../sse-json.js';
 
 export interface StartRunBatchResult {
   started: Array<{
@@ -118,7 +119,7 @@ export function registerStartRunBatch(
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(result, null, 2),
+              text: sseJsonStringify(result),
             },
           ],
         };
@@ -151,7 +152,7 @@ export function registerStartRunBatch(
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(envelope, null, 2),
+              text: sseJsonStringify(envelope),
             },
           ],
         };

--- a/packages/mcp-server/src/tools/start-run.ts
+++ b/packages/mcp-server/src/tools/start-run.ts
@@ -14,6 +14,7 @@ import {
   type TraceBufferStore,
   ExtensionRegistry,
 } from '@sensigo/realm';
+import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleRunStores {
   runStore?: JsonFileStore;
@@ -108,7 +109,7 @@ export function registerStartRun(
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify({ ...result, command: 'start_run' }, null, 2),
+              text: sseJsonStringify({ ...result, command: 'start_run' }),
             },
           ],
         };
@@ -137,7 +138,7 @@ export function registerStartRun(
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(envelope, null, 2),
+              text: sseJsonStringify(envelope),
             },
           ],
         };

--- a/packages/mcp-server/src/tools/submit-human-response.ts
+++ b/packages/mcp-server/src/tools/submit-human-response.ts
@@ -10,6 +10,7 @@ import {
   type ResponseEnvelope,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
+import { sseJsonStringify } from '../sse-json.js';
 
 /**
  * Business logic for the submit_human_response tool.
@@ -48,7 +49,7 @@ export function registerSubmitHumanResponse(server: McpServer, opts?: HandleRunS
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify({ ...result, data: {}, evidence: [] }, null, 2),
+              text: sseJsonStringify({ ...result, data: {}, evidence: [] }),
             },
           ],
         };
@@ -79,7 +80,7 @@ export function registerSubmitHumanResponse(server: McpServer, opts?: HandleRunS
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(envelope, null, 2),
+              text: sseJsonStringify(envelope),
             },
           ],
         };


### PR DESCRIPTION
## Context

Investigating a `JSONDecodeError` on `start_run` in the Bradley-max batch script revealed a vulnerability in how the Realm MCP server serialises tool responses over SSE. The error was reproducible: `run_id=None` with nothing recoverable, triggered when ticket content or error messages contained certain Unicode characters.

## Root Cause

Two interacting bugs at different layers:

**Server (Realm):** Node.js `JSON.stringify` leaves three Unicode characters unescaped in its output: U+0085 (NEXT LINE), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR). The MCP SDK's `writeSSEEvent` places the full JSON-RPC envelope on a single `data:` line. Any of these three characters appearing in string values (ticket subjects, error messages, abort context, API error bodies) results in them appearing as literal bytes in the SSE stream.

**Client (external):** Python's `str.splitlines()` — a natural SSE parsing idiom — treats all three as line terminators (not just `\n`/`\r\n`). The `data:` line is split mid-JSON, the client receives truncated JSON, and `json.loads` raises `JSONDecodeError`.

## Changes

**New shared utility — `packages/mcp-server/src/sse-json.ts`:**

Introduces `sseJsonStringify(value)`, which calls `JSON.stringify(value, null, 2)` then escapes the three problematic characters as `\uXXXX` sequences. The targeted approach — escaping only U+0085, U+2028, U+2029 — is preferred over escaping all non-ASCII: it closes the exact vulnerability without payload inflation on multilingual ticket content (Dutch, Polish, French workflows). Confirmed correct after peer architect review.

**16 call sites updated across 9 tool files:**

Every `text:` field in every MCP tool response was using `JSON.stringify(x, null, 2)` directly. All 16 sites now use `sseJsonStringify(x)`.

**5 new tests — `packages/mcp-server/src/sse-json.test.ts`:**

- U+0085, U+2028, U+2029 each escaped (not present in output + round-trip)
- Pure ASCII content unchanged
- Regular non-ASCII (é, ü) passes through unchanged (payload inflation test)

## Verification

```bash
# Confirm no raw JSON.stringify in production tool files
grep -n "JSON.stringify.*null, 2" packages/mcp-server/src/tools/*.ts | grep -v "\.test\."
# must return nothing

# Build
npm run build
# must show: 4 successful

# Tests
npm run test --workspace=packages/mcp-server
# must show: 72 passed, 0 skipped

# Lint
npm run lint
# must exit 0
```

## Rollback

```bash
git revert HEAD~3..HEAD
```

This reverts the three commits on this branch (tool file changes, regex revision, CHANGELOG entry). The `sseJsonStringify` import in `start-run.ts` would also need reverting — that file was modified on the branch before this PR was opened.
