### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project are documented here.
 
 ---
 
+## [0.6.2] — 2026-06-16
+
+### Added
+
+- **GorgiasAdapter — 7 new operations** covering the full ticket and customer resource surface:
+  - `fetch('list_tickets', { order_by?, cursor?, limit?, ... })` — GET `/tickets`; returns one page of raw results including `meta.next_cursor` for caller-managed pagination
+  - `fetch('get_customer', { customer_id })` — GET `/customers/{id}`; follows Gorgias 301 redirects for merged customers transparently
+  - `fetch('list_customers', { order_by?, cursor?, limit?, ... })` — GET `/customers`; same single-page passthrough as `list_tickets`
+  - `create('create_ticket', { messages, ...ticketFields })` — POST `/tickets`; full params forwarded as body
+  - `create('create_customer', { channels, ...customerFields })` — POST `/customers`; full params forwarded as body
+  - `update('update_ticket', { ticket_id, ...ticketFields })` — PUT `/tickets/{id}`; `ticket_id` becomes the path param and is stripped from the body
+  - `update('update_customer', { customer_id, ...customerFields })` — PUT `/customers/{id}`; same pattern
+
+  List operations (`list_tickets`, `list_customers`) forward all scalar (`string | number | boolean`) params as URL-encoded query params; non-scalar values (arrays, objects) are silently skipped.
+
+### Changed
+
+- **GorgiasAdapter `get_messages` — `ticket_id` is now optional** — when absent the filter is omitted from the URL, enabling cross-ticket message queries. When present and invalid, `ADAPTER_VALIDATION_FAILED` is still thrown.
+- **GorgiasAdapter `get_messages` — `order_by` is omitted when not supplied** — previously defaulted to `created_datetime:asc` regardless of caller intent. Now omitted, letting the Gorgias API apply its own default (`created_datetime:desc`). Callers who need ascending order must pass `order_by: 'created_datetime:asc'` explicitly.
+- **GorgiasAdapter `GorgiasMessage` interface** — six previously undeclared fields now documented: `auth_customer_identity`, `integration_id`, `intents`, `rule_id`, `replied_by`, `replied_to`. These were always preserved at runtime via the index signature; the change is documentation only.
+
+### Fixed
+
+- **GorgiasAdapter universal passthrough** — `get_messages` previously cherry-picked fields and computed a derived `body` field from HTML content. All normalisation code (`normalize()`, `NormalizedMessage`, `stripHtmlTags`, `HTML_ENTITIES`) has been removed. Raw Gorgias message objects are now returned as-is, with all 35 API fields intact.
+- **GorgiasAdapter `create_message` replaces `post_internal_note`** — the previous `post_internal_note` operation hardcoded `channel: 'note'`, `public: false`, `from_agent: true` regardless of caller input. Replaced with `create_message`, which forwards all caller-supplied fields unchanged.
+
+---
+
 ## [0.6.1] — 2026-06-15
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.6.1');
+program.name('realm').description('Realm workflow engine CLI').version('0.6.2');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.6.1';
+export const VERSION = '0.6.2';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.6.1';
+export const VERSION = '0.6.2';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.6.1',
+    version: '0.6.2',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.6.1';
+export const VERSION = '0.6.2';


### PR DESCRIPTION
## Context

Release v0.6.2 — GorgiasAdapter universal passthrough and new operations.

## Changes

See [CHANGELOG.md](CHANGELOG.md) for full details.

**Added:** 7 new GorgiasAdapter operations — `list_tickets`, `get_customer`, `list_customers`, `create_ticket`, `create_customer`, `update_ticket`, `update_customer`

**Changed:** `get_messages` optional `ticket_id`; `order_by` omitted when not supplied; `GorgiasMessage` interface documents 6 previously undeclared fields

**Fixed:** Removed all normalization/stripping from `get_messages`; replaced `post_internal_note` with universal `create_message`

Core test suite: 1149 → 1172 (+23 tests)

## Verification

```bash
npm run build
npm run test --workspace=packages/core
# → 1172 passed, 0 skipped
npm run lint
```

## Rollback

```bash
git revert HEAD~2..HEAD
```
