### PR TITLE
fix(engine): guard executeChain entry against terminal runs (defense-in-depth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Defense-in-depth: `executeChain` now no-ops on an already-terminal run.** When invoked for a run whose phase is terminal (`completed`/`failed`/`aborted`/`abandoned`), `executeChain` returns immediately without executing a step or writing the store, instead of attempting to drive it. This is unreachable in normal operation — the eligibility guard added in 0.7.1 already prevents it — and has no observable effect on valid workflows; it hardens the chain boundary so the "terminal runs are never driven" invariant holds at the structural boundary regardless of how a caller reaches `executeChain`.
+
+---
+
 ## [0.7.1] — 2026-06-22
 
 ### Fixed

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -4402,3 +4402,89 @@ describe('_debug stripping on direct auto-step invocation', () => {
     expect(snap?.debug_output).toBe('note');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #91: executeChain terminal-run entry guard (defense-in-depth)
+// ---------------------------------------------------------------------------
+
+describe('executeChain — terminal-run entry guard (#91)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-chain-entry-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  it('is a byte-unchanged no-op on a terminal aborted run (no step claimed)', async () => {
+    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      run_phase: 'aborted',
+      terminal_state: true,
+      terminal_reason: "Guard 'g' aborted the run",
+      aborted_at: { step_id: 'step-one' },
+    });
+    const before = await store.get(run.id);
+    const dispatcher = vi.fn(echoDispatcher);
+
+    const envelope = await executeChain(store, definition, {
+      runId: run.id,
+      command: 'step-one',
+      input: {},
+      dispatcher,
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(envelope.agent_action).toBe('stop');
+    expect(envelope.next_actions).toEqual([]);
+    expect(envelope.run_version).toBe(before.version);
+    expect(dispatcher).not.toHaveBeenCalled(); // no step executed
+    const after = await store.get(run.id);
+    expect(after).toEqual(before); // byte-unchanged (version, step sets, everything)
+  });
+
+  it('is a byte-unchanged no-op on a terminal completed run (no aborted_at)', async () => {
+    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      completed_steps: ['step-one', 'step-two'],
+    });
+    const before = await store.get(run.id);
+    const dispatcher = vi.fn(echoDispatcher);
+
+    const envelope = await executeChain(store, definition, {
+      runId: run.id,
+      command: 'step-one',
+      input: {},
+      dispatcher,
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(envelope.agent_action).toBe('stop');
+    expect(dispatcher).not.toHaveBeenCalled();
+    const after = await store.get(run.id);
+    expect(after).toEqual(before);
+  });
+
+  it('does NOT over-fire — a non-terminal (running) run is still driven', async () => {
+    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const createdVersion = run.version;
+    const dispatcher = vi.fn(echoDispatcher);
+
+    await executeChain(store, definition, {
+      runId: run.id,
+      command: 'step-one',
+      input: {},
+      dispatcher,
+    });
+
+    expect(dispatcher).toHaveBeenCalled(); // the running run was driven
+    const after = await store.get(run.id);
+    expect(after.completed_steps).toContain('step-one');
+    expect(after.version).toBeGreaterThan(createdVersion);
+  });
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -29,7 +29,7 @@ import {
 } from '../validation/input-schema.js';
 import { normalizeTrace } from './trace-normalizer.js';
 import type { NormalizeTraceResult } from './trace-normalizer.js';
-import { TERMINAL_PHASES } from './lifecycle.js';
+import { TERMINAL_PHASES, isTerminalPhase } from './lifecycle.js';
 import {
   checkPreconditions,
   evaluateAllPreconditions,
@@ -1950,6 +1950,33 @@ export async function executeChain(
   definition: WorkflowDefinition,
   options: ExecuteChainOptions,
 ): Promise<ResponseEnvelope> {
+  // Defense-in-depth: never drive a run that is already terminal. The eligibility guard
+  // (findEligibleSteps) makes this unreachable in normal operation, but guarding the chain
+  // boundary protects every executeChain caller regardless of how it reached here. Placed in the
+  // public wrapper so it fires exactly once at entry; recursive depth>0 calls and runs that become
+  // terminal mid-chain are covered by the existing mid-chain check in executeChainInternal.
+  let entryRun: RunRecord | undefined;
+  try {
+    entryRun = await store.get(options.runId);
+  } catch {
+    entryRun = undefined; // run not readable → fall through to the normal path
+  }
+  if (entryRun !== undefined && isTerminalPhase(entryRun.run_phase)) {
+    return {
+      command: options.command,
+      run_id: options.runId,
+      run_version: entryRun.version,
+      status: 'ok',
+      data: {},
+      evidence: [],
+      warnings: [],
+      errors: [],
+      agent_action: 'stop' as const,
+      context_hint: `Run '${options.runId}' is already terminal (${entryRun.run_phase}); no steps executed.`,
+      next_actions: [],
+    };
+  }
+
   const effectiveOptions: ExecuteChainOptions = {
     ...options,
     registry: options.registry ?? createDefaultRegistry(),


### PR DESCRIPTION
## Context

Follow-up defense-in-depth hardening to the v0.7.1 terminal-run fix (PR #93). Issue #91, filed as a deliberately-deferred gap from the terminal-guard analysis.

## Motivation

v0.7.1 stopped terminal runs from being re-driven at the **eligibility** chokepoint (`findEligibleSteps`), which makes the corrupting re-drive unreachable in normal operation. But `executeChain` itself had no terminal-state check at its boundary — protection relied entirely on every caller routing through eligibility first. A guard at the chain boundary makes "a terminal run is never driven" true structurally, independent of how a caller reaches `executeChain`, so a future caller or refactor can't silently re-expose the boundary.

This is **defense-in-depth**: it is unreachable after v0.7.1 and has **no observable effect** on valid workflows.

## Changes

**`packages/core/src/engine/execution-loop.ts`** (+29/−1)
- Added `isTerminalPhase` to the existing `./lifecycle.js` import (no new import line).
- At the top of the public `executeChain` wrapper: load the run once; if `isTerminalPhase(run.run_phase)`, return a benign no-op `ResponseEnvelope` (`status: 'ok'`, `agent_action: 'stop'`, empty `next_actions`, `run_version` = current version) **without** calling `executeStep`/`claimStep` or writing the store. If the run can't be read, fall through to the normal path.
- The existing mid-chain terminal check inside `executeChainInternal` (for runs that *become* terminal during a chain) and recursive depth>0 calls are left untouched — the two checks are complementary (entry vs. progression).

**`CHANGELOG.md`** — new `## [Unreleased]` with a `### Changed` entry describing the hardening.

## Verification

```bash
npm run lint     # exit 0, zero warnings
npm run test     # core 1237 (was 1234, +3), cli 347, testing 47, mcp 74 — all green
npm run build    # tsc --build, 4/4 successful
node scripts/check-versions.mjs   # consistent at 0.7.1 (no version bump)
```

New tests in `packages/core/src/engine/execution-loop.test.ts` (`describe('executeChain — terminal-run entry guard (#91)')`):
- terminal `aborted` run → no-op, run byte-unchanged (`toEqual(before)`), dispatcher never called, `run_version` identical;
- terminal `completed` run (no `aborted_at`) → same (proves the guard keys on `isTerminalPhase`, not `aborted_at`);
- non-terminal `running` run still drives (dispatcher called, step completed, version advances) — proves the guard does not over-fire.

## Rollback

```bash
git revert <merge-commit>
```

Pure code change, no out-of-band mutations. Reverting removes the boundary hardening only; the v0.7.1 eligibility guard (the load-bearing fix) is unaffected.

## Related

Closes #91. Sibling deferred item #92 (cross-batch idempotency-key semantics) is a separate decision, not addressed here. No release is cut for this PR alone — it rides to npm with the next release.
