### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.7.1] — 2026-06-22
 
 ### Fixed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.7.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.7.1');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.7.0';
+export const VERSION = '0.7.1';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.7.0';
+export const VERSION = '0.7.1';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.7.0',
+    version: '0.7.1',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.7.0';
+export const VERSION = '0.7.1';


### PR DESCRIPTION
## Context

Release **v0.7.1** — patch release cutting the Issue-2 engine correctness fix (PR #93) to npm. All four packages (`@sensigo/realm`, `@sensigo/realm-cli`, `@sensigo/realm-mcp`, `@sensigo/realm-testing`) bumped 0.7.0 → 0.7.1.

## Motivation

PR #93 fixed a terminal-run re-drive corruption (terminal aborted runs silently un-aborted and re-driven via a permanent idempotency-key match) and made `realm resume` functional. These are all `### Fixed` changes with no breaking API surface, so this is a patch bump.

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.7.1] — 2026-06-22`.
- Version bumped to `0.7.1` across all four `package.json` files and the five source `VERSION` constants (via `scripts/release.mjs`).

The release commit `cb7aedd` is tagged `v0.7.1`. **Merge with a merge commit** (not rebase/squash) so the tagged commit's SHA is preserved and reachable from `main` — the publish workflow depends on it.

## Verification

```bash
node scripts/check-versions.mjs   # all 0.7.1, consistent
npm run test                      # full suite green (verified on PR #93 + pre-release)
```

After merge + tag push, `publish.yml` builds and publishes all four packages to npm via OIDC trusted publishing. Post-publish:

```bash
mkdir /tmp/test-071 && cd /tmp/test-071 && npm init -y
npm install @sensigo/realm@0.7.1
node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"  # 0.7.1
```

## Rollback

If the publish workflow fails partway, re-push the tag (already-published packages skip with `EPUBLISHCONFLICT`). If a published artifact is broken, cut a patch release (0.7.2) following the same Part B sequence.

## Related

Cuts PR #93 to npm. Deferred follow-ups tracked in #91, #92.
