### PR TITLE
fix(core): universal passthrough for Gorgias adapter

### DIFF
--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -103,6 +103,16 @@ function makeMsg(
     public: boolean;
     channel: string;
     created_datetime: string;
+    sender: {
+      id?: number;
+      email?: string | null;
+      name?: string | null;
+      firstname?: string | null;
+      lastname?: string | null;
+    } | null;
+    subject: string | null;
+    stripped_text: string | null;
+    via: string | null;
   }> = {},
 ) {
   return {
@@ -113,6 +123,10 @@ function makeMsg(
     body_text: overrides.body_text !== undefined ? overrides.body_text : `Message ${id}`,
     body_html: overrides.body_html !== undefined ? overrides.body_html : null,
     created_datetime: overrides.created_datetime ?? '2024-01-01T00:00:00Z',
+    sender: overrides.sender !== undefined ? overrides.sender : null,
+    subject: overrides.subject !== undefined ? overrides.subject : null,
+    stripped_text: overrides.stripped_text !== undefined ? overrides.stripped_text : null,
+    via: overrides.via !== undefined ? overrides.via : null,
   };
 }
 
@@ -323,37 +337,111 @@ describe("GorgiasAdapter fetch('get_messages')", () => {
     expect(data.truncated).toBe(true);
   });
 
-  it('body_text present: used as body; body_html ignored', async () => {
+  it('body_text and body_html are returned as-is', async () => {
     respond(200, {
       data: [makeMsg(1, { body_text: 'plain text', body_html: '<p>html</p>' })],
       meta: { next_cursor: null },
     });
     const adapter = makeAdapter();
     const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
-    const data = result.data as { messages: Array<{ body: string }> };
-    expect(data.messages[0]?.body).toBe('plain text');
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    const msg = data.messages[0]!;
+    expect(msg['body_text']).toBe('plain text');
+    expect(msg['body_html']).toBe('<p>html</p>');
   });
 
-  it('body_text absent, body_html present: HTML tags and entities stripped', async () => {
+  it('body_html is returned verbatim without HTML stripping', async () => {
     respond(200, {
-      data: [makeMsg(1, { body_text: null, body_html: '<p>Hello &amp; world &lt;test&gt;</p>' })],
+      data: [makeMsg(1, { body_text: null, body_html: '<p>Hello &amp; world</p>' })],
       meta: { next_cursor: null },
     });
     const adapter = makeAdapter();
     const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
-    const data = result.data as { messages: Array<{ body: string }> };
-    expect(data.messages[0]?.body).toBe('Hello & world <test>');
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    const msg = data.messages[0]!;
+    expect(msg['body_text']).toBeNull();
+    expect(msg['body_html']).toBe('<p>Hello &amp; world</p>');
   });
 
-  it('both body_text and body_html absent: body === ""', async () => {
+  it('does not add a computed body field to messages', async () => {
     respond(200, {
-      data: [makeMsg(1, { body_text: null, body_html: null })],
+      data: [makeMsg(1)],
       meta: { next_cursor: null },
     });
     const adapter = makeAdapter();
     const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
-    const data = result.data as { messages: Array<{ body: string }> };
-    expect(data.messages[0]?.body).toBe('');
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    expect('body' in (data.messages[0] ?? {})).toBe(false);
+  });
+
+  it('sender fields pass through to message output', async () => {
+    respond(200, {
+      data: [makeMsg(1, { sender: { id: 100, email: 'customer@example.com', name: 'Alice' } })],
+      meta: { next_cursor: null },
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    const sender = data.messages[0]!['sender'] as Record<string, unknown>;
+    expect(sender['email']).toBe('customer@example.com');
+    expect(sender['name']).toBe('Alice');
+  });
+
+  it('null sender is preserved in output', async () => {
+    respond(200, {
+      data: [makeMsg(1, { sender: null })],
+      meta: { next_cursor: null },
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    expect(data.messages[0]!['sender']).toBeNull();
+  });
+
+  it('extra fields not in the interface are preserved', async () => {
+    const msgWithExtra = { ...makeMsg(1), some_future_field: 'future_value' };
+    respond(200, { data: [msgWithExtra], meta: { next_cursor: null } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    expect(data.messages[0]!['some_future_field']).toBe('future_value');
+  });
+
+  it('subject and stripped_text pass through', async () => {
+    respond(200, {
+      data: [makeMsg(1, { subject: 'Order help', stripped_text: 'stripped body' })],
+      meta: { next_cursor: null },
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    const data = result.data as { messages: Array<Record<string, unknown>> };
+    const msg = data.messages[0]!;
+    expect(msg['subject']).toBe('Order help');
+    expect(msg['stripped_text']).toBe('stripped body');
+  });
+
+  it('default order_by is created_datetime:asc when not supplied', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    expect(capturedUrl).toContain('order_by=created_datetime%3Aasc');
+  });
+
+  it('caller-supplied order_by is forwarded in the URL', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_messages', { ticket_id: 10, order_by: 'created_datetime:desc' }, {});
+    expect(capturedUrl).toContain('order_by=created_datetime%3Adesc');
   });
 
   it('aborting signal mid-loop (after page 1) → throws STEP_ABORTED', async () => {
@@ -384,89 +472,105 @@ describe("GorgiasAdapter fetch('get_messages')", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: create('post_internal_note')
+// Tests: create('create_message')
 // ---------------------------------------------------------------------------
 
-describe("GorgiasAdapter create('post_internal_note')", () => {
-  it('sends correct body and returns { ok: true, note_id }', async () => {
-    respondEcho(201, (_req, body) => {
-      const parsed = JSON.parse(body) as Record<string, unknown>;
-      return { id: 999, echoed: parsed };
-    });
-    const adapter = makeAdapter();
-    const result = await adapter.create(
-      'post_internal_note',
-      { ticket_id: 42, body_html: '<p>Internal note</p>' },
-      {},
-    );
-    expect(result.status).toBe(201);
-    const data = result.data as { ok: boolean; note_id: number };
-    expect(data.ok).toBe(true);
-    expect(data.note_id).toBe(999);
-  });
-
-  it('sends exactly { channel: "note", public: false, from_agent: true, body_html }', async () => {
-    respondEcho(201, (_req, body) => {
-      const parsed = JSON.parse(body) as Record<string, unknown>;
-      return { id: 1, body: parsed };
-    });
-    const adapter = makeAdapter();
-    await adapter.create('post_internal_note', { ticket_id: 42, body_html: '<b>note</b>' }, {});
-
-    // Re-check via another call that records the request body
-    respondEcho(201, (_req, body) => {
-      return { id: 2, _body: body };
-    });
-    const result2 = await adapter.create(
-      'post_internal_note',
-      { ticket_id: 42, body_html: '<b>note</b>' },
-      {},
-    );
-    // Parse from a fresh call
-    void result2; // just checking it doesn't throw
-  });
-
-  it('asserts correct request body fields', async () => {
-    let capturedBody: unknown;
-    handlers.push((_req, res, body) => {
-      capturedBody = JSON.parse(body);
-      res.writeHead(201, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ id: 1 }));
-    });
-    const adapter = makeAdapter();
-    await adapter.create('post_internal_note', { ticket_id: 42, body_html: '<p>hi</p>' }, {});
-    expect(capturedBody).toEqual({
+describe("GorgiasAdapter create('create_message')", () => {
+  it('returns the raw Gorgias message response', async () => {
+    respond(201, {
+      id: 999,
       channel: 'note',
       public: false,
       from_agent: true,
       body_html: '<p>hi</p>',
+      created_datetime: '2024-01-01T00:00:00Z',
+    });
+    const adapter = makeAdapter();
+    const result = await adapter.create(
+      'create_message',
+      { ticket_id: 42, body_html: '<p>hi</p>', channel: 'note', public: false, from_agent: true },
+      {},
+    );
+    expect(result.status).toBe(201);
+    const data = result.data as Record<string, unknown>;
+    expect(data['id']).toBe(999);
+    expect(data['channel']).toBe('note');
+  });
+
+  it('passes caller-supplied fields as the request body (ticket_id excluded)', async () => {
+    let capturedBody: unknown;
+    handlers.push((_req, res, body) => {
+      capturedBody = JSON.parse(body);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: 1, channel: 'email' }));
+    });
+    const adapter = makeAdapter();
+    await adapter.create(
+      'create_message',
+      {
+        ticket_id: 42,
+        channel: 'email',
+        public: true,
+        from_agent: true,
+        body_html: '<p>reply</p>',
+        subject: 'Re: your order',
+      },
+      {},
+    );
+    expect(capturedBody).toEqual({
+      channel: 'email',
+      public: true,
+      from_agent: true,
+      body_html: '<p>reply</p>',
+      subject: 'Re: your order',
     });
   });
 
-  it('body_html missing → throws ADAPTER_VALIDATION_FAILED', async () => {
+  it('channel: "note" works when caller supplies it', async () => {
+    let capturedBody: unknown;
+    handlers.push((_req, res, body) => {
+      capturedBody = JSON.parse(body);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: 2 }));
+    });
     const adapter = makeAdapter();
-    await expect(adapter.create('post_internal_note', { ticket_id: 42 }, {})).rejects.toMatchObject(
-      { code: 'ADAPTER_VALIDATION_FAILED' },
+    await adapter.create(
+      'create_message',
+      { ticket_id: 42, channel: 'note', public: false, from_agent: true, body_html: '<p>note</p>' },
+      {},
     );
+    expect((capturedBody as Record<string, unknown>)['channel']).toBe('note');
+    expect((capturedBody as Record<string, unknown>)['public']).toBe(false);
   });
 
   it('mock returns 403 → throws SERVICE_HTTP_4XX with message containing "permission"', async () => {
     respond(403, { error: 'Forbidden' });
     const adapter = makeAdapter();
     const err = await adapter
-      .create('post_internal_note', { ticket_id: 42, body_html: '<p>hi</p>' }, {})
+      .create('create_message', { ticket_id: 42, body_html: '<p>hi</p>' }, {})
       .catch((e: unknown) => e as WorkflowError);
     expect(err).toBeInstanceOf(WorkflowError);
     expect(err.code).toBe('SERVICE_HTTP_4XX');
     expect(err.message).toContain('permission');
   });
 
-  it('mock returns 201 but with no id field → throws SERVICE_RESPONSE_INVALID', async () => {
-    respond(201, { ok: true });
+  it('channel: "email" is forwarded — not restricted to note', async () => {
+    respond(201, { id: 3, channel: 'email' });
     const adapter = makeAdapter();
-    await expect(
-      adapter.create('post_internal_note', { ticket_id: 42, body_html: '<p>hi</p>' }, {}),
-    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+    const result = await adapter.create(
+      'create_message',
+      { ticket_id: 42, channel: 'email', public: true, body_html: '<p>reply</p>' },
+      {},
+    );
+    expect(result.status).toBe(201);
+    expect((result.data as Record<string, unknown>)['channel']).toBe('email');
+  });
+
+  it('ticket_id missing → throws ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.create('create_message', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
   });
 });
 

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -288,6 +288,8 @@ export class GorgiasAdapter implements ServiceAdapter {
       const effectiveLimit = Math.min(userLimit, 200);
       const PAGE_SIZE = 100;
 
+      const orderBy =
+        typeof params['order_by'] === 'string' ? params['order_by'] : 'created_datetime:asc';
       const accumulated: GorgiasMessage[] = [];
       let cursor: string | undefined = undefined;
       let truncated = false;
@@ -295,8 +297,6 @@ export class GorgiasAdapter implements ServiceAdapter {
       for (;;) {
         this.checkAborted(signal);
 
-        const orderBy =
-          typeof params['order_by'] === 'string' ? params['order_by'] : 'created_datetime:asc';
         const url =
           `${this.baseUrl}/messages?ticket_id=${ticketId}&limit=${PAGE_SIZE}&order_by=${encodeURIComponent(orderBy)}` +
           (cursor !== undefined ? `&cursor=${cursor}` : '');

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -21,54 +21,49 @@ export interface GorgiasAdapterConfig {
 /** Raw Gorgias message shape from the API. */
 interface GorgiasMessage {
   id: number;
-  from_agent: boolean;
+  uri?: string | null;
+  message_id?: string | null;
+  ticket_id?: number | null;
+  external_id?: string | null;
   public: boolean;
   channel: string;
+  via?: string | null;
+  source?: unknown;
+  sender?: {
+    id?: number | null;
+    email?: string | null;
+    name?: string | null;
+    firstname?: string | null;
+    lastname?: string | null;
+    meta?: Record<string, unknown> | null;
+  } | null;
+  receiver?: {
+    id?: number | null;
+    email?: string | null;
+    name?: string | null;
+  } | null;
+  from_agent: boolean;
+  subject?: string | null;
   body_text?: string | null;
   body_html?: string | null;
+  stripped_text?: string | null;
+  stripped_html?: string | null;
+  stripped_signature?: string | null;
+  headers?: unknown;
+  attachments?: unknown[];
+  actions?: unknown[];
+  macros?: unknown[];
+  meta?: unknown;
   created_datetime: string;
-}
-
-/** Normalized message shape returned by get_messages. */
-interface NormalizedMessage {
-  id: number;
-  from_agent: boolean;
-  public: boolean;
-  channel: string;
-  body: string;
-  created_datetime: string;
-}
-
-/** HTML entity map used by stripHtmlTags. */
-const HTML_ENTITIES: Record<string, string> = {
-  '&amp;': '&',
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#039;': "'",
-};
-
-/**
- * Converts an HTML string to plain text.
- *
- * Tag removal is applied in a loop until stable so that patterns like
- * `<scr<x>ipt>` cannot survive a single-pass strip. Entity decoding is done
- * in a single regex pass to prevent double-unescaping (e.g. `&amp;lt;` must
- * produce `&lt;`, not `<`).
- */
-function stripHtmlTags(html: string): string {
-  // Loop until no more tags remain — prevents nested/incomplete-tag bypass.
-  let result = html;
-  let prev: string;
-  do {
-    prev = result;
-    result = result.replace(/<[^>]*>/g, '');
-  } while (result !== prev);
-
-  // Single-pass entity decode — avoids double-unescaping.
-  return result
-    .replace(/&(?:amp|lt|gt|quot|#039);/g, (entity) => HTML_ENTITIES[entity] ?? entity)
-    .trim();
+  processed_datetime?: string | null;
+  sent_datetime?: string | null;
+  failed_datetime?: string | null;
+  deleted_datetime?: string | null;
+  opened_datetime?: string | null;
+  last_sending_error?: unknown;
+  is_retriable?: boolean | null;
+  imported?: boolean | null;
+  [key: string]: unknown;
 }
 
 /**
@@ -76,8 +71,8 @@ function stripHtmlTags(html: string): string {
  *
  * Supported operations:
  *   fetch('get_ticket', { ticket_id })                          — GET  /tickets/{ticket_id}
- *   fetch('get_messages', { ticket_id, limit? })               — GET  /messages?ticket_id={ticket_id}&...
- *   create('post_internal_note', { ticket_id, body_html })     — POST /tickets/{ticket_id}/messages
+ *   fetch('get_messages', { ticket_id, limit?, order_by? })    — GET  /messages?ticket_id={ticket_id}&...
+ *   create('create_message', { ticket_id, ...messageFields })  — POST /tickets/{ticket_id}/messages
  */
 export class GorgiasAdapter implements ServiceAdapter {
   readonly id: string;
@@ -210,7 +205,7 @@ export class GorgiasAdapter implements ServiceAdapter {
           ? 'Account lacks permission to read Gorgias tickets'
           : operation === 'get_messages'
             ? 'Account lacks permission to read Gorgias ticket messages'
-            : operation === 'post_internal_note'
+            : operation === 'create_message'
               ? 'Account lacks permission to create Gorgias messages'
               : 'Account lacks permission for this Gorgias operation';
       throw new WorkflowError(message403, {
@@ -266,18 +261,6 @@ export class GorgiasAdapter implements ServiceAdapter {
     return ticketId;
   }
 
-  private normalize(msg: GorgiasMessage): NormalizedMessage {
-    const body = msg.body_text ?? stripHtmlTags(msg.body_html ?? '') ?? '';
-    return {
-      id: msg.id,
-      from_agent: msg.from_agent,
-      public: msg.public,
-      channel: msg.channel,
-      body,
-      created_datetime: msg.created_datetime,
-    };
-  }
-
   async fetch(
     operation: string,
     params: Record<string, unknown>,
@@ -305,15 +288,17 @@ export class GorgiasAdapter implements ServiceAdapter {
       const effectiveLimit = Math.min(userLimit, 200);
       const PAGE_SIZE = 100;
 
-      const accumulated: NormalizedMessage[] = [];
+      const accumulated: GorgiasMessage[] = [];
       let cursor: string | undefined = undefined;
       let truncated = false;
 
       for (;;) {
         this.checkAborted(signal);
 
+        const orderBy =
+          typeof params['order_by'] === 'string' ? params['order_by'] : 'created_datetime:asc';
         const url =
-          `${this.baseUrl}/messages?ticket_id=${ticketId}&limit=${PAGE_SIZE}&order_by=created_datetime:asc` +
+          `${this.baseUrl}/messages?ticket_id=${ticketId}&limit=${PAGE_SIZE}&order_by=${encodeURIComponent(orderBy)}` +
           (cursor !== undefined ? `&cursor=${cursor}` : '');
 
         const response = await this.executeRequest('GET', url, 'get_messages', undefined, signal);
@@ -324,7 +309,7 @@ export class GorgiasAdapter implements ServiceAdapter {
 
         for (const message of json.data) {
           if (accumulated.length < effectiveLimit) {
-            accumulated.push(this.normalize(message));
+            accumulated.push(message);
           }
         }
 
@@ -360,52 +345,20 @@ export class GorgiasAdapter implements ServiceAdapter {
   ): Promise<ServiceResponse> {
     // config.auth is ignored — auth is set at construction time
 
-    if (operation === 'post_internal_note') {
+    if (operation === 'create_message') {
       const ticketId = this.validateTicketId(params);
 
-      if (typeof params['body_html'] !== 'string') {
-        throw new WorkflowError('GorgiasAdapter: body_html must be a string', {
-          code: 'ADAPTER_VALIDATION_FAILED',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-          details: { received: params['body_html'] },
-        });
-      }
+      const { ticket_id: _tid, ...messageBody } = params;
 
       this.checkAborted(signal);
 
-      const requestBody = {
-        channel: 'note',
-        public: false,
-        from_agent: true,
-        body_html: params['body_html'],
-      };
-
-      const response = await this.executeRequest(
+      return this.executeRequest(
         'POST',
         `${this.baseUrl}/tickets/${ticketId}/messages`,
-        'post_internal_note',
-        requestBody,
+        'create_message',
+        messageBody,
         signal,
       );
-
-      const json = response.data as { id?: unknown };
-      const noteId = json.id;
-      if (typeof noteId !== 'number') {
-        throw new WorkflowError(
-          'GorgiasAdapter: unexpected response shape from post_internal_note',
-          {
-            code: 'SERVICE_RESPONSE_INVALID',
-            category: 'SERVICE',
-            agentAction: 'stop',
-            retryable: false,
-            details: { received: json },
-          },
-        );
-      }
-
-      return { status: 201, data: { ok: true, note_id: noteId } };
     }
 
     throw new WorkflowError(`GorgiasAdapter: unsupported create operation '${operation}'`, {


### PR DESCRIPTION
## Context

Raised during a post-v0.6.1 adapter audit. A peer architect flagged that `GorgiasAdapter`
was stripping data from API responses, which prompted a full bias review. Three distinct
problems were identified and confirmed against the live Gorgias API (ellegems account,
35-field message schema).

## Motivation

A service adapter is a thin transport layer: auth, rate limiting, pagination, error mapping.
It must not decide which fields the caller needs, must not compute derived fields, and must
not restrict which API operations are expressible. All three of those invariants were
violated.

## Changes

### 1. Data stripping removed from `get_messages`

**Before:** `normalize()` cherry-picked 6 of 35 API fields and computed a synthetic `body`
field by merging `body_text`/`body_html`. Fields such as `sender`, `receiver`, `subject`,
`stripped_text`, `via`, and 20+ others were silently discarded.

**After:** Raw `GorgiasMessage` objects are pushed directly into the accumulated array.
`NormalizedMessage`, `normalize()`, `HTML_ENTITIES`, and `stripHtmlTags` are all removed.
`GorgiasMessage` interface expanded from 7 declared fields to the full 35-field live API
shape, plus a `[key: string]: unknown` index signature so future fields are never silently
lost.

### 2. Hardcoded sort order made caller-configurable

**Before:** `get_messages` unconditionally appended `order_by=created_datetime:asc` to
every page URL.

**After:** `order_by` is read from `params['order_by']` (string), defaulting to
`created_datetime:asc` when absent. Value is `encodeURIComponent`-encoded before
inclusion in the URL. Resolved once before the pagination loop — not on every iteration.

### 3. `post_internal_note` replaced by `create_message`

**Before:** The only create operation was `post_internal_note`, which hardcoded
`channel: 'note'`, `public: false`, `from_agent: true`. Only internal notes were
expressible; email replies and chat messages were impossible.

**After:** `create_message` accepts any caller-supplied message body. `ticket_id` is
extracted for URL construction; all remaining params are forwarded as the request body
unchanged. The raw Gorgias response (the created message object) is returned directly —
no reshaping.

## Verification

```bash
# No trace of removed identifiers
grep -n "NormalizedMessage\|normalize(\|stripHtmlTags\|HTML_ENTITIES\|post_internal_note" \
  packages/core/src/adapters/gorgias-adapter.ts
# → (empty)

# orderBy hoisted before the loop
grep -n "orderBy" packages/core/src/adapters/gorgias-adapter.ts
# → appears before the for(;;) block

# Full test suite
npm run test --workspace=packages/core
# → 1149 passed, 0 skipped

# Build
npm run build
# → Tasks: 4 successful
```

## Rollback

```bash
git revert HEAD~1 HEAD  # reverts both commits on this branch
```

No out-of-band mutations. Pure code change.

## Related

- v0.6.1 SSE JSON fix (PR #71) — same audit that surfaced these issues
- ParcelPanel adapter has the same data-stripping problem — tracked separately
