### PR TITLE
docs: add stacked-PR policy to git workflow

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -107,6 +107,19 @@ type(scope): short imperative description
 
 ---
 
+## Stacked / Dependent Branches
+
+Never open a PR from a branch that is based on another unmerged feature branch.
+
+For sequentially-dependent work, choose one of two approaches:
+
+- **Combine** — put both phases in a single branch and open one PR.
+- **Sequence** — merge the first PR before branching the second.
+
+Opening PR2 while PR1 is unmerged creates a rebase dependency: PR2's diff on GitHub shows both branches combined, auto-merge becomes unreliable, and a rebase is required after PR1 lands. This is avoidable.
+
+---
+
 ## Draft PRs
 
 Open a draft PR when:


### PR DESCRIPTION
## Context

We created two dependent PRs (#74 and #75) by branching `feat/core/gorgias-new-ops` from `feat/core/gorgias-prereqs` before #74 had merged. This produced a stacked-PR situation: #75 showed both branches' diffs combined on GitHub, auto-merge on #75 entered `DIRTY` state after #74 rebased onto main, and a manual rebase was required.

## Motivation

The git workflow policy described the single-branch case only. There was no rule covering what to do with sequentially-dependent work. Filling that gap prevents the same situation from recurring.

## Changes

Added a `## Stacked / Dependent Branches` section to `git-workflow.instructions.md`:

- Never open a PR from a branch based on another unmerged feature branch
- Two permitted approaches: combine into one branch, or merge PR1 before branching PR2
- Explains why: unreadable diffs, unreliable auto-merge, required rebase

## Verification

```bash
grep -A 12 "## Stacked" .github/instructions/git-workflow.instructions.md
```

## Rollback

```bash
git revert HEAD
```
