### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
-
-> **Version intent: 0.9.0.** Additive, backward-compatible loosenings of load-time validation (previously-invalid YAML becomes valid; no existing valid workflow changes behavior).
+## [0.9.0] — 2026-06-24
 
 ### Changed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.8.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.9.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.8.0';
+export const VERSION = '0.9.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.8.0';
+export const VERSION = '0.9.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.8.0',
+    version: '0.9.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.8.0';
+export const VERSION = '0.9.0';


### PR DESCRIPTION
## Context

Release **v0.9.0** — additive, backward-compatible feature release. Carries one change: `$literal` (input_map) now accepts any JSON value (arrays/objects, not just scalars), and step `config` may hold nested objects (the redundant load-time "v1" ban is removed; adapter `config_schema` remains the validator).

## Motivation

Ship the literal-value loosening (PR #99) so consumers can pass literal arrays/objects into handlers via `input_map`. Minor bump — backward-compatible (previously-invalid YAML becomes valid; no existing valid workflow changes behavior).

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.9.0] — 2026-06-24` (version-intent note removed).
- Version bumped to `0.9.0` across all four `package.json` files and the five source `VERSION` constants (via `scripts/release.mjs`).

Release commit is tagged `v0.9.0`. **Merge with a merge commit** so the tagged SHA stays reachable from `main` (publish workflow depends on it).

## Verification

```bash
node scripts/check-versions.mjs   # all 0.9.0
npm run test                      # full suite green (verified on #99 + pre-release)
```
After merge + tag push, `publish.yml` publishes all four packages via OIDC. Post-publish: `npm install @sensigo/realm@0.9.0` + ESM `import { VERSION }` → `0.9.0`.

## Rollback

If publish fails partway, re-push the tag (already-published packages skip with `EPUBLISHCONFLICT`). If an artifact is broken, cut 0.9.1 via the same Part B sequence.

## Related

Cuts PR #99 to npm. No breaking changes.
