### PR TITLE
chore(deps): clear HIGH npm-audit advisory in hono (lockfile-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2633,9 +2633,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4543,7 +4553,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.4.0",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4594,7 +4604,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.4.0",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -4639,7 +4649,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.4.0",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4660,7 +4670,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.4.0",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",


### PR DESCRIPTION
## Context

`npm audit --omit=dev --audit-level=high` exits 1 with a **HIGH** advisory in `hono` (installed `4.12.23`; [GHSA-wwfh-h76j-fc44](https://github.com/advisories/GHSA-wwfh-h76j-fc44) path traversal in `serve-static`, plus four related advisories), reachable via the published tree `@sensigo/realm-cli → @modelcontextprotocol/sdk@1.29.0 → @hono/node-server → hono`. A MODERATE `js-yaml` advisory (`4.1.1`) is also present.

This is **pre-existing and unrelated to the webhook feature** (PR #87 changed no dependencies — `main` is already in this state). It does not block PR #87, but the release process requires a clean `npm audit --audit-level=high` before the **0.7.0** tag, so it is fixed here as its own standalone change.

## Root Cause

`@modelcontextprotocol/sdk@1.29.0` transitively pulls `hono@4.12.23` via `@hono/node-server`. The advisory is fixed in `hono > 4.12.24`, and the SDK's declared `hono` range already permits the fixed version — so the vulnerable version was only pinned by a stale lockfile entry, not by any `package.json` constraint.

## Changes

`npm audit fix` (no `--force`) — re-resolved the lockfile within existing semver ranges. **`package-lock.json` only**; no `package.json` change, no source change.

- `hono`: `4.12.23` → `4.12.26` (clears the HIGH advisory)
- `js-yaml`: `4.1.1` → `4.2.0` (clears the MODERATE advisory in the same pass — also non-breaking)
- `@modelcontextprotocol/sdk` stays pinned at `1.29.0` (no SDK bump needed; no MCP surface change).

No breaking `--force` fix was required, so the STOP-and-report path (reserved for a breaking SDK major) did not apply.

## Verification

```bash
npm audit --omit=dev --audit-level=high
# → found 0 vulnerabilities (exit 0)

npm run build --workspace=packages/core && npm run build --workspace=packages/cli && npm run build --workspace=packages/mcp-server
# → all exit 0

npm run test  --workspace=packages/core && npm run test  --workspace=packages/cli && npm run test  --workspace=packages/mcp-server
# → core 1178 passed · cli 284 passed · mcp-server 72 passed (the 72 mcp-server tests exercise the @modelcontextprotocol/sdk path)

npm run lint  --workspace=packages/core && npm run lint  --workspace=packages/cli && npm run lint  --workspace=packages/mcp-server
# → all exit 0

git diff --stat   # package-lock.json only (+20 / -10); no source, no package.json
```

## Rollback

```bash
git revert HEAD   # restores the prior lockfile
```

Lockfile-only; a plain revert fully restores the previous dependency resolution. No data or external state involved.

## Related

Independent of PR #87 (`feat/webhook-listen`). Clears the last pre-`0.7.0`-tag audit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
