### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
-
-> **Version intent: 0.8.0.** This release carries a breaking change to the `RunStore` interface (see below). On a 0.x line a breaking change bumps the minor segment.
+## [0.8.0] — 2026-06-24
 
 ### Changed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.7.1');
+program.name('realm').description('Realm workflow engine CLI').version('0.8.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.7.1';
+export const VERSION = '0.8.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.7.1';
+export const VERSION = '0.8.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.7.1',
+    version: '0.8.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.7.1';
+export const VERSION = '0.8.0';


### PR DESCRIPTION
## Context

Release **v0.8.0** — minor bump (breaking change on a 0.x line). Batches three merged pieces: #91 (`executeChain` terminal-run guard), #92 PR 1 (idempotency pointer-index identity + re-encounter signal), #92 PR 2 (re-encounter policy). All four packages bumped 0.7.1 → 0.8.0.

## Motivation

Ship the idempotency identity-model work (#92) and the defense-in-depth chain guard (#91). 0.8.0 (not a patch) because PR 1 carries a **breaking** `RunStore.create()` signature change.

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.8.0] — 2026-06-24` (version-intent note removed).
- Version bumped to `0.8.0` across all four `package.json` files and the five source `VERSION` constants (via `scripts/release.mjs`).

Release commit `b4d40de` is tagged `v0.8.0`. **Merge with a merge commit** (not rebase/squash) so the tagged commit's SHA stays reachable from `main` — the publish workflow depends on it.

## Verification

```bash
node scripts/check-versions.mjs   # all 0.8.0, consistent
npm run test                      # full suite green (verified on #96/#97 + pre-release)
```
After merge + tag push, `publish.yml` publishes all four packages via OIDC. Post-publish:
```bash
mkdir /tmp/test-080 && cd /tmp/test-080 && npm init -y
npm install @sensigo/realm@0.8.0
node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"  # 0.8.0
```

## Rollback

If publish fails partway, re-push the tag (already-published packages skip with `EPUBLISHCONFLICT`). If a published artifact is broken, cut 0.8.1 following the same Part B sequence.

## Related

Cuts #91 + #92 (closed) to npm. **Breaking:** external `RunStore` implementations (cloud Postgres store) must update `create()` to return `{ run, created }` before bumping to 0.8.0.
