### PR TITLE
refactor(core): ShopifyAdapter — GraphQL passthrough, remove NormalizedOrder

### DIFF
--- a/packages/core/src/adapters/shopify-adapter.test.ts
+++ b/packages/core/src/adapters/shopify-adapter.test.ts
@@ -1,7 +1,7 @@
 import * as http from 'node:http';
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { ShopifyAdapter } from './shopify-adapter.js';
-import type { ShopifyAdapterConfig, NormalizedOrder } from './shopify-adapter.js';
+import type { ShopifyAdapterConfig } from './shopify-adapter.js';
 import { WorkflowError } from '../types/workflow-error.js';
 
 // ---------------------------------------------------------------------------
@@ -89,56 +89,6 @@ function makeAdapter(overrides: Partial<ShopifyAdapterConfig> = {}): ShopifyAdap
 }
 
 // ---------------------------------------------------------------------------
-// Complete order fixture
-// ---------------------------------------------------------------------------
-
-const FULL_ORDER_NODE = {
-  id: 'gid://shopify/Order/450789469',
-  legacyResourceId: '450789469',
-  number: 1234,
-  name: '#1234',
-  displayFinancialStatus: 'PAID',
-  displayFulfillmentStatus: 'FULFILLED',
-  cancelledAt: null,
-  cancelReason: null,
-  createdAt: '2024-01-15T10:30:00Z',
-  customer: {
-    firstName: 'Jane',
-    lastName: 'Doe',
-    email: 'jane@example.com',
-  },
-  currentTotalPriceSet: { shopMoney: { amount: '99.99', currencyCode: 'EUR' } },
-  currentSubtotalPriceSet: { shopMoney: { amount: '89.99' } },
-  currentShippingPriceSet: { shopMoney: { amount: '5.00' } },
-  discountCodes: ['SUMMER10'],
-  lineItems: {
-    edges: [
-      {
-        node: {
-          name: 'Blue T-Shirt',
-          quantity: 2,
-          originalUnitPriceSet: { shopMoney: { amount: '44.99' } },
-        },
-      },
-    ],
-  },
-};
-
-function gqlSuccess(node: unknown) {
-  return {
-    data: {
-      orders: {
-        edges: [{ node }],
-      },
-    },
-  };
-}
-
-function gqlEmpty() {
-  return { data: { orders: { edges: [] } } };
-}
-
-// ---------------------------------------------------------------------------
 // Tests: Constructor validation
 // ---------------------------------------------------------------------------
 
@@ -187,53 +137,59 @@ describe('ShopifyAdapter construction', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: fetch('get_order') — param validation
+// Tests: fetch('query') — param validation
 // ---------------------------------------------------------------------------
 
-describe("ShopifyAdapter fetch('get_order') param validation", () => {
+describe("ShopifyAdapter fetch('query') param validation", () => {
   it('throws ADAPTER_VALIDATION_FAILED when store is a number', async () => {
     const adapter = makeAdapter();
     await expect(
-      adapter.fetch('get_order', { store: 42, order_name: '#1234' }, {}),
+      adapter.fetch('query', { store: 42, query: '{ shop { name } }' }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('throws ADAPTER_VALIDATION_FAILED when store is empty string', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('query', { store: '', query: '{ shop { name } }' }, {}),
     ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
   });
 
   it('throws ADAPTER_VALIDATION_FAILED with details.store when store not in map', async () => {
     const adapter = makeAdapter();
     const err = await adapter
-      .fetch('get_order', { store: 'unknown', order_name: '#1234' }, {})
+      .fetch('query', { store: 'unknown', query: '{ shop { name } }' }, {})
       .catch((e: unknown) => e as WorkflowError);
     expect(err).toBeInstanceOf(WorkflowError);
     expect(err.code).toBe('ADAPTER_VALIDATION_FAILED');
     expect(err.details['store']).toBe('unknown');
   });
 
-  it('throws ADAPTER_VALIDATION_FAILED when order_name is empty string', async () => {
+  it('throws ADAPTER_VALIDATION_FAILED when query is missing', async () => {
     const adapter = makeAdapter();
-    await expect(
-      adapter.fetch('get_order', { store: 'mystore', order_name: '' }, {}),
-    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    await expect(adapter.fetch('query', { store: 'mystore' }, {})).rejects.toMatchObject({
+      code: 'ADAPTER_VALIDATION_FAILED',
+    });
   });
 
-  it('normalizes "1234" to "#1234" before sending to API', async () => {
-    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+  it('throws ADAPTER_VALIDATION_FAILED when query is empty string', async () => {
     const adapter = makeAdapter();
-    await adapter.fetch('get_order', { store: 'mystore', order_name: '1234' }, {});
-    const reqBody = JSON.parse(lastRequestBody) as { variables: { query: string } };
-    expect(reqBody.variables.query).toBe('name:#1234');
+    await expect(adapter.fetch('query', { store: 'mystore', query: '' }, {})).rejects.toMatchObject(
+      { code: 'ADAPTER_VALIDATION_FAILED' },
+    );
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: fetch('get_order') — HTTP errors
+// Tests: fetch('query') — HTTP errors
 // ---------------------------------------------------------------------------
 
-describe("ShopifyAdapter fetch('get_order') HTTP errors", () => {
+describe("ShopifyAdapter fetch('query') HTTP errors", () => {
   it('throws SERVICE_AUTH_FAILED on HTTP 401', async () => {
     respondWith(401, { errors: 'Unauthorized' });
     const adapter = makeAdapter();
     await expect(
-      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+      adapter.fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {}),
     ).rejects.toMatchObject({ code: 'SERVICE_AUTH_FAILED' });
   });
 
@@ -241,7 +197,7 @@ describe("ShopifyAdapter fetch('get_order') HTTP errors", () => {
     respondWith(429, { errors: 'Too Many Requests' }, { 'Retry-After': '10' });
     const adapter = makeAdapter();
     const err = await adapter
-      .fetch('get_order', { store: 'mystore', order_name: '#1234' }, {})
+      .fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {})
       .catch((e: unknown) => e as WorkflowError);
     expect(err).toBeInstanceOf(WorkflowError);
     expect(err.code).toBe('SERVICE_RATE_LIMITED');
@@ -254,7 +210,7 @@ describe("ShopifyAdapter fetch('get_order') HTTP errors", () => {
     respondWith(429, { errors: 'Too Many Requests' });
     const adapter = makeAdapter();
     const err = await adapter
-      .fetch('get_order', { store: 'mystore', order_name: '#1234' }, {})
+      .fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {})
       .catch((e: unknown) => e as WorkflowError);
     expect(err).toBeInstanceOf(WorkflowError);
     expect(err.code).toBe('SERVICE_RATE_LIMITED');
@@ -263,11 +219,23 @@ describe("ShopifyAdapter fetch('get_order') HTTP errors", () => {
     expect(adapter.defaultRetryAfterSeconds).toBe(30);
   });
 
+  it('throws SERVICE_HTTP_4XX on HTTP 403', async () => {
+    respondWith(403, { errors: 'Forbidden' });
+    const adapter = makeAdapter();
+    const err = await adapter
+      .fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {})
+      .catch((e: unknown) => e as WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.code).toBe('SERVICE_HTTP_4XX');
+    expect(err.retryable).toBe(false);
+    expect(err.agentAction).toBe('stop');
+  });
+
   it('throws SERVICE_HTTP_4XX on HTTP 422', async () => {
     respondWith(422, { errors: 'Unprocessable Entity' });
     const adapter = makeAdapter();
     await expect(
-      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+      adapter.fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {}),
     ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX' });
   });
 
@@ -275,23 +243,23 @@ describe("ShopifyAdapter fetch('get_order') HTTP errors", () => {
     respondWith(503, { errors: 'Service Unavailable' });
     const adapter = makeAdapter();
     await expect(
-      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
+      adapter.fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {}),
     ).rejects.toMatchObject({ code: 'SERVICE_HTTP_5XX', retryable: true });
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: fetch('get_order') — GraphQL errors
+// Tests: fetch('query') — GraphQL errors
 // ---------------------------------------------------------------------------
 
-describe("ShopifyAdapter fetch('get_order') GraphQL errors", () => {
+describe("ShopifyAdapter fetch('query') GraphQL errors", () => {
   it('throws SERVICE_RATE_LIMITED when errors[0].extensions.code === "THROTTLED"', async () => {
     respondWith(200, {
       errors: [{ message: 'Throttled', extensions: { code: 'THROTTLED' } }],
     });
     const adapter = makeAdapter();
     const err = await adapter
-      .fetch('get_order', { store: 'mystore', order_name: '#1234' }, {})
+      .fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {})
       .catch((e: unknown) => e as WorkflowError);
     expect(err).toBeInstanceOf(WorkflowError);
     expect(err.code).toBe('SERVICE_RATE_LIMITED');
@@ -299,107 +267,59 @@ describe("ShopifyAdapter fetch('get_order') GraphQL errors", () => {
     expect(err.retry_after).toBe(2);
   });
 
-  it('throws SERVICE_RESPONSE_INVALID for non-throttle GraphQL error', async () => {
-    respondWith(200, {
+  it('resolves with raw body when GraphQL errors are non-THROTTLED', async () => {
+    const rawBody = {
+      data: null,
       errors: [{ message: 'Field not found', extensions: { code: 'FIELD_ERROR' } }],
-    });
+    };
+    respondWith(200, rawBody);
     const adapter = makeAdapter();
-    await expect(
-      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}),
-    ).rejects.toMatchObject({ code: 'SERVICE_RESPONSE_INVALID' });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: fetch('get_order') — not found
-// ---------------------------------------------------------------------------
-
-describe("ShopifyAdapter fetch('get_order') not found", () => {
-  it('throws SERVICE_NOT_FOUND with details when edges is empty', async () => {
-    respondWith(200, gqlEmpty());
-    const adapter = makeAdapter();
-    const err = await adapter
-      .fetch('get_order', { store: 'mystore', order_name: '#1234' }, {})
-      .catch((e: unknown) => e as WorkflowError);
-    expect(err).toBeInstanceOf(WorkflowError);
-    expect(err.code).toBe('SERVICE_NOT_FOUND');
-    expect(err.details['store']).toBe('mystore');
-    expect(err.details['order_name']).toBe('#1234');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: fetch('get_order') — successful normalization
-// ---------------------------------------------------------------------------
-
-describe("ShopifyAdapter fetch('get_order') normalization", () => {
-  it('returns { status: 200, data: NormalizedOrder } with all fields populated', async () => {
-    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
-    const adapter = makeAdapter();
-    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
+    const result = await adapter.fetch(
+      'query',
+      { store: 'mystore', query: '{ shop { name } }' },
+      {},
+    );
     expect(result.status).toBe(200);
-    const data = result.data as NormalizedOrder;
-    expect(data.id).toBe('gid://shopify/Order/450789469');
-    expect(data.legacy_id).toBe('450789469');
-    expect(data.order_number).toBe(1234);
-    expect(data.name).toBe('#1234');
-    expect(data.financial_status).toBe('PAID');
-    expect(data.fulfillment_status).toBe('FULFILLED');
-    expect(data.cancelled_at).toBeNull();
-    expect(data.cancel_reason).toBeNull();
-    expect(data.created_at).toBe('2024-01-15T10:30:00Z');
-    expect(data.customer).toEqual({
-      first_name: 'Jane',
-      last_name: 'Doe',
-      email: 'jane@example.com',
-    });
-    expect(data.total_price).toBe('99.99');
-    expect(data.subtotal_price).toBe('89.99');
-    expect(data.shipping_total).toBe('5.00');
-    expect(data.currency).toBe('EUR');
-    expect(data.discount_codes).toEqual(['SUMMER10']);
-    expect(data.line_items).toEqual([{ name: 'Blue T-Shirt', quantity: 2, price: '44.99' }]);
+    expect(result.data).toEqual(rawBody);
   });
+});
 
-  it('customer is null for guest checkout (node.customer is null)', async () => {
-    const node = { ...FULL_ORDER_NODE, customer: null };
-    respondWith(200, gqlSuccess(node));
+// ---------------------------------------------------------------------------
+// Tests: fetch('query') — request forwarding
+// ---------------------------------------------------------------------------
+
+describe("ShopifyAdapter fetch('query') request forwarding", () => {
+  it('forwards query string verbatim to request body', async () => {
+    const gqlQuery = 'query TestQuery { shop { name } }';
+    respondWith(200, { data: { shop: { name: 'My Store' } } });
     const adapter = makeAdapter();
-    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
-    expect((result.data as NormalizedOrder).customer).toBeNull();
+    await adapter.fetch('query', { store: 'mystore', query: gqlQuery }, {});
+    const body = JSON.parse(lastRequestBody) as { query: string };
+    expect(body.query).toBe(gqlQuery);
   });
 
-  it('customer.email is null when node.customer.email is empty string', async () => {
-    const node = {
-      ...FULL_ORDER_NODE,
-      customer: { firstName: 'Jo', lastName: 'Blank', email: '' },
-    };
-    respondWith(200, gqlSuccess(node));
+  it('forwards variables when provided', async () => {
+    respondWith(200, { data: { orders: { edges: [] } } });
     const adapter = makeAdapter();
-    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
-    expect((result.data as NormalizedOrder).customer?.email).toBeNull();
+    const vars = { orderId: 'gid://shopify/Order/123' };
+    await adapter.fetch(
+      'query',
+      { store: 'mystore', query: '{ shop { name } }', variables: vars },
+      {},
+    );
+    const body = JSON.parse(lastRequestBody) as { variables: unknown };
+    expect(body.variables).toEqual(vars);
   });
 
-  it('discount_codes is [] when node.discountCodes is []', async () => {
-    const node = { ...FULL_ORDER_NODE, discountCodes: [] };
-    respondWith(200, gqlSuccess(node));
+  it('omits variables from request body when not provided', async () => {
+    respondWith(200, { data: { shop: { name: 'My Store' } } });
     const adapter = makeAdapter();
-    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
-    expect((result.data as NormalizedOrder).discount_codes).toEqual([]);
+    await adapter.fetch('query', { store: 'mystore', query: '{ shop { name } }' }, {});
+    const body = JSON.parse(lastRequestBody) as Record<string, unknown>;
+    expect(body['variables']).toBeUndefined();
   });
 
-  it('shipping_total is "0.00" when currentShippingPriceSet.shopMoney.amount is "0.00"', async () => {
-    const node = {
-      ...FULL_ORDER_NODE,
-      currentShippingPriceSet: { shopMoney: { amount: '0.00' } },
-    };
-    respondWith(200, gqlSuccess(node));
-    const adapter = makeAdapter();
-    const result = await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
-    expect((result.data as NormalizedOrder).shipping_total).toBe('0.00');
-  });
-
-  it('uses correct X-Shopify-Access-Token header per store (multi-store)', async () => {
+  it('uses correct X-Shopify-Access-Token header per store', async () => {
     const multiAdapter = new ShopifyAdapter('shopify', {
       stores: {
         store_a: { shop_domain: 'store-a.myshopify.com', access_token: 'token_a' },
@@ -408,37 +328,52 @@ describe("ShopifyAdapter fetch('get_order') normalization", () => {
       base_url: `http://127.0.0.1:${port}`,
     });
 
-    // First: store_a
-    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
-    await multiAdapter.fetch('get_order', { store: 'store_a', order_name: '#1234' }, {});
+    respondWith(200, { data: { shop: { name: 'A' } } });
+    await multiAdapter.fetch('query', { store: 'store_a', query: '{ shop { name } }' }, {});
     expect(lastRequestHeaders['x-shopify-access-token']).toBe('token_a');
 
-    // Second: store_b
-    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
-    await multiAdapter.fetch('get_order', { store: 'store_b', order_name: '#1234' }, {});
+    respondWith(200, { data: { shop: { name: 'B' } } });
+    await multiAdapter.fetch('query', { store: 'store_b', query: '{ shop { name } }' }, {});
     expect(lastRequestHeaders['x-shopify-access-token']).toBe('token_b');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: request construction
+// Tests: fetch('query') — response passthrough
 // ---------------------------------------------------------------------------
 
-describe("ShopifyAdapter fetch('get_order') request construction", () => {
-  it('request body contains correct variables: { query: "name:#1234" }', async () => {
-    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+describe("ShopifyAdapter fetch('query') response passthrough", () => {
+  it('returns raw GraphQL response body — data field preserved as-is', async () => {
+    const rawBody = {
+      data: {
+        orders: { edges: [{ node: { id: 'gid://shopify/Order/123', name: '#1001' } }] },
+      },
+    };
+    respondWith(200, rawBody);
     const adapter = makeAdapter();
-    await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
-    const body = JSON.parse(lastRequestBody) as { variables: { query: string } };
-    expect(body.variables).toEqual({ query: 'name:#1234' });
+    const result = await adapter.fetch(
+      'query',
+      { store: 'mystore', query: '{ shop { name } }' },
+      {},
+    );
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual(rawBody);
   });
 
-  it('request body query field contains "OrderByName"', async () => {
-    respondWith(200, gqlSuccess(FULL_ORDER_NODE));
+  it('returns raw body including errors array when GraphQL errors are non-THROTTLED', async () => {
+    const rawBody = {
+      data: null,
+      errors: [{ message: 'Field not found', extensions: { code: 'FIELD_ERROR' } }],
+    };
+    respondWith(200, rawBody);
     const adapter = makeAdapter();
-    await adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {});
-    const body = JSON.parse(lastRequestBody) as { query: string };
-    expect(body.query).toContain('OrderByName');
+    const result = await adapter.fetch(
+      'query',
+      { store: 'mystore', query: '{ shop { name } }' },
+      {},
+    );
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual(rawBody);
   });
 });
 
@@ -474,7 +409,12 @@ describe('ShopifyAdapter AbortSignal', () => {
     const controller = new AbortController();
     controller.abort();
     await expect(
-      adapter.fetch('get_order', { store: 'mystore', order_name: '#1234' }, {}, controller.signal),
+      adapter.fetch(
+        'query',
+        { store: 'mystore', query: '{ shop { name } }' },
+        {},
+        controller.signal,
+      ),
     ).rejects.toMatchObject({ code: 'STEP_ABORTED' });
     // No handler was consumed — confirms no network call was made
     expect(handlers).toHaveLength(0);

--- a/packages/core/src/adapters/shopify-adapter.ts
+++ b/packages/core/src/adapters/shopify-adapter.ts
@@ -5,52 +5,6 @@ import { parseRetryAfterHeader } from './adapter-utils.js';
 
 const SHOPIFY_DEFAULT_API_VERSION = '2024-04';
 
-const ORDERS_BY_NAME_QUERY = `
-query OrderByName($query: String!) {
-  orders(first: 1, query: $query) {
-    edges {
-      node {
-        id
-        legacyResourceId
-        number
-        name
-        displayFinancialStatus
-        displayFulfillmentStatus
-        cancelledAt
-        cancelReason
-        createdAt
-        customer {
-          firstName
-          lastName
-          email
-        }
-        currentTotalPriceSet {
-          shopMoney { amount currencyCode }
-        }
-        currentSubtotalPriceSet {
-          shopMoney { amount }
-        }
-        currentShippingPriceSet {
-          shopMoney { amount }
-        }
-        discountCodes
-        lineItems(first: 50) {
-          edges {
-            node {
-              name
-              quantity
-              originalUnitPriceSet {
-                shopMoney { amount }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-`.trim();
-
 /**
  * Configuration for ShopifyAdapter.
  */
@@ -80,96 +34,18 @@ export interface ShopifyAdapterConfig {
   base_url?: string;
 }
 
-/** Normalized order returned by fetch('get_order'). */
-export interface NormalizedOrder {
-  /** Shopify global ID, e.g. "gid://shopify/Order/450789469" */
-  id: string;
-  /** Legacy numeric REST resource ID, e.g. "450789469" */
-  legacy_id: string;
-  /** Sequential order number, e.g. 1234 */
-  order_number: number;
-  /** Order name with store prefix, e.g. "#1234" or "#B1001" */
-  name: string;
-  /** Financial status for display, e.g. "PAID". Null if not available. */
-  financial_status: string | null;
-  /** Fulfillment status for display, e.g. "FULFILLED". Always present. */
-  fulfillment_status: string;
-  /** ISO 8601 datetime when the order was cancelled, or null. */
-  cancelled_at: string | null;
-  /** Cancellation reason, or null. */
-  cancel_reason: string | null;
-  /** ISO 8601 datetime when the order was created. */
-  created_at: string;
-  /** Customer details. Null for guest checkouts. */
-  customer: {
-    first_name: string;
-    last_name: string;
-    /** Customer email. Null for phone-only customers. */
-    email: string | null;
-  } | null;
-  /** Total order price including taxes and discounts, as a decimal string e.g. "99.99". */
-  total_price: string;
-  /** Subtotal price, as a decimal string. */
-  subtotal_price: string;
-  /** Current shipping price after refunds and discounts, as a decimal string. "0.00" if no shipping. */
-  shipping_total: string;
-  /** Currency code for shop money, e.g. "EUR". */
-  currency: string;
-  /** Discount codes applied to the order. */
-  discount_codes: string[];
-  /** Order line items. */
-  line_items: Array<{
-    name: string;
-    quantity: number;
-    price: string;
-  }>;
-}
-
-/** Raw GraphQL node shape from the Shopify API. */
-interface ShopifyOrderNode {
-  id: unknown;
-  legacyResourceId: unknown;
-  number: unknown;
-  name: unknown;
-  displayFinancialStatus: unknown;
-  displayFulfillmentStatus: unknown;
-  cancelledAt: unknown;
-  cancelReason: unknown;
-  createdAt: unknown;
-  customer:
-    | {
-        firstName: string;
-        lastName: string;
-        email: string;
-      }
-    | null
-    | undefined;
-  currentTotalPriceSet:
-    | { shopMoney: { amount: unknown; currencyCode: unknown } }
-    | null
-    | undefined;
-  currentSubtotalPriceSet: { shopMoney: { amount: unknown } } | null | undefined;
-  currentShippingPriceSet: { shopMoney: { amount: unknown } } | null | undefined;
-  discountCodes: unknown;
-  lineItems:
-    | {
-        edges: Array<{
-          node: {
-            name: string;
-            quantity: number;
-            originalUnitPriceSet: { shopMoney: { amount: unknown } } | null | undefined;
-          };
-        }>;
-      }
-    | null
-    | undefined;
-}
-
 /**
  * ShopifyAdapter communicates with the Shopify Admin GraphQL API.
  *
  * Supported operations:
- *   fetch('get_order', { store, order_name })   — POST /admin/api/{version}/graphql.json
+ *   fetch('query', { store, query, variables? })   — POST /admin/api/{version}/graphql.json
+ *
+ * The caller provides the complete GraphQL query string and optional variables.
+ * The adapter handles authentication, store routing, and error classification.
+ * The raw GraphQL response body is returned — no field selection or renaming.
+ *
+ * Throws SERVICE_RATE_LIMITED on HTTP 429 or GraphQL THROTTLED.
+ * All other GraphQL errors (partial success, field errors) pass through to the caller.
  */
 export class ShopifyAdapter implements ServiceAdapter {
   readonly id: string;
@@ -282,6 +158,16 @@ export class ShopifyAdapter implements ServiceAdapter {
       });
     }
 
+    if (status === 403) {
+      throw new WorkflowError(`Account lacks permission for Shopify operation '${operation}'`, {
+        code: 'SERVICE_HTTP_4XX',
+        category: 'SERVICE',
+        agentAction: 'stop',
+        retryable: false,
+        details,
+      });
+    }
+
     if (status >= 400 && status < 500) {
       throw new WorkflowError(`HTTP ${status}: ${response.statusText}`, {
         code: 'SERVICE_HTTP_4XX',
@@ -302,117 +188,17 @@ export class ShopifyAdapter implements ServiceAdapter {
     });
   }
 
-  private normalizeOrder(
-    node: ShopifyOrderNode,
-    store: string,
-    normalizedOrderName: string,
-  ): NormalizedOrder {
-    if (typeof node.id !== 'string' || node.id === '') {
-      throw new WorkflowError('ShopifyAdapter: missing order id in response', {
-        code: 'SERVICE_RESPONSE_INVALID',
-        category: 'SERVICE',
-        agentAction: 'report_to_user',
-        retryable: false,
-      });
-    }
-    if (typeof node.number !== 'number') {
-      throw new WorkflowError('ShopifyAdapter: missing order number in response', {
-        code: 'SERVICE_RESPONSE_INVALID',
-        category: 'SERVICE',
-        agentAction: 'report_to_user',
-        retryable: false,
-      });
-    }
-    if (typeof node.displayFulfillmentStatus !== 'string' || node.displayFulfillmentStatus === '') {
-      throw new WorkflowError('ShopifyAdapter: missing fulfillment_status in response', {
-        code: 'SERVICE_RESPONSE_INVALID',
-        category: 'SERVICE',
-        agentAction: 'report_to_user',
-        retryable: false,
-      });
-    }
-    if (typeof node.createdAt !== 'string') {
-      throw new WorkflowError('ShopifyAdapter: missing created_at in response', {
-        code: 'SERVICE_RESPONSE_INVALID',
-        category: 'SERVICE',
-        agentAction: 'report_to_user',
-        retryable: false,
-      });
-    }
-
-    const totalPrice = node.currentTotalPriceSet?.shopMoney?.amount;
-    if (typeof totalPrice !== 'string') {
-      throw new WorkflowError('ShopifyAdapter: missing total_price in response', {
-        code: 'SERVICE_RESPONSE_INVALID',
-        category: 'SERVICE',
-        agentAction: 'report_to_user',
-        retryable: false,
-      });
-    }
-
-    const subtotalPrice = node.currentSubtotalPriceSet?.shopMoney?.amount;
-    if (typeof subtotalPrice !== 'string') {
-      throw new WorkflowError('ShopifyAdapter: missing subtotal_price in response', {
-        code: 'SERVICE_RESPONSE_INVALID',
-        category: 'SERVICE',
-        agentAction: 'report_to_user',
-        retryable: false,
-      });
-    }
-
-    const customer =
-      node.customer != null
-        ? {
-            first_name: node.customer.firstName,
-            last_name: node.customer.lastName,
-            email: node.customer.email || null,
-          }
-        : null;
-
-    const lineItems = (node.lineItems?.edges ?? []).map((edge) => ({
-      name: edge.node.name,
-      quantity: edge.node.quantity,
-      price: (edge.node.originalUnitPriceSet?.shopMoney?.amount as string | undefined) ?? '0.00',
-    }));
-
-    void store;
-    void normalizedOrderName;
-
-    return {
-      id: node.id,
-      legacy_id: String(node.legacyResourceId ?? ''),
-      order_number: node.number,
-      name: String(node.name ?? ''),
-      financial_status:
-        typeof node.displayFinancialStatus === 'string' ? node.displayFinancialStatus : null,
-      fulfillment_status: node.displayFulfillmentStatus,
-      cancelled_at: typeof node.cancelledAt === 'string' ? node.cancelledAt : null,
-      cancel_reason: typeof node.cancelReason === 'string' ? node.cancelReason : null,
-      created_at: node.createdAt,
-      customer,
-      total_price: totalPrice,
-      subtotal_price: subtotalPrice,
-      shipping_total:
-        (node.currentShippingPriceSet?.shopMoney?.amount as string | undefined) ?? '0.00',
-      currency: (node.currentTotalPriceSet?.shopMoney?.currencyCode as string | undefined) ?? '',
-      discount_codes: Array.isArray(node.discountCodes) ? (node.discountCodes as string[]) : [],
-      line_items: lineItems,
-    };
-  }
-
   async fetch(
     operation: string,
     params: Record<string, unknown>,
     _config: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<ServiceResponse> {
-    // config.auth is ignored — auth is set at construction time via stores map
-
-    if (operation === 'get_order') {
-      // Validate store param
+    if (operation === 'query') {
+      // Validate store
       const store = params['store'];
-      if (typeof store !== 'string') {
-        throw new WorkflowError('ShopifyAdapter: store param must be a string', {
+      if (typeof store !== 'string' || store === '') {
+        throw new WorkflowError('ShopifyAdapter: store param must be a non-empty string', {
           code: 'ADAPTER_VALIDATION_FAILED',
           category: 'ENGINE',
           agentAction: 'provide_input',
@@ -430,10 +216,10 @@ export class ShopifyAdapter implements ServiceAdapter {
         });
       }
 
-      // Validate order_name
-      const rawOrderName = params['order_name'];
-      if (typeof rawOrderName !== 'string' || rawOrderName === '') {
-        throw new WorkflowError('ShopifyAdapter: order_name param must be a non-empty string', {
+      // Validate query
+      const query = params['query'];
+      if (typeof query !== 'string' || query === '') {
+        throw new WorkflowError('ShopifyAdapter: query param must be a non-empty string', {
           code: 'ADAPTER_VALIDATION_FAILED',
           category: 'ENGINE',
           agentAction: 'provide_input',
@@ -441,22 +227,16 @@ export class ShopifyAdapter implements ServiceAdapter {
         });
       }
 
-      // Normalize order_name
-      let normalizedOrderName = rawOrderName.trim();
-      if (!normalizedOrderName.startsWith('#')) {
-        normalizedOrderName = '#' + normalizedOrderName;
-      }
-      if (!/^#.+$/.test(normalizedOrderName)) {
-        throw new WorkflowError('ShopifyAdapter: order_name is invalid after normalization', {
-          code: 'ADAPTER_VALIDATION_FAILED',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-        });
-      }
+      // Variables are optional — no validation, passed through as-is
+      const variables = params['variables'];
 
       const base = this.baseUrlOverride ?? `https://${storeConfig.shop_domain}`;
       const url = `${base}/admin/api/${this.apiVersion}/graphql.json`;
+
+      const requestBody: Record<string, unknown> = { query };
+      if (variables !== undefined && variables !== null) {
+        requestBody['variables'] = variables;
+      }
 
       const requestOptions: RequestInit = {
         method: 'POST',
@@ -465,22 +245,18 @@ export class ShopifyAdapter implements ServiceAdapter {
           'Content-Type': 'application/json',
           Accept: 'application/json',
         },
-        body: JSON.stringify({
-          query: ORDERS_BY_NAME_QUERY,
-          variables: { query: `name:${normalizedOrderName}` },
-        }),
+        body: JSON.stringify(requestBody),
       };
 
       const response = await this.executeRequest(url, requestOptions, signal);
 
       if (!response.ok) {
-        await this.throwHttpError(response, 'get_order');
+        await this.throwHttpError(response, 'query');
       }
 
-      // Parse JSON response
-      let gqlBody: unknown;
+      let json: unknown;
       try {
-        gqlBody = await response.json();
+        json = await response.json();
       } catch {
         throw new WorkflowError('ShopifyAdapter: failed to parse GraphQL response', {
           code: 'SERVICE_RESPONSE_INVALID',
@@ -490,9 +266,8 @@ export class ShopifyAdapter implements ServiceAdapter {
         });
       }
 
-      const body = gqlBody as Record<string, unknown>;
-
-      // Check for GraphQL errors
+      // Throw only on THROTTLED — all other GraphQL errors pass through to the caller
+      const body = json as Record<string, unknown>;
       if (Array.isArray(body['errors']) && (body['errors'] as unknown[]).length > 0) {
         const errors = body['errors'] as Array<Record<string, unknown>>;
         const firstError = errors[0] as Record<string, unknown> | undefined;
@@ -506,50 +281,9 @@ export class ShopifyAdapter implements ServiceAdapter {
             retry_after: 2,
           });
         }
-        throw new WorkflowError('ShopifyAdapter: GraphQL errors in response', {
-          code: 'SERVICE_RESPONSE_INVALID',
-          category: 'SERVICE',
-          agentAction: 'report_to_user',
-          retryable: false,
-          details: { errors: body['errors'] },
-        });
       }
 
-      // Validate edges shape
-      const data = body['data'] as Record<string, unknown> | undefined;
-      const orders = data?.['orders'] as Record<string, unknown> | undefined;
-      const edges = orders?.['edges'];
-      if (!Array.isArray(edges)) {
-        throw new WorkflowError('ShopifyAdapter: unexpected response shape — edges not an array', {
-          code: 'SERVICE_RESPONSE_INVALID',
-          category: 'SERVICE',
-          agentAction: 'report_to_user',
-          retryable: false,
-        });
-      }
-
-      if (edges.length === 0) {
-        throw new WorkflowError('ShopifyAdapter: order not found', {
-          code: 'SERVICE_NOT_FOUND',
-          category: 'SERVICE',
-          agentAction: 'provide_input',
-          retryable: false,
-          details: { store, order_name: normalizedOrderName },
-        });
-      }
-
-      if (edges.length > 1) {
-        throw new WorkflowError('ShopifyAdapter: unexpected multiple edges for first:1 query', {
-          code: 'SERVICE_RESPONSE_INVALID',
-          category: 'SERVICE',
-          agentAction: 'report_to_user',
-          retryable: false,
-        });
-      }
-
-      const edge = edges[0] as { node: ShopifyOrderNode };
-      const normalizedOrder = this.normalizeOrder(edge.node, store, normalizedOrderName);
-      return { status: 200, data: normalizedOrder };
+      return { status: response.status, data: json };
     }
 
     throw new WorkflowError(`ShopifyAdapter: unsupported fetch operation '${operation}'`, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,10 +69,7 @@ export type { SlackAdapterConfig } from './adapters/slack-adapter.js';
 export { GorgiasAdapter } from './adapters/gorgias-adapter.js';
 export type { GorgiasAdapterConfig } from './adapters/gorgias-adapter.js';
 export { ShopifyAdapter } from './adapters/shopify-adapter.js';
-export type {
-  ShopifyAdapterConfig,
-  NormalizedOrder as ShopifyNormalizedOrder,
-} from './adapters/shopify-adapter.js';
+export type { ShopifyAdapterConfig } from './adapters/shopify-adapter.js';
 export { ParcelPanelAdapter } from './adapters/parcelpanel-adapter.js';
 export type {
   ParcelPanelAdapterConfig,


### PR DESCRIPTION
## Context

ShopifyAdapter previously hardcoded a `get_order` operation with `ORDERS_BY_NAME_QUERY`, field-selection, type coercion, and a `NormalizedOrder` output shape. This caused the same data-stripping problems identified in the ParcelPanel overhaul: adapters should be thin transports, not opinionated transformers.

## Motivation

Callers need to issue arbitrary Shopify Admin GraphQL queries — product lookups, metafield reads, customer data — none of which the old `get_order` operation could serve. Removing the normalization layer also eliminates a class of bugs where missing or renamed fields in the GraphQL response silently threw `SERVICE_RESPONSE_INVALID` rather than passing data through.

## Changes

### Deleted

- `ORDERS_BY_NAME_QUERY` constant (~45 lines) — hardcoded GQL query no longer needed
- `NormalizedOrder` exported interface (~44 lines) — caller now receives raw GQL body
- `ShopifyOrderNode` private interface (~39 lines) — used only by the deleted normalizer
- `normalizeOrder()` private method (~97 lines) — field extraction, type guards, dead `void` calls
- `get_order` operation block (~143 lines) — replaced entirely

### Added

- `fetch('query', { store, query, variables? })` operation — POST to `/admin/api/{version}/graphql.json` with the caller-supplied query string and optional variables
- Explicit 403 handler in `throwHttpError()` — `SERVICE_HTTP_4XX`, `agentAction: 'stop'`, matches GorgiasAdapter and ParcelPanelAdapter patterns
- THROTTLED-only GraphQL error gate — only `extensions.code === 'THROTTLED'` throws `SERVICE_RATE_LIMITED`; all other GraphQL errors (partial data, field errors) pass through as raw response body

### `index.ts`

Removed `NormalizedOrder as ShopifyNormalizedOrder` re-export. `ShopifyAdapter` and `ShopifyAdapterConfig` remain exported.

### Net size

- `shopify-adapter.ts`: 593 → 327 lines (−266)
- `shopify-adapter.test.ts`: 482 → 417 lines (−65, new describe blocks added)

## Verification

```bash
# Deleted symbols gone
grep -c "NormalizedOrder" packages/core/src/adapters/shopify-adapter.ts   # 0
grep -c "normalizeOrder"  packages/core/src/adapters/shopify-adapter.ts   # 0
grep -c "ORDERS_BY_NAME_QUERY" packages/core/src/adapters/shopify-adapter.ts # 0
grep -c "ShopifyOrderNode" packages/core/src/adapters/shopify-adapter.ts  # 0
grep -c "get_order"       packages/core/src/adapters/shopify-adapter.ts   # 0
grep -c "NormalizedOrder" packages/core/src/index.ts                      # 0

# New symbols present
grep -n "operation === 'query'" packages/core/src/adapters/shopify-adapter.ts  # 1 match
grep -n "status === 403"        packages/core/src/adapters/shopify-adapter.ts  # 1 match

# Test suite
npm test --workspace=packages/core
# Tests  1178 passed (1178), 0 skipped

# Build
npm run build --workspace=packages/core
# exit 0

# Lint
npm run lint --workspace=packages/core
# exit 0
```

## Rollback

```bash
git revert HEAD
```

No database writes or external API calls — revert is clean.

## Related

Follows the same overhaul pattern applied to ParcelPanelAdapter (PRs #80, #81).
