### PR TITLE
feat(core): add get_tracking_by_id and expand interfaces in ParcelPanelAdapter

### DIFF
--- a/packages/core/src/adapters/parcelpanel-adapter.test.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.test.ts
@@ -512,6 +512,71 @@ describe('ParcelPanelAdapter normalization', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: fetch(get_tracking_by_id)
+// ---------------------------------------------------------------------------
+
+describe('ParcelPanelAdapter fetch(get_tracking_by_id)', () => {
+  it('order_id as number — raw passthrough with order data', async () => {
+    respond(200, fulfilledOrderBody());
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'get_tracking_by_id',
+      { store: 'mystore', order_id: 6140516335690 },
+      {},
+    );
+    expect(result.status).toBe(200);
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    expect(order['order_id']).toBe(6140516335690);
+    expect(typeof order['tracking_link']).toBe('string');
+  });
+
+  it('order_id as string — raw passthrough with order data', async () => {
+    respond(200, fulfilledOrderBody());
+    const adapter = makeAdapter();
+    const result = await adapter.fetch(
+      'get_tracking_by_id',
+      { store: 'mystore', order_id: '6140516335690' },
+      {},
+    );
+    expect(result.status).toBe(200);
+    const data = result.data as Record<string, unknown>;
+    const order = data['order'] as Record<string, unknown>;
+    expect(order['order_id']).toBe(6140516335690);
+    expect(typeof order['tracking_link']).toBe('string');
+  });
+
+  it('correct query string — order_id in URL, not order_number', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(fulfilledOrderBody()));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('get_tracking_by_id', { store: 'mystore', order_id: 6140516335690 }, {});
+    expect(capturedUrl).toContain('order_id=6140516335690');
+    expect(capturedUrl).not.toContain('order_number');
+  });
+
+  it('missing order_id → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking_by_id', { store: 'mystore' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    expect(handlers).toHaveLength(0);
+  });
+
+  it('invalid order_id (negative number) → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking_by_id', { store: 'mystore', order_id: -1 }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    expect(handlers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: Unsupported operations
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/adapters/parcelpanel-adapter.test.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.test.ts
@@ -574,6 +574,23 @@ describe('ParcelPanelAdapter fetch(get_tracking_by_id)', () => {
     ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
     expect(handlers).toHaveLength(0);
   });
+
+  it('missing store param → ADAPTER_VALIDATION_FAILED', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('get_tracking_by_id', { order_id: 6140516335690 }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('unknown store → ADAPTER_VALIDATION_FAILED with details.store', async () => {
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('get_tracking_by_id', { store: 'no-such-store', order_id: 6140516335690 }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
+    expect(err.details['store']).toBe('no-such-store');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/adapters/parcelpanel-adapter.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.ts
@@ -175,6 +175,29 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     };
   }
 
+  private resolveApiKey(params: Record<string, unknown>): string {
+    const store = params['store'];
+    if (typeof store !== 'string' || store === '') {
+      throw new WorkflowError('ParcelPanelAdapter: store param must be a non-empty string', {
+        code: 'ADAPTER_VALIDATION_FAILED',
+        category: 'ENGINE',
+        agentAction: 'provide_input',
+        retryable: false,
+      });
+    }
+    const apiKey = this.storesMap.get(store);
+    if (apiKey === undefined) {
+      throw new WorkflowError(`ParcelPanelAdapter: unknown store "${store}"`, {
+        code: 'ADAPTER_VALIDATION_FAILED',
+        category: 'ENGINE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: { store },
+      });
+    }
+    return apiKey;
+  }
+
   private validateOrderId(params: Record<string, unknown>): string {
     const orderId = params['order_id'];
     if (typeof orderId === 'number') {
@@ -347,26 +370,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     signal?: AbortSignal,
   ): Promise<ServiceResponse> {
     if (operation === 'get_tracking') {
-      // Validate store param
-      const store = params['store'];
-      if (typeof store !== 'string' || store === '') {
-        throw new WorkflowError('ParcelPanelAdapter: store param must be a non-empty string', {
-          code: 'ADAPTER_VALIDATION_FAILED',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-        });
-      }
-      const apiKey = this.storesMap.get(store);
-      if (apiKey === undefined) {
-        throw new WorkflowError(`ParcelPanelAdapter: unknown store "${store}"`, {
-          code: 'ADAPTER_VALIDATION_FAILED',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-          details: { store },
-        });
-      }
+      const apiKey = this.resolveApiKey(params);
 
       // Validate order_number param
       const rawOrderNumber = params['order_number'];
@@ -395,26 +399,7 @@ export class ParcelPanelAdapter implements ServiceAdapter {
     }
 
     if (operation === 'get_tracking_by_id') {
-      // Validate store param
-      const store = params['store'];
-      if (typeof store !== 'string' || store === '') {
-        throw new WorkflowError('ParcelPanelAdapter: store param must be a non-empty string', {
-          code: 'ADAPTER_VALIDATION_FAILED',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-        });
-      }
-      const apiKey = this.storesMap.get(store);
-      if (apiKey === undefined) {
-        throw new WorkflowError(`ParcelPanelAdapter: unknown store "${store}"`, {
-          code: 'ADAPTER_VALIDATION_FAILED',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-          details: { store },
-        });
-      }
+      const apiKey = this.resolveApiKey(params);
 
       const orderId = this.validateOrderId(params);
 

--- a/packages/core/src/adapters/parcelpanel-adapter.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.ts
@@ -31,8 +31,56 @@ export interface ParcelPanelAdapterConfig {
 export interface ParcelPanelShipment {
   status?: string | null;
   status_label?: string | null;
+  substatus?: string | null;
+  substatus_label?: string | null;
   tracking_number?: string | null;
-  carrier?: { name?: string | null; code?: string | null } | null;
+  carrier?: {
+    name?: string | null;
+    code?: string | null;
+    contact?: string | null;
+    logo_url?: string | null;
+    url?: string | null;
+  } | null;
+  transit_time?: number | null;
+  residence_time?: number | null;
+  estimated_delivery_date?: {
+    source?: string | null;
+    display_text?: string | null;
+  } | null;
+  order_date?: string | null;
+  fulfillment_date?: string | null;
+  pickup_date?: string | null;
+  pickup_location?: string | null;
+  location?: { name?: string | null } | null;
+  delivery_date?: string | null;
+  last_mile_tracking_supported?: boolean | null;
+  last_mile?: {
+    carrier_name?: string | null;
+    carrier_code?: string | null;
+    tracking_number?: string | null;
+    carrier_contact?: string | null;
+    carrier_logo_url?: string | null;
+    carrier_url?: string | null;
+  } | null;
+  products?: Array<{
+    id?: number | null;
+    title?: string | null;
+    variant_id?: number | null;
+    variant_title?: string | null;
+    quantity?: number | null;
+    image_url?: string | null;
+    url?: string | null;
+    [key: string]: unknown;
+  }> | null;
+  checkpoints?: Array<{
+    detail?: string | null;
+    status?: string | null;
+    status_label?: string | null;
+    substatus?: string | null;
+    substatus_label?: string | null;
+    checkpoint_time?: string | null;
+    [key: string]: unknown;
+  }> | null;
   [key: string]: unknown;
 }
 
@@ -41,6 +89,27 @@ export interface ParcelPanelOrderBody {
   order?: {
     order_id?: number | null;
     order_number?: string | null;
+    order_tags?: string[] | null;
+    store?: { name?: string | null; url?: string | null } | null;
+    customer?: {
+      name?: string | null;
+      email?: string | null;
+      phone?: string | null;
+    } | null;
+    shipping_address?: {
+      name?: string | null;
+      phone?: string | null;
+      country?: string | null;
+      country_code?: string | null;
+      province?: string | null;
+      province_code?: string | null;
+      city?: string | null;
+      zip?: string | null;
+      address1?: string | null;
+      address2?: string | null;
+      company?: string | null;
+      [key: string]: unknown;
+    } | null;
     tracking_link?: string | null;
     shipments?: ParcelPanelShipment[];
     [key: string]: unknown;
@@ -52,11 +121,14 @@ export interface ParcelPanelOrderBody {
  * ParcelPanelAdapter communicates with the ParcelPanel / ParcelWILL tracking API v2.
  *
  * Supported operations:
- *   fetch('get_tracking', { store, order_number })   — GET /api/v2/tracking/order?order_number={n}
+ *   fetch('get_tracking',       { store, order_number })   — GET /api/v2/tracking/order?order_number={n}
+ *   fetch('get_tracking_by_id', { store, order_id })       — GET /api/v2/tracking/order?order_id={id}
  *
  * order_number normalisation: leading whitespace is trimmed and a leading '#' is stripped before
  * the request is sent. Shopify formats order numbers as '#1030'; ParcelPanel expects '1030'.
  * Pass either format — the adapter handles both correctly.
+ *
+ * order_id: the Shopify numeric order ID (e.g. 6140516335690). Accepted as number or string.
  */
 export class ParcelPanelAdapter implements ServiceAdapter {
   readonly id: string;
@@ -101,6 +173,38 @@ export class ParcelPanelAdapter implements ServiceAdapter {
       'x-parcelpanel-api-key': apiKey,
       Accept: 'application/json',
     };
+  }
+
+  private validateOrderId(params: Record<string, unknown>): string {
+    const orderId = params['order_id'];
+    if (typeof orderId === 'number') {
+      if (!Number.isInteger(orderId) || orderId <= 0) {
+        throw new WorkflowError(
+          'ParcelPanelAdapter: order_id must be a positive integer or non-empty string',
+          {
+            code: 'ADAPTER_VALIDATION_FAILED',
+            category: 'ENGINE',
+            agentAction: 'provide_input',
+            retryable: false,
+            details: { received: orderId },
+          },
+        );
+      }
+      return String(orderId);
+    }
+    if (typeof orderId === 'string' && orderId !== '') {
+      return orderId;
+    }
+    throw new WorkflowError(
+      'ParcelPanelAdapter: order_id must be a positive integer or non-empty string',
+      {
+        code: 'ADAPTER_VALIDATION_FAILED',
+        category: 'ENGINE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: { received: orderId },
+      },
+    );
   }
 
   private async executeRequest(
@@ -288,6 +392,35 @@ export class ParcelPanelAdapter implements ServiceAdapter {
       const url = `${this.baseUrl}/api/v2/tracking/order?order_number=${encodeURIComponent(normalizedOrderNumber)}`;
 
       return this.executeRequest('GET', url, 'get_tracking', apiKey, undefined, signal);
+    }
+
+    if (operation === 'get_tracking_by_id') {
+      // Validate store param
+      const store = params['store'];
+      if (typeof store !== 'string' || store === '') {
+        throw new WorkflowError('ParcelPanelAdapter: store param must be a non-empty string', {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+        });
+      }
+      const apiKey = this.storesMap.get(store);
+      if (apiKey === undefined) {
+        throw new WorkflowError(`ParcelPanelAdapter: unknown store "${store}"`, {
+          code: 'ADAPTER_VALIDATION_FAILED',
+          category: 'ENGINE',
+          agentAction: 'provide_input',
+          retryable: false,
+          details: { store },
+        });
+      }
+
+      const orderId = this.validateOrderId(params);
+
+      const url = `${this.baseUrl}/api/v2/tracking/order?order_id=${encodeURIComponent(orderId)}`;
+
+      return this.executeRequest('GET', url, 'get_tracking_by_id', apiKey, undefined, signal);
     }
 
     throw new WorkflowError(`ParcelPanelAdapter: operation "${operation}" is not supported`, {


### PR DESCRIPTION
## Context

Extends the ParcelPanel adapter with a second tracking lookup operation: `get_tracking_by_id`. The existing `get_tracking` operation looks up orders by order number (e.g. `#1030`), but Shopify workflows often have the numeric order ID (`6140516335690`) available first. This avoids a round-trip to convert between formats.

Also expands both `ParcelPanelShipment` and `ParcelPanelOrderBody` to cover the full known API response shape — previously these were minimal stubs.

## Motivation

Callers working with Shopify webhooks receive the `order_id` directly. Without this operation they need to look up the order number first, then use `get_tracking`. The new operation eliminates that extra step.

## Changes

### Change 1 — `validateOrderId()` private method

New helper between `buildHeaders()` and `executeRequest()`. Accepts `order_id` as either `number` (positive integer) or non-empty `string`. Both are normalised to `string` for the URL query param. Negative or non-integer numbers throw `ADAPTER_VALIDATION_FAILED`.

### Change 2 — `get_tracking_by_id` operation in `fetch()`

New `if` block after `get_tracking`, before the final unsupported throw:
- Validates `store` (same pattern as `get_tracking`)
- Calls `this.validateOrderId(params)`
- Builds URL: `GET /api/v2/tracking/order?order_id={id}`
- Returns raw `executeRequest` result

### Change 3 — Update class JSDoc

Added `get_tracking_by_id` to the operations list and added the `order_id` normalisation note.

### Change 4 — Expand `ParcelPanelOrderBody` interface

Added: `order_tags`, `store` (name/url), `customer` (name/email/phone), `shipping_address` (full address block with index signature).

### Change 5 — Expand `ParcelPanelShipment` interface

Added: `substatus`, `substatus_label`, `transit_time`, `residence_time`, `estimated_delivery_date`, `order_date`, `fulfillment_date`, `pickup_date`, `pickup_location`, `location`, `delivery_date`, `last_mile_tracking_supported`, `last_mile` (full carrier block), `products` (array with id/title/variant fields), `checkpoints` (array with status/substatus/time). Expanded `carrier` with `contact`, `logo_url`, `url`.

### Tests — new `describe('ParcelPanelAdapter fetch(get_tracking_by_id)')` block

5 new tests:
1. `order_id` as number — raw passthrough
2. `order_id` as string — raw passthrough
3. Correct URL query string (`order_id=…`, no `order_number`)
4. Missing `order_id` → `ADAPTER_VALIDATION_FAILED`
5. Negative `order_id` → `ADAPTER_VALIDATION_FAILED`

## Verification

```bash
# New symbols present
grep -n "get_tracking_by_id" packages/core/src/adapters/parcelpanel-adapter.ts
# Expect: JSDoc + operation branch + executeRequest call (3 matches)

grep -n "validateOrderId" packages/core/src/adapters/parcelpanel-adapter.ts
# Expect: 2 matches — definition + call site

grep -n "order_id=" packages/core/src/adapters/parcelpanel-adapter.ts
# Expect: URL construction present

# Existing operation untouched
grep -n "normalizedOrderNumber" packages/core/src/adapters/parcelpanel-adapter.ts
# Expect: 4 matches

# Interface expansion
grep -n "checkpoints" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "last_mile" packages/core/src/adapters/parcelpanel-adapter.ts
grep -n "shipping_address" packages/core/src/adapters/parcelpanel-adapter.ts

# Test suite
npm test --workspace=packages/core
# Expected: 1177 passed, 0 skipped

# Build
npm run build --workspace=packages/core
# Expected: exit 0

# Lint
npm run lint --workspace=packages/core
# Expected: exit 0
```

## Rollback

```bash
git revert HEAD
```

No external side effects. The change is additive — existing `get_tracking` behaviour is unchanged.

## Related

Follows the prereqs in PR #80 (`fix(core): remove NormalizedTracking, return raw API data from ParcelPanelAdapter`).
