### PR TITLE
feat(core): add list_tickets, get/list/create customers, create_ticket, update_ticket/customer to Gorgias adapter

### DIFF
--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -264,6 +264,46 @@ describe("GorgiasAdapter fetch('get_ticket')", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: fetch('list_tickets')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter fetch('list_tickets')", () => {
+  it('returns raw ticket list from GET /tickets', async () => {
+    respond(200, { data: [{ id: 1, status: 'open' }], meta: { next_cursor: null } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_tickets', {}, {});
+    expect(result.status).toBe(200);
+    const data = result.data as { data: unknown[]; meta: unknown };
+    expect(data.data).toHaveLength(1);
+  });
+
+  it('passes scalar params as query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_tickets', { order_by: 'created_datetime:desc', limit: 10 }, {});
+    expect(capturedUrl).toContain('order_by=created_datetime%3Adesc');
+    expect(capturedUrl).toContain('limit=10');
+  });
+
+  it('no params: URL path has no query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_tickets', {}, {});
+    expect(capturedUrl).toBe('/tickets');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: fetch('get_messages')
 // ---------------------------------------------------------------------------
 
@@ -508,6 +548,97 @@ describe("GorgiasAdapter fetch('get_messages')", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: fetch('get_customer')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter fetch('get_customer')", () => {
+  it('returns raw customer data from GET /customers/{id}', async () => {
+    respond(200, { id: 42, email: 'test@example.com', name: 'Test User' });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_customer', { customer_id: 42 }, {});
+    expect(result.status).toBe(200);
+    const data = result.data as Record<string, unknown>;
+    expect(data['id']).toBe(42);
+    expect(data['email']).toBe('test@example.com');
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when customer_id is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_customer', {}, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED for invalid customer_id (0 and string)', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.fetch('get_customer', { customer_id: 0 }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+    await expect(adapter.fetch('get_customer', { customer_id: 'abc' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: fetch('list_customers')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter fetch('list_customers')", () => {
+  it('returns raw customer list from GET /customers', async () => {
+    respond(200, { data: [{ id: 1, email: 'a@example.com' }], meta: { next_cursor: null } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_customers', {}, {});
+    expect(result.status).toBe(200);
+    const data = result.data as { data: unknown[]; meta: unknown };
+    expect(data.data).toHaveLength(1);
+  });
+
+  it('passes scalar params as query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_customers', { email: 'test@example.com', limit: 5 }, {});
+    expect(capturedUrl).toContain('email=test%40example.com');
+    expect(capturedUrl).toContain('limit=5');
+  });
+
+  it('skips non-scalar params (arrays, objects) from query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch(
+      'list_customers',
+      { limit: 10, tags: ['vip', 'new'], nested: { key: 'val' } },
+      {},
+    );
+    expect(capturedUrl).toContain('limit=10');
+    expect(capturedUrl).not.toContain('tags=');
+    expect(capturedUrl).not.toContain('nested=');
+  });
+
+  it('no params: URL path has no query string', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_customers', {}, {});
+    expect(capturedUrl).toBe('/customers');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: create('create_message')
 // ---------------------------------------------------------------------------
 
@@ -611,6 +742,88 @@ describe("GorgiasAdapter create('create_message')", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: create('create_ticket')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter create('create_ticket')", () => {
+  it('returns raw ticket response', async () => {
+    respond(201, { id: 100, status: 'open', channel: 'email' });
+    const adapter = makeAdapter();
+    const result = await adapter.create(
+      'create_ticket',
+      { messages: [{ channel: 'email', from_agent: false }] },
+      {},
+    );
+    expect(result.status).toBe(201);
+    const data = result.data as Record<string, unknown>;
+    expect(data['id']).toBe(100);
+  });
+
+  it('passes all params as request body', async () => {
+    let capturedBody: unknown;
+    handlers.push((_req, res, body) => {
+      capturedBody = JSON.parse(body);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: 1 }));
+    });
+    const adapter = makeAdapter();
+    await adapter.create(
+      'create_ticket',
+      {
+        messages: [{ channel: 'email', from_agent: false }],
+        subject: 'Help needed',
+        status: 'open',
+      },
+      {},
+    );
+    expect(capturedBody).toEqual({
+      messages: [{ channel: 'email', from_agent: false }],
+      subject: 'Help needed',
+      status: 'open',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: create('create_customer')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter create('create_customer')", () => {
+  it('returns raw customer response', async () => {
+    respond(201, { id: 55, email: 'new@example.com' });
+    const adapter = makeAdapter();
+    const result = await adapter.create(
+      'create_customer',
+      { channels: [{ type: 'email', address: 'new@example.com' }] },
+      {},
+    );
+    expect(result.status).toBe(201);
+    const data = result.data as Record<string, unknown>;
+    expect(data['id']).toBe(55);
+  });
+
+  it('passes all params as request body', async () => {
+    let capturedBody: unknown;
+    handlers.push((_req, res, body) => {
+      capturedBody = JSON.parse(body);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: 2 }));
+    });
+    const adapter = makeAdapter();
+    await adapter.create(
+      'create_customer',
+      { channels: [{ type: 'email', address: 'x@y.com' }], name: 'Jane', language: 'en' },
+      {},
+    );
+    expect(capturedBody).toEqual({
+      channels: [{ type: 'email', address: 'x@y.com' }],
+      name: 'Jane',
+      language: 'en',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: update()
 // ---------------------------------------------------------------------------
 
@@ -621,6 +834,84 @@ describe('GorgiasAdapter update()', () => {
       code: 'ADAPTER_OP_UNSUPPORTED',
     });
     await expect(adapter.update('anything', {}, {})).rejects.toBeInstanceOf(WorkflowError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: update('update_ticket')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter update('update_ticket')", () => {
+  it('returns 202 with raw updated ticket', async () => {
+    respond(202, { id: 10, status: 'closed' });
+    const adapter = makeAdapter();
+    const result = await adapter.update('update_ticket', { ticket_id: 10, status: 'closed' }, {});
+    expect(result.status).toBe(202);
+    const data = result.data as Record<string, unknown>;
+    expect(data['status']).toBe('closed');
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when ticket_id is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_ticket', { status: 'closed' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('strips ticket_id from the PUT body', async () => {
+    let capturedBody: unknown;
+    handlers.push((_req, res, body) => {
+      capturedBody = JSON.parse(body);
+      res.writeHead(202, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: 10 }));
+    });
+    const adapter = makeAdapter();
+    await adapter.update(
+      'update_ticket',
+      { ticket_id: 10, status: 'closed', tags: [{ name: 'resolved' }] },
+      {},
+    );
+    expect(capturedBody).toEqual({ status: 'closed', tags: [{ name: 'resolved' }] });
+    expect((capturedBody as Record<string, unknown>)['ticket_id']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: update('update_customer')
+// ---------------------------------------------------------------------------
+
+describe("GorgiasAdapter update('update_customer')", () => {
+  it('returns 202 with raw updated customer', async () => {
+    respond(202, { id: 42, name: 'Updated Name' });
+    const adapter = makeAdapter();
+    const result = await adapter.update(
+      'update_customer',
+      { customer_id: 42, name: 'Updated Name' },
+      {},
+    );
+    expect(result.status).toBe(202);
+    const data = result.data as Record<string, unknown>;
+    expect(data['name']).toBe('Updated Name');
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when customer_id is missing', async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.update('update_customer', { name: 'X' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
+  });
+
+  it('strips customer_id from the PUT body', async () => {
+    let capturedBody: unknown;
+    handlers.push((_req, res, body) => {
+      capturedBody = JSON.parse(body);
+      res.writeHead(202, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ id: 42 }));
+    });
+    const adapter = makeAdapter();
+    await adapter.update('update_customer', { customer_id: 42, name: 'Jane', language: 'fr' }, {});
+    expect(capturedBody).toEqual({ name: 'Jane', language: 'fr' });
+    expect((capturedBody as Record<string, unknown>)['customer_id']).toBeUndefined();
   });
 });
 

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -76,9 +76,20 @@ interface GorgiasMessage {
  * GorgiasAdapter communicates with the Gorgias REST API.
  *
  * Supported operations:
- *   fetch('get_ticket', { ticket_id })                          — GET  /tickets/{ticket_id}
- *   fetch('get_messages', { ticket_id?, limit?, order_by? })    — GET  /messages (ticket_id optional filter; order_by omitted when absent, API default applies)
- *   create('create_message', { ticket_id, ...messageFields })  — POST /tickets/{ticket_id}/messages
+ *   fetch('get_ticket',       { ticket_id })                         — GET  /tickets/{id}
+ *   fetch('list_tickets',     { order_by?, cursor?, limit?, ... })   — GET  /tickets
+ *   fetch('get_messages',     { ticket_id?, limit?, order_by? })     — GET  /messages
+ *   fetch('get_customer',     { customer_id })                       — GET  /customers/{id}
+ *   fetch('list_customers',   { order_by?, cursor?, limit?, ... })   — GET  /customers
+ *   create('create_message',  { ticket_id, ...messageFields })       — POST /tickets/{id}/messages
+ *   create('create_ticket',   { messages, ...ticketFields })         — POST /tickets
+ *   create('create_customer', { channels, ...customerFields })       — POST /customers
+ *   update('update_ticket',   { ticket_id, ...ticketFields })        — PUT  /tickets/{id}
+ *   update('update_customer', { customer_id, ...customerFields })    — PUT  /customers/{id}
+ *
+ * list_tickets and list_customers return a single page; pass cursor from response meta
+ * to retrieve subsequent pages. Scalar params (string | number | boolean) are forwarded
+ * as query params. Non-scalar values (arrays, objects) are silently skipped.
  */
 export class GorgiasAdapter implements ServiceAdapter {
   readonly id: string;
@@ -259,6 +270,20 @@ export class GorgiasAdapter implements ServiceAdapter {
     return ticketId;
   }
 
+  private validateCustomerId(params: Record<string, unknown>): number {
+    const customerId = params['customer_id'];
+    if (typeof customerId !== 'number' || !Number.isInteger(customerId) || customerId <= 0) {
+      throw new WorkflowError('GorgiasAdapter: customer_id must be a positive integer', {
+        code: 'ADAPTER_VALIDATION_FAILED',
+        category: 'ENGINE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: { received: customerId },
+      });
+    }
+    return customerId;
+  }
+
   async fetch(
     operation: string,
     params: Record<string, unknown>,
@@ -328,6 +353,54 @@ export class GorgiasAdapter implements ServiceAdapter {
       return { status: 200, data: { messages: accumulated, truncated } };
     }
 
+    if (operation === 'list_tickets') {
+      this.checkAborted(signal);
+      const queryParts: string[] = [];
+      for (const [key, value] of Object.entries(params)) {
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+          queryParts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+        }
+      }
+      const queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
+      return this.executeRequest(
+        'GET',
+        `${this.baseUrl}/tickets${queryString}`,
+        'list_tickets',
+        undefined,
+        signal,
+      );
+    }
+
+    if (operation === 'get_customer') {
+      const customerId = this.validateCustomerId(params);
+      this.checkAborted(signal);
+      return this.executeRequest(
+        'GET',
+        `${this.baseUrl}/customers/${customerId}`,
+        'get_customer',
+        undefined,
+        signal,
+      );
+    }
+
+    if (operation === 'list_customers') {
+      this.checkAborted(signal);
+      const queryParts: string[] = [];
+      for (const [key, value] of Object.entries(params)) {
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+          queryParts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+        }
+      }
+      const queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
+      return this.executeRequest(
+        'GET',
+        `${this.baseUrl}/customers${queryString}`,
+        'list_customers',
+        undefined,
+        signal,
+      );
+    }
+
     throw new WorkflowError(`GorgiasAdapter: unsupported fetch operation '${operation}'`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
@@ -361,6 +434,28 @@ export class GorgiasAdapter implements ServiceAdapter {
       );
     }
 
+    if (operation === 'create_ticket') {
+      this.checkAborted(signal);
+      return this.executeRequest(
+        'POST',
+        `${this.baseUrl}/tickets`,
+        'create_ticket',
+        params,
+        signal,
+      );
+    }
+
+    if (operation === 'create_customer') {
+      this.checkAborted(signal);
+      return this.executeRequest(
+        'POST',
+        `${this.baseUrl}/customers`,
+        'create_customer',
+        params,
+        signal,
+      );
+    }
+
     throw new WorkflowError(`GorgiasAdapter: unsupported create operation '${operation}'`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
@@ -372,11 +467,39 @@ export class GorgiasAdapter implements ServiceAdapter {
 
   async update(
     operation: string,
-    _params: Record<string, unknown>,
+    params: Record<string, unknown>,
     _config: Record<string, unknown>,
-    _signal?: AbortSignal,
+    signal?: AbortSignal,
   ): Promise<ServiceResponse> {
-    throw new WorkflowError(`GorgiasAdapter: update is not supported (operation: '${operation}')`, {
+    // config.auth is ignored — auth is set at construction time
+
+    if (operation === 'update_ticket') {
+      const ticketId = this.validateTicketId(params);
+      const { ticket_id: _tid, ...ticketBody } = params;
+      this.checkAborted(signal);
+      return this.executeRequest(
+        'PUT',
+        `${this.baseUrl}/tickets/${ticketId}`,
+        'update_ticket',
+        ticketBody,
+        signal,
+      );
+    }
+
+    if (operation === 'update_customer') {
+      const customerId = this.validateCustomerId(params);
+      const { customer_id: _cid, ...customerBody } = params;
+      this.checkAborted(signal);
+      return this.executeRequest(
+        'PUT',
+        `${this.baseUrl}/customers/${customerId}`,
+        'update_customer',
+        customerBody,
+        signal,
+      );
+    }
+
+    throw new WorkflowError(`GorgiasAdapter: unsupported update operation '${operation}'`, {
       code: 'ADAPTER_OP_UNSUPPORTED',
       category: 'ENGINE',
       agentAction: 'report_to_user',


### PR DESCRIPTION
## Context

Follow-up to #74 (prereqs branch). Extends the Gorgias adapter with 7 new operations covering the ticket and customer resource surfaces.

**Depends on #74** — `feat/core/gorgias-new-ops` is branched from `feat/core/gorgias-prereqs`. Merge #74 first; this PR's diff will automatically narrow to the new-ops commit only after that merge.

## Motivation

After the universal passthrough work (PR #73) and bias fixes (#74), the adapter covered only 3 operations: `get_ticket`, `get_messages`, `create_message`. The Gorgias REST API exposes ticket and customer CRUD that realm workflows need. Adding these operations completes the core adapter surface without any opinion on how callers use them.

## Changes

### `validateCustomerId()` — new private helper
Parallel to the existing `validateTicketId()`. Validates `customer_id` as a positive integer, throws `ADAPTER_VALIDATION_FAILED` if invalid.

### `fetch()` — three new operations

| Operation | Method | URL |
|---|---|---|
| `list_tickets` | GET | `/tickets?[scalar params]` |
| `get_customer` | GET | `/customers/{customer_id}` |
| `list_customers` | GET | `/customers?[scalar params]` |

`list_tickets` and `list_customers` are **single-page passthrough** — they return the raw Gorgias response including `meta.next_cursor`. The caller controls pagination by passing `cursor` on subsequent calls. Scalar params (`string | number | boolean`) are forwarded as URL-encoded query params. Non-scalar values (arrays, objects) are silently skipped.

### `create()` — two new operations

| Operation | Method | URL |
|---|---|---|
| `create_ticket` | POST | `/tickets` |
| `create_customer` | POST | `/customers` |

Full `params` forwarded as request body — no stripping (unlike `create_message` which strips `ticket_id` since it becomes a path param).

### `update()` — replace unconditional throw with dispatch

| Operation | Method | URL |
|---|---|---|
| `update_ticket` | PUT | `/tickets/{ticket_id}` |
| `update_customer` | PUT | `/customers/{customer_id}` |

Both operations strip the ID param from the request body (path param only) and forward the rest. Unknown operations fall through to the existing `ADAPTER_OP_UNSUPPORTED` throw — the existing test is unchanged.

### Class JSDoc — updated to list all 10 operations

## Verification

```bash
# Run from repo root
git checkout feat/core/gorgias-new-ops

# Confirm all 10 operation branches present
grep -n "operation === " packages/core/src/adapters/gorgias-adapter.ts
# → get_ticket, list_tickets, get_messages, get_customer, list_customers,
#   create_message, create_ticket, create_customer, update_ticket, update_customer

# Confirm update() no longer throws unconditionally
grep -n "update is not supported" packages/core/src/adapters/gorgias-adapter.ts
# → must return nothing

# Build, test, lint
npm run build
npm run test --workspace=packages/core
# → 1172 passed, 0 skipped
npm run lint
```

## Rollback

```bash
git revert HEAD
```

No external state mutations. Safe to revert.

## Related

Depends on #74
