### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
-
-> Planned version: **0.7.0** — the `realm webhook` removal is a breaking change; under SemVer 0.x the breaking signal is the minor segment.
+## [0.7.0] — 2026-06-21
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.6.4');
+program.name('realm').description('Realm workflow engine CLI').version('0.7.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.6.4';
+export const VERSION = '0.7.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.6.4';
+export const VERSION = '0.7.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.6.4',
+    version: '0.7.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.6.4';
+export const VERSION = '0.7.0';


### PR DESCRIPTION
## Context

Release PR for **v0.7.0**, cut after PR #87 (the `realm listen` webhook feature) merged to `main` and the pre-existing `hono`/`js-yaml` audit findings were cleared on `main` by Dependabot (#78, #79). Created 2026-06-21 per the release process in `.github/instructions/pre-publication.instructions.md` (Part B).

## Motivation

`[Unreleased]` accumulated a user-facing feature addition **and** a breaking change (the `realm webhook` command was removed), so a version must be cut to publish them to npm. Per SemVer's 0.x rule a breaking change bumps the **minor** segment → `0.6.4 → 0.7.0`.

## Changes

This PR contains only the release mechanics (the feature itself landed in #87):

- **`CHANGELOG.md`** — renamed `## [Unreleased]` → `## [0.7.0] — 2026-06-21`. The entry records:
  - **Added:** `realm listen` general-purpose webhook server; the workflow `trigger:` block (`auth` modes `shared_secret`/`github`/`stripe`/`hmac`/`none`, optional `filter`/`dedup`/`params_map`); new exported types (`WebhookTrigger`, `TriggerDefinition`, `WebhookAuth` + members, `FilterCondition`, `TriggerFilter`, `DedupConfig`); new `RunRecord` fields `agent_pid`/`agent_started_at`.
  - **Removed:** the GitHub-only `realm webhook` command (now an erroring alias → `realm listen`) and the duplicate `checkWebhookSignature` helper.
- **Version bump to `0.7.0`** across the four published packages (`@sensigo/realm`, `@sensigo/realm-cli`, `@sensigo/realm-mcp`, `@sensigo/realm-testing`) and the five source `VERSION` constants, via `npm run release -- --version 0.7.0` (commit `chore: release v0.7.0`).

The release commit is tagged `v0.7.0` on this branch; **this PR must be merged with a merge commit** (not rebase/squash) so the tagged commit stays reachable from `main` and `publish.yml` resolves it.

## Verification

```bash
npm run build --workspace=packages/core && npm run build --workspace=packages/cli \
  && npm run build --workspace=packages/mcp-server && npm run build --workspace=packages/testing   # all exit 0
npm run test  --workspace=packages/core    # 1223 passed
npm run test  --workspace=packages/cli     # 346 passed
npm run lint  --workspace=packages/core && npm run lint --workspace=packages/cli   # exit 0
npm audit --omit=dev --audit-level=high    # found 0 vulnerabilities

# Version bump landed on all four published packages + the tag exists:
grep '"version"' package.json packages/*/package.json | grep -v node_modules   # all 0.7.0
git tag -l v0.7.0                          # v0.7.0, on the release commit
```

## Rollback

Before the tag is pushed nothing is published — close this PR and delete the `release/v0.7.0` branch + `v0.7.0` tag. After merge but before `git push --tags`:

```bash
git revert -m 1 <merge-commit-sha>                       # undo the release merge on main
git tag -d v0.7.0 && git push origin :refs/tags/v0.7.0   # remove the tag if pushed
```

If the tag has already been pushed and `publish.yml` has published to npm, packages cannot be unpublished after 72h — roll forward with a `0.7.1` patch release (Part B step 8) rather than attempting to unpublish.

## Related

Releases the webhook feature merged in #87. Audit findings cleared by Dependabot #78 / #79 (#88 closed as redundant).
