### PR TITLE
feat(engine): idempotency as first-class pointer-index identity + re-encounter signal (#92 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+> **Version intent: 0.8.0.** This release carries a breaking change to the `RunStore` interface (see below). On a 0.x line a breaking change bumps the minor segment.
+
 ### Changed
 
 - **Defense-in-depth: `executeChain` now no-ops on an already-terminal run.** When invoked for a run whose phase is terminal (`completed`/`failed`/`aborted`/`abandoned`), `executeChain` returns immediately without executing a step or writing the store, instead of attempting to drive it. This is unreachable in normal operation — the eligibility guard added in 0.7.1 already prevents it — and has no observable effect on valid workflows; it hardens the chain boundary so the "terminal runs are never driven" invariant holds at the structural boundary regardless of how a caller reaches `executeChain`.
+- **BREAKING — `RunStore.create()` now returns `{ run, created }` instead of `RunRecord`.** `created` is `true` for a freshly written run and `false` when an existing run matched the supplied `idempotencyKey`. In-repo callers and both bundled stores (`JsonFileStore`, `InMemoryStore`) are updated. **External `RunStore` implementations (e.g. the cloud Postgres store) must update their `create()` signature and return the new shape** — destructure `{ run }` at call sites that only need the record.
+
+### Added
+
+- **Idempotency keys are now a first-class, atomically-managed identity.** `JsonFileStore` resolves an `idempotencyKey` through a deterministic per-key pointer index (`<runsDir>/keys/<sha256(workflowId\0key)>.json`) under a per-key lock, instead of an O(n) `readdir` scan with a first-match race. This closes a class of latent issues at the root (TOCTOU double-insert, readdir-order nondeterminism, per-create O(n) cost, silent key↔payload mismatch, and the `save()` import back door) and is crash-safe (run file written before pointer; a pointer to a missing run self-heals; a run written without its pointer is recovered by a lazy legacy-field fallback). Behavior is otherwise equivalent to the previous default: a key match returns the existing run unchanged — nothing is re-driven.
+- **`realm run reconcile`** — eagerly builds the key pointer index from existing run records (`--workflow <id>` to scope, `--dry-run` to report without writing). Idempotent and reversible (only creates `keys/`; never mutates run files). Skipping it is safe — the store self-migrates lazily on first touch.
+- **Idempotency re-encounter signal.** `ResponseEnvelope` gains an optional `run_phase` (present whenever a run is loaded). `start_run` reports `deduped: boolean`, a state-accurate `context_hint` on a match, and observational warnings when the matched run is still active or was created with different params. `start_run_batch` reports the same per `started[]` item (`deduped`, `run_phase`, `terminal_reason?`, `warnings`). Dedup activity is logged at the tool boundary.
 
 ---
 

--- a/packages/cli/src/agent/run-agent.test.ts
+++ b/packages/cli/src/agent/run-agent.test.ts
@@ -290,7 +290,7 @@ describe('runAgent — MCP tools integration', () => {
   it('--run-id attaches to a persisted run and drives it to completion', async () => {
     // Create the run first using the normal path.
     const store = new InMemoryStore();
-    const initialRecord = await store.create({
+    const { run: initialRecord } = await store.create({
       workflowId: 'agent-only',
       workflowVersion: 1,
       params: {},
@@ -339,7 +339,7 @@ describe('runAgent — MCP tools integration', () => {
 
   it('--run-id on a terminal run throws error containing run id and terminal state', async () => {
     const store = new InMemoryStore();
-    const initialRecord = await store.create({
+    const { run: initialRecord } = await store.create({
       workflowId: 'agent-only',
       workflowVersion: 1,
       params: {},

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -177,7 +177,7 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
     // in_progress_steps on attach: handled by engine's existing eligibility logic — no restart needed
   } else {
     // Normal path: create new run
-    const initialRecord = await deps.store.create({
+    const { run: initialRecord } = await deps.store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: options.params,

--- a/packages/cli/src/commands-registry.ts
+++ b/packages/cli/src/commands-registry.ts
@@ -6,6 +6,7 @@ import { registerCommand } from './commands/register.js';
 import { runCommand } from './commands/run.js';
 import { resumeCommand } from './commands/resume.js';
 import { cleanupCommand } from './commands/cleanup.js';
+import { reconcileCommand } from './commands/reconcile.js';
 import { respondCommand } from './commands/respond.js';
 import { inspectCommand } from './commands/inspect.js';
 import { replayCommand } from './commands/replay.js';
@@ -41,6 +42,7 @@ export const runCommands = [
   resumeCommand,
   respondCommand,
   cleanupCommand,
+  reconcileCommand,
 ];
 
 /** Top-level commands not nested under a subgroup. */

--- a/packages/cli/src/commands/listen.ts
+++ b/packages/cli/src/commands/listen.ts
@@ -366,12 +366,15 @@ export function makeListenHandler(
       await deps.workflowStore.register(entry.definition);
       let run;
       try {
-        run = await deps.runStore.create({
+        // `created` is intentionally unused here: the DedupStore.check() above already
+        // short-circuits duplicates, so the run-store idempotency match is only a backstop.
+        // Do NOT wire the re-encounter signal here — it would risk a double-spawn.
+        ({ run } = await deps.runStore.create({
           workflowId: entry.definition.id,
           workflowVersion: entry.definition.version,
           params,
           ...(dedupId !== undefined ? { idempotencyKey: dedupId } : {}),
-        });
+        }));
       } catch (err) {
         deps.logger.error('webhook: run creation failed', { path, error: String(err) });
         respond(res, 500, { error: 'store_error', status: 'failed' });

--- a/packages/cli/src/commands/reconcile.ts
+++ b/packages/cli/src/commands/reconcile.ts
@@ -1,0 +1,41 @@
+// reconcile command — builds the idempotency-key pointer index from existing run records.
+// Lets operators front-load the index (e.g. pausing the producer) so no lazy O(n) fallback
+// hits occur at runtime. Skipping it is safe: the store self-migrates lazily on first touch.
+import { Command } from 'commander';
+
+export const reconcileCommand = new Command('reconcile')
+  .description('Build the idempotency-key pointer index from existing runs')
+  .option('--workflow <id>', 'Reconcile only runs of this workflow')
+  .option('--dry-run', 'Report what would be written without writing anything')
+  .action(async (opts: { workflow?: string; dryRun?: boolean }) => {
+    const { JsonFileStore } = await import('@sensigo/realm');
+    const store = new JsonFileStore();
+    try {
+      const summary = await store.reconcileKeys(opts.workflow, opts.dryRun ?? false);
+      const verb = summary.dryRun ? 'Would write' : 'Wrote';
+      console.log(
+        `${verb} ${summary.keysWritten} pointer(s) across ${summary.groups} key group(s); ${summary.keysUnchanged} already current.`,
+      );
+      if (summary.duplicateGroups.length > 0) {
+        console.log(`Duplicate-key groups: ${summary.duplicateGroups.length}`);
+        for (const g of summary.duplicateGroups) {
+          console.log(
+            `  - workflow '${g.workflow_id}' → canonical ${g.canonical_run_id}; other runs: ${g.other_run_ids.join(', ')}`,
+          );
+        }
+      }
+      if (summary.multipleLiveGroups.length > 0) {
+        console.log(
+          `WARNING: ${summary.multipleLiveGroups.length} key group(s) have more than one live run (data-integrity finding):`,
+        );
+        for (const g of summary.multipleLiveGroups) {
+          console.log(
+            `  - workflow '${g.workflow_id}' → canonical ${g.canonical_run_id}; extra live runs: ${g.extra_live_run_ids.join(', ')}`,
+          );
+        }
+      }
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/commands/respond.test.ts
+++ b/packages/cli/src/commands/respond.test.ts
@@ -43,7 +43,7 @@ describe('respondToGate', () => {
   });
 
   it('advances a gate-waiting run to completed on valid choice', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'respond-test-wf',
       workflowVersion: 1,
       params: {},
@@ -73,7 +73,7 @@ describe('respondToGate', () => {
   });
 
   it('throws WorkflowError when gate_id does not match', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'respond-test-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -53,7 +53,7 @@ describe('resumeRun', () => {
   });
 
   it('removes the step from failed_steps, re-enabling it for execution', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'resume-test-wf',
       workflowVersion: 1,
       params: {},
@@ -74,7 +74,7 @@ describe('resumeRun', () => {
   });
 
   it('throws when the run is in a non-resumable state (completed)', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'resume-test-wf',
       workflowVersion: 1,
       params: {},
@@ -96,7 +96,7 @@ describe('resumeRun', () => {
   });
 
   it('throws when the step name does not exist in the workflow', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'resume-test-wf',
       workflowVersion: 1,
       params: {},
@@ -120,7 +120,7 @@ describe('resumeRun', () => {
 
   it('re-drives a failed run: resets to running, clears terminal_reason, re-derives skipped_steps, re-enables the step', async () => {
     await workflowStore.register(redriveWorkflow);
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'resume-redrive-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -43,7 +43,7 @@ export const runCommand = new Command('run')
     // 3. Create store and initial run record
     const store = new JsonFileStore();
 
-    const initialRecord = await store.create({
+    const { run: initialRecord } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params,

--- a/packages/core/src/engine/auto-chain.test.ts
+++ b/packages/core/src/engine/auto-chain.test.ts
@@ -103,7 +103,7 @@ describe('executeChain', () => {
 
   it('auto-chains 3 auto steps in one call — run ends at completed', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'chain-wf',
       workflowVersion: 1,
       params: {},
@@ -126,7 +126,7 @@ describe('executeChain', () => {
 
   it('stops at an agent step — step-b is NOT executed', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'stop-agent-wf',
       workflowVersion: 1,
       params: {},
@@ -151,7 +151,7 @@ describe('executeChain', () => {
 
   it('chains into trust: human_confirmed — step-b opens gate and returns confirm_required', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'stop-gate-wf',
       workflowVersion: 1,
       params: {},
@@ -173,7 +173,7 @@ describe('executeChain', () => {
 
   it('stops and returns error when a step fails — run is marked failed', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'fail-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/core/src/engine/branching.test.ts
+++ b/packages/core/src/engine/branching.test.ts
@@ -132,7 +132,7 @@ describe('trigger_rule: all_failed — recovery after step failure', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'always_fail', new FailingHandler());
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -164,7 +164,7 @@ describe('trigger_rule: all_failed — recovery after step failure', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'always_fail', new FailingHandler());
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -189,7 +189,7 @@ describe('trigger_rule: all_failed — recovery after step failure', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'always_fail', new FailingHandler());
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -276,7 +276,7 @@ describe('when condition routing', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'confidence_handler', new ConfidenceHandler('high'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -301,7 +301,7 @@ describe('when condition routing', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'confidence_handler', new ConfidenceHandler('low'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -326,7 +326,7 @@ describe('when condition routing', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'confidence_handler', new ConfidenceHandler('high'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -362,7 +362,7 @@ describe('when condition routing', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'confidence_handler', new ConfidenceHandler('low'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -422,7 +422,7 @@ describe('fan-out: multiple steps eligible simultaneously', () => {
         'step-c': { description: 'Branch 2', execution: 'agent', depends_on: ['step-a'] },
       },
     };
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: 1,
       params: {},
@@ -481,7 +481,7 @@ describe('gate-response flow', () => {
   });
 
   it('approve advances run — confirm moves to completed_steps, post-approve is eligible', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: autoGateDef.id,
       workflowVersion: 1,
       params: {},
@@ -525,7 +525,7 @@ describe('gate-response flow', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: singleGateDef.id,
       workflowVersion: 1,
       params: {},

--- a/packages/core/src/engine/eligibility.test.ts
+++ b/packages/core/src/engine/eligibility.test.ts
@@ -710,7 +710,11 @@ describe('claimStep — double-claim prevention', () => {
   it('first claimStep adds the step to in_progress_steps', async () => {
     const store = new JsonFileStore(runDir);
     const definition = makeWorkflow({ 'step-a': { depends_on: [] } });
-    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     const claimed = await store.claimStep(run.id, 'step-a', definition);
     expect(claimed.in_progress_steps).toContain('step-a');
@@ -719,7 +723,11 @@ describe('claimStep — double-claim prevention', () => {
   it('second claimStep on the same step throws STATE_STEP_ALREADY_CLAIMED', async () => {
     const store = new JsonFileStore(runDir);
     const definition = makeWorkflow({ 'step-a': { depends_on: [] } });
-    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await store.claimStep(run.id, 'step-a', definition);
 
@@ -731,7 +739,11 @@ describe('claimStep — double-claim prevention', () => {
   it('claimStep on a completed step throws', async () => {
     const store = new JsonFileStore(runDir);
     const definition = makeWorkflow({ 'step-a': { depends_on: [] } });
-    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     const claimed = await store.claimStep(run.id, 'step-a', definition);
 
     // Move step-a to completed_steps.

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -59,7 +59,7 @@ describe('executeStep', () => {
   });
 
   it('successful step returns status ok and updates completed_steps', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -88,7 +88,7 @@ describe('executeStep', () => {
   });
 
   it('blocked state returns blocked envelope with blocked_reason', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -126,7 +126,7 @@ describe('executeStep', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'blocked-wf',
       workflowVersion: 1,
       params: {},
@@ -146,7 +146,7 @@ describe('executeStep', () => {
   });
 
   it('dispatcher error returns error envelope with evidence', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -167,7 +167,7 @@ describe('executeStep', () => {
   });
 
   it('completing final step sets run_phase to completed', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -232,7 +232,7 @@ describe('executeStep', () => {
         },
       },
     };
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -266,7 +266,7 @@ describe('executeStep', () => {
         },
       },
     };
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -309,7 +309,7 @@ describe('executeStep', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -350,7 +350,7 @@ describe('executeStep', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -384,7 +384,7 @@ describe('executeStep', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -417,7 +417,7 @@ describe('executeStep', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'test-wf',
       workflowVersion: 1,
       params: {},
@@ -478,7 +478,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('adapter', 'mock_adapter', adapter);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -519,7 +519,7 @@ describe('executeStep', () => {
       };
       const registry = new ExtensionRegistry();
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -540,7 +540,7 @@ describe('executeStep', () => {
     it('returns error envelope when adapter is not registered in the registry', async () => {
       const registry = new ExtensionRegistry(); // empty — no adapter registered
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -564,7 +564,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('adapter', 'mock_adapter', adapter);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -587,7 +587,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('adapter', 'mock_adapter', adapter);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -626,7 +626,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -665,7 +665,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -705,7 +705,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -745,7 +745,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -769,7 +769,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('adapter', 'mock_adapter', adapter);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -806,7 +806,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -843,7 +843,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -875,7 +875,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('adapter', 'mock_adapter', adapter);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'adapter-wf',
         workflowVersion: 1,
         params: {},
@@ -928,7 +928,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: { source: 'doc-1' },
@@ -957,7 +957,7 @@ describe('executeStep', () => {
     it('returns error envelope when handler is not registered', async () => {
       const registry = new ExtensionRegistry(); // empty
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1021,7 +1021,7 @@ describe('executeStep', () => {
       registry.register('adapter', 'mock_adapter', adapter);
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'two-step-wf',
         workflowVersion: 1,
         params: {},
@@ -1058,7 +1058,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1109,7 +1109,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'two-step-handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1139,7 +1139,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1168,7 +1168,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1193,7 +1193,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1225,7 +1225,7 @@ describe('executeStep', () => {
       const registry = new ExtensionRegistry();
       registry.register('handler', 'my_handler', handler);
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'handler-wf',
         workflowVersion: 1,
         params: {},
@@ -1272,7 +1272,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'prompt-wf',
         workflowVersion: 1,
         params: {},
@@ -1314,7 +1314,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-prompt-wf',
         workflowVersion: 1,
         params: {},
@@ -1361,7 +1361,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'agent-instr-wf',
         workflowVersion: 1,
         params: {},
@@ -1405,7 +1405,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'auto-instr-wf',
         workflowVersion: 1,
         params: {},
@@ -1436,7 +1436,7 @@ describe('executeStep', () => {
           },
         },
       };
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-nav-wf',
         workflowVersion: 1,
         params: {},
@@ -1492,7 +1492,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-owner-wf',
         workflowVersion: 1,
         params: {},
@@ -1526,7 +1526,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-no-owner-wf',
         workflowVersion: 1,
         params: {},
@@ -1552,7 +1552,7 @@ describe('executeStep', () => {
 
   describe('cleanup failure warning', () => {
     it('surfaces cleanup failure as warning when the failed-state store.update throws', async () => {
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'test-wf',
         workflowVersion: 1,
         params: {},
@@ -1606,7 +1606,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'chain-cmd-wf',
         workflowVersion: 1,
         params: {},
@@ -1648,7 +1648,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'profile-wf',
         workflowVersion: 1,
         params: {},
@@ -1668,7 +1668,7 @@ describe('executeStep', () => {
     });
 
     it('agent step without profile has no agent_profile on evidence', async () => {
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'test-wf',
         workflowVersion: 1,
         params: {},
@@ -1719,7 +1719,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-msg-broken-wf',
         workflowVersion: 1,
         params: {},
@@ -1761,7 +1761,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-msg-happy-wf',
         workflowVersion: 1,
         params: {},
@@ -1800,7 +1800,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-msg-evidence-wf',
         workflowVersion: 1,
         params: {},
@@ -1847,7 +1847,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-no-msg-wf',
         workflowVersion: 1,
         params: {},
@@ -1883,7 +1883,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-no-msg-ev-wf',
         workflowVersion: 1,
         params: {},
@@ -1930,7 +1930,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'gate-msg-over-prompt-wf',
         workflowVersion: 1,
         params: {},
@@ -1964,7 +1964,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-agent-wf',
         workflowVersion: 1,
         params: {},
@@ -1994,7 +1994,11 @@ describe('executeStep', () => {
 
     it('non-agent step silently drops provided trace', async () => {
       // step-one is execution: 'auto' in the default definition
-      const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+      const { run: run } = await store.create({
+        workflowId: 'test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
       const envelope = await executeStep(store, definition, {
         runId: run.id,
         command: 'step-one',
@@ -2020,7 +2024,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-reserved-wf',
         workflowVersion: 1,
         params: {},
@@ -2053,7 +2057,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-count-wf',
         workflowVersion: 1,
         params: {},
@@ -2086,7 +2090,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run1 = await store.create({
+      const { run: run1 } = await store.create({
         workflowId: 'trace-hash-stable-wf',
         workflowVersion: 1,
         params: {},
@@ -2099,7 +2103,7 @@ describe('executeStep', () => {
         trace: [{ event: 'trace_a' }],
       });
 
-      const run2 = await store.create({
+      const { run: run2 } = await store.create({
         workflowId: 'trace-hash-stable-wf',
         workflowVersion: 1,
         params: {},
@@ -2126,7 +2130,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run1 = await store.create({
+      const { run: run1 } = await store.create({
         workflowId: 'trace-digest-diff-wf',
         workflowVersion: 1,
         params: {},
@@ -2139,7 +2143,7 @@ describe('executeStep', () => {
         trace: [{ event: 'alpha' }],
       });
 
-      const run2 = await store.create({
+      const { run: run2 } = await store.create({
         workflowId: 'trace-digest-diff-wf',
         workflowVersion: 1,
         params: {},
@@ -2200,7 +2204,7 @@ describe('executeStep', () => {
         return echoDispatcher(step, input, run, signal);
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2236,7 +2240,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2275,7 +2279,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2307,7 +2311,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2337,7 +2341,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2360,7 +2364,7 @@ describe('executeStep', () => {
 
     it('trace_schema default mode is warn when trace_schema set but mode omitted', async () => {
       // traceSchemaDefinitionBase has trace_schema but no trace_validation_mode
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2391,7 +2395,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2436,7 +2440,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2470,7 +2474,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2502,7 +2506,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2545,7 +2549,7 @@ describe('executeStep', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'trace-schema-wf',
         workflowVersion: 1,
         params: {},
@@ -2599,7 +2603,11 @@ describe('WAL trace buffer integration (B-lite)', () => {
 
   it('WAL entries present + no execute_step.trace → evidence has trace from WAL', async () => {
     const bufferStore = new InMemoryTraceBufferStore();
-    const run = await store.create({ workflowId: 'wal-test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'wal-test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await bufferStore.append(run.id, 'step-agent', [
       { event: 'wal_event', data: { phase: 'pre' } },
@@ -2621,7 +2629,11 @@ describe('WAL trace buffer integration (B-lite)', () => {
 
   it('WAL entries + execute_step.trace entries → merged, WAL entries first', async () => {
     const bufferStore = new InMemoryTraceBufferStore();
-    const run = await store.create({ workflowId: 'wal-test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'wal-test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await bufferStore.append(run.id, 'step-agent', [{ event: 'wal_first' }]);
 
@@ -2665,7 +2677,11 @@ describe('WAL trace buffer integration (B-lite)', () => {
     };
 
     const bufferStore = new InMemoryTraceBufferStore();
-    const run = await store.create({ workflowId: 'wal-schema-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'wal-schema-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await bufferStore.append(run.id, 'step-agent', [{ event: 'buffered' }]);
 
@@ -2689,7 +2705,11 @@ describe('WAL trace buffer integration (B-lite)', () => {
 
   it('execute_step succeeds → WAL is deleted', async () => {
     const bufferStore = new InMemoryTraceBufferStore();
-    const run = await store.create({ workflowId: 'wal-test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'wal-test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await bufferStore.append(run.id, 'step-agent', [{ event: 'pre_step' }]);
 
@@ -2708,7 +2728,11 @@ describe('WAL trace buffer integration (B-lite)', () => {
 
   it('execute_step dispatch fails → WAL is deleted', async () => {
     const bufferStore = new InMemoryTraceBufferStore();
-    const run = await store.create({ workflowId: 'wal-test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'wal-test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await bufferStore.append(run.id, 'step-agent', [{ event: 'pre_fail' }]);
 
@@ -2733,7 +2757,11 @@ describe('WAL trace buffer integration (B-lite)', () => {
   });
 
   it('no traceBufferStore configured → behaviour identical to pre-B-lite (regression)', async () => {
-    const run = await store.create({ workflowId: 'wal-test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'wal-test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     const envelope = await executeStep(store, agentDef, {
       runId: run.id,
@@ -2785,7 +2813,7 @@ describe('Step 5 dispatch-failure envelope', () => {
   };
 
   it('non-terminal failure with wait_for_human exposes recovery branch', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-wf',
       workflowVersion: 1,
       params: {},
@@ -2816,7 +2844,7 @@ describe('Step 5 dispatch-failure envelope', () => {
   });
 
   it('non-terminal failure with provide_input is translated to report_to_user and exposes recovery branch', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-wf',
       workflowVersion: 1,
       params: {},
@@ -2843,7 +2871,7 @@ describe('Step 5 dispatch-failure envelope', () => {
   });
 
   it('non-terminal failure with stop is translated to report_to_user and exposes recovery branch', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-wf',
       workflowVersion: 1,
       params: {},
@@ -2883,7 +2911,7 @@ describe('Step 5 dispatch-failure envelope', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'single-step-wf',
       workflowVersion: 1,
       params: {},
@@ -2912,7 +2940,7 @@ describe('Step 5 dispatch-failure envelope', () => {
     const bufferStore = new InMemoryTraceBufferStore();
     vi.spyOn(bufferStore, 'delete').mockRejectedValue(new Error('disk contention'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-wf',
       workflowVersion: 1,
       params: {},
@@ -2944,7 +2972,7 @@ describe('Step 5 dispatch-failure envelope', () => {
   });
 
   it('store.update failure suppresses next_actions', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-wf',
       workflowVersion: 1,
       params: {},
@@ -2975,7 +3003,7 @@ describe('Step 5 dispatch-failure envelope', () => {
   });
 
   it('run_version reflects persisted version not stale pre-persist version', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'single-step-wf',
       workflowVersion: 1,
       params: {},
@@ -3057,7 +3085,7 @@ describe('retry_after on ResponseEnvelope', () => {
   };
 
   it('retry_after appears in ResponseEnvelope for wait_and_proceed dispatch failure', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-retry-wf',
       workflowVersion: 1,
       params: {},
@@ -3084,7 +3112,7 @@ describe('retry_after on ResponseEnvelope', () => {
   });
 
   it('retry_after is absent from ResponseEnvelope when not set on the error', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'two-step-retry-wf',
       workflowVersion: 1,
       params: {},
@@ -3168,7 +3196,7 @@ describe('retry_after on ResponseEnvelope', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'retry-delay-wf',
         workflowVersion: 1,
         params: {},
@@ -3230,7 +3258,7 @@ describe('retry_after on ResponseEnvelope', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'retry-fallback-wf',
         workflowVersion: 1,
         params: {},
@@ -3334,7 +3362,7 @@ describe('min_retry_seconds floor', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'min-retry-floor-wf',
         workflowVersion: 1,
         params: {},
@@ -3412,7 +3440,7 @@ describe('min_retry_seconds floor', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'min-retry-fallback-wf',
         workflowVersion: 1,
         params: {},
@@ -3490,7 +3518,7 @@ describe('min_retry_seconds floor', () => {
         },
       };
 
-      const run = await store.create({
+      const { run: run } = await store.create({
         workflowId: 'min-retry-regression-wf',
         workflowVersion: 1,
         params: {},
@@ -3551,7 +3579,11 @@ describe('guard step execution', () => {
   });
 
   it('guard passes — run continues with downstream agent step in next_actions', async () => {
-    const run = await store.create({ workflowId: 'guard-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'guard-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     const envelope = await executeChain(store, guardWorkflow, {
       runId: run.id,
@@ -3574,7 +3606,11 @@ describe('guard step execution', () => {
   });
 
   it('guard aborts — run_phase becomes aborted, next_actions is empty, aborted_at set', async () => {
-    const run = await store.create({ workflowId: 'guard-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'guard-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     const envelope = await executeChain(store, guardWorkflow, {
       runId: run.id,
@@ -3597,7 +3633,11 @@ describe('guard step execution', () => {
   });
 
   it('guard abort skips downstream steps (step_c goes into skipped_steps)', async () => {
-    const run = await store.create({ workflowId: 'guard-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'guard-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeChain(store, guardWorkflow, {
       runId: run.id,
@@ -3611,7 +3651,11 @@ describe('guard step execution', () => {
   });
 
   it('guard resolution error — run_phase becomes failed, guard in failed_steps', async () => {
-    const run = await store.create({ workflowId: 'guard-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'guard-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     // Dispatcher returns no 'status' field — path step_a.status is unresolvable
     const envelope = await executeChain(store, guardWorkflow, {
@@ -3647,7 +3691,11 @@ describe('guard step execution', () => {
       },
     };
 
-    const run = await store.create({ workflowId: 'guard-msg-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'guard-msg-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeChain(store, workflowWithMessage, {
       runId: run.id,
@@ -3683,7 +3731,7 @@ describe('guard step execution', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'cascade-guard-wf',
       workflowVersion: 1,
       params: {},
@@ -3730,7 +3778,7 @@ describe('guard step execution', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'cascade-abort-wf',
       workflowVersion: 1,
       params: {},
@@ -3788,7 +3836,11 @@ describe('handler warn result', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'warn_handler', handler);
 
-    const run = await store.create({ workflowId: 'warn-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'warn-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     const envelope = await executeStep(store, warnDefinition, {
       runId: run.id,
       command: 'validate',
@@ -3824,7 +3876,11 @@ describe('handler warn result', () => {
       },
     };
 
-    const run = await store.create({ workflowId: 'warn-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'warn-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     await executeStep(store, retryDef, {
       runId: run.id,
       command: 'validate',
@@ -3867,7 +3923,11 @@ describe('handler warn result', () => {
       },
     };
 
-    const run = await store.create({ workflowId: 'warn-chain-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'warn-chain-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     const envelope = await executeChain(store, chainDef, {
       runId: run.id,
       command: 'step1',
@@ -3888,7 +3948,11 @@ describe('handler warn result', () => {
     const registry = new ExtensionRegistry();
     registry.register('handler', 'warn_handler', handler);
 
-    const run = await store.create({ workflowId: 'warn-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'warn-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     const envelope = await executeStep(store, warnDefinition, {
       runId: run.id,
       command: 'validate',
@@ -3952,7 +4016,7 @@ describe('when: run.params integration', () => {
     registry.register('handler', 'classify_handler', classifyHandler);
     registry.register('handler', 'post_handler', postHandler);
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'shadow-wf',
       workflowVersion: 1,
       params: { mode: 'shadow' },
@@ -4011,7 +4075,7 @@ describe('input_map on handler steps', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'inputmap-handler-wf',
       workflowVersion: 1,
       params: {},
@@ -4054,7 +4118,7 @@ describe('input_map on handler steps', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'inputmap-params-wf',
       workflowVersion: 1,
       params: { ticket_id: 'TKT-42' },
@@ -4097,7 +4161,7 @@ describe('input_map on handler steps', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'inputmap-evidence-wf',
       workflowVersion: 1,
       params: {},
@@ -4136,7 +4200,7 @@ describe('input_map on handler steps', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'no-inputmap-wf',
       workflowVersion: 1,
       params: {},
@@ -4185,7 +4249,11 @@ describe('_debug field capture', () => {
   };
 
   it('_debug passes schema validation and is stored as debug_output (not in output_summary)', async () => {
-    const run = await store.create({ workflowId: 'debug-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'debug-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, debugDef, {
       runId: run.id,
@@ -4202,7 +4270,11 @@ describe('_debug field capture', () => {
   });
 
   it('_debug does not appear in output_summary', async () => {
-    const run = await store.create({ workflowId: 'debug-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'debug-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, debugDef, {
       runId: run.id,
@@ -4216,7 +4288,11 @@ describe('_debug field capture', () => {
   });
 
   it('evidence_hash is the same whether or not _debug is present', async () => {
-    const run1 = await store.create({ workflowId: 'debug-wf', workflowVersion: 1, params: {} });
+    const { run: run1 } = await store.create({
+      workflowId: 'debug-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     await executeStep(store, debugDef, {
       runId: run1.id,
       command: 'classify',
@@ -4224,7 +4300,11 @@ describe('_debug field capture', () => {
       dispatcher: echoDispatcher,
     });
 
-    const run2 = await store.create({ workflowId: 'debug-wf', workflowVersion: 1, params: {} });
+    const { run: run2 } = await store.create({
+      workflowId: 'debug-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     await executeStep(store, debugDef, {
       runId: run2.id,
       command: 'classify',
@@ -4238,7 +4318,11 @@ describe('_debug field capture', () => {
   });
 
   it('step without _debug produces no debug_output field on the snapshot', async () => {
-    const run = await store.create({ workflowId: 'debug-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'debug-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, debugDef, {
       runId: run.id,
@@ -4289,7 +4373,7 @@ describe('_debug stripping on direct auto-step invocation', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'debug-strip-handler-wf',
       workflowVersion: 1,
       params: {},
@@ -4340,7 +4424,7 @@ describe('_debug stripping on direct auto-step invocation', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'debug-strip-adapter-wf',
       workflowVersion: 1,
       params: {},
@@ -4383,7 +4467,7 @@ describe('_debug stripping on direct auto-step invocation', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'debug-strip-abort-wf',
       workflowVersion: 1,
       params: {},
@@ -4417,7 +4501,11 @@ describe('executeChain — terminal-run entry guard (#91)', () => {
   });
 
   it('is a byte-unchanged no-op on a terminal aborted run (no step claimed)', async () => {
-    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     await store.update({
       ...run,
       run_phase: 'aborted',
@@ -4439,13 +4527,18 @@ describe('executeChain — terminal-run entry guard (#91)', () => {
     expect(envelope.agent_action).toBe('stop');
     expect(envelope.next_actions).toEqual([]);
     expect(envelope.run_version).toBe(before.version);
+    expect(envelope.run_phase).toBe('aborted'); // #92: signal present on the entry-guard envelope
     expect(dispatcher).not.toHaveBeenCalled(); // no step executed
     const after = await store.get(run.id);
     expect(after).toEqual(before); // byte-unchanged (version, step sets, everything)
   });
 
   it('is a byte-unchanged no-op on a terminal completed run (no aborted_at)', async () => {
-    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     await store.update({
       ...run,
       run_phase: 'completed',
@@ -4471,7 +4564,11 @@ describe('executeChain — terminal-run entry guard (#91)', () => {
   });
 
   it('does NOT over-fire — a non-terminal (running) run is still driven', async () => {
-    const run = await store.create({ workflowId: 'test-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'test-wf',
+      workflowVersion: 1,
+      params: {},
+    });
     const createdVersion = run.version;
     const dispatcher = vi.fn(echoDispatcher);
 

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -4,6 +4,7 @@
 // auto-chaining with fan-out, and registry-based dispatch for adapter and handler steps.
 import type {
   RunRecord,
+  RunPhase,
   EvidenceSnapshot,
   WorkflowContextSnapshot,
   AgentTraceEntry,
@@ -590,6 +591,7 @@ function errorEnvelope(
   runVersion: number,
   err: WorkflowError,
   contextHint?: string,
+  runPhase?: RunPhase,
 ): ResponseEnvelope {
   return {
     command,
@@ -605,6 +607,7 @@ function errorEnvelope(
     agent_action: err.agentAction,
     ...(err.retry_after !== undefined ? { retry_after: err.retry_after } : {}),
     context_hint: contextHint ?? `Error during '${command}'.`,
+    ...(runPhase !== undefined ? { run_phase: runPhase } : {}),
     next_actions: [],
   };
 }
@@ -655,6 +658,7 @@ function makeErrorEnvelope(
     run !== null ? run.version : 0,
     err,
     hint,
+    run !== null ? run.run_phase : undefined,
   );
   // Apply pre-execution translation: provide_input / resolve_precondition cannot
   // apply before claimStep — translate them to report_to_user.
@@ -712,6 +716,7 @@ export async function executeStep(
       errors: [],
       agent_action: 'resolve_precondition' as const,
       context_hint: `Step '${options.command}' is not eligible in the current run state.`,
+      run_phase: run.run_phase,
       next_actions: nextActions,
       blocked_reason:
         nextActions.length > 0
@@ -744,6 +749,7 @@ export async function executeStep(
         errors: [],
         agent_action: 'stop' as const,
         context_hint: `Precondition failed for step '${options.command}'.`,
+        run_phase: run.run_phase,
         next_actions: [],
         blocked_reason: {
           eligible_steps: eligible,
@@ -879,6 +885,7 @@ export async function executeStep(
           errors: [],
           agent_action: 'resolve_precondition' as const,
           context_hint: `Step '${options.command}' was already claimed by another process.`,
+          run_phase: freshRun.run_phase,
           next_actions: buildNextActions(definition, freshRun),
           blocked_reason: {
             eligible_steps: findEligibleSteps(definition, freshRun),
@@ -1047,6 +1054,7 @@ export async function executeStep(
           warnings: [],
           errors: [],
           context_hint: `Handler step '${options.command}' aborted the run: ${abortMessage}`,
+          run_phase: (persistedAbortRun ?? abortedRun).run_phase,
           next_actions: [],
         };
       }
@@ -1243,6 +1251,7 @@ export async function executeStep(
         ? { retry_after: dispatchError.retry_after }
         : {}),
       context_hint: contextHint,
+      run_phase: (persistedRun ?? failedRun).run_phase,
       next_actions: nextActions,
     };
   }
@@ -1403,7 +1412,7 @@ export async function executeStep(
       warnings: [...traceWarnings],
       errors: [],
       context_hint: `Run is paused at gate '${gate_id}'. Available choices: ${choices.join(', ')}.`,
-
+      run_phase: gateRun.run_phase,
       next_actions: [gateNextAction],
       gate: {
         gate_id,
@@ -1493,6 +1502,7 @@ export async function executeStep(
     warnings: mergeWarnings(traceWarnings, currentWarn),
     errors: [],
     context_hint: orientation,
+    run_phase: savedRun.run_phase,
     next_actions: nextActions,
   };
 }
@@ -1636,6 +1646,7 @@ export async function submitHumanResponse(
       run.version,
       e,
       `Failed to persist gate response.`,
+      run.run_phase,
     );
   }
 
@@ -1656,6 +1667,7 @@ export async function submitHumanResponse(
     warnings: [],
     errors: [],
     context_hint: orientation,
+    run_phase: savedRun.run_phase,
     next_actions: nextActions,
   };
 }
@@ -1875,6 +1887,7 @@ async function executeChainInternal(
         errors: [`Failed to persist guard step '${guardName}': ${msg}`],
         agent_action: 'stop' as const,
         context_hint: `Guard step '${guardName}' could not be persisted. Run state may be inconsistent.`,
+        run_phase: run.run_phase,
         next_actions: [],
       };
     }
@@ -1898,6 +1911,7 @@ async function executeChainInternal(
         warnings: [],
         errors: [],
         context_hint: contextHint,
+        run_phase: persistedGuardRun.run_phase,
         next_actions: [],
       };
     }
@@ -1973,6 +1987,7 @@ export async function executeChain(
       errors: [],
       agent_action: 'stop' as const,
       context_hint: `Run '${options.runId}' is already terminal (${entryRun.run_phase}); no steps executed.`,
+      run_phase: entryRun.run_phase,
       next_actions: [],
     };
   }

--- a/packages/core/src/engine/human-gate.test.ts
+++ b/packages/core/src/engine/human-gate.test.ts
@@ -50,7 +50,7 @@ describe('human gate', () => {
 
   it('trust: human_confirmed step opens gate after dispatcher runs', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'auto-gate-wf',
       workflowVersion: 1,
       params: {},
@@ -78,7 +78,7 @@ describe('human gate', () => {
 
   it('agent step with trust: human_confirmed exposes agent output as gate preview', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'agent-gate-wf',
       workflowVersion: 1,
       params: {},
@@ -98,7 +98,7 @@ describe('human gate', () => {
 
   it('submitHumanResponse with valid choice advances state', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'auto-gate-wf',
       workflowVersion: 1,
       params: {},
@@ -127,7 +127,7 @@ describe('human gate', () => {
 
   it('submitHumanResponse with wrong gate_id returns error', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'auto-gate-wf',
       workflowVersion: 1,
       params: {},
@@ -152,7 +152,7 @@ describe('human gate', () => {
 
   it('submitHumanResponse with invalid choice returns error', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'auto-gate-wf',
       workflowVersion: 1,
       params: {},
@@ -177,7 +177,7 @@ describe('human gate', () => {
 
   it('submitHumanResponse records a gate_response evidence entry', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'auto-gate-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/core/src/engine/input-map.test.ts
+++ b/packages/core/src/engine/input-map.test.ts
@@ -41,7 +41,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: {},
@@ -91,7 +91,7 @@ describe('input_map', () => {
     const store = new JsonFileStore(dir);
 
     // Start run with params.repo = 'acme/api'
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { repo: 'acme/api' },
@@ -159,7 +159,7 @@ describe('input_map', () => {
     registry.register('handler', 'make-pr', handler);
     const store = new JsonFileStore(dir);
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: {},
@@ -207,7 +207,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: {},
@@ -245,7 +245,7 @@ describe('input_map', () => {
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { repo: 'acme/api' },
@@ -285,7 +285,7 @@ describe('input_map', () => {
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: {},
@@ -331,7 +331,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { customer_name: 'Alice', email: 'alice@example.com' },
@@ -379,7 +379,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { table: 'tbl_abc', status: 'open' },
@@ -423,7 +423,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { name: 'Bob' },
@@ -464,7 +464,11 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'imap-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, def, {
       runId: run.id,
@@ -503,7 +507,11 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'imap-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, def, {
       runId: run.id,
@@ -542,7 +550,11 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'imap-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, def, {
       runId: run.id,
@@ -581,7 +593,11 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({ workflowId: 'imap-wf', workflowVersion: 1, params: {} });
+    const { run: run } = await store.create({
+      workflowId: 'imap-wf',
+      workflowVersion: 1,
+      params: {},
+    });
 
     await executeStep(store, def, {
       runId: run.id,
@@ -618,7 +634,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { id: 'rec123' },
@@ -666,7 +682,7 @@ describe('input_map', () => {
     const registry = new ExtensionRegistry();
     registry.register('adapter', 'mock', adapter);
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'imap-wf',
       workflowVersion: 1,
       params: { id: 'rec456' },

--- a/packages/core/src/engine/precondition.test.ts
+++ b/packages/core/src/engine/precondition.test.ts
@@ -79,7 +79,7 @@ describe('executeStep blocks when precondition fails', () => {
     };
 
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'precond-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/core/src/engine/reliability.test.ts
+++ b/packages/core/src/engine/reliability.test.ts
@@ -82,7 +82,7 @@ describe('reliability', () => {
 
   it('timeout fires — step returns error and run is marked failed', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'timeout-wf',
       workflowVersion: 1,
       params: {},
@@ -108,7 +108,7 @@ describe('reliability', () => {
 
   it('step without timeout completes normally', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'no-timeout-wf',
       workflowVersion: 1,
       params: {},
@@ -130,7 +130,7 @@ describe('reliability', () => {
 
   it('retry succeeds on 2nd attempt — evidence has 2 entries with attempt numbers', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'retry-wf',
       workflowVersion: 1,
       params: {},
@@ -161,7 +161,7 @@ describe('reliability', () => {
 
   it('retry exhaustion — returns STEP_RETRY_EXHAUSTED and run is marked failed', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'retry-wf',
       workflowVersion: 1,
       params: {},
@@ -191,7 +191,7 @@ describe('reliability', () => {
 
   it('non-retryable error — dispatcher called exactly once and run is failed', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'retry-wf',
       workflowVersion: 1,
       params: {},
@@ -218,7 +218,7 @@ describe('reliability', () => {
 
   it('double-claim: two concurrent executeStep calls on the same step — second is blocked', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'no-timeout-wf',
       workflowVersion: 1,
       params: {},
@@ -273,7 +273,7 @@ describe('reliability', () => {
 
   it('pending state is written to the store while dispatcher is running', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'no-timeout-wf',
       workflowVersion: 1,
       params: {},
@@ -312,7 +312,7 @@ describe('reliability', () => {
 
   it('failed run is marked terminal — terminal_state is true', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'no-timeout-wf',
       workflowVersion: 1,
       params: {},
@@ -335,7 +335,7 @@ describe('reliability', () => {
 
   it('AbortSignal is aborted when timeout fires', async () => {
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'timeout-wf',
       workflowVersion: 1,
       params: {},
@@ -388,7 +388,7 @@ describe('reliability', () => {
       },
     };
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'optional-retry-wf',
       workflowVersion: 1,
       params: {},
@@ -427,7 +427,7 @@ describe('reliability', () => {
       },
     };
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'rate-limited-retry-wf',
       workflowVersion: 1,
       params: {},
@@ -521,7 +521,7 @@ describe('reliability', () => {
     };
 
     const store = new JsonFileStore(dir);
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'rate-limit-integration-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export { resolvePreExecutionAgentAction } from './engine/error-resolution.js';
 export * from './types/workflow-definition.js';
 export * from './store/store-interface.js';
 export { JsonFileStore } from './store/json-file-store.js';
+export type { ReconcileSummary } from './store/json-file-store.js';
+export { hashParams, canonicalJson } from './store/params-hash.js';
 export { executeStep } from './engine/execution-loop.js';
 export type { StepDispatcher, ExecuteStepOptions } from './engine/execution-loop.js';
 export {

--- a/packages/core/src/store/json-file-store.test.ts
+++ b/packages/core/src/store/json-file-store.test.ts
@@ -1,11 +1,45 @@
 // Tests for JsonFileStore: create, get, update, list, and claimStep operations.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, readdir, writeFile, readFile, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { JsonFileStore } from './json-file-store.js';
 import { WorkflowError } from '../types/workflow-error.js';
+import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
+
+/** Recompute the pointer-file path the store uses (sha256 of workflowId\0key). */
+function keyPointerPath(dir: string, workflowId: string, key: string): string {
+  const hash = createHash('sha256').update(`${workflowId}\0${key}`).digest('hex');
+  return join(dir, 'keys', `${hash}.json`);
+}
+
+/** Build a complete RunRecord for direct on-disk seeding (bypassing create()). */
+function makeRunRecord(over: Partial<RunRecord> & { id: string; workflow_id: string }): RunRecord {
+  return {
+    workflow_version: 1,
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: [],
+    skipped_steps: [],
+    run_phase: 'running',
+    version: 0,
+    params: {},
+    evidence: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    terminal_state: false,
+    ...over,
+  };
+}
+
+/** Count top-level run files (excludes the keys/ subdir). */
+async function countRunFiles(dir: string): Promise<number> {
+  const entries = await readdir(dir);
+  return entries.filter((f) => f.endsWith('.json')).length;
+}
 
 async function makeTmpStore(): Promise<{ store: JsonFileStore; dir: string }> {
   const dir = await mkdtemp(join(tmpdir(), 'realm-test-'));
@@ -30,7 +64,7 @@ describe('JsonFileStore', () => {
   });
 
   it('create() produces a record with correct fields', async () => {
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: { key: 'value' },
@@ -51,7 +85,7 @@ describe('JsonFileStore', () => {
   });
 
   it('create() writes file to disk', async () => {
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -61,7 +95,7 @@ describe('JsonFileStore', () => {
   });
 
   it('get() returns the created record', async () => {
-    const created = await store.create({
+    const { run: created } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -78,7 +112,7 @@ describe('JsonFileStore', () => {
   });
 
   it('update() increments version and updates updated_at', async () => {
-    const created = await store.create({
+    const { run: created } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -98,7 +132,7 @@ describe('JsonFileStore', () => {
   });
 
   it('update() throws STATE_SNAPSHOT_MISMATCH on version conflict', async () => {
-    const created = await store.create({
+    const { run: created } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -134,7 +168,7 @@ describe('JsonFileStore', () => {
   });
 
   it('claimStep() returns run with step in in_progress_steps', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -146,7 +180,7 @@ describe('JsonFileStore', () => {
   });
 
   it('claimStep() throws STATE_STEP_ALREADY_CLAIMED when step already in progress', async () => {
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -170,7 +204,7 @@ describe('JsonFileStore', () => {
       },
     };
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -199,7 +233,11 @@ describe('JsonFileStore.save()', () => {
   });
 
   it('writes a new record to disk', async () => {
-    const record = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    const { run: record } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+    });
     // Delete it and re-save as an import.
     const newRecord = { ...record, id: 'imported-run-1' };
     await store.save(newRecord);
@@ -209,7 +247,11 @@ describe('JsonFileStore.save()', () => {
   });
 
   it('is a no-op when called twice with the same record (same version)', async () => {
-    const record = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    const { run: record } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+    });
     const importRecord = { ...record, id: 'import-idempotent' };
     await store.save(importRecord);
     // Second call with same version — must not throw.
@@ -217,7 +259,11 @@ describe('JsonFileStore.save()', () => {
   });
 
   it('throws STATE_RUN_DIVERGED when same ID exists with a different version', async () => {
-    const record = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    const { run: record } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+    });
     const importRecord = { ...record, id: 'import-diverged' };
     await store.save(importRecord);
     // Same ID, different version.
@@ -247,19 +293,19 @@ describe('JsonFileStore idempotency', () => {
   });
 
   it('create() without idempotencyKey always creates a new run', async () => {
-    const r1 = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
-    const r2 = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    const { run: r1 } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    const { run: r2 } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
     expect(r1.id).not.toBe(r2.id);
   });
 
   it('create() with idempotencyKey returns the same run on second call', async () => {
-    const r1 = await store.create({
+    const { run: r1 } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
       idempotencyKey: 'k1',
     });
-    const r2 = await store.create({
+    const { run: r2 } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -269,7 +315,7 @@ describe('JsonFileStore idempotency', () => {
   });
 
   it('create() stores idempotency_key on the record', async () => {
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -279,7 +325,7 @@ describe('JsonFileStore idempotency', () => {
   });
 
   it('create() with parentRunId stores parent_run_id on the record', async () => {
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -289,18 +335,343 @@ describe('JsonFileStore idempotency', () => {
   });
 
   it('idempotency is scoped per workflow — same key on different workflowId creates a new run', async () => {
-    const r1 = await store.create({
+    const { run: r1 } = await store.create({
       workflowId: 'wf-a',
       workflowVersion: 1,
       params: {},
       idempotencyKey: 'k1',
     });
-    const r2 = await store.create({
+    const { run: r2 } = await store.create({
       workflowId: 'wf-b',
       workflowVersion: 1,
       params: {},
       idempotencyKey: 'k1',
     });
     expect(r1.id).not.toBe(r2.id);
+  });
+});
+
+// ── pointer-index identity (#92 PR 1) ──────────────────────────────────────────
+
+describe('JsonFileStore pointer index', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ store, dir } = await makeTmpStore());
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reports created:true then created:false for the same key', async () => {
+    const first = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(first.created).toBe(true);
+    const second = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(second.created).toBe(false);
+    expect(second.run.id).toBe(first.run.id);
+  });
+
+  it('writes a pointer file under keys/ and keeps it invisible to list()', async () => {
+    const { run } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: { a: 1 },
+      idempotencyKey: 'k1',
+    });
+    const ptrPath = keyPointerPath(dir, 'wf-1', 'k1');
+    expect(existsSync(ptrPath)).toBe(true);
+    const ptr = JSON.parse(await readFile(ptrPath, 'utf8'));
+    expect(ptr.run_id).toBe(run.id);
+    expect(ptr.params_hash).toMatch(/^[0-9a-f]{64}$/);
+    // The keys/ subdir must not surface in list().
+    const all = await store.list();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.id).toBe(run.id);
+  });
+
+  it('atomic claim: concurrent same-key creates yield one created:true and one run', async () => {
+    const opts = {
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: { x: 1 },
+      idempotencyKey: 'race',
+    } as const;
+    const [a, b] = await Promise.all([store.create({ ...opts }), store.create({ ...opts })]);
+    const createdFlags = [a.created, b.created].sort();
+    expect(createdFlags).toEqual([false, true]);
+    expect(a.run.id).toBe(b.run.id);
+    // Exactly one run file for the key.
+    const matches = (await store.list('wf-1')).filter((r) => r.idempotency_key === 'race');
+    expect(matches).toHaveLength(1);
+    expect(await countRunFiles(dir)).toBe(1);
+  });
+
+  it('deterministic resolution: repeated create returns the same run regardless of other runs', async () => {
+    const { run: owner } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    // Add unrelated runs to perturb readdir order.
+    await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+    for (let i = 0; i < 3; i++) {
+      const { run, created } = await store.create({
+        workflowId: 'wf-1',
+        workflowVersion: 1,
+        params: {},
+        idempotencyKey: 'k1',
+      });
+      expect(created).toBe(false);
+      expect(run.id).toBe(owner.id);
+    }
+  });
+
+  it('self-heal: a pointer to a deleted run reclaims (created:true, repoints)', async () => {
+    const { run: first } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    // Simulate a crash-orphan: delete the run file but leave the pointer.
+    await unlink(join(dir, `${first.id}.json`));
+    const { run: second, created } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(created).toBe(true);
+    expect(second.id).not.toBe(first.id);
+    // Pointer now points at the reclaimed run.
+    const ptr = JSON.parse(await readFile(keyPointerPath(dir, 'wf-1', 'k1'), 'utf8'));
+    expect(ptr.run_id).toBe(second.id);
+  });
+
+  it('lazy legacy migration: adopts a pre-existing keyed run with no pointer and writes the pointer', async () => {
+    // Seed a legacy run directly on disk (has the field, no pointer).
+    const legacy = makeRunRecord({ id: 'legacy-1', workflow_id: 'wf-1', idempotency_key: 'k1' });
+    await writeFile(join(dir, 'legacy-1.json'), JSON.stringify(legacy, null, 2), 'utf8');
+    expect(existsSync(keyPointerPath(dir, 'wf-1', 'k1'))).toBe(false);
+
+    const { run, created } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(created).toBe(false);
+    expect(run.id).toBe('legacy-1');
+    expect(existsSync(keyPointerPath(dir, 'wf-1', 'k1'))).toBe(true);
+  });
+
+  it('lazy legacy migration: a duplicated-key group adopts the canonical (single live) run', async () => {
+    // One terminal + one live run sharing the same key.
+    const terminal = makeRunRecord({
+      id: 'dup-terminal',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      run_phase: 'completed',
+      terminal_state: true,
+      created_at: '2026-01-02T00:00:00.000Z',
+    });
+    const live = makeRunRecord({
+      id: 'dup-live',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      created_at: '2026-01-01T00:00:00.000Z', // older, but the only live one
+    });
+    await writeFile(join(dir, 'dup-terminal.json'), JSON.stringify(terminal, null, 2), 'utf8');
+    await writeFile(join(dir, 'dup-live.json'), JSON.stringify(live, null, 2), 'utf8');
+
+    const { run, created } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(created).toBe(false);
+    expect(run.id).toBe('dup-live'); // single live run wins regardless of created_at
+  });
+
+  it('param mismatch is detectable: matched run keeps its original params', async () => {
+    const { run: owner } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: { a: 1 },
+      idempotencyKey: 'k1',
+    });
+    const { run, created } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: { a: 2 }, // different payload, same key
+      idempotencyKey: 'k1',
+    });
+    expect(created).toBe(false);
+    expect(run.id).toBe(owner.id);
+    expect(run.params).toEqual({ a: 1 }); // original payload preserved
+  });
+});
+
+// ── reconcileKeys (#92 PR 1) ───────────────────────────────────────────────────
+
+describe('JsonFileStore.reconcileKeys()', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ store, dir } = await makeTmpStore());
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function seedDuplicateGroup(): Promise<void> {
+    // Same key, all terminal → canonical is newest by created_at, tie-break greatest id.
+    const a = makeRunRecord({
+      id: 'aaa',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      run_phase: 'completed',
+      terminal_state: true,
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    const b = makeRunRecord({
+      id: 'bbb',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      run_phase: 'failed',
+      terminal_state: true,
+      created_at: '2026-01-03T00:00:00.000Z', // newest → canonical
+    });
+    await writeFile(join(dir, 'aaa.json'), JSON.stringify(a, null, 2), 'utf8');
+    await writeFile(join(dir, 'bbb.json'), JSON.stringify(b, null, 2), 'utf8');
+  }
+
+  it('picks the canonical run and reports duplicate groups', async () => {
+    await seedDuplicateGroup();
+    const summary = await store.reconcileKeys();
+    expect(summary.groups).toBe(1);
+    expect(summary.keysWritten).toBe(1);
+    expect(summary.duplicateGroups).toHaveLength(1);
+    expect(summary.duplicateGroups[0]!.canonical_run_id).toBe('bbb'); // newest terminal
+    const ptr = JSON.parse(await readFile(keyPointerPath(dir, 'wf-1', 'k1'), 'utf8'));
+    expect(ptr.run_id).toBe('bbb');
+  });
+
+  it('is idempotent — a second run writes nothing new', async () => {
+    await seedDuplicateGroup();
+    await store.reconcileKeys();
+    const second = await store.reconcileKeys();
+    expect(second.keysWritten).toBe(0);
+    expect(second.keysUnchanged).toBe(1);
+  });
+
+  it('--dry-run writes no files', async () => {
+    await seedDuplicateGroup();
+    const summary = await store.reconcileKeys(undefined, true);
+    expect(summary.dryRun).toBe(true);
+    expect(summary.keysWritten).toBe(1); // would-write count
+    expect(existsSync(keyPointerPath(dir, 'wf-1', 'k1'))).toBe(false);
+    expect(existsSync(join(dir, 'keys'))).toBe(false);
+  });
+
+  it('reports multiple live runs as a data-integrity finding', async () => {
+    const live1 = makeRunRecord({
+      id: 'live1',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    const live2 = makeRunRecord({
+      id: 'live2',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      created_at: '2026-01-02T00:00:00.000Z', // newest live → canonical
+    });
+    await writeFile(join(dir, 'live1.json'), JSON.stringify(live1, null, 2), 'utf8');
+    await writeFile(join(dir, 'live2.json'), JSON.stringify(live2, null, 2), 'utf8');
+    const summary = await store.reconcileKeys();
+    expect(summary.multipleLiveGroups).toHaveLength(1);
+    expect(summary.multipleLiveGroups[0]!.canonical_run_id).toBe('live2');
+    expect(summary.multipleLiveGroups[0]!.extra_live_run_ids).toEqual(['live1']);
+  });
+});
+
+// ── save() index routing (#92 PR 1) ────────────────────────────────────────────
+
+describe('JsonFileStore.save() index routing', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ store, dir } = await makeTmpStore());
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('registers a key pointer for an imported keyed run', async () => {
+    const imported = makeRunRecord({ id: 'imp-1', workflow_id: 'wf-1', idempotency_key: 'k1' });
+    await store.save(imported);
+    const ptr = JSON.parse(await readFile(keyPointerPath(dir, 'wf-1', 'k1'), 'utf8'));
+    expect(ptr.run_id).toBe('imp-1');
+    // A later create() with the same key resolves to the imported run.
+    const { run, created } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(created).toBe(false);
+    expect(run.id).toBe('imp-1');
+  });
+
+  it('throws when the key is already owned by a different live run', async () => {
+    // create() establishes a live owner for k1.
+    const { run: owner } = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(owner.terminal_state).toBe(false);
+    const conflicting = makeRunRecord({ id: 'imp-2', workflow_id: 'wf-1', idempotency_key: 'k1' });
+    await expect(store.save(conflicting)).rejects.toMatchObject({ code: 'STATE_RUN_DIVERGED' });
+  });
+
+  it('repoints when the prior owner is terminal', async () => {
+    const terminalOwner = makeRunRecord({
+      id: 'old-owner',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+      run_phase: 'completed',
+      terminal_state: true,
+    });
+    await store.save(terminalOwner);
+    const replacement = makeRunRecord({
+      id: 'new-owner',
+      workflow_id: 'wf-1',
+      idempotency_key: 'k1',
+    });
+    await store.save(replacement); // prior owner terminal → safe to repoint
+    const ptr = JSON.parse(await readFile(keyPointerPath(dir, 'wf-1', 'k1'), 'utf8'));
+    expect(ptr.run_id).toBe('new-owner');
   });
 });

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -2,6 +2,7 @@
 // Uses proper-lockfile to prevent concurrent writes.
 import { mkdir, readFile, writeFile, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { v4 as uuidv4 } from 'uuid';
@@ -11,8 +12,76 @@ import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import type { RunStore, CreateRunOptions } from './store-interface.js';
 import { findEligibleSteps, deriveRunPhase } from '../engine/eligibility.js';
+import { hashParams } from './params-hash.js';
 
 const DEFAULT_RUNS_DIR = join(homedir(), '.realm', 'runs');
+
+/** Bounded per-key lock retry policy — used for the resolve-or-claim critical section. */
+const KEY_LOCK_RETRIES = { retries: 10, minTimeout: 50 } as const;
+
+/**
+ * A pointer file: the authoritative, deterministic index entry for one idempotency key.
+ * Stored at `<runsDir>/keys/<sha256(workflowId\0key)>.json`.
+ */
+interface KeyPointer {
+  run_id: string;
+  workflow_id: string;
+  key: string;
+  /** sha256 of the canonical params of the run this pointer owns. */
+  params_hash: string;
+  updated_at: string;
+}
+
+/** Summary returned by {@link JsonFileStore.reconcileKeys}. */
+export interface ReconcileSummary {
+  /** Number of distinct (workflow_id, idempotency_key) groups encountered. */
+  groups: number;
+  /** Number of pointers written (or, in dry-run, that would be written). */
+  keysWritten: number;
+  /** Pointers already pointing at the canonical run (no write needed). */
+  keysUnchanged: number;
+  /** True when no files were written. */
+  dryRun: boolean;
+  /** Groups that had more than one run sharing the same key. */
+  duplicateGroups: Array<{
+    workflow_id: string;
+    key: string;
+    canonical_run_id: string;
+    other_run_ids: string[];
+  }>;
+  /** Data-integrity finding: groups with more than one *live* (non-terminal) run. */
+  multipleLiveGroups: Array<{
+    workflow_id: string;
+    key: string;
+    canonical_run_id: string;
+    extra_live_run_ids: string[];
+  }>;
+}
+
+/**
+ * Newest-first comparator: by `created_at` descending, tie-broken by lexicographically
+ * greatest `id`. Used to deterministically pick a canonical run for a key.
+ */
+function compareCanonical(a: RunRecord, b: RunRecord): number {
+  if (a.created_at !== b.created_at) return a.created_at < b.created_at ? 1 : -1;
+  return a.id < b.id ? 1 : -1;
+}
+
+/**
+ * Canonical-pick rule (decision on record): exactly one live (non-terminal) run → it;
+ * multiple live → newest live by created_at (the rest are reported as extraLive); else
+ * the newest terminal by created_at (tie-break: greatest id).
+ */
+function pickCanonical(runs: RunRecord[]): { canonical: RunRecord; extraLive: RunRecord[] } {
+  const live = runs.filter((r) => !r.terminal_state);
+  if (live.length === 1) return { canonical: live[0]!, extraLive: [] };
+  if (live.length > 1) {
+    const sorted = [...live].sort(compareCanonical);
+    return { canonical: sorted[0]!, extraLive: sorted.slice(1) };
+  }
+  const sorted = [...runs].sort(compareCanonical);
+  return { canonical: sorted[0]!, extraLive: [] };
+}
 
 export class JsonFileStore implements RunStore {
   private readonly runsDir: string;
@@ -30,20 +99,49 @@ export class JsonFileStore implements RunStore {
     return join(this.runsDir, `${runId}.json`);
   }
 
+  /** Directory holding the idempotency-key pointer index. Invisible to `list()` (no `.json` suffix). */
+  private keysDir(): string {
+    return join(this.runsDir, 'keys');
+  }
+
+  /** Pointer file path for one (workflowId, key) pair. */
+  private keyPath(workflowId: string, key: string): string {
+    const hash = createHash('sha256').update(`${workflowId}\0${key}`).digest('hex');
+    return join(this.keysDir(), `${hash}.json`);
+  }
+
   private async ensureDir(): Promise<void> {
     await mkdir(this.runsDir, { recursive: true });
   }
 
-  async create(options: CreateRunOptions): Promise<RunRecord> {
-    await this.ensureDir();
+  private async ensureKeysDir(): Promise<void> {
+    await mkdir(this.keysDir(), { recursive: true });
+  }
 
-    // Idempotency check: if a key is supplied, return the existing run if one matches.
-    if (options.idempotencyKey !== undefined) {
-      const existing = await this.list(options.workflowId);
-      const match = existing.find((r) => r.idempotency_key === options.idempotencyKey);
-      if (match !== undefined) return match;
+  /** Read a pointer file; returns undefined if absent or unparseable (self-heals via reclaim/fallback). */
+  private async readPointer(keyPath: string): Promise<KeyPointer | undefined> {
+    if (!existsSync(keyPath)) return undefined;
+    try {
+      return JSON.parse(await readFile(keyPath, 'utf8')) as KeyPointer;
+    } catch {
+      return undefined;
     }
+  }
 
+  /** Write (or overwrite) a pointer file for `run` under `key`. params_hash is derived from the owned run. */
+  private async writePointer(keyPath: string, run: RunRecord, key: string): Promise<void> {
+    const pointer: KeyPointer = {
+      run_id: run.id,
+      workflow_id: run.workflow_id,
+      key,
+      params_hash: hashParams(run.params),
+      updated_at: new Date().toISOString(),
+    };
+    await writeFile(keyPath, JSON.stringify(pointer, null, 2), 'utf8');
+  }
+
+  /** Build and persist a brand-new run record (today's path, factored out). */
+  private async writeFreshRun(options: CreateRunOptions): Promise<RunRecord> {
     const now = new Date().toISOString();
     const record: RunRecord = {
       id: uuidv4(),
@@ -65,6 +163,66 @@ export class JsonFileStore implements RunStore {
     };
     await writeFile(this.filePath(record.id), JSON.stringify(record, null, 2), 'utf8');
     return record;
+  }
+
+  /** Find the canonical pre-existing run for (workflowId, key) via the legacy `idempotency_key` field. */
+  private async findCanonicalLegacyRun(
+    workflowId: string,
+    key: string,
+  ): Promise<RunRecord | undefined> {
+    const matches = (await this.list(workflowId)).filter((r) => r.idempotency_key === key);
+    if (matches.length === 0) return undefined;
+    return pickCanonical(matches).canonical;
+  }
+
+  async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    await this.ensureDir();
+
+    // No idempotency key → always a fresh run.
+    if (options.idempotencyKey === undefined) {
+      const run = await this.writeFreshRun(options);
+      return { run, created: true };
+    }
+
+    await this.ensureKeysDir();
+    const key = options.idempotencyKey;
+    const keyPath = this.keyPath(options.workflowId, key);
+
+    // Per-key mutual exclusion for the whole resolve-or-claim critical section.
+    // realpath:false lets us lock a key path whose pointer file does not exist yet.
+    const release = await lockfile.lock(keyPath, {
+      realpath: false,
+      retries: KEY_LOCK_RETRIES,
+    });
+    try {
+      const pointer = await this.readPointer(keyPath);
+      if (pointer !== undefined) {
+        // (b) Pointer present → load the target run.
+        const target = await this.get(pointer.run_id).catch((err: unknown) => {
+          if (err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND') return undefined;
+          throw err;
+        });
+        if (target !== undefined) {
+          return { run: target, created: false };
+        }
+        // target missing → crash-orphan pointer; fall through to reclaim (d).
+      } else {
+        // (c) Pointer absent → lazy legacy fallback (self-migrates pre-existing data and
+        // recovers run-written-but-pointer-not crash orphans, which still carry the field).
+        const canonical = await this.findCanonicalLegacyRun(options.workflowId, key);
+        if (canonical !== undefined) {
+          await this.writePointer(keyPath, canonical, key);
+          return { run: canonical, created: false };
+        }
+      }
+
+      // (d) Fresh claim / reclaim: run file FIRST, then pointer (overwrite on reclaim).
+      const run = await this.writeFreshRun(options);
+      await this.writePointer(keyPath, run, key);
+      return { run, created: true };
+    } finally {
+      await release();
+    }
   }
 
   async get(runId: string): Promise<RunRecord> {
@@ -218,6 +376,8 @@ export class JsonFileStore implements RunStore {
    * Used for importing records fetched from a remote store.
    * Idempotent: if the record already exists with the same version, this is a no-op.
    * Does NOT increment version or apply the optimistic lock — this is an import, not an update.
+   * When the record carries an idempotency_key, the key pointer is registered/repointed
+   * (closing the import back door): a conflict with a different *live* owner throws.
    */
   async save(record: RunRecord): Promise<void> {
     await this.ensureDir();
@@ -241,7 +401,110 @@ export class JsonFileStore implements RunStore {
         },
       );
     }
+    // Run file FIRST (consistent with create()), then register the key pointer.
     await writeFile(path, JSON.stringify(record, null, 2), 'utf8');
+    await this.registerImportedKey(record);
+  }
+
+  /**
+   * Register (or repoint) the idempotency-key pointer for an imported record, under the
+   * per-key lock. If the key is already owned by a DIFFERENT live run, refuse and throw
+   * (a missing or terminal prior owner is safely repointed).
+   */
+  private async registerImportedKey(record: RunRecord): Promise<void> {
+    if (record.idempotency_key === undefined) return;
+    await this.ensureKeysDir();
+    const key = record.idempotency_key;
+    const keyPath = this.keyPath(record.workflow_id, key);
+    const release = await lockfile.lock(keyPath, { realpath: false, retries: KEY_LOCK_RETRIES });
+    try {
+      const pointer = await this.readPointer(keyPath);
+      if (pointer !== undefined && pointer.run_id !== record.id) {
+        const owner = await this.get(pointer.run_id).catch(() => undefined);
+        if (owner !== undefined && !owner.terminal_state) {
+          throw new WorkflowError(
+            `Idempotency key for workflow '${record.workflow_id}' is already owned by a different live run '${owner.id}'; refusing to repoint to imported run '${record.id}'.`,
+            {
+              code: 'STATE_RUN_DIVERGED',
+              category: 'STATE',
+              agentAction: 'report_to_user',
+              retryable: false,
+              details: { runId: record.id, existingOwnerRunId: owner.id },
+            },
+          );
+        }
+        // owner missing or terminal → safe to repoint to the imported record.
+      }
+      await this.writePointer(keyPath, record, key);
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Eager migration: build the key pointer index from the legacy `idempotency_key` field on
+   * existing runs. Groups runs by (workflow_id, key), writes the pointer to the canonical run
+   * (see {@link pickCanonical}). Idempotent (re-running writes nothing new), reversible (only
+   * touches `keys/`; never mutates or deletes run files).
+   */
+  async reconcileKeys(workflowId?: string, dryRun = false): Promise<ReconcileSummary> {
+    await this.ensureDir();
+    if (!dryRun) await this.ensureKeysDir();
+
+    const groups = new Map<string, RunRecord[]>();
+    for (const run of await this.list(workflowId)) {
+      if (run.idempotency_key === undefined) continue;
+      const gk = `${run.workflow_id}\0${run.idempotency_key}`;
+      const arr = groups.get(gk);
+      if (arr === undefined) groups.set(gk, [run]);
+      else arr.push(run);
+    }
+
+    const summary: ReconcileSummary = {
+      groups: groups.size,
+      keysWritten: 0,
+      keysUnchanged: 0,
+      dryRun,
+      duplicateGroups: [],
+      multipleLiveGroups: [],
+    };
+
+    for (const runs of groups.values()) {
+      const { canonical, extraLive } = pickCanonical(runs);
+      const key = canonical.idempotency_key!;
+      const keyPath = this.keyPath(canonical.workflow_id, key);
+
+      if (runs.length > 1) {
+        summary.duplicateGroups.push({
+          workflow_id: canonical.workflow_id,
+          key,
+          canonical_run_id: canonical.id,
+          other_run_ids: runs.filter((r) => r.id !== canonical.id).map((r) => r.id),
+        });
+      }
+      if (extraLive.length > 0) {
+        summary.multipleLiveGroups.push({
+          workflow_id: canonical.workflow_id,
+          key,
+          canonical_run_id: canonical.id,
+          extra_live_run_ids: extraLive.map((r) => r.id),
+        });
+      }
+
+      const existing = await this.readPointer(keyPath);
+      const unchanged =
+        existing !== undefined &&
+        existing.run_id === canonical.id &&
+        existing.params_hash === hashParams(canonical.params);
+      if (unchanged) {
+        summary.keysUnchanged++;
+        continue;
+      }
+      summary.keysWritten++;
+      if (!dryRun) await this.writePointer(keyPath, canonical, key);
+    }
+
+    return summary;
   }
 
   async list(workflowId?: string): Promise<RunRecord[]> {

--- a/packages/core/src/store/params-hash.ts
+++ b/packages/core/src/store/params-hash.ts
@@ -1,0 +1,30 @@
+// Canonical, dependency-free hashing of a params object for idempotency identity.
+// Used by the run store's pointer index and by the MCP tools to detect a key↔payload
+// mismatch on an idempotency re-encounter.
+import { createHash } from 'node:crypto';
+
+/**
+ * Produce a canonical JSON string: object keys sorted recursively so that two
+ * params objects that are deeply equal (regardless of key insertion order) yield
+ * the same string. `undefined` is treated as `null` in arrays and omitted in
+ * objects, matching `JSON.stringify` semantics.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) return 'null';
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalJson(v)).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(',')}}`;
+}
+
+/** sha256 hex of the canonical JSON of a params object. Stable across key ordering. */
+export function hashParams(params: Record<string, unknown>): string {
+  return createHash('sha256').update(canonicalJson(params)).digest('hex');
+}

--- a/packages/core/src/store/store-interface.ts
+++ b/packages/core/src/store/store-interface.ts
@@ -13,8 +13,19 @@ export interface CreateRunOptions {
 }
 
 export interface RunStore {
-  /** Create a new run record. Returns the created record. */
-  create(options: CreateRunOptions): Promise<RunRecord>;
+  /**
+   * Create a new run record, or — when an `idempotencyKey` is supplied and a run with the
+   * same `(workflowId, idempotencyKey)` already exists — return that existing run instead.
+   *
+   * Returns `{ run, created }`:
+   * - `created: true`  — a new run record was written.
+   * - `created: false` — an existing run matched the idempotency key and is returned unchanged
+   *   (nothing is re-driven; callers inspect `run.run_phase` to decide what to surface).
+   *
+   * NOTE (breaking, 0.8.0): this previously returned `Promise<RunRecord>`. External store
+   * implementations (e.g. the cloud Postgres store) must update to the `{ run, created }` shape.
+   */
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }>;
 
   /** Get a run record by ID. Throws WorkflowError(STATE_RUN_NOT_FOUND) if not found. */
   get(runId: string): Promise<RunRecord>;

--- a/packages/core/src/types/response-envelope.ts
+++ b/packages/core/src/types/response-envelope.ts
@@ -1,5 +1,5 @@
 // Types for the ResponseEnvelope returned by every step execution.
-import type { EvidenceSnapshot } from './run-record.js';
+import type { EvidenceSnapshot, RunPhase } from './run-record.js';
 import type { AgentAction, ErrorCode } from './workflow-error.js';
 
 export interface NextAction {
@@ -82,6 +82,12 @@ export interface ResponseEnvelope {
   retry_after?: number;
   /** Current state orientation. Always populated — describes what just happened and what state the run is in. */
   context_hint: string;
+  /**
+   * Derived phase of the run at the time of this response. Present whenever a run is loaded
+   * (sourced from `run.run_phase`); absent only on pre-execution error envelopes where no run
+   * could be loaded (`buildPreExecutionErrorEnvelope` / `errorEnvelope`).
+   */
+  run_phase?: RunPhase;
   /** Steps available for execution. Empty array means terminal or blocked — check status and run_phase. */
   next_actions: NextAction[];
   blocked_reason?: BlockedReason;

--- a/packages/core/src/workflow/workflow-e2e.test.ts
+++ b/packages/core/src/workflow/workflow-e2e.test.ts
@@ -41,7 +41,7 @@ describe('workflow end-to-end', () => {
     const definition = loadWorkflowFromString(WORKFLOW_YAML);
     const dispatcher = async () => ({});
 
-    const run0 = await store.create({
+    const { run: run0 } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -73,7 +73,7 @@ describe('workflow end-to-end', () => {
     const definition = loadWorkflowFromString(WORKFLOW_YAML);
     const dispatcher = async () => ({});
 
-    const run0 = await store.create({
+    const { run: run0 } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -103,7 +103,7 @@ describe('workflow end-to-end', () => {
   it('depends_on blocks out-of-order execution', async () => {
     const definition = loadWorkflowFromString(WORKFLOW_YAML);
 
-    const run0 = await store.create({
+    const { run: run0 } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -149,7 +149,7 @@ steps:
     const registry = new ExtensionRegistry();
     registry.register('handler', 'config_capture', captureHandler);
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -192,7 +192,7 @@ describe('workflow_context integration', () => {
     );
     const definition = loadWorkflowFromFile(join(wfDir, 'workflow.yaml'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -220,7 +220,7 @@ describe('workflow_context integration', () => {
     );
     const definition = loadWorkflowFromFile(join(wfDir, 'workflow.yaml'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -260,7 +260,7 @@ describe('workflow_context integration', () => {
     );
     const definition = loadWorkflowFromFile(join(wfDir, 'workflow.yaml'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},
@@ -289,7 +289,7 @@ describe('workflow_context integration', () => {
     );
     const definition = loadWorkflowFromFile(join(wfDir, 'workflow.yaml'));
 
-    const run = await store.create({
+    const { run: run } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: {},

--- a/packages/mcp-server/src/tools/append-trace.test.ts
+++ b/packages/mcp-server/src/tools/append-trace.test.ts
@@ -68,7 +68,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('throws STEP_NOT_FOUND when step_id is not in the workflow', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -85,7 +85,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('throws STATE_STEP_NOT_ELIGIBLE when the step is auto', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -103,7 +103,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('throws STATE_STEP_NOT_ELIGIBLE when step is in completed_steps', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -126,7 +126,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('throws STATE_STEP_NOT_ELIGIBLE when step is in in_progress_steps', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -148,7 +148,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('returns status: ok with AppendResult fields when step is eligible and entries are valid', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -171,7 +171,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('empty entries array returns current buffer state without writing', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -193,7 +193,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('propagates BUFFER_FULL error from the buffer store', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -211,7 +211,7 @@ describe('handleAppendTrace', () => {
   });
 
   it('reserved-prefix events are dropped by per-entry normalization; buffer_count reflects only stored entries', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -287,7 +287,7 @@ describe('registerAppendTrace — ResponseEnvelope error shape', () => {
   });
 
   it('returns ResponseEnvelope with error_code on step not found', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},
@@ -305,7 +305,7 @@ describe('registerAppendTrace — ResponseEnvelope error shape', () => {
   });
 
   it('returns ResponseEnvelope with error_code on step not eligible', async () => {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/mcp-server/src/tools/mcp-tools.test.ts
+++ b/packages/mcp-server/src/tools/mcp-tools.test.ts
@@ -531,7 +531,7 @@ describe('mcp tool handlers', () => {
     const workflowStore = new JsonWorkflowStore(workflowDir);
     await workflowStore.register(makeSingleServiceDef());
     const runStore = new JsonFileStore(runDir);
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'single-service-wf',
       workflowVersion: 1,
       params: {},
@@ -563,7 +563,7 @@ describe('mcp tool handlers', () => {
     const workflowStore = new JsonWorkflowStore(workflowDir);
     await workflowStore.register(makeTwoStepServiceDef());
     const runStore = new JsonFileStore(runDir);
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'two-step-service-wf',
       workflowVersion: 1,
       params: {},
@@ -596,7 +596,7 @@ describe('mcp tool handlers', () => {
     const workflowStore = new JsonWorkflowStore(workflowDir);
     await workflowStore.register(makeTwoStepServiceDef());
     const runStore = new JsonFileStore(runDir);
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'two-step-service-wf',
       workflowVersion: 1,
       params: {},
@@ -627,7 +627,7 @@ describe('mcp tool handlers', () => {
     const workflowStore = new JsonWorkflowStore(workflowDir);
     await workflowStore.register(makeTwoStepServiceDef());
     const runStore = new JsonFileStore(runDir);
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'two-step-service-wf',
       workflowVersion: 1,
       params: {},

--- a/packages/mcp-server/src/tools/start-run-batch.ts
+++ b/packages/mcp-server/src/tools/start-run-batch.ts
@@ -7,16 +7,31 @@ import {
   WorkflowError,
   buildPreExecutionErrorEnvelope,
   validateInputSchema,
+  hashParams,
   type ResponseEnvelope,
+  type RunPhase,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
 import { sseJsonStringify } from '../sse-json.js';
+
+/** Lightweight structured telemetry. stderr is safe under the MCP stdio/SSE transport. */
+function logBatchDedup(fields: Record<string, unknown>): void {
+  console.error(JSON.stringify({ event: 'idempotency_dedup', ...fields }));
+}
 
 export interface StartRunBatchResult {
   started: Array<{
     run_id: string;
     idempotency_key?: string;
     params: Record<string, unknown>;
+    /** True when an existing run matched the idempotency key (inverse of the store's `created`). */
+    deduped: boolean;
+    /** Derived phase of the run at enqueue time — identical field name to the single-run path. */
+    run_phase: RunPhase;
+    /** Present only for a terminal matched run. */
+    terminal_reason?: string;
+    /** Observational warnings (active-match / param-mismatch) — identical field name to the single-run path. */
+    warnings: string[];
   }>;
 }
 
@@ -74,18 +89,50 @@ export async function handleStartRunBatch(
   }
 
   const started: StartRunBatchResult['started'] = [];
+  let dedupHits = 0;
   for (const item of args.items) {
-    const run = await runStore.create({
+    const { run, created } = await runStore.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: item.params,
       ...(item.idempotency_key !== undefined ? { idempotencyKey: item.idempotency_key } : {}),
       ...(args.parent_run_id !== undefined ? { parentRunId: args.parent_run_id } : {}),
     });
+    // The store reports `created`; the batch surfaces its inverse, `deduped`, per item.
+    const deduped = !created;
+    if (deduped) dedupHits++;
+
+    const warnings: string[] = [];
+    if (deduped) {
+      if (run.run_phase === 'running' || run.run_phase === 'gate_waiting') {
+        warnings.push(`Idempotency key matched a run still in phase '${run.run_phase}'.`);
+      }
+      if (
+        item.idempotency_key !== undefined &&
+        hashParams(item.params) !== hashParams(run.params)
+      ) {
+        warnings.push(
+          `Idempotency key matched an existing run created with different params; the original run is returned unchanged (params not updated).`,
+        );
+      }
+    }
+
     started.push({
       run_id: run.id,
       ...(item.idempotency_key !== undefined ? { idempotency_key: item.idempotency_key } : {}),
       params: item.params,
+      deduped,
+      run_phase: run.run_phase,
+      ...(run.terminal_reason !== undefined ? { terminal_reason: run.terminal_reason } : {}),
+      warnings,
+    });
+  }
+  if (dedupHits > 0) {
+    logBatchDedup({
+      tool: 'start_run_batch',
+      workflow_id: definition.id,
+      dedup_hits: dedupHits,
+      total: args.items.length,
     });
   }
   return { started };

--- a/packages/mcp-server/src/tools/start-run-idempotency-noop.test.ts
+++ b/packages/mcp-server/src/tools/start-run-idempotency-noop.test.ts
@@ -43,7 +43,7 @@ describe('start_run / start_run_batch on a terminal aborted run (idempotency no-
 
   /** Seeds a terminal aborted run carrying the permanent idempotency key. */
   async function seedAbortedRun(): Promise<RunRecord> {
-    const run = await runStore.create({
+    const { run: run } = await runStore.create({
       workflowId: 'cs1',
       workflowVersion: 1,
       params: {},

--- a/packages/mcp-server/src/tools/start-run-signal.test.ts
+++ b/packages/mcp-server/src/tools/start-run-signal.test.ts
@@ -1,0 +1,191 @@
+// #92 PR 1: the idempotency re-encounter signal on start_run / start_run_batch
+// (deduped, run_phase, accurate context_hint, observational warnings) and run_phase on the envelope.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+  buildPreExecutionErrorEnvelope,
+  WorkflowError,
+} from '@sensigo/realm';
+import type { WorkflowDefinition } from '@sensigo/realm';
+import { handleStartRun } from './start-run.js';
+import { handleStartRunBatch } from './start-run-batch.js';
+
+// Agent-first workflow: a fresh run's only eligible step is an agent step, so start_run takes the
+// NON-chained return path (no auto step to chain into) — exercising the deduped hint/warnings.
+const agentFirst: WorkflowDefinition = {
+  id: 'agentflow',
+  name: 'Agent First',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    review: { description: 'Agent step', execution: 'agent', depends_on: [] },
+  },
+};
+
+// Auto-first workflow: a fresh run chains immediately through an auto step (the chained return path).
+const autoFirst: WorkflowDefinition = {
+  id: 'autoflow',
+  name: 'Auto First',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    compute: { description: 'Auto step', execution: 'auto', depends_on: [] },
+  },
+};
+
+describe('start_run idempotency signal', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    runStore = new JsonFileStore(await mkdtemp(join(tmpdir(), 'sig-run-')));
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'sig-wf-')));
+    await workflowStore.register(agentFirst);
+    await workflowStore.register(autoFirst);
+  });
+
+  it('fresh run → deduped:false, run_phase running, created hint', async () => {
+    const env = await handleStartRun({ workflow_id: 'agentflow' }, { runStore, workflowStore });
+    expect(env.deduped).toBe(false);
+    expect(env.run_phase).toBe('running');
+    expect(env.context_hint).toContain('created');
+  });
+
+  it('terminal match → deduped:true, run_phase set, accurate hint, run byte-unchanged', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    const aborted = await runStore.update({
+      ...run,
+      run_phase: 'aborted',
+      terminal_state: true,
+      terminal_reason: 'aborted by guard',
+      aborted_at: { step_id: 'review' },
+    });
+    const before = await runStore.get(run.id);
+
+    const env = await handleStartRun(
+      { workflow_id: 'agentflow', idempotency_key: 'k1' },
+      { runStore, workflowStore },
+    );
+
+    expect(env.deduped).toBe(true);
+    expect(env.run_phase).toBe('aborted');
+    expect(env.context_hint).toContain('Matched existing run');
+    expect(env.context_hint).not.toContain('created for workflow');
+    // No re-drive: the record is byte-unchanged.
+    const after = await runStore.get(run.id);
+    expect(after).toEqual(before);
+    expect(after.version).toBe(aborted.version);
+  });
+
+  it('running match → deduped:true + observational warning naming the phase', async () => {
+    await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k2',
+    });
+    const env = await handleStartRun(
+      { workflow_id: 'agentflow', idempotency_key: 'k2' },
+      { runStore, workflowStore },
+    );
+    expect(env.deduped).toBe(true);
+    expect(env.run_phase).toBe('running');
+    expect(env.warnings.some((w) => w.includes("phase 'running'"))).toBe(true);
+  });
+
+  it('param mismatch on a re-encounter → warning, original run returned', async () => {
+    const { run: owner } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: { a: 1 },
+      idempotencyKey: 'k3',
+    });
+    const env = await handleStartRun(
+      { workflow_id: 'agentflow', params: { a: 2 }, idempotency_key: 'k3' },
+      { runStore, workflowStore },
+    );
+    expect(env.deduped).toBe(true);
+    expect(env.run_id).toBe(owner.id);
+    expect(env.warnings.some((w) => w.includes('different params'))).toBe(true);
+  });
+
+  it('run_phase is present on the chained (auto-first) return path', async () => {
+    const env = await handleStartRun({ workflow_id: 'autoflow' }, { runStore, workflowStore });
+    expect(env.run_phase).toBeDefined();
+    expect(env.deduped).toBe(false);
+  });
+});
+
+describe('start_run_batch idempotency signal (per-item)', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    runStore = new JsonFileStore(await mkdtemp(join(tmpdir(), 'sigb-run-')));
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'sigb-wf-')));
+    await workflowStore.register(agentFirst);
+  });
+
+  it('each started item carries deduped, run_phase, terminal_reason, warnings', async () => {
+    // Pre-seed a terminal run for key 'dup'.
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'dup',
+    });
+    await runStore.update({
+      ...run,
+      completed_steps: ['review'],
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+    });
+
+    const result = await handleStartRunBatch(
+      {
+        workflow_id: 'agentflow',
+        items: [
+          { params: {}, idempotency_key: 'dup' }, // matches the terminal run
+          { params: {}, idempotency_key: 'fresh' }, // new
+        ],
+      },
+      { runStore, workflowStore },
+    );
+
+    const dup = result.started[0]!;
+    expect(dup.deduped).toBe(true);
+    expect(dup.run_phase).toBe('completed');
+    expect(dup.terminal_reason).toBe('Workflow completed.');
+    expect(Array.isArray(dup.warnings)).toBe(true);
+
+    const fresh = result.started[1]!;
+    expect(fresh.deduped).toBe(false);
+    expect(fresh.run_phase).toBe('running');
+    expect(fresh.terminal_reason).toBeUndefined();
+    expect(fresh.warnings).toEqual([]);
+  });
+});
+
+describe('run_phase on the envelope', () => {
+  it('is absent on a pre-execution error envelope (no run loaded)', () => {
+    const err = new WorkflowError('boom', {
+      code: 'STATE_WORKFLOW_NOT_FOUND',
+      category: 'STATE',
+      agentAction: 'report_to_user',
+      retryable: false,
+    });
+    const env = buildPreExecutionErrorEnvelope('start_run', '', 0, err, 'not found');
+    expect(env.run_phase).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/tools/start-run.ts
+++ b/packages/mcp-server/src/tools/start-run.ts
@@ -7,6 +7,7 @@ import {
   executeChain,
   buildNextActions,
   findEligibleSteps,
+  hashParams,
   WorkflowError,
   buildPreExecutionErrorEnvelope,
   type StepDispatcher,
@@ -15,6 +16,11 @@ import {
   ExtensionRegistry,
 } from '@sensigo/realm';
 import { sseJsonStringify } from '../sse-json.js';
+
+/** Lightweight structured telemetry. stderr is safe under the MCP stdio/SSE transport. */
+function logDedup(fields: Record<string, unknown>): void {
+  console.error(JSON.stringify({ event: 'idempotency_dedup', ...fields }));
+}
 
 export interface HandleRunStores {
   runStore?: JsonFileStore;
@@ -41,18 +47,40 @@ export async function handleStartRun(
     idempotency_key?: string | undefined;
   },
   stores?: HandleRunStores,
-): Promise<ResponseEnvelope> {
+): Promise<ResponseEnvelope & { deduped: boolean }> {
   const workflowStore = stores?.workflowStore ?? new JsonWorkflowStore();
   const runStore = stores?.runStore ?? new JsonFileStore();
   const definition = await workflowStore.get(args.workflow_id);
   const params = args.params ?? {};
 
-  const run = await runStore.create({
+  const { run, created } = await runStore.create({
     workflowId: definition.id,
     workflowVersion: definition.version,
     params,
     ...(args.idempotency_key !== undefined ? { idempotencyKey: args.idempotency_key } : {}),
   });
+  // The store reports `created`; the tool surfaces its inverse, `deduped`.
+  const deduped = !created;
+
+  const warnings: string[] = [];
+  if (deduped) {
+    // Observational only — a legitimate same-caller retry also hits an active run.
+    if (run.run_phase === 'running' || run.run_phase === 'gate_waiting') {
+      warnings.push(`Idempotency key matched a run still in phase '${run.run_phase}'.`);
+    }
+    // PR 1 warns on a key↔payload mismatch; PR 2 may make this policy.
+    if (args.idempotency_key !== undefined && hashParams(params) !== hashParams(run.params)) {
+      warnings.push(
+        `Idempotency key matched an existing run created with different params; the original run is returned unchanged (params not updated).`,
+      );
+    }
+    logDedup({
+      tool: 'start_run',
+      workflow_id: definition.id,
+      run_id: run.id,
+      run_phase: run.run_phase,
+    });
+  }
 
   const eligible = findEligibleSteps(definition, run);
   const firstAutoStep = eligible.find((name) => definition.steps[name]?.execution === 'auto');
@@ -66,7 +94,17 @@ export async function handleStartRun(
       ...(stores?.registry !== undefined ? { registry: stores.registry } : {}),
       ...(stores?.secrets !== undefined ? { secrets: stores.secrets } : {}),
     });
-    return { ...result, run_id: run.id, data: {}, evidence: [] };
+    // Source run_phase from the final run so the spread can't drop it.
+    const finalRun = await runStore.get(run.id).catch(() => run);
+    return {
+      ...result,
+      run_id: run.id,
+      data: {},
+      evidence: [],
+      run_phase: finalRun.run_phase,
+      warnings: [...result.warnings, ...warnings],
+      deduped,
+    };
   }
 
   const nextActions = buildNextActions(definition, run);
@@ -77,9 +115,13 @@ export async function handleStartRun(
     status: 'ok',
     data: {},
     evidence: [],
-    warnings: [],
+    warnings,
     errors: [],
-    context_hint: `Run '${run.id}' created for workflow '${definition.id}'.`,
+    context_hint: deduped
+      ? `Matched existing run '${run.id}' (idempotent) in phase '${run.run_phase}'; no new run created.`
+      : `Run '${run.id}' created for workflow '${definition.id}'.`,
+    run_phase: run.run_phase,
+    deduped,
     next_actions: nextActions,
   };
 }

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -80,7 +80,7 @@ function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
 describe('InMemoryStore', () => {
   it('create() returns a record with version 0', async () => {
     const store = new InMemoryStore();
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -92,7 +92,7 @@ describe('InMemoryStore', () => {
 
   it('get() returns the created record', async () => {
     const store = new InMemoryStore();
-    const created = await store.create({
+    const { run: created } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -110,7 +110,7 @@ describe('InMemoryStore', () => {
 
   it('update() increments version on success', async () => {
     const store = new InMemoryStore();
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -122,7 +122,7 @@ describe('InMemoryStore', () => {
 
   it('update() throws WorkflowError(STATE_SNAPSHOT_MISMATCH) on version mismatch', async () => {
     const store = new InMemoryStore();
-    const record = await store.create({
+    const { run: record } = await store.create({
       workflowId: 'wf-1',
       workflowVersion: 1,
       params: {},
@@ -164,6 +164,46 @@ describe('InMemoryStore', () => {
     });
     const all = await store.list();
     expect(all).toHaveLength(2);
+  });
+
+  it('create() reports created:true for a new run and created:false on a same-key match (parity with JsonFileStore)', async () => {
+    const store = new InMemoryStore();
+    const first = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(first.created).toBe(true);
+    const second = await store.create({
+      workflowId: 'wf-1',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(second.created).toBe(false);
+    expect(second.run.id).toBe(first.run.id);
+    // Only one run exists for the key.
+    const all = await store.list('wf-1');
+    expect(all).toHaveLength(1);
+  });
+
+  it('create() idempotency is scoped per workflow and stores the key field', async () => {
+    const store = new InMemoryStore();
+    const { run: a } = await store.create({
+      workflowId: 'wf-a',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    const { run: b } = await store.create({
+      workflowId: 'wf-b',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: 'k1',
+    });
+    expect(a.id).not.toBe(b.id);
+    expect(a.idempotency_key).toBe('k1');
   });
 });
 

--- a/packages/testing/src/runner/test-runner.ts
+++ b/packages/testing/src/runner/test-runner.ts
@@ -67,7 +67,7 @@ async function runSingleFixture(
       fixture.agent_errors,
     );
 
-    const run = await store.create({
+    const { run } = await store.create({
       workflowId: definition.id,
       workflowVersion: definition.version,
       params: fixture.params,

--- a/packages/testing/src/store/in-memory-store.ts
+++ b/packages/testing/src/store/in-memory-store.ts
@@ -12,13 +12,30 @@ import {
 /** In-memory implementation of RunStore. Uses a Map keyed by run ID. No I/O, no locking. */
 export class InMemoryStore implements RunStore {
   private readonly runs = new Map<string, RunRecord>();
+  /** Idempotency-key pointer equivalent: `${workflowId}\0${key}` → runId. Parity with JsonFileStore. */
+  private readonly keyIndex = new Map<string, string>();
 
-  async create(options: CreateRunOptions): Promise<RunRecord> {
+  async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    // Idempotency: a key match returns the existing run (any phase), like JsonFileStore.
+    if (options.idempotencyKey !== undefined) {
+      const gk = `${options.workflowId}\0${options.idempotencyKey}`;
+      const existingId = this.keyIndex.get(gk);
+      if (existingId !== undefined) {
+        const existing = this.runs.get(existingId);
+        if (existing !== undefined) {
+          return { run: existing, created: false };
+        }
+        // mapped run vanished → reclaim by falling through to a fresh create.
+      }
+    }
+
     const now = new Date().toISOString();
     const record: RunRecord = {
       id: crypto.randomUUID(),
       workflow_id: options.workflowId,
       workflow_version: options.workflowVersion,
+      ...(options.parentRunId !== undefined ? { parent_run_id: options.parentRunId } : {}),
+      ...(options.idempotencyKey !== undefined ? { idempotency_key: options.idempotencyKey } : {}),
       completed_steps: [],
       in_progress_steps: [],
       failed_steps: [],
@@ -32,7 +49,10 @@ export class InMemoryStore implements RunStore {
       terminal_state: false,
     };
     this.runs.set(record.id, record);
-    return record;
+    if (options.idempotencyKey !== undefined) {
+      this.keyIndex.set(`${options.workflowId}\0${options.idempotencyKey}`, record.id);
+    }
+    return { run: record, created: true };
   }
 
   async get(runId: string): Promise<RunRecord> {


### PR DESCRIPTION
## Context

#92 (idempotency re-encounter semantics), **PR 1 of 2** — the foundation. Converged through a full design debate (Peer + 3 Design-Reviewer rounds + industry research: Stripe `Idempotent-Replayed`, Temporal reuse/conflict policy, AWS Powertools). The debate established that Realm's prior out-of-scope observations (TOCTOU double-insert, readdir-nondeterminism, O(n)-per-create cost, silent key↔payload mismatch, `save()` back door) all share one root cause: `idempotency_key` was a mutable field discovered by an O(n) scan, not a first-class identity.

## Motivation

Make `idempotency_key` a **first-class, atomically-managed identity**, closing that whole class of issues at the root, and surface idempotency re-encounters with a truthful signal. The v0.7.1/#95 guards already closed the corruption hole, so this is soundness + observability (the re-encounter *policy* is PR 2).

## Changes

- **Pointer index (`JsonFileStore`).** A deterministic per-key pointer at `<runsDir>/keys/<sha256(workflowId\0key)>.json` (run id + `params_hash`), resolved by one path read under a per-key `proper-lockfile`. **Crash-safe:** run file written before pointer; a pointer to a missing run self-heals (reclaim); a run written without its pointer is recovered by a lazy legacy-field fallback. `keys/` is invisible to `list()`.
- **`RunStore.create()` → `{ run, created }`** (BREAKING — see CHANGELOG; external cloud Postgres store must update). Both bundled stores updated; `InMemoryStore` brought to idempotency parity (was a no-op). All 6 in-repo callers destructure `{ run }`.
- **Re-encounter signal.** `ResponseEnvelope` gains optional `run_phase` (present whenever a run is loaded — fixes a dangling doc comment). `start_run` reports `deduped`, an accurate `context_hint` on a match, and observational warnings (matched run still active / created with different params). `start_run_batch` reports the same per `started[]` item. Dedup activity logged at the tool boundary.
- **`realm run reconcile`** — eager, idempotent, reversible migration of existing runs into the index (`--workflow`, `--dry-run`). Skipping it is safe (lazy self-migration).
- **`save()`** routes keyed imports through the index (conflicting live owner throws).

## Verification

```bash
npm run lint     # exit 0, zero warnings
npm run test     # core 1252 (+15), cli 347 (=), testing 49 (+2), mcp 81 (+7) — all green
npm run build    # tsc --build 4/4
node scripts/check-versions.mjs   # 0.7.1, no bump
```
Key new tests: **atomic claim** (concurrent `Promise.all` same-key → one `created:true`, same id, exactly one run file); deterministic resolution; self-heal (pointer→deleted run); lazy legacy migration; `reconcileKeys` canonical-pick + idempotency + dry-run; `save()` index routing + conflict; the full re-encounter signal on both tools; `run_phase` present on loaded-run envelopes incl. the #95 guard, absent on pre-execution errors.

## Rollback

```bash
git revert <merge-commit>
```
Pure code change. The `keys/` index is additive (deleting it falls back to lazy rebuild); no run files are mutated. Reverting restores the prior scan-based `create()` and `RunRecord`-returning signature (external store impls that updated to `{ run, created }` would then need to revert too).

## Related

PR 1 of 2 toward #92 (does not close it — PR 2 adds the re-encounter policy and carries `Closes #92`). Batches (unreleased) with #91 for the **0.8.0** release.
