### PR TITLE
chore: release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented here.
 
 ---
 
+## [0.6.3] — 2026-06-16
+
+### Added
+
+- **ParcelPanelAdapter — `fetch('get_tracking_by_id', { store, order_id })`** — look up tracking data by Shopify numeric order ID instead of order number. Same endpoint (`GET /api/v2/tracking/order`), different query param (`?order_id=`). Accepts `order_id` as either `number` or `string`; both formats are normalised to a string before the request is sent.
+
+### Changed
+
+- **ParcelPanelAdapter — `ParcelPanelShipment` and `ParcelPanelOrderBody` interfaces expanded** — now cover the complete ParcelPanel API response shape: `substatus`, `transit_time`, `estimated_delivery_date`, `last_mile`, `products`, `checkpoints`, `customer`, `shipping_address`, `store`, `order_tags`, and more. Both interfaces are now exported from `@sensigo/realm` so callers can type raw API responses directly.
+
+### Fixed
+
+- **ParcelPanelAdapter universal passthrough** — `get_tracking` previously returned a normalised 4-field `NormalizedTracking` object (`tracking_url`, `carrier`, `tracking_number`, `status`), silently discarding the entire API response including all shipments beyond the first, all checkpoint events, customer data, and shipping address. Now returns the complete raw API response as-is.
+
+### Removed
+
+- **`NormalizedTracking` exported interface removed** — callers who were typing `result.data as NormalizedTracking` should switch to `result.data as ParcelPanelOrderBody`, which covers the full response shape.
+
+---
+
 ## [0.6.2] — 2026-06-16
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.6.2');
+program.name('realm').description('Realm workflow engine CLI').version('0.6.3');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.6.2',
+    version: '0.6.3',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.6.2';
+export const VERSION = '0.6.3';


### PR DESCRIPTION
## Release v0.6.3

### Added
- **ParcelPanelAdapter — `fetch('get_tracking_by_id', { store, order_id })`** — lookup by Shopify numeric order ID; accepts `number` or `string`

### Changed
- **`ParcelPanelShipment` and `ParcelPanelOrderBody` interfaces expanded** — full API response shape modelled; both now exported from `@sensigo/realm`

### Fixed
- **ParcelPanelAdapter universal passthrough** — `get_tracking` previously returned a 4-field `NormalizedTracking` object; now returns the complete raw API response

### Removed
- **`NormalizedTracking` exported interface removed** — callers should switch to `ParcelPanelOrderBody`

---

## Test suite

Core: **1179 passed, 0 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
