### PR TITLE
fix(engine): guard terminal runs from re-drive and make resume functional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Terminal runs are no longer re-driven or un-aborted when re-encountered through an idempotency key.** `findEligibleSteps` and `findEligibleGuardSteps` now return no eligible steps for a run in a terminal state, so `start_run` / `start_run_batch` are a clean no-op on an already-processed run (previously a terminal aborted run could be silently re-driven via a permanent idempotency-key match, corrupting it on disk).
+- **`deriveRunPhase` now treats `aborted_at` as authoritative.** An aborted run can no longer revert to `running` (or be silently reclassified as `completed`) if a write-path recomputes `terminal_state` while the record still carries `aborted_at`.
+- **`realm resume` now actually re-enables a failed run for re-execution.** It resets the run to `running`, re-derives skipped steps, and clears the terminal reason, so the run can be driven with `realm agent --run-id <id>`. Previously it only edited `failed_steps`, leaving the run terminal and un-runnable.
+
+---
+
 ## [0.7.0] — 2026-06-21
 
 ### Added

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -9,8 +9,21 @@ import {
   JsonWorkflowStore,
   WorkflowError,
   CURRENT_WORKFLOW_SCHEMA_VERSION,
+  findEligibleSteps,
 } from '@sensigo/realm';
 import type { WorkflowDefinition } from '@sensigo/realm';
+
+/** Two-step workflow (step-a → step-b) — used to prove skipped_steps re-derivation on resume. */
+const redriveWorkflow: WorkflowDefinition = {
+  id: 'resume-redrive-wf',
+  name: 'Resume Re-drive Workflow',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    'step-a': { description: 'First step', execution: 'agent' },
+    'step-b': { description: 'Second step', execution: 'agent', depends_on: ['step-a'] },
+  },
+};
 
 const testWorkflow: WorkflowDefinition = {
   id: 'resume-test-wf',
@@ -103,5 +116,35 @@ describe('resumeRun', () => {
     await expect(resumeRun(run.id, 'nonexistent-step', runStore, workflowStore)).rejects.toThrow(
       'not found',
     );
+  });
+
+  it('re-drives a failed run: resets to running, clears terminal_reason, re-derives skipped_steps, re-enables the step', async () => {
+    await workflowStore.register(redriveWorkflow);
+    const run = await runStore.create({
+      workflowId: 'resume-redrive-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    // step-a failed → step-b was skipped (all_success can no longer be satisfied) → run terminal failed.
+    await runStore.update({
+      ...run,
+      run_phase: 'failed',
+      failed_steps: ['step-a'],
+      skipped_steps: ['step-b'],
+      terminal_state: true,
+      terminal_reason: 'step-a failed',
+    });
+
+    await resumeRun(run.id, 'step-a', runStore, workflowStore);
+
+    const resumed = await runStore.get(run.id);
+    expect(resumed.terminal_state).toBe(false);
+    expect(resumed.run_phase).toBe('running');
+    expect(resumed.failed_steps).not.toContain('step-a');
+    expect(resumed.terminal_reason).toBeUndefined();
+    // step-b was skipped only because step-a failed — re-derived away now that step-a is re-enabled.
+    expect(resumed.skipped_steps).not.toContain('step-b');
+    // The re-enabled step is now eligible (proving the run is genuinely runnable again).
+    expect(findEligibleSteps(redriveWorkflow, resumed)).toContain('step-a');
   });
 });

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import type { RunStore } from '@sensigo/realm';
 import type { WorkflowRegistrar } from '@sensigo/realm';
 import { WorkflowError } from '@sensigo/realm';
-import { RESUMABLE_PHASES } from '@sensigo/realm';
+import { RESUMABLE_PHASES, propagateSkips } from '@sensigo/realm';
 
 /**
  * Removes `stepName` from `failed_steps` so the DAG engine can re-evaluate its
@@ -54,9 +54,23 @@ export async function resumeRun(
     });
   }
 
+  // Re-enable the failed step AND make the run runnable again. Filtering failed_steps alone leaves
+  // the run terminal (terminal_state:true), so `realm agent --run-id` throws on it and the
+  // `while (!terminal_state)` drivers skip it. Mirror the test-harness reference: strip
+  // terminal_reason (destructure-and-omit to honour exactOptionalPropertyTypes), re-derive
+  // skipped_steps from scratch so steps skipped only because of this failure become eligible again,
+  // and reset terminal_state to false. update() recomputes run_phase → 'running'.
+  const { terminal_reason: _terminalReason, ...rest } = run;
+  const failedSteps = rest.failed_steps.filter((s) => s !== stepName);
+  const skippedSteps = propagateSkips(
+    { ...rest, failed_steps: failedSteps, skipped_steps: [] as string[] },
+    workflow,
+  );
   await runStore.update({
-    ...run,
-    failed_steps: run.failed_steps.filter((s) => s !== stepName),
+    ...rest,
+    failed_steps: failedSteps,
+    skipped_steps: skippedSteps,
+    terminal_state: false,
   });
 }
 
@@ -70,7 +84,10 @@ export const resumeCommand = new Command('resume')
     const workflowStore = new JsonWorkflowStore();
     try {
       await resumeRun(runId, opts.from, runStore, workflowStore);
-      console.log(`Resumed: step '${opts.from}' removed from failed_steps on run '${runId}'.`);
+      console.log(
+        `Resumed run '${runId}': step '${opts.from}' re-enabled and run reset to 'running'.\n` +
+          `Drive it with: realm agent --run-id ${runId}`,
+      );
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/core/src/engine/eligibility.test.ts
+++ b/packages/core/src/engine/eligibility.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   findEligibleSteps,
+  findEligibleGuardSteps,
   triggerRuleSatisfied,
   evaluateWhenCondition,
   deriveRunPhase,
@@ -741,5 +742,106 @@ describe('claimStep — double-claim prevention', () => {
     });
 
     await expect(store.claimStep(run.id, 'step-a', definition)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue-2: terminal-run eligibility guard
+// ---------------------------------------------------------------------------
+
+describe('findEligibleSteps / findEligibleGuardSteps — terminal-run guard', () => {
+  it('returns no eligible steps for a terminal aborted run (none_failed downstream of a skipped dep)', () => {
+    // Reproduces the bug shape: a guard aborted the run; its downstream none_failed step has only a
+    // *skipped* (not failed) dependency, so pre-fix it was returned eligible and re-executed.
+    const wf = makeWorkflow({
+      guard_step: { execution: 'agent' },
+      downstream: { execution: 'agent', depends_on: ['guard_step'], trigger_rule: 'none_failed' },
+    });
+    const abortedRun = makeRun({
+      terminal_state: true,
+      run_phase: 'aborted',
+      aborted_at: { step_id: 'guard_step' },
+      skipped_steps: ['guard_step'], // aborting step skipped, NOT failed
+      // 'downstream' left unsettled — none_failed is satisfied (no failed dep), so pre-fix eligible
+    });
+    expect(findEligibleSteps(wf, abortedRun)).toEqual([]);
+  });
+
+  it('returns no eligible guard steps for a terminal aborted run', () => {
+    const wf = makeWorkflow({
+      check: { execution: 'guard', abort_unless: ['ctx.ok'] },
+    });
+    const abortedRun = makeRun({
+      terminal_state: true,
+      run_phase: 'aborted',
+      aborted_at: { step_id: 'other' },
+      // 'check' guard unsettled — pre-fix it would be returned eligible
+    });
+    expect(findEligibleGuardSteps(wf, abortedRun)).toEqual([]);
+  });
+
+  it('still returns eligible steps for a non-terminal (running) run (guard does not over-fire)', () => {
+    const wf = makeWorkflow({ open_step: { execution: 'agent' } });
+    const runningRun = makeRun({ terminal_state: false, run_phase: 'running' });
+    expect(findEligibleSteps(wf, runningRun)).toEqual(['open_step']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue-2: deriveRunPhase — aborted_at is authoritative
+// ---------------------------------------------------------------------------
+
+describe('deriveRunPhase — aborted_at precedence (Issue-2)', () => {
+  const aborted = { step_id: 'guard_step' };
+
+  it('a record carrying aborted_at with terminal_state:false derives back to aborted (the fix)', () => {
+    expect(deriveRunPhase(makeRun({ terminal_state: false, aborted_at: aborted }))).toBe('aborted');
+  });
+
+  it("aborted_at outranks a stale 'Workflow completed.' reason", () => {
+    expect(
+      deriveRunPhase(
+        makeRun({
+          terminal_state: true,
+          aborted_at: aborted,
+          terminal_reason: 'Workflow completed.',
+        }),
+      ),
+    ).toBe('aborted');
+  });
+
+  // Regression matrix — every normal derivation is unchanged by the reorder.
+  it('normal aborted run is unchanged', () => {
+    expect(
+      deriveRunPhase(
+        makeRun({ terminal_state: true, aborted_at: aborted, terminal_reason: 'guard aborted' }),
+      ),
+    ).toBe('aborted');
+  });
+  it('completed (no aborted_at) is unchanged', () => {
+    expect(
+      deriveRunPhase(makeRun({ terminal_state: true, terminal_reason: 'Workflow completed.' })),
+    ).toBe('completed');
+  });
+  it('failed (no aborted_at) is unchanged', () => {
+    expect(deriveRunPhase(makeRun({ terminal_state: true, failed_steps: ['s'] }))).toBe('failed');
+  });
+  it('abandoned (no aborted_at) is unchanged', () => {
+    expect(deriveRunPhase(makeRun({ terminal_state: true }))).toBe('abandoned');
+  });
+  it('running (no aborted_at) is unchanged', () => {
+    expect(deriveRunPhase(makeRun({ terminal_state: false }))).toBe('running');
+  });
+  it('gate_waiting outranks everything', () => {
+    const gate: PendingGate = {
+      gate_id: 'g1',
+      step_name: 'review',
+      preview: {},
+      choices: ['approve', 'reject'],
+      opened_at: '2024-01-01T00:00:00.000Z',
+    };
+    expect(
+      deriveRunPhase(makeRun({ pending_gate: gate, terminal_state: false, aborted_at: aborted })),
+    ).toBe('gate_waiting');
   });
 });

--- a/packages/core/src/engine/eligibility.ts
+++ b/packages/core/src/engine/eligibility.ts
@@ -21,12 +21,18 @@ export function deriveRunPhase(
   >,
 ): RunPhase {
   if (run.pending_gate !== undefined) return 'gate_waiting';
+  // aborted_at is authoritative and is checked before both !terminal_state and the
+  // 'Workflow completed.' check. The only records that carry aborted_at are guard/handler-aborted
+  // runs (always written terminal_state:true); legitimately resumable runs (failed/abandoned) never
+  // carry it. Promoting this branch means an aborted run can never revert to 'running' if a
+  // write-path recomputes terminal_state while the record still carries aborted_at, and a stale
+  // success reason can never mask an abort — while every normal derivation is unchanged.
+  if (run.aborted_at !== undefined) return 'aborted';
   if (!run.terminal_state) return 'running';
   // A terminal run that completed successfully sets terminal_reason to 'Workflow completed.'.
   // Recovery workflows end with failed_steps non-empty but are still considered completed
-  // when the final recovery step succeeds, so terminal_reason takes precedence.
+  // when the final recovery step succeeds, so terminal_reason takes precedence over failed_steps.
   if (run.terminal_reason === 'Workflow completed.') return 'completed';
-  if (run.aborted_at !== undefined) return 'aborted';
   if (run.failed_steps.length > 0) return 'failed';
   // terminal_state is true but the run neither completed normally nor failed — it was abandoned.
   return 'abandoned';
@@ -180,6 +186,9 @@ export function buildEvidenceByStep(run: RunRecord): Record<string, Record<strin
  *   - when-condition (if present) is truthy
  */
 export function findEligibleSteps(definition: WorkflowDefinition, run: RunRecord): string[] {
+  // A terminal run has no eligible steps — never re-drive a completed/failed/aborted/abandoned run
+  // (e.g. when re-encountered through an idempotency-key match on start_run/start_run_batch).
+  if (run.terminal_state) return [];
   // Gate serialization: if a gate is open, no new steps are eligible.
   if (run.pending_gate !== undefined) return [];
 
@@ -222,6 +231,9 @@ export function findEligibleSteps(definition: WorkflowDefinition, run: RunRecord
  * not via agent execute_step calls).
  */
 export function findEligibleGuardSteps(definition: WorkflowDefinition, run: RunRecord): string[] {
+  // A terminal run has no eligible guard steps either — symmetric with findEligibleSteps so a
+  // terminal run is never re-driven through the guard surface.
+  if (run.terminal_state) return [];
   if (run.pending_gate !== undefined) return [];
 
   const eligible: string[] = [];

--- a/packages/mcp-server/src/tools/start-run-idempotency-noop.test.ts
+++ b/packages/mcp-server/src/tools/start-run-idempotency-noop.test.ts
@@ -1,0 +1,96 @@
+// Issue-2 headline regression: re-encountering a TERMINAL aborted run through a permanent
+// idempotency key must be a clean no-op — start_run / start_run_batch must NOT re-drive or un-abort it.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore, JsonWorkflowStore, CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
+import type { WorkflowDefinition, RunRecord } from '@sensigo/realm';
+import { handleStartRun } from './start-run.js';
+import { handleStartRunBatch } from './start-run-batch.js';
+
+// guard_step aborts → its downstream `process` (auto, none_failed) has only a *skipped* dependency,
+// so pre-fix start_run found it eligible and re-executed it on the terminal run.
+const workflow: WorkflowDefinition = {
+  id: 'cs1',
+  name: 'CS1',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    guard_step: { description: 'Guard', execution: 'agent', depends_on: [] },
+    process: {
+      description: 'Process',
+      execution: 'auto',
+      depends_on: ['guard_step'],
+      trigger_rule: 'none_failed',
+    },
+  },
+};
+
+const IDEMPOTENCY_KEY = 'cs1-live-12345';
+
+describe('start_run / start_run_batch on a terminal aborted run (idempotency no-op)', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    const runDir = await mkdtemp(join(tmpdir(), 'cs1-run-'));
+    const wfDir = await mkdtemp(join(tmpdir(), 'cs1-wf-'));
+    runStore = new JsonFileStore(runDir);
+    workflowStore = new JsonWorkflowStore(wfDir);
+    await workflowStore.register(workflow);
+  });
+
+  /** Seeds a terminal aborted run carrying the permanent idempotency key. */
+  async function seedAbortedRun(): Promise<RunRecord> {
+    const run = await runStore.create({
+      workflowId: 'cs1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    await runStore.update({
+      ...run,
+      run_phase: 'aborted',
+      terminal_state: true,
+      terminal_reason: "Guard 'guard_step' aborted the run",
+      aborted_at: { step_id: 'guard_step' },
+      skipped_steps: ['guard_step'], // aborting step skipped, NOT failed
+    });
+    return runStore.get(run.id);
+  }
+
+  it('start_run re-encountering the key leaves the run byte-unchanged (no re-drive, no un-abort)', async () => {
+    const before = await seedAbortedRun();
+
+    await handleStartRun(
+      { workflow_id: 'cs1', idempotency_key: IDEMPOTENCY_KEY },
+      { runStore, workflowStore },
+    );
+
+    const after = await runStore.get(before.id);
+    // The invariant (not a specific corrupted phase): the record is untouched.
+    expect(after).toEqual(before);
+    expect(after.run_phase).toBe('aborted');
+    expect(after.terminal_state).toBe(true);
+    expect(after.failed_steps).not.toContain('process'); // downstream NOT re-driven into failed_steps
+    expect(after.version).toBe(before.version); // no write
+  });
+
+  it('start_run_batch re-encountering the key leaves the run byte-unchanged', async () => {
+    const before = await seedAbortedRun();
+
+    const result = await handleStartRunBatch(
+      { workflow_id: 'cs1', items: [{ params: {}, idempotency_key: IDEMPOTENCY_KEY }] },
+      { runStore, workflowStore },
+    );
+
+    // Batch returns the existing run id (deduped) and never drives it.
+    expect(result.started[0]?.run_id).toBe(before.id);
+    const after = await runStore.get(before.id);
+    expect(after).toEqual(before);
+    expect(after.run_phase).toBe('aborted');
+    expect(after.terminal_state).toBe(true);
+    expect(after.version).toBe(before.version);
+  });
+});


### PR DESCRIPTION
## Context

A terminal **aborted** run, when re-encountered through a permanent, mode-agnostic idempotency key (e.g. `cs1-live-{ticket_id}`), was silently un-aborted and re-driven — corrupting it on disk (observed on run `2019a62b`: an aborted run flipped back to `run_phase: running` with a stale `aborted_at` and the previously-skipped downstream step pushed into `failed_steps`). Surfaced via an external engine-fix proposal; root-caused and scoped by the Master Architect (deterministic reads + a 5-agent adversarial workflow against the compiled engine and the real CS1 workflow YAML).

## Root Cause

Two cooperating engine defects, plus a long-standing resume gap:

1. **No terminal guard on the eligibility chokepoint.** `findEligibleSteps` only short-circuited on `pending_gate`. The MCP `start_run` / `start_run_batch` path calls `JsonFileStore.create()` (which returns *any* idempotency-key match regardless of phase) → `findEligibleSteps` → `executeChain` with no phase gate. On a terminal aborted run, a downstream `none_failed` step whose dependencies are *skipped* (not failed) was returned eligible and re-executed. (The interactive CLI drivers self-gate on `while (!terminal_state)`, so only the MCP path was exposed.)
2. **`deriveRunPhase` ordering.** `!terminal_state → 'running'` was evaluated *before* `aborted_at → 'aborted'`, so the dispatch-failure write-path — which rebuilds the record carrying the stale `aborted_at` forward while setting `terminal_state=false` — caused the run to derive back to `'running'`, making the corruption stick.
3. **`realm resume` was a no-op for re-drive.** `resumeRun` only filtered `failed_steps`, leaving `terminal_state: true`; every wired driver refuses a terminal run, so a resumed run could never actually re-execute.

## Changes

**`packages/core/src/engine/eligibility.ts`**
- `findEligibleSteps` and `findEligibleGuardSteps`: add `if (run.terminal_state) return [];` as the first statement, so a terminal run is never re-driven through either surface — `start_run` / `start_run_batch` become a clean no-op on an already-processed run.
- `deriveRunPhase`: move the `aborted_at → 'aborted'` check above both `!terminal_state` and the `'Workflow completed.'` check. An aborted run can no longer revert to `running` (or be silently reclassified as `completed`) if a write-path recomputes `terminal_state` while the record still carries `aborted_at`. `'Workflow completed.'` still precedes `failed_steps`, so recovery-workflow precedence is preserved. Only guard/handler-aborted runs carry `aborted_at` (always written `terminal_state: true`); resumable `failed`/`abandoned` runs never carry it, so no normal derivation changes.

**`packages/cli/src/commands/resume.ts`**
- `resumeRun` now produces a runnable record (mirrors the test-harness reference): strips `terminal_reason` (destructure-and-omit, honouring `exactOptionalPropertyTypes`), re-derives `skipped_steps` from scratch via `propagateSkips` (so steps skipped only because of the failed step become eligible again), and sets `terminal_state: false` — `update()` then recomputes `run_phase → 'running'`. The run can be driven with `realm agent --run-id <id>`. The three pre-existing validations are unchanged. This makes the eligibility guard and resume compose **by construction** rather than by luck.

**`CHANGELOG.md`** — new `## [Unreleased]` with three `### Fixed` entries. No version bump (handled at release).

## Verification

```bash
# Full monorepo suite — all green
npm run test
#   @sensigo/realm        50 files  1234 passed
#   @sensigo/realm-cli    31 files   347 passed
#   @sensigo/realm-testing            47 passed
#   @sensigo/realm-mcp     8 files    74 passed

npm run lint          # exit 0, zero errors/warnings
npm run build         # tsc --build, 4/4 successful
node scripts/check-versions.mjs   # all 0.7.0, no accidental bump
```

Targeted regression coverage added:
- `packages/core/src/engine/eligibility.test.ts` — terminal-run guard on both surfaces; `deriveRunPhase` `aborted_at`-precedence + full regression matrix (normal aborted/completed/failed/abandoned/running/gate_waiting unchanged); non-terminal run still returns its eligible step (guard does not over-fire).
- `packages/cli/src/commands/resume.test.ts` — resume re-drive end-to-end: after resume the run is `running`/`terminal_state:false`, the step is re-eligible via `findEligibleSteps`, `terminal_reason` cleared, downstream skip re-derived.
- `packages/mcp-server/src/tools/start-run-idempotency-noop.test.ts` (new) — headline regression: re-encountering a terminal aborted run via the idempotency key through `handleStartRun` **and** `handleStartRunBatch` leaves the record byte-unchanged (asserts the invariant, not a specific corrupted phase).

## Rollback

```bash
git revert <merge-commit>
```

Pure code change, no out-of-band data mutations — a `git revert` fully restores prior behaviour. (Note: reverting re-exposes the terminal-run re-drive corruption on the MCP `start_run` path.)

## Related

- Follow-up defense-in-depth and product-semantics items deliberately deferred (not addressed here): #91 (`executeChainInternal` entry guard) and #92 (cross-batch idempotency-key semantics).
