### PR TITLE
release: v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here.
 
 ---
 
+## [0.6.4] — 2026-06-17
+
+### Changed
+
+- **ShopifyAdapter — GraphQL passthrough** — the previous `fetch('get_order', { store, order_name })` operation performed a fixed query (`ORDERS_BY_NAME_QUERY`), selected specific fields, and returned a normalised `NormalizedOrder` object. Replaced with a single `fetch('query', { store, query, variables? })` operation that accepts any GraphQL query or mutation string and returns the raw GraphQL response body. The caller owns all field selection; the adapter handles authentication, store routing, and error classification only.
+
+### Removed
+
+- **`ShopifyNormalizedOrder` exported type removed** — callers who were typing `result.data as ShopifyNormalizedOrder` should switch to a locally defined type that matches the fields they request in their own query.
+- **`get_order` operation removed** — replaced by `fetch('query', { store, query, variables? })`. Callers who were using `get_order` should rewrite the step to pass the `ORDERS_BY_NAME_QUERY` (or any query of their choice) as the `query` param.
+
+### Added
+
+- **Adapter reference documentation** — `docs/reference/adapters.md` now documents all seven shipped adapters. Four new sections added: `GorgiasAdapter` (10 operations), `ParcelPanelAdapter` (2 operations), `ShopifyAdapter` (1 GraphQL passthrough operation), `NotionAdapter` (8 operations). Each section covers constructor config, YAML declaration, per-operation param tables, and an error classification table.
+
+---
+
 ## [0.6.3] — 2026-06-16
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.6.3');
+program.name('realm').description('Realm workflow engine CLI').version('0.6.4');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.6.3';
+export const VERSION = '0.6.4';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.6.3';
+export const VERSION = '0.6.4';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.6.3',
+    version: '0.6.4',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.6.3';
+export const VERSION = '0.6.4';


### PR DESCRIPTION
## Summary

- ShopifyAdapter full overhaul: replaced `get_order` + `NormalizedOrder` with a single `fetch('query', { store, query, variables? })` GraphQL passthrough operation. The caller provides the complete query string; the adapter owns only auth, store routing, and error classification.
- Adapter reference documentation: added four new sections to `docs/reference/adapters.md` — GorgiasAdapter (10 operations), ParcelPanelAdapter (2 operations), ShopifyAdapter (1 GraphQL passthrough operation), NotionAdapter (8 operations).

## Breaking changes

- `ShopifyNormalizedOrder` exported type removed. Callers should define a local type matching the fields they request.
- `get_order` operation removed. Callers should migrate to `fetch('query', { store, query, variables? })` passing their own query string.

## Test plan

- [ ] CI passes on this PR (TypeScript, lint, core test suite)
- [ ] `npm run build --workspace=packages/core` exits 0
- [ ] Core test suite: 1178 passed, 0 skipped
- [ ] `grep -c "ShopifyNormalizedOrder\|NormalizedOrder\|get_order" packages/core/src/adapters/shopify-adapter.ts` returns 0
- [ ] `grep -c "operation === 'query'" packages/core/src/adapters/shopify-adapter.ts` returns 1
- [ ] `grep -c "## GorgiasAdapter\|## ParcelPanelAdapter\|## ShopifyAdapter\|## NotionAdapter" docs/reference/adapters.md` returns 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
