### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.6.1] — 2026-06-15
 
 ### Fixed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.6.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.6.1');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.6.0';
+export const VERSION = '0.6.1';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.6.0';
+export const VERSION = '0.6.1';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.6.0',
+    version: '0.6.1',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.6.0';
+export const VERSION = '0.6.1';


### PR DESCRIPTION
## Context

Patch release cutting the SSE JSON serialisation fix (PR #71) to npm.

## Changes

- `packages/mcp-server`: `sseJsonStringify` utility escaping U+0085/U+2028/U+2029 in all MCP tool responses — prevents `JSONDecodeError` on clients using `str.splitlines()` for SSE parsing.
- All four packages bumped from `0.6.0` → `0.6.1`.

See PR #71 for the full change description and root cause analysis.

## Verification

```bash
# After merge + tag push, confirm all four packages appear at 0.6.1:
npm view @sensigo/realm version
npm view @sensigo/realm-mcp version
npm view @sensigo/realm-testing version
npm view @sensigo/realm-cli version
# each must return 0.6.1

# Spot-check the fix is present in the published artifact:
mkdir /tmp/test-061 && cd /tmp/test-061
npm init -y && npm install @sensigo/realm-mcp@0.6.1
node -e "const { VERSION } = require('@sensigo/realm-mcp'); console.log(VERSION);"
# must print: 0.6.1
```

## Rollback

If the publish workflow fails after partial publication: re-push the tag (`git push --delete origin v0.6.1 && git push --tags`). `npm publish` will skip already-published packages with `EPUBLISHCONFLICT`.

If the artifact is broken post-publish: publish `0.6.2` as a hotfix following the full Part B sequence.
