### PR TITLE
fix(core): remove NormalizedTracking, return raw API data from ParcelPanelAdapter

### DIFF
--- a/packages/core/src/adapters/parcelpanel-adapter.probe.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.probe.ts
@@ -3,7 +3,6 @@
 // PARCELPANEL_TEST_ORDER_NUMBER). Run via `npm run test:contract --workspace=packages/core`.
 import { it, expect } from 'vitest';
 import { ParcelPanelAdapter } from './parcelpanel-adapter.js';
-import type { NormalizedTracking } from './parcelpanel-adapter.js';
 
 it.skipIf(!process.env['PARCELPANEL_TEST_API_KEY'] || !process.env['PARCELPANEL_TEST_STORE'])(
   'contract probe — real API (requires PARCELPANEL_TEST_API_KEY and PARCELPANEL_TEST_STORE)',
@@ -18,8 +17,8 @@ it.skipIf(!process.env['PARCELPANEL_TEST_API_KEY'] || !process.env['PARCELPANEL_
 
     const result = await adapter.fetch('get_tracking', { store, order_number: orderNumber }, {});
     expect(result.status).toBe(200);
-    const data = result.data as NormalizedTracking;
-    expect(typeof data.tracking_url).toBe('string');
-    expect(data.tracking_url.length).toBeGreaterThan(0);
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    expect(typeof order['tracking_link']).toBe('string');
   },
 );

--- a/packages/core/src/adapters/parcelpanel-adapter.test.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.test.ts
@@ -2,7 +2,7 @@ import * as http from 'node:http';
 import * as net from 'node:net';
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { ParcelPanelAdapter } from './parcelpanel-adapter.js';
-import type { ParcelPanelAdapterConfig, NormalizedTracking } from './parcelpanel-adapter.js';
+import type { ParcelPanelAdapterConfig } from './parcelpanel-adapter.js';
 import { WorkflowError } from '../types/workflow-error.js';
 
 // ---------------------------------------------------------------------------
@@ -419,11 +419,11 @@ describe('ParcelPanelAdapter AbortSignal', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: Normalization — fulfilled order
+// Tests: Normalization — raw passthrough
 // ---------------------------------------------------------------------------
 
 describe('ParcelPanelAdapter normalization', () => {
-  it('fulfilled order: all four NormalizedTracking fields populated', async () => {
+  it('fulfilled order: raw data passthrough — order_id, tracking_link, and shipment status present', async () => {
     respond(200, fulfilledOrderBody());
     const adapter = makeAdapter();
     const result = await adapter.fetch(
@@ -432,14 +432,17 @@ describe('ParcelPanelAdapter normalization', () => {
       {},
     );
     expect(result.status).toBe(200);
-    const data = result.data as NormalizedTracking;
-    expect(data.tracking_url).toBe('https://example.myshopify.com/apps/parcelpanel?order=1030');
-    expect(data.carrier).toBe('YunExpress');
-    expect(data.tracking_number).toBe('YT2436021211003147');
-    expect(data.status).toBe('IN_TRANSIT');
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    expect(order['order_id']).toBe(6140516335690);
+    expect(order['tracking_link']).toBe(
+      'https://example.myshopify.com/apps/parcelpanel?order=1030',
+    );
+    const shipments = order['shipments'] as Record<string, unknown>[];
+    expect((shipments[0] as Record<string, unknown>)['status']).toBe('IN_TRANSIT');
   });
 
-  it('unfulfilled order: tracking_url set, carrier/tracking_number/status all null', async () => {
+  it('unfulfilled order: raw data passthrough — shipments is empty array', async () => {
     respond(200, unfulfilledOrderBody());
     const adapter = makeAdapter();
     const result = await adapter.fetch(
@@ -447,28 +450,20 @@ describe('ParcelPanelAdapter normalization', () => {
       { store: 'mystore', order_number: '1030' },
       {},
     );
-    const data = result.data as NormalizedTracking;
-    expect(data.tracking_url).toBe('https://example.myshopify.com/apps/parcelpanel?order=1030');
-    expect(data.carrier).toBeNull();
-    expect(data.tracking_number).toBeNull();
-    expect(data.status).toBeNull();
+    expect(result.status).toBe(200);
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    expect(Array.isArray(order['shipments'])).toBe(true);
+    expect((order['shipments'] as unknown[]).length).toBe(0);
   });
 
-  it('split fulfillment: uses shipments[0], second shipment silently ignored', async () => {
+  it('split fulfillment: both shipments present in result (not just first)', async () => {
     respond(
       200,
       fulfilledOrderBody({
         shipments: [
-          {
-            status: 'DELIVERED',
-            tracking_number: 'TN_FIRST',
-            carrier: { name: 'FedEx' },
-          },
-          {
-            status: 'IN_TRANSIT',
-            tracking_number: 'TN_SECOND',
-            carrier: { name: 'UPS' },
-          },
+          { status: 'DELIVERED', tracking_number: 'TN_FIRST', carrier: { name: 'FedEx' } },
+          { status: 'IN_TRANSIT', tracking_number: 'TN_SECOND', carrier: { name: 'UPS' } },
         ],
       }),
     );
@@ -478,26 +473,41 @@ describe('ParcelPanelAdapter normalization', () => {
       { store: 'mystore', order_number: '1030' },
       {},
     );
-    const data = result.data as NormalizedTracking;
-    expect(data.carrier).toBe('FedEx');
-    expect(data.tracking_number).toBe('TN_FIRST');
-    expect(data.status).toBe('DELIVERED');
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    const shipments = order['shipments'] as Record<string, unknown>[];
+    expect(shipments).toHaveLength(2);
+    expect(shipments[0]?.['tracking_number']).toBe('TN_FIRST');
+    expect(shipments[1]?.['tracking_number']).toBe('TN_SECOND');
   });
 
-  it('200 with missing order key → SERVICE_RESPONSE_INVALID', async () => {
+  it('fulfilled order: new interface fields status_label and carrier.code present in raw data', async () => {
+    respond(200, fulfilledOrderBody());
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'get_tracking',
+      { store: 'mystore', order_number: '1030' },
+      {},
+    );
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    const shipments = order['shipments'] as Record<string, unknown>[];
+    const ship = shipments[0] as Record<string, unknown>;
+    expect(ship['status_label']).toBe('In transit');
+    const carrier = ship['carrier'] as Record<string, unknown>;
+    expect(carrier['code']).toBe('yunexpress');
+  });
+
+  it('200 with arbitrary shape — no throw, returns raw data', async () => {
     respond(200, { something: 'else' });
     const adapter = makeAdapter();
-    await expect(
-      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
-    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
-  });
-
-  it('200 with order.tracking_link not a string → SERVICE_RESPONSE_INVALID', async () => {
-    respond(200, { order: { tracking_link: 12345, shipments: [] } });
-    const adapter = makeAdapter();
-    await expect(
-      adapter.fetch('get_tracking', { store: 'mystore', order_number: '1234' }, {}),
-    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
+    const result = await adapter.fetch(
+      'get_tracking',
+      { store: 'mystore', order_number: '1234' },
+      {},
+    );
+    expect(result.status).toBe(200);
+    expect(result.data).toMatchObject({ something: 'else' });
   });
 });
 

--- a/packages/core/src/adapters/parcelpanel-adapter.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.ts
@@ -27,39 +27,25 @@ export interface ParcelPanelAdapterConfig {
   base_url?: string;
 }
 
-/**
- * Normalized tracking data returned by ParcelPanelAdapter.
- *
- * tracking_url is always present when the order exists (sourced from order.tracking_link,
- * documented as non-null in the ParcelPanel API).
- *
- * carrier, tracking_number, and status are all null in tandem when order.shipments is empty
- * (order exists but has not yet been fulfilled).
- */
-export interface NormalizedTracking {
-  /** ParcelPanel-hosted tracking page URL. Always a non-empty string when the order exists. */
-  tracking_url: string;
-  /** Primary carrier name, e.g. "YunExpress". Null if order has no shipments yet. */
-  carrier: string | null;
-  /** Primary carrier tracking number. Null if order has no shipments yet. */
-  tracking_number: string | null;
-  /** Primary shipment status code, e.g. "IN_TRANSIT". Null if order has no shipments yet. */
-  status: string | null;
-}
-
 /** Raw shipment shape from the ParcelPanel API. */
-interface ParcelPanelShipment {
-  status?: string;
-  tracking_number?: string;
-  carrier?: { name?: string } | null;
+export interface ParcelPanelShipment {
+  status?: string | null;
+  status_label?: string | null;
+  tracking_number?: string | null;
+  carrier?: { name?: string | null; code?: string | null } | null;
+  [key: string]: unknown;
 }
 
 /** Raw order body shape from the ParcelPanel API. */
-interface ParcelPanelOrderBody {
+export interface ParcelPanelOrderBody {
   order?: {
-    tracking_link?: unknown;
+    order_id?: number | null;
+    order_number?: string | null;
+    tracking_link?: string | null;
     shipments?: ParcelPanelShipment[];
-  };
+    [key: string]: unknown;
+  } | null;
+  [key: string]: unknown;
 }
 
 /**
@@ -67,6 +53,10 @@ interface ParcelPanelOrderBody {
  *
  * Supported operations:
  *   fetch('get_tracking', { store, order_number })   — GET /api/v2/tracking/order?order_number={n}
+ *
+ * order_number normalisation: leading whitespace is trimmed and a leading '#' is stripped before
+ * the request is sent. Shopify formats order numbers as '#1030'; ParcelPanel expects '1030'.
+ * Pass either format — the adapter handles both correctly.
  */
 export class ParcelPanelAdapter implements ServiceAdapter {
   readonly id: string;
@@ -114,18 +104,27 @@ export class ParcelPanelAdapter implements ServiceAdapter {
   }
 
   private async executeRequest(
+    method: 'GET' | 'POST' | 'PUT',
     url: string,
+    operation: string,
     apiKey: string,
+    body?: unknown,
     signal?: AbortSignal,
-  ): Promise<Response> {
+  ): Promise<ServiceResponse> {
     this.checkAborted(signal);
+    const fetchOptions: RequestInit =
+      method === 'GET'
+        ? { method, headers: this.buildHeaders(apiKey), signal: signal ?? null }
+        : {
+            method,
+            headers: { ...this.buildHeaders(apiKey), 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            signal: signal ?? null,
+          };
+
     let response: Response;
     try {
-      response = await fetch(url, {
-        method: 'GET',
-        headers: this.buildHeaders(apiKey),
-        signal: signal ?? null,
-      });
+      response = await fetch(url, fetchOptions);
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         throw new WorkflowError('Adapter request aborted', {
@@ -143,7 +142,23 @@ export class ParcelPanelAdapter implements ServiceAdapter {
         retryable: true,
       });
     }
-    return response;
+
+    if (!response.ok) {
+      await this.throwHttpError(response, operation);
+    }
+
+    let json: unknown;
+    try {
+      json = await response.json();
+    } catch {
+      throw new WorkflowError('ParcelPanelAdapter: failed to parse response body', {
+        code: 'SERVICE_RESPONSE_INVALID',
+        category: 'SERVICE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    return { status: response.status, data: json };
   }
 
   private async throwHttpError(response: Response, operation: string): Promise<never> {
@@ -174,6 +189,16 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     if (status === 401) {
       throw new WorkflowError('ParcelPanel authentication failed — check API key', {
         code: 'SERVICE_AUTH_FAILED',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details,
+      });
+    }
+
+    if (status === 403) {
+      throw new WorkflowError(`Account lacks permission for ParcelPanel operation '${operation}'`, {
+        code: 'SERVICE_HTTP_4XX',
         category: 'SERVICE',
         agentAction: 'stop',
         retryable: false,
@@ -253,7 +278,8 @@ export class ParcelPanelAdapter implements ServiceAdapter {
         );
       }
 
-      // Normalize order_number: trim whitespace then strip leading '#'
+      // Normalise order_number: trim whitespace then strip leading '#'.
+      // Shopify formats order numbers as '#1030'; ParcelPanel expects '1030'.
       let normalizedOrderNumber = rawOrderNumber.trim();
       if (normalizedOrderNumber.startsWith('#')) {
         normalizedOrderNumber = normalizedOrderNumber.slice(1);
@@ -261,68 +287,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
 
       const url = `${this.baseUrl}/api/v2/tracking/order?order_number=${encodeURIComponent(normalizedOrderNumber)}`;
 
-      const response = await this.executeRequest(url, apiKey, signal);
-
-      if (!response.ok) {
-        await this.throwHttpError(response, 'get_tracking');
-      }
-
-      // Parse response body
-      let parsed: unknown;
-      try {
-        parsed = await response.json();
-      } catch {
-        throw new WorkflowError('ParcelPanelAdapter: failed to parse response body', {
-          code: 'SERVICE_RESPONSE_INVALID',
-          category: 'SERVICE',
-          agentAction: 'report_to_user',
-          retryable: false,
-        });
-      }
-
-      const body = parsed as ParcelPanelOrderBody;
-
-      // Validate shape
-      if (body.order === undefined || body.order === null) {
-        throw new WorkflowError('ParcelPanelAdapter: response missing order field', {
-          code: 'SERVICE_RESPONSE_INVALID',
-          category: 'SERVICE',
-          agentAction: 'report_to_user',
-          retryable: false,
-        });
-      }
-
-      if (typeof body.order.tracking_link !== 'string') {
-        throw new WorkflowError(
-          'ParcelPanelAdapter: response missing or invalid order.tracking_link',
-          {
-            code: 'SERVICE_RESPONSE_INVALID',
-            category: 'SERVICE',
-            agentAction: 'report_to_user',
-            retryable: false,
-          },
-        );
-      }
-
-      const shipments = body.order.shipments ?? [];
-      const firstShipment = shipments[0];
-
-      const normalized: NormalizedTracking =
-        firstShipment !== undefined
-          ? {
-              tracking_url: body.order.tracking_link,
-              carrier: firstShipment.carrier?.name ?? null,
-              tracking_number: firstShipment.tracking_number ?? null,
-              status: firstShipment.status ?? null,
-            }
-          : {
-              tracking_url: body.order.tracking_link,
-              carrier: null,
-              tracking_number: null,
-              status: null,
-            };
-
-      return { status: 200, data: normalized };
+      return this.executeRequest('GET', url, 'get_tracking', apiKey, undefined, signal);
     }
 
     throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {

--- a/packages/core/src/adapters/parcelpanel-adapter.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.ts
@@ -226,7 +226,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
       });
     }
 
-    // Any other 4xx (400, 403, 422, etc.)
+    // Any other 4xx (400, 422, etc.)
     throw new WorkflowError(`HTTP ${status}: ${response.statusText}`, {
       code: 'SERVICE_HTTP_4XX',
       category: 'SERVICE',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,7 +76,8 @@ export type {
 export { ParcelPanelAdapter } from './adapters/parcelpanel-adapter.js';
 export type {
   ParcelPanelAdapterConfig,
-  NormalizedTracking as ParcelPanelNormalizedTracking,
+  ParcelPanelShipment,
+  ParcelPanelOrderBody,
 } from './adapters/parcelpanel-adapter.js';
 export { AirtableAdapter } from './adapters/airtable-adapter.js';
 export type { AirtableAdapterConfig } from './adapters/airtable-adapter.js';


### PR DESCRIPTION
## Context

ParcelPanel adapter was applying adapter-level normalization that violated the thin-transport-layer principle. The `NormalizedTracking` interface flattened multi-shipment orders (silently dropping all but the first shipment) and enforced presence of `order.tracking_link` with `SERVICE_RESPONSE_INVALID` guards. This prevented callers from accessing the full raw API response.

This is a prerequisite fix before new operations can be added to the adapter.

## Motivation

Remove all adapter-level bias from `ParcelPanelAdapter` so callers receive raw API data. Expand the internal interface types to cover known fields. Prepare `executeRequest` for future POST/PUT operations.

## Changes

### Change 1 — Remove `NormalizedTracking` exported interface
Removed the `NormalizedTracking` interface and its JSDoc from the adapter and from `src/index.ts`. It is no longer exported.

### Change 2 — Expand `ParcelPanelShipment` interface
Added `status_label`, nullable variants of existing fields, and `carrier.code`. Added `[key: string]: unknown` index signature.

### Change 3 — Expand `ParcelPanelOrderBody` interface
Added `order_id`, `order_number`, typed `tracking_link` as `string | null`, nullable `order`, and `[key: string]: unknown` on both levels.

Both `ParcelPanelShipment` and `ParcelPanelOrderBody` are now exported (previously private) so they are useful to callers who want to type raw API responses.

### Change 4 — Add explicit HTTP 403 handler in `throwHttpError`
Inserted between the 401 and 404 branches: throws `SERVICE_HTTP_4XX` with message `Account lacks permission for ParcelPanel operation '${operation}'`.

### Change 5 — Restructure `executeRequest` to return `ServiceResponse`
Replaced the old `(url, apiKey, signal) → Promise<Response>` signature with `(method, url, operation, apiKey, body?, signal?) → Promise<ServiceResponse>`. The method now:
- Accepts `'GET' | 'POST' | 'PUT'` for future operations
- Calls `throwHttpError` internally on non-2xx responses
- Returns `{ status: response.status, data: json }` directly
- Wraps `response.json()` in a try/catch to preserve `SERVICE_RESPONSE_INVALID` for non-JSON bodies (existing test requires this)

### Change 6 — Rewrite `get_tracking` block
Removed the `SERVICE_RESPONSE_INVALID` shape-validation guards (missing `order`, invalid `tracking_link`). Kept store validation, order_number validation, and the normalization block (trim + `#` strip). Call site now: `return this.executeRequest('GET', url, 'get_tracking', apiKey, undefined, signal)`.

### Change 7 — Update class JSDoc
Added normalisation documentation noting the `#`-strip behaviour for Shopify-formatted order numbers.

### Test changes (Change 8)
Rewrote the `normalization` describe block (5 tests → 5 tests, same count):
- Replaced NormalizedTracking assertions with raw passthrough assertions
- Added test for split fulfillment returning both shipments (regression for the silently-dropped second shipment)
- Added test for `status_label` and `carrier.code` fields (new interface fields)
- Replaced the two `SERVICE_RESPONSE_INVALID` shape-validation tests with one "arbitrary shape — no throw" test
- Removed `NormalizedTracking` import

### Probe change (Change 9)
Replaced `NormalizedTracking` cast with `Record<string, unknown>` and checks `order.tracking_link` instead of `data.tracking_url`.

## Verification

```bash
# Removed symbols — all must return empty
grep -n "NormalizedTracking" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "normalized:" packages/core/src/adapters/parcelpanel-adapter.ts

# New/preserved symbols — all must return matches
grep -n "ParcelPanelShipment" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "\[key: string\]: unknown" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "status === 403" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "method: 'GET' | 'POST' | 'PUT'" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "normalizedOrderNumber" packages/core/src/adapters/parcelpanel-adapter.ts

# Probe file — no NormalizedTracking
grep -n "NormalizedTracking" packages/core/src/adapters/parcelpanel-adapter.probe.ts

# Test suite
npm test --workspace=packages/core
# Expected: 1172 passed, 0 skipped

# Build
npm run build --workspace=packages/core
# Expected: exit 0

# Lint
npm run lint --workspace=packages/core
# Expected: exit 0

# Net-negative gate on adapter source file
git diff --stat
# parcelpanel-adapter.ts must show net reduction (363 → 334 lines, -29)
```

## Rollback

```bash
git revert HEAD
```

No external side effects. The change is purely internal adapter code.

## Related

Follows the same passthrough pattern applied to GorgiasAdapter (PR #73).
Next step: `prompts/parcelpanel-p2-new-ops.md` — new operations building on this foundation.
