### PR TITLE
chore(ci): bump actions to v5, drop invalid setup-node input, fix ESM verify snippet

### DIFF
--- a/.github/instructions/pre-publication.instructions.md
+++ b/.github/instructions/pre-publication.instructions.md
@@ -133,13 +133,13 @@ Go to https://github.com/sensigo-hq/realm/actions and confirm the **Publish** wo
 
 **7. Verify the published artifact**
 
-Install the package in a clean environment and confirm the minimal working example from the README runs correctly:
+Install the package in a clean environment and confirm the minimal working example from the README runs correctly. `@sensigo/realm` is **ESM-only**, so verify with an ESM `import` — `require()` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`:
 
 ```bash
 mkdir /tmp/test-install && cd /tmp/test-install
 npm init -y
 npm install @sensigo/realm@<version>
-node -e "const { VERSION } = require('@sensigo/realm'); console.log(VERSION);"
+node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"
 ```
 
 **8. Rollback note**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     env:
       TURBO_TELEMETRY_DISABLED: '1'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Analyse TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initialise CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,14 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false # never cache in release builds
+          # `cache` is intentionally unset — setup-node only caches when `cache` is
+          # provided, so release builds run uncached without any extra input.
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Context

Post-release hygiene surfaced during the v0.7.0 release (executed 2026-06-21). The `publish.yml` run for `v0.7.0` succeeded but emitted two annotations, and the pre-publication checklist's artifact-verification snippet was found to be wrong for the (ESM-only) published package. None blocked the release; this PR cleans them up so the next release is annotation-free and the checklist is runnable as written.

## Motivation

- **Node-20 action deprecation:** GitHub is force-running `actions/checkout@v4` / `actions/setup-node@v4` on Node 24 and warns they target the deprecated Node 20. The v5 majors target Node 24 natively — bumping removes the warning and future-proofs CI before the actions are dropped.
- **Invalid `setup-node` input:** `publish.yml` passed `package-manager-cache: false`, which is not a valid `actions/setup-node` input (it was silently ignored, emitting an "Unexpected input(s)" annotation). The intent ("never cache in release builds") is already the default — `setup-node` only caches when `cache:` is set.
- **Broken verify snippet:** the pre-publication checklist's step-7 artifact check uses `require('@sensigo/realm')`, but the package is ESM-only, so it throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. Anyone following the checklist verbatim hits an error verifying a perfectly-good publish (as happened during v0.7.0).

## Changes

- **`.github/workflows/publish.yml`** — `actions/checkout@v4→v5`, `actions/setup-node@v4→v5`; removed the invalid `package-manager-cache: false` line and replaced it with a comment explaining that omitting `cache` is what keeps release builds uncached (no behaviour change — caching was already off).
- **`.github/workflows/ci.yml`** — `actions/checkout@v4→v5`, `actions/setup-node@v4→v5` (keeps `node-version: '24'` + `cache: 'npm'`).
- **`.github/workflows/codeql.yml`** — `actions/checkout@v4→v5`.
- **`.github/instructions/pre-publication.instructions.md`** (step 7) — verify snippet changed from `node -e "...require('@sensigo/realm')..."` to `node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"`, with a note that the package is ESM-only.

No source/test/published-package changes; OIDC trusted-publishing config (`id-token: write`, `registry-url`) is untouched.

## Verification

```bash
# Workflow YAML is well-formed:
for f in publish ci codeql; do python3 -c "import yaml; yaml.safe_load(open('.github/workflows/$f.yml')); print('$f ok')"; done

# No deprecated action versions / invalid input remain:
grep -rn 'actions/checkout@v4\|actions/setup-node@v4\|package-manager-cache' .github/workflows/   # (no matches)

# The corrected step-7 snippet works against the published 0.7.0 (verified):
mkdir /tmp/ti && cd /tmp/ti && npm init -y && npm install @sensigo/realm@0.7.0
node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"   # → 0.7.0
```

`ci.yml` and `codeql.yml` changes are exercised by this PR's own CI run; `publish.yml` runs only on a `v*` tag, so its identical `@v5` bump is validated by YAML correctness + the CI run proving `setup-node@v5` works, and will be exercised at the next release.

## Rollback

```bash
git revert HEAD
```

Workflow/doc-only; no source, no migration, no published artifact affected. Reverting restores the prior action versions and the old snippet.

## Related

Follow-up to the v0.7.0 release (#89). Addresses the annotations from publish run on tag `v0.7.0`.
