### PR TITLE
feat(engine): run-lifecycle recovery bundle — abandon_run, abandoned_at, get_run_state diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+> **Version intent: 0.10.0.** Additive run-recovery surface; defaults preserve current behavior, no breaking changes.
+
+### Added
+
+- **`abandon_run` MCP tool + `realm run abandon <run-id> [--reason …]` CLI** — explicitly abandon a non-terminal run (marks it terminal, phase `abandoned`) via a shared core `abandonRun()` primitive. Idempotent; refuses already-terminal runs (`STATE_RUN_TERMINAL`) and `gate_waiting` runs (`STATE_TRANSITION_DENIED` — resolve the gate via `submit_human_response` first); concurrency-safe (a live writer wins, abandon propagates `STATE_SNAPSHOT_MISMATCH` rather than corrupting). Brings the MCP tool count to 10.
+- **`get_run_state` now returns `next_actions` + `next_actions_status`** (`ok` / `auto_pending` / `awaiting_human` / `workflow_unresolved` / `skipped_terminal`) — read-only recovery diagnostics that distinguish a genuinely-parked run from one with no pending agent action.
+- **`realm run list --stuck`** — lists advanced-but-parked runs (phase `running` with no claimed step), with idle age.
+- **`docs/reference/operating-runs.md`** — "Operating & recovering runs" decision table + recovery loop.
+
+### Changed
+
+- **`deriveRunPhase` honors a new authoritative `abandoned_at` marker** (set by `abandon_run` / `realm run abandon` / `realm run cleanup`): its presence makes `abandoned` the derived phase regardless of `failed_steps` / `terminal_reason`. Fixes a latent case where an idle `running` run carrying `failed_steps` would be mislabeled `failed` on cleanup.
+- **`submit_human_response` now rejects a gate response on a terminal run** (`STATE_RUN_TERMINAL`) — defense-in-depth so a late response cannot re-drive a finished run.
+
+---
+
 ## [0.9.0] — 2026-06-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You define workflows in YAML. The engine enforces step order, validates every ag
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `@sensigo/realm`         | [![npm](https://img.shields.io/npm/v/@sensigo/realm)](https://www.npmjs.com/package/@sensigo/realm)                 | Core engine — state guard, execution loop, evidence capture              |
 | `@sensigo/realm-cli`     | [![npm](https://img.shields.io/npm/v/@sensigo/realm-cli)](https://www.npmjs.com/package/@sensigo/realm-cli)         | `realm` CLI — 18 commands for building, operating, and serving workflows |
-| `@sensigo/realm-mcp`     | [![npm](https://img.shields.io/npm/v/@sensigo/realm-mcp)](https://www.npmjs.com/package/@sensigo/realm-mcp)         | `realm-mcp` MCP server — 9 tools for AI agent connections                |
+| `@sensigo/realm-mcp`     | [![npm](https://img.shields.io/npm/v/@sensigo/realm-mcp)](https://www.npmjs.com/package/@sensigo/realm-mcp)         | `realm-mcp` MCP server — 10 tools for AI agent connections               |
 | `@sensigo/realm-testing` | [![npm](https://img.shields.io/npm/v/@sensigo/realm-testing)](https://www.npmjs.com/package/@sensigo/realm-testing) | Testing utilities — fixtures, assertions, in-memory store                |
 
 ## Installation
@@ -131,7 +131,7 @@ REALM_SERVE_TOKEN=<secret> realm serve --port 3001
 
 This starts an HTTP MCP server protected by Bearer token authentication. Use `--dev` to skip auth during local development.
 
-Once connected the agent has access to 9 tools: `list_workflows`, `get_workflow_protocol`, `start_run`, `start_run_batch`, `execute_step`, `submit_human_response`, `get_run_state`, `create_workflow`, and `list_runs`.
+Once connected the agent has access to 10 tools: `list_workflows`, `get_workflow_protocol`, `start_run`, `start_run_batch`, `execute_step`, `submit_human_response`, `get_run_state`, `abandon_run`, `create_workflow`, and `list_runs`.
 
 The agent calls `list_workflows` to discover registered workflows, then `get_workflow_protocol` for the matched workflow to receive explicit step-by-step instructions. It cannot execute a step out of order or submit output that fails schema validation.
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -231,11 +231,16 @@ Lists all runs, sorted by most recent first.
 realm run list
 realm run list --workflow <workflow-id>   # filter by workflow
 realm run list --status <phase>           # filter by run phase
+realm run list --stuck                    # only advanced-but-parked runs (running, no claimed step)
 ```
 
 Valid `--status` values: `running`, `gate_waiting`, `completed`, `failed`, `abandoned`.
 
 When filtering by `gate_waiting`, each line also shows the gate step name and gate age (time since the gate opened).
+
+`--stuck` (mutually exclusive with `--status`) shows only runs in phase `running` with no claimed
+step (`in_progress_steps` empty) — the stuck-run incident signature — and appends each run's idle
+age. See [Operating & recovering runs](operating-runs.md).
 
 Output per run: `run-id  workflow-id vN  run_phase  timestamp  N step(s)`
 
@@ -346,6 +351,23 @@ Resets a failed or abandoned run to a state where a specific step can re-execute
 ```bash
 realm run resume abc123 --from <step-name>
 ```
+
+---
+
+### `realm run abandon <run-id>`
+
+Explicitly abandons a non-terminal run — marks it terminal with phase `abandoned`. Use it on a run
+that is parked and not coming back (see `realm run list --stuck`).
+
+```bash
+realm run abandon abc123
+realm run abandon abc123 --reason "stale runner, no longer processing"
+```
+
+Idempotent (abandoning an already-abandoned run succeeds). Refuses an already-terminal run, and
+refuses a `gate_waiting` run (resolve the gate via `realm run respond` first). To re-run the same
+work afterward, use `start_run` with `on_terminal_match: 'rerun'` or a fresh idempotency key — the
+default returns the abandoned run. See [Operating & recovering runs](operating-runs.md).
 
 ---
 

--- a/docs/reference/mcp-protocol.md
+++ b/docs/reference/mcp-protocol.md
@@ -1,6 +1,6 @@
 # MCP Protocol Reference
 
-Realm exposes 9 MCP tools. This document covers the full protocol: tool call patterns, response envelope fields, and error recovery.
+Realm exposes 10 MCP tools. This document covers the full protocol: tool call patterns, response envelope fields, and error recovery.
 
 ---
 
@@ -14,9 +14,28 @@ Realm exposes 9 MCP tools. This document covers the full protocol: tool call pat
 | `start_run_batch`       | Atomically enqueues multiple runs of the same workflow. Accepts a single `workflow_id`, an `items` array (each item has `params` and optional `idempotency_key`), optional `parent_run_id`, and optional `max_items` (default 100). All items are validated before any run is created.                                                                                               |
 | `execute_step`          | Submits agent output for the current step. Accepts `run_id`, `command` (step name), and `params`.                                                                                                                                                                                                                                                                                    |
 | `submit_human_response` | Submits a human gate response. Accepts `run_id`, `gate_id`, and `choice`.                                                                                                                                                                                                                                                                                                            |
-| `get_run_state`         | Returns the current state, evidence chain, and terminal status of a run. When `run_phase` is `aborted`, also returns `abort_context` (guard step ID, evaluated conditions, optional abort message).                                                                                                                                                                                  |
+| `get_run_state`         | Returns the current state, evidence chain, and terminal status of a run. When `run_phase` is `aborted`, also returns `abort_context` (guard step ID, evaluated conditions, optional abort message). Also returns `next_actions` + `next_actions_status` (see below).                                                                                                                 |
+| `abandon_run`           | Abandons a non-terminal run — marks it terminal with phase `abandoned`. Accepts `run_id` and optional `reason`. Idempotent; refuses already-terminal runs (`STATE_RUN_TERMINAL`) and `gate_waiting` runs (`STATE_TRANSITION_DENIED` — resolve the gate first). See [Operating & recovering runs](operating-runs.md).                                                                 |
 | `create_workflow`       | Registers a dynamic workflow from a `steps` array and immediately starts a run. No YAML file or `realm register` required.                                                                                                                                                                                                                                                           |
 | `list_runs`             | Lists runs, optionally filtered by `workflow_id` or `status`.                                                                                                                                                                                                                                                                                                                        |
+
+---
+
+## `get_run_state` diagnostics
+
+`get_run_state` is read-only and returns, in addition to the state summary, the run's eligible
+agent/handler steps as `next_actions` plus a `next_actions_status` that classifies the run:
+
+| `next_actions_status` | Meaning                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `ok`                  | `next_actions` is authoritative — agent steps to call, or a healthy run with nothing pending now.             |
+| `auto_pending`        | Eligible steps exist but are all `auto` — the engine drives them; the run is not awaiting the agent.          |
+| `awaiting_human`      | A human gate is open — answer with `submit_human_response`.                                                   |
+| `skipped_terminal`    | The run is terminal; nothing to do.                                                                           |
+| `workflow_unresolved` | The workflow definition could not be loaded (unregistered / no workflow store) — `next_actions` not computed. |
+
+`auto_pending` vs an empty `ok` distinguishes a genuinely-parked run from one with no pending agent
+action. See [Operating & recovering runs](operating-runs.md).
 
 ---
 

--- a/docs/reference/operating-runs.md
+++ b/docs/reference/operating-runs.md
@@ -1,0 +1,65 @@
+# Operating & recovering runs
+
+How to diagnose and recover runs that are stuck, dead, or idle. Realm is daemonless: there is no
+background process driving runs — an agent drives a run by calling tools, and the run record on disk
+is the source of truth. Recovery is therefore about the **record**, not about killing a process.
+
+---
+
+## Decision table
+
+| Situation             | Symptom                                                                                              | Action                                                                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stuck but recoverable | A run is terminal `failed` because one step errored, but the work can be retried                     | `realm resume <run-id> --from <step>` — re-enables the failed step and resets the run to `running`, then drive with `realm agent --run-id <run-id>`. |
+| Stuck and dead        | A run is `running` with no claimed step (`in_progress_steps: []`) and no agent is coming back for it | `realm run abandon <run-id> [--reason …]` (or the `abandon_run` MCP tool), then re-run (see [Recovery loop](#recovery-loop)).                        |
+| Bulk idle             | Many old non-terminal runs left parked                                                               | `realm run cleanup --older-than 30d` — abandons idle non-terminal runs (skips `gate_waiting`).                                                       |
+| Fleet visibility      | "Which runs are stuck right now?"                                                                    | `realm run list --stuck` (running ∧ no claimed step, with idle age) and `get_run_state` → `next_actions_status`.                                     |
+| Awaiting a human      | A run is `gate_waiting`                                                                              | Resolve it via `submit_human_response` (the `respond` MCP tool / `realm run respond`). **Do NOT abandon a gated run** — abandon refuses it.          |
+
+### `next_actions_status` (from `get_run_state`)
+
+`get_run_state` returns `next_actions` plus a `next_actions_status` that classifies the run:
+
+| Status                | Meaning                                                                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ok`                  | `next_actions` is authoritative — either there are agent steps to call, or the run is healthy with nothing pending right now.                    |
+| `auto_pending`        | Eligible steps exist but they are all `auto` — the engine drives them on the next `execute_step`/chain; the run is **not** waiting on the agent. |
+| `awaiting_human`      | A human gate is open — answer it with `submit_human_response`.                                                                                   |
+| `skipped_terminal`    | The run is terminal; nothing to do.                                                                                                              |
+| `workflow_unresolved` | The workflow definition could not be loaded (not registered, or no workflow store wired) — `next_actions` could not be computed.                 |
+
+`auto_pending` vs an empty `ok` is the key diagnostic that separates a genuinely-parked run from one
+that simply has no agent action pending.
+
+---
+
+## Abandoning a run
+
+`abandon_run` (MCP) / `realm run abandon` (CLI) stamps an authoritative `abandoned_at` marker, which
+makes the run derive to phase `abandoned` regardless of any `failed_steps` it carries. It:
+
+- is **idempotent** — abandoning an already-abandoned run is a no-op success;
+- **refuses a terminal run** (`completed`/`failed`/`aborted`) with `STATE_RUN_TERMINAL` — it never clobbers a finished run;
+- **refuses a `gate_waiting` run** with `STATE_TRANSITION_DENIED` — resolve the gate first (gate abandonment is intentionally not supported in this version);
+- is **concurrency-safe** — if a live writer advances the run while abandon is in flight, abandon loses (propagates `STATE_SNAPSHOT_MISMATCH`) rather than corrupting the record.
+
+### Honesty note
+
+Abandoning closes the **record**, not any detached agent process. Realm cannot stop a detached
+`realm agent` that may still be running elsewhere. This is safe: the engine's terminal-run guards
+make that agent's next `execute_step` / `submit_human_response` / `executeChain` call a no-op on the
+now-terminal run — it cannot re-drive or un-abandon it.
+
+---
+
+## Recovery loop
+
+After abandoning a run you usually want to re-run the same work. Because the original run keeps its
+idempotency key, the **default** `start_run` policy (`on_terminal_match: 'reuse'`) returns the
+abandoned run instead of starting fresh. To actually re-run, either:
+
+- call `start_run(..., on_terminal_match: 'rerun')` (or `'rerun_if_failed'`) to **supersede** the
+  abandoned run with a fresh one, or
+- start with a **new idempotency key**.
+
+See the idempotency re-encounter policy in [mcp-protocol.md](mcp-protocol.md#idempotency-re-encounter-policy).

--- a/packages/cli/src/commands-registry.ts
+++ b/packages/cli/src/commands-registry.ts
@@ -5,6 +5,7 @@ import { validateCommand } from './commands/validate.js';
 import { registerCommand } from './commands/register.js';
 import { runCommand } from './commands/run.js';
 import { resumeCommand } from './commands/resume.js';
+import { abandonCommand } from './commands/abandon.js';
 import { cleanupCommand } from './commands/cleanup.js';
 import { reconcileCommand } from './commands/reconcile.js';
 import { respondCommand } from './commands/respond.js';
@@ -40,6 +41,7 @@ export const runCommands = [
   replayCommand,
   diffCommand,
   resumeCommand,
+  abandonCommand,
   respondCommand,
   cleanupCommand,
   reconcileCommand,

--- a/packages/cli/src/commands/abandon.test.ts
+++ b/packages/cli/src/commands/abandon.test.ts
@@ -1,0 +1,63 @@
+// Tests for the `realm run abandon` CLI command. The command constructs a JsonFileStore against
+// $HOME/.realm/runs (like resume/cleanup). JsonFileStore's default dir is computed at module-load,
+// so we set $HOME before the FIRST `@sensigo/realm` import (no static import here; load it lazily
+// inside the tests, after beforeEach has pointed $HOME at a temp dir).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { abandonCommand } from './abandon.js';
+
+describe('realm run abandon (CLI command)', () => {
+  let home: string;
+  let runsDir: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'realm-abandon-cli-'));
+    runsDir = join(home, '.realm', 'runs');
+    await mkdir(runsDir, { recursive: true });
+    originalHome = process.env['HOME'];
+    process.env['HOME'] = home;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = originalHome;
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('success: abandons a running run and reports it', async () => {
+    const { JsonFileStore } = await import('@sensigo/realm');
+    const store = new JsonFileStore(); // default dir = $HOME/.realm/runs (temp)
+    const { run } = await store.create({ workflowId: 'wf', workflowVersion: 1, params: {} });
+
+    await abandonCommand.parseAsync([run.id, '--reason', 'stale'], { from: 'user' });
+
+    const reloaded = await store.get(run.id);
+    expect(reloaded.run_phase).toBe('abandoned');
+    expect(reloaded.abandoned_at).toBeDefined();
+    expect(reloaded.terminal_reason).toBe('stale');
+    expect(logSpy).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('error: a missing run prints an error and exits non-zero', async () => {
+    await expect(abandonCommand.parseAsync(['no-such-run'], { from: 'user' })).rejects.toThrow(
+      'process.exit',
+    );
+    expect(errSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/abandon.ts
+++ b/packages/cli/src/commands/abandon.ts
@@ -1,0 +1,21 @@
+// abandon command — explicitly abandons a non-terminal run via the shared core primitive.
+import { Command } from 'commander';
+
+export const abandonCommand = new Command('abandon')
+  .description('Abandon a non-terminal run (marks it terminal with phase "abandoned")')
+  .argument('<run-id>', 'ID of the run to abandon')
+  .option('--reason <text>', 'Human-readable reason recorded as terminal_reason')
+  .action(async (runId: string, opts: { reason?: string }) => {
+    const { JsonFileStore, abandonRun } = await import('@sensigo/realm');
+    const runStore = new JsonFileStore();
+    try {
+      const run = await abandonRun(runStore, runId, opts.reason);
+      console.log(
+        `Run '${runId}' abandoned (phase: '${run.run_phase}'). Reason: ${run.terminal_reason}.\n` +
+          `To re-run the same idempotency key, use start_run with on_terminal_match: 'rerun' (default 'reuse' returns this abandoned run).`,
+      );
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/commands/cleanup.test.ts
+++ b/packages/cli/src/commands/cleanup.test.ts
@@ -137,4 +137,24 @@ describe('cleanupRuns', () => {
     expect(unchanged.run_phase).toBe('gate_waiting');
     expect(unchanged.terminal_state).toBe(false);
   });
+
+  it('sets abandoned_at and derives abandoned (not failed) for an idle running run carrying failed_steps', async () => {
+    const now = new Date('2024-06-01T12:00:00Z');
+    vi.setSystemTime(now);
+
+    const oldTime = new Date(now.getTime() - 2 * 86_400_000).toISOString();
+    // A running run that already accumulated a failed step — without the authoritative marker this
+    // would derive to 'failed' on cleanup's update().
+    const run = makeRun({ updated_at: oldTime, run_phase: 'running', failed_steps: ['step_a'] });
+    await injectRun(dir, run);
+
+    const store = new JsonFileStore(dir);
+    const { affected } = await cleanupRuns({ olderThan: '1d' }, store);
+    expect(affected).toHaveLength(1);
+
+    const updated = await store.get(run.id);
+    expect(updated.abandoned_at).toBeDefined();
+    expect(updated.run_phase).toBe('abandoned'); // authoritative marker beats failed_steps
+    expect(updated.terminal_state).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/cleanup.ts
+++ b/packages/cli/src/commands/cleanup.ts
@@ -57,6 +57,7 @@ export async function cleanupRuns(
     for (const run of affected) {
       await runStore.update({
         ...run,
+        abandoned_at: new Date().toISOString(),
         run_phase: 'abandoned',
         terminal_state: true,
         terminal_reason: 'Marked abandoned by realm cleanup',

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -150,6 +150,39 @@ describe('listRuns', () => {
     expect(result).toContain('run-a');
     expect(result).not.toContain('run-b');
   });
+
+  // --stuck diagnostic (0.10.0)
+  it('--stuck shows only running runs with no claimed step', async () => {
+    const stuck = makeRun({
+      id: 'run-stuck',
+      run_phase: 'running',
+      terminal_state: false,
+      in_progress_steps: [],
+    });
+    const active = makeRun({
+      id: 'run-active',
+      run_phase: 'running',
+      terminal_state: false,
+      in_progress_steps: ['step_a'],
+    });
+    const done = makeRun({ id: 'run-done', run_phase: 'completed', terminal_state: true });
+    const result = await listRuns(undefined, makeStore([stuck, active, done]), undefined, true);
+    expect(result).toContain('run-stuck');
+    expect(result).not.toContain('run-active'); // has a claimed step
+    expect(result).not.toContain('run-done'); // terminal
+    expect(result).toContain('idle:'); // idle age shown
+  });
+
+  it('--stuck returns a no-stuck-runs message when none match', async () => {
+    const active = makeRun({
+      id: 'run-active',
+      run_phase: 'running',
+      terminal_state: false,
+      in_progress_steps: ['step_a'],
+    });
+    const result = await listRuns(undefined, makeStore([active]), undefined, true);
+    expect(result).toContain('No stuck runs found');
+  });
 });
 
 describe('listRuns statusFilter', () => {

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -44,16 +44,21 @@ export async function listRuns(
   workflowId: string | undefined,
   store: RunStore,
   statusFilter?: RunPhase,
+  stuck?: boolean,
 ): Promise<string> {
   const runs = await store.list(workflowId);
 
-  const filtered =
-    statusFilter !== undefined ? runs.filter((r) => r.run_phase === statusFilter) : runs;
+  let filtered = runs;
+  if (stuck === true) {
+    // Advanced-but-parked: phase running with no claimed step (the stuck-run incident signature).
+    filtered = runs.filter((r) => r.run_phase === 'running' && r.in_progress_steps.length === 0);
+  } else if (statusFilter !== undefined) {
+    filtered = runs.filter((r) => r.run_phase === statusFilter);
+  }
 
   if (filtered.length === 0) {
-    return workflowId !== undefined
-      ? `No runs found for workflow '${workflowId}'.`
-      : 'No runs found.';
+    const scope = workflowId !== undefined ? ` for workflow '${workflowId}'` : '';
+    return stuck === true ? `No stuck runs found${scope}.` : `No runs found${scope}.`;
   }
 
   filtered.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
@@ -66,7 +71,10 @@ export async function listRuns(
       run.evidence.filter((e) => e.kind !== 'gate_response').map((e) => e.step_id),
     ).size;
     let line = `${chalk.dim(run.id)}  ${chalk.bold(run.workflow_id)} v${run.workflow_version}  ${state}  ${updated}  ${steps} step(s)`;
-    if (run.run_phase === 'gate_waiting' && run.pending_gate !== undefined) {
+    if (stuck === true) {
+      // Show how long the run has been parked (idle age since last update).
+      line += `  idle: ${formatGateAge(run.updated_at)}`;
+    } else if (run.run_phase === 'gate_waiting' && run.pending_gate !== undefined) {
       const age = formatGateAge(run.pending_gate.opened_at);
       line += `  gate: ${run.pending_gate.step_name} (${age})`;
     }
@@ -80,9 +88,15 @@ export const listCommand = new Command('list')
   .description('List all runs, sorted by most recent first')
   .option('--workflow <id>', 'Filter by workflow ID')
   .option('--status <phase>', `Filter by run phase (${VALID_PHASES.join(', ')})`)
-  .action(async (opts: { workflow?: string; status?: string }) => {
+  .option('--stuck', 'Show only advanced-but-parked runs (running with no claimed step)')
+  .action(async (opts: { workflow?: string; status?: string; stuck?: boolean }) => {
     const { JsonFileStore } = await import('@sensigo/realm');
     const store = new JsonFileStore();
+
+    if (opts.stuck === true && opts.status !== undefined) {
+      console.error('--stuck cannot be combined with --status.');
+      process.exit(1);
+    }
 
     let statusFilter: RunPhase | undefined;
     if (opts.status !== undefined) {
@@ -96,7 +110,7 @@ export const listCommand = new Command('list')
     }
 
     try {
-      const output = await listRuns(opts.workflow, store, statusFilter);
+      const output = await listRuns(opts.workflow, store, statusFilter, opts.stuck);
       console.log(output);
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));

--- a/packages/core/src/engine/abandon-run.test.ts
+++ b/packages/core/src/engine/abandon-run.test.ts
@@ -1,0 +1,204 @@
+// Tests for abandonRun — the shared run-abandonment primitive (#92 follow-up / 0.10.0).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { abandonRun } from './abandon-run.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { WorkflowError } from '../types/workflow-error.js';
+import type { RunStore } from '../store/store-interface.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { PendingGate } from '../types/run-record.js';
+
+/** Minimal running RunRecord for stub-store tests. */
+function runningRecord(over: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: 'r1',
+    workflow_id: 'wf',
+    workflow_version: 1,
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: [],
+    skipped_steps: [],
+    run_phase: 'running',
+    version: 0,
+    params: {},
+    evidence: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    terminal_state: false,
+    ...over,
+  };
+}
+
+function snapshotMismatch(): WorkflowError {
+  return new WorkflowError('Version conflict', {
+    code: 'STATE_SNAPSHOT_MISMATCH',
+    category: 'STATE',
+    agentAction: 'report_to_user',
+    retryable: true,
+  });
+}
+
+describe('abandonRun (JsonFileStore)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-abandon-'));
+    store = new JsonFileStore(dir);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function freshRunning(): Promise<RunRecord> {
+    const { run } = await store.create({ workflowId: 'wf', workflowVersion: 1, params: {} });
+    return run;
+  }
+
+  it('running → abandoned: sets abandoned_at, bumps version, derives phase abandoned', async () => {
+    const run = await freshRunning();
+    const result = await abandonRun(store, run.id, 'operator cleanup');
+    expect(result.abandoned_at).toBeDefined();
+    expect(result.terminal_state).toBe(true);
+    expect(result.run_phase).toBe('abandoned');
+    expect(result.terminal_reason).toBe('operator cleanup');
+    expect(result.version).toBe(run.version + 1);
+    // Persisted.
+    const reloaded = await store.get(run.id);
+    expect(reloaded.run_phase).toBe('abandoned');
+    expect(reloaded.abandoned_at).toBe(result.abandoned_at);
+  });
+
+  it('running WITH failed_steps → abandoned (NOT failed) — the key correctness case', async () => {
+    const run = await freshRunning();
+    // Drive the run to carry a failed step while still running (terminal_state stays false).
+    const withFailed = await store.update({ ...run, failed_steps: ['step_a'] });
+    expect(withFailed.run_phase).toBe('running'); // not terminal yet
+    const result = await abandonRun(store, run.id);
+    expect(result.run_phase).toBe('abandoned'); // authoritative marker beats failed_steps
+    expect(result.failed_steps).toEqual(['step_a']); // failed_steps preserved, not the phase driver
+  });
+
+  it('default reason when none supplied', async () => {
+    const run = await freshRunning();
+    const result = await abandonRun(store, run.id);
+    expect(result.terminal_reason).toBe('Abandoned via abandon_run');
+  });
+
+  it('already abandoned → idempotent no-op (same record, version unchanged)', async () => {
+    const run = await freshRunning();
+    const first = await abandonRun(store, run.id, 'first');
+    const second = await abandonRun(store, run.id, 'second');
+    expect(second.version).toBe(first.version); // no second write
+    expect(second.abandoned_at).toBe(first.abandoned_at);
+    expect(second.terminal_reason).toBe('first'); // reason not overwritten
+  });
+
+  it('completed → STATE_RUN_TERMINAL', async () => {
+    const run = await freshRunning();
+    await store.update({
+      ...run,
+      completed_steps: ['s'],
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+    });
+    await expect(abandonRun(store, run.id)).rejects.toMatchObject({ code: 'STATE_RUN_TERMINAL' });
+  });
+
+  it('failed → STATE_RUN_TERMINAL', async () => {
+    const run = await freshRunning();
+    await store.update({
+      ...run,
+      failed_steps: ['s'],
+      terminal_state: true,
+      terminal_reason: "Step 's' failed",
+    });
+    await expect(abandonRun(store, run.id)).rejects.toMatchObject({ code: 'STATE_RUN_TERMINAL' });
+  });
+
+  it('aborted → STATE_RUN_TERMINAL', async () => {
+    const run = await freshRunning();
+    await store.update({ ...run, terminal_state: true, aborted_at: { step_id: 'g' } });
+    await expect(abandonRun(store, run.id)).rejects.toMatchObject({ code: 'STATE_RUN_TERMINAL' });
+  });
+
+  it('gate_waiting → STATE_TRANSITION_DENIED (gate abandonment refused)', async () => {
+    const run = await freshRunning();
+    const gate: PendingGate = {
+      gate_id: 'g1',
+      step_name: 'review',
+      choices: ['approve', 'reject'],
+      opened_at: new Date().toISOString(),
+      preview: {},
+    };
+    await store.update({ ...run, pending_gate: gate });
+    await expect(abandonRun(store, run.id)).rejects.toMatchObject({
+      code: 'STATE_TRANSITION_DENIED',
+    });
+  });
+
+  it('missing run → STATE_RUN_NOT_FOUND', async () => {
+    await expect(abandonRun(store, 'no-such-run')).rejects.toMatchObject({
+      code: 'STATE_RUN_NOT_FOUND',
+    });
+  });
+
+  it('real-store concurrent abandons are idempotent-safe (no corruption)', async () => {
+    const run = await freshRunning();
+    const results = await Promise.allSettled([
+      abandonRun(store, run.id),
+      abandonRun(store, run.id),
+    ]);
+    expect(results.filter((r) => r.status === 'fulfilled').length).toBeGreaterThanOrEqual(1);
+    const reloaded = await store.get(run.id);
+    expect(reloaded.run_phase).toBe('abandoned');
+    expect(reloaded.abandoned_at).toBeDefined();
+  });
+});
+
+describe('abandonRun — CAS concurrency branch (deterministic stub store)', () => {
+  it('update mismatch then reload shows abandoned → idempotent success (returns reloaded)', async () => {
+    const reloaded = runningRecord({
+      version: 1,
+      terminal_state: true,
+      abandoned_at: '2026-06-26T00:00:00.000Z',
+      run_phase: 'abandoned',
+    });
+    let getCalls = 0;
+    const stub: Partial<RunStore> = {
+      get: async () => {
+        getCalls++;
+        return getCalls === 1 ? runningRecord() : reloaded; // 1st: running; reload: abandoned
+      },
+      update: async () => {
+        throw snapshotMismatch(); // a competing writer bumped the version
+      },
+    };
+    const result = await abandonRun(stub as RunStore, 'r1');
+    expect(result.abandoned_at).toBe('2026-06-26T00:00:00.000Z');
+    expect(getCalls).toBe(2); // read once + reload once, no further retry
+  });
+
+  it('update mismatch then reload shows a non-abandoned (live) run → propagates STATE_SNAPSHOT_MISMATCH', async () => {
+    let getCalls = 0;
+    const stub: Partial<RunStore> = {
+      get: async () => {
+        getCalls++;
+        // 1st: running; reload: still running but advanced by a live writer (version bumped).
+        return getCalls === 1
+          ? runningRecord()
+          : runningRecord({ version: 1, failed_steps: ['x'] });
+      },
+      update: async () => {
+        throw snapshotMismatch();
+      },
+    };
+    await expect(abandonRun(stub as RunStore, 'r1')).rejects.toMatchObject({
+      code: 'STATE_SNAPSHOT_MISMATCH',
+    });
+    expect(getCalls).toBe(2); // reloaded exactly once, then propagated (no loop)
+  });
+});

--- a/packages/core/src/engine/abandon-run.ts
+++ b/packages/core/src/engine/abandon-run.ts
@@ -1,0 +1,83 @@
+// abandonRun — the single mutation primitive for explicitly abandoning a run.
+// Used by both the abandon_run MCP tool and the `realm run abandon` CLI command.
+// Run-mutation primitives live in core; command/tool wiring lives in cli/mcp.
+import type { RunStore } from '../store/store-interface.js';
+import type { RunRecord } from '../types/run-record.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+/**
+ * Explicitly abandon a run by stamping the authoritative `abandoned_at` marker. The run's phase
+ * derives to `abandoned` (via {@link deriveRunPhase}) regardless of `failed_steps`/`terminal_reason`.
+ *
+ * Behavior:
+ * - Missing run → propagates `STATE_RUN_NOT_FOUND` (from `store.get`).
+ * - Already abandoned (`abandoned_at` set) → idempotent no-op, returns the existing run.
+ * - `gate_waiting` (or `pending_gate` set) → throws `STATE_TRANSITION_DENIED` (gate abandonment is
+ *   out of scope — resolve/reject the gate via `submit_human_response` first).
+ * - Terminal (`completed`/`failed`/`aborted`) → throws `STATE_RUN_TERMINAL` (do not clobber a finished run).
+ * - Otherwise (`running`) → stamps `abandoned_at`, sets `terminal_state:true` + `terminal_reason`.
+ *
+ * Concurrency: if `update()` raises `STATE_SNAPSHOT_MISMATCH`, the run is reloaded once — if it is now
+ * abandoned, that is idempotent success; otherwise the mismatch is propagated (the run changed under
+ * us — likely a live runner — and abandon should lose). No retry loop beyond the single reload.
+ */
+export async function abandonRun(
+  store: RunStore,
+  runId: string,
+  reason?: string,
+): Promise<RunRecord> {
+  const run = await store.get(runId);
+
+  // Already abandoned → idempotent no-op.
+  if (run.abandoned_at !== undefined) {
+    return run;
+  }
+
+  // Gate abandonment is deliberately out of scope.
+  if (run.run_phase === 'gate_waiting' || run.pending_gate !== undefined) {
+    throw new WorkflowError(
+      `Run '${runId}' is waiting on a human gate; resolve or reject the gate via submit_human_response before abandoning.`,
+      {
+        code: 'STATE_TRANSITION_DENIED',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+        details: { runId, run_phase: run.run_phase },
+      },
+    );
+  }
+
+  // Do not clobber a finished run.
+  if (run.terminal_state) {
+    throw new WorkflowError(
+      `Run '${runId}' is already terminal (${run.run_phase}); cannot abandon a finished run.`,
+      {
+        code: 'STATE_RUN_TERMINAL',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+        details: { runId, run_phase: run.run_phase },
+      },
+    );
+  }
+
+  const abandonedReason = reason ?? 'Abandoned via abandon_run';
+  try {
+    return await store.update({
+      ...run,
+      abandoned_at: new Date().toISOString(),
+      terminal_state: true,
+      terminal_reason: abandonedReason,
+    });
+  } catch (err) {
+    if (err instanceof WorkflowError && err.code === 'STATE_SNAPSHOT_MISMATCH') {
+      // The run changed under us — reload once.
+      const reloaded = await store.get(runId);
+      if (reloaded.abandoned_at !== undefined) {
+        return reloaded; // someone else abandoned it concurrently → idempotent success
+      }
+      throw err; // a live writer advanced the run — abandon loses; do not retry
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/engine/eligibility.test.ts
+++ b/packages/core/src/engine/eligibility.test.ts
@@ -160,6 +160,30 @@ describe('deriveRunPhase', () => {
       }),
     ).toBe('aborted');
   });
+
+  it('returns abandoned when abandoned_at is set (authoritative), even with failed_steps + a non-completed reason', () => {
+    expect(
+      deriveRunPhase({
+        pending_gate: undefined,
+        terminal_state: true,
+        failed_steps: ['main_step'],
+        terminal_reason: 'Abandoned via abandon_run',
+        abandoned_at: '2026-06-26T00:00:00.000Z',
+      }),
+    ).toBe('abandoned');
+  });
+
+  it('abandoned_at outranks a Workflow completed. reason (authoritative marker wins)', () => {
+    expect(
+      deriveRunPhase({
+        pending_gate: undefined,
+        terminal_state: true,
+        failed_steps: [],
+        terminal_reason: 'Workflow completed.',
+        abandoned_at: '2026-06-26T00:00:00.000Z',
+      }),
+    ).toBe('abandoned');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/engine/eligibility.ts
+++ b/packages/core/src/engine/eligibility.ts
@@ -17,9 +17,19 @@ import { resolvePath } from './render-template.js';
 export function deriveRunPhase(
   run: Pick<
     RunRecord,
-    'pending_gate' | 'terminal_state' | 'failed_steps' | 'terminal_reason' | 'aborted_at'
+    | 'pending_gate'
+    | 'terminal_state'
+    | 'failed_steps'
+    | 'terminal_reason'
+    | 'aborted_at'
+    | 'abandoned_at'
   >,
 ): RunPhase {
+  // abandoned_at is authoritative — explicit operator/cleanup abandonment wins over any field
+  // (failed_steps, pending_gate, terminal_reason). It is only ever set on a running run
+  // (gate_waiting abandonment is refused by abandonRun), so it never co-occurs with pending_gate
+  // in practice; top placement is future-proof and mirrors the aborted_at promotion rationale below.
+  if (run.abandoned_at !== undefined) return 'abandoned';
   if (run.pending_gate !== undefined) return 'gate_waiting';
   // aborted_at is authoritative and is checked before both !terminal_state and the
   // 'Workflow completed.' check. The only records that carry aborted_at are guard/handler-aborted

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -4585,3 +4585,69 @@ describe('executeChain — terminal-run entry guard (#91)', () => {
     expect(after.version).toBeGreaterThan(createdVersion);
   });
 });
+
+// Issue #92 follow-up (0.10.0): submitHumanResponse defensive terminal guard.
+describe('submitHumanResponse — terminal-run guard', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  const gateWf: WorkflowDefinition = {
+    id: 'gate-terminal-wf',
+    name: 'Gate Terminal WF',
+    version: 1,
+    steps: {
+      gate_step: {
+        description: 'Gate',
+        execution: 'auto',
+        trust: 'human_confirmed',
+        depends_on: [],
+        gate: { choices: ['approve', 'reject'] },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-gate-terminal-'));
+    store = new JsonFileStore(dir);
+  });
+
+  it('a gate response on a terminal run is rejected with STATE_RUN_TERMINAL (no re-drive)', async () => {
+    const { run } = await store.create({
+      workflowId: 'gate-terminal-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    // Open the gate.
+    const opened = await executeStep(store, gateWf, {
+      runId: run.id,
+      command: 'gate_step',
+      input: {},
+      dispatcher: async () => ({}),
+    });
+    expect(opened.status).toBe('confirm_required');
+    const gateId = opened.gate!.gate_id;
+
+    // Force the run terminal underneath the open gate (simulating a late abandon/completion path),
+    // then attempt a late gate response.
+    const gated = await store.get(run.id);
+    await store.update({ ...gated, terminal_state: true, abandoned_at: new Date().toISOString() });
+    const before = await store.get(run.id);
+
+    const envelope = await submitHumanResponse(store, gateWf, {
+      runId: run.id,
+      gateId,
+      choice: 'approve',
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('STATE_RUN_TERMINAL');
+    // Run not re-driven by the late response.
+    const after = await store.get(run.id);
+    expect(after.version).toBe(before.version);
+    expect(after.terminal_state).toBe(true);
+  });
+
+  it('cleanup', async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -1533,6 +1533,24 @@ export async function submitHumanResponse(
     return errorEnvelope('submit_gate', options.runId, 0, e);
   }
 
+  // 1a. Defensive terminal guard (mirrors #91/#95): a late gate response must never re-drive a
+  // run that has already reached a terminal phase.
+  if (run.terminal_state) {
+    return errorEnvelope(
+      'submit_gate',
+      options.runId,
+      run.version,
+      new WorkflowError(`Run '${options.runId}' is terminal; cannot submit a gate response.`, {
+        code: 'STATE_RUN_TERMINAL',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+        details: { runId: options.runId, run_phase: run.run_phase },
+      }),
+      `Run is terminal (${run.run_phase}); cannot submit a gate response.`,
+    );
+  }
+
   // 2. Verify a gate is open.
   if (run.pending_gate === undefined) {
     return errorEnvelope(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export { hashParams, canonicalJson } from './store/params-hash.js';
 export { decideIdempotencyPolicy } from './store/idempotency-policy.js';
 export type { IdempotencyDecision } from './store/idempotency-policy.js';
 export { executeStep } from './engine/execution-loop.js';
+export { abandonRun } from './engine/abandon-run.js';
 export type { StepDispatcher, ExecuteStepOptions } from './engine/execution-loop.js';
 export {
   submitHumanResponse,

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -229,4 +229,10 @@ export interface RunRecord {
     conditions?: Array<{ condition: string; resolved_value: unknown; passed: boolean }>;
     abort_message?: string;
   };
+  /**
+   * ISO timestamp set when a run is explicitly abandoned via `abandon_run` / `realm run abandon` /
+   * `realm run cleanup`. Authoritative for `deriveRunPhase`: its presence makes `abandoned` the
+   * derived phase regardless of `failed_steps` / `terminal_reason` (mirrors `aborted_at`).
+   */
+  abandoned_at?: string;
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -66,7 +66,18 @@ export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer
   // adapters. When a registry is provided, the caller is responsible for its contents.
   const effectiveRegistry = options?.registry ?? createDefaultRegistry();
 
-  const effectiveOptions: RealmMcpServerOptions = { ...options, registry: effectiveRegistry };
+  // Default the workflow store the same way (mirrors effectiveRegistry / effectiveRunStore). This is
+  // what lets get_run_state compute next_actions on the option-less entrypoint path — without it,
+  // get_run_state would silently degrade to 'workflow_unresolved'. Behaviour-preserving for every
+  // other tool: start_run/start_run_batch/etc. already fall back to the same default
+  // (`~/.realm/workflows`) internally, so receiving it explicitly changes nothing for them.
+  const effectiveWorkflowStore = options?.workflowStore ?? new JsonWorkflowStore();
+
+  const effectiveOptions: RealmMcpServerOptions = {
+    ...options,
+    registry: effectiveRegistry,
+    workflowStore: effectiveWorkflowStore,
+  };
 
   // Shared trace buffer store: one instance used by both append_trace and execute_step so
   // WAL entries written by append_trace are visible when execute_step finalizes the step.

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -15,6 +15,7 @@ import { registerStartRun } from './tools/start-run.js';
 import { registerExecuteStep } from './tools/execute-step.js';
 import { registerSubmitHumanResponse } from './tools/submit-human-response.js';
 import { registerGetRunState } from './tools/get-run-state.js';
+import { registerAbandonRun } from './tools/abandon-run.js';
 import { registerCreateWorkflow } from './tools/create-workflow.js';
 import { registerAppendTrace } from './tools/append-trace.js';
 import { registerStartRunBatch } from './tools/start-run-batch.js';
@@ -79,6 +80,7 @@ export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer
   registerExecuteStep(server, { ...effectiveOptions, traceBufferStore });
   registerSubmitHumanResponse(server, effectiveOptions);
   registerGetRunState(server, effectiveOptions);
+  registerAbandonRun(server, effectiveOptions);
   registerCreateWorkflow(server, effectiveOptions);
   registerAppendTrace(server, {
     runStore: effectiveRunStore,

--- a/packages/mcp-server/src/tools/abandon-run.ts
+++ b/packages/mcp-server/src/tools/abandon-run.ts
@@ -1,0 +1,88 @@
+// abandon-run tool — explicitly abandons a non-terminal run (stamps the authoritative marker).
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  JsonFileStore,
+  WorkflowError,
+  abandonRun,
+  resolvePreExecutionAgentAction,
+  type RunPhase,
+} from '@sensigo/realm';
+import { sseJsonStringify } from '../sse-json.js';
+
+export interface HandleAbandonRunStores {
+  runStore?: JsonFileStore;
+}
+
+export interface AbandonRunSummary {
+  run_id: string;
+  run_phase: RunPhase;
+  terminal_state: boolean;
+  terminal_reason: string | undefined;
+}
+
+/**
+ * Business logic for the abandon_run tool. Abandons a non-terminal run via the shared core
+ * primitive and returns a minimal state summary.
+ */
+export async function handleAbandonRun(
+  args: { run_id: string; reason?: string | undefined },
+  stores?: HandleAbandonRunStores,
+): Promise<AbandonRunSummary> {
+  const runStore = stores?.runStore ?? new JsonFileStore();
+  const run = await abandonRun(runStore, args.run_id, args.reason);
+  return {
+    run_id: run.id,
+    run_phase: run.run_phase,
+    terminal_state: run.terminal_state,
+    terminal_reason: run.terminal_reason,
+  };
+}
+
+/** Registers the abandon_run MCP tool on the server. */
+export function registerAbandonRun(server: McpServer, opts?: HandleAbandonRunStores): void {
+  server.tool(
+    'abandon_run',
+    'Abandon a non-terminal workflow run (marks it terminal with phase "abandoned"). Refuses runs waiting on a human gate (resolve via submit_human_response) and already-terminal runs.',
+    { run_id: z.string(), reason: z.string().optional() },
+    async (args) => {
+      try {
+        const result = await handleAbandonRun(args, opts);
+        return { content: [{ type: 'text' as const, text: sseJsonStringify(result) }] };
+      } catch (err) {
+        const agentAction =
+          err instanceof WorkflowError ? resolvePreExecutionAgentAction(err) : 'report_to_user';
+        const message = err instanceof Error ? err.message : String(err);
+        const code = err instanceof WorkflowError ? err.code : undefined;
+        const contextHint =
+          code === 'STATE_RUN_NOT_FOUND'
+            ? `Run '${args.run_id}' not found.`
+            : code === 'STATE_RUN_TERMINAL'
+              ? `Run '${args.run_id}' is already terminal; nothing to abandon.`
+              : code === 'STATE_TRANSITION_DENIED'
+                ? `Run '${args.run_id}' is waiting on a human gate; resolve it before abandoning.`
+                : `An error occurred while abandoning the run.`;
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: sseJsonStringify({
+                command: 'abandon_run',
+                run_id: args.run_id,
+                status: 'error',
+                data: {},
+                evidence: [],
+                warnings: [],
+                errors: [message],
+                ...(code !== undefined ? { error_code: code } : {}),
+                agent_action: agentAction,
+                context_hint: contextHint,
+                next_actions: [],
+              }),
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -3,15 +3,42 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   JsonFileStore,
+  JsonWorkflowStore,
   WorkflowError,
   resolvePreExecutionAgentAction,
+  buildNextActions,
+  findEligibleSteps,
   type RunPhase,
+  type NextAction,
 } from '@sensigo/realm';
 import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleRunStateStores {
   runStore?: JsonFileStore;
+  /**
+   * Optional workflow store used to compute `next_actions`. When absent (or the workflow is not
+   * registered), `next_actions_status` is `'workflow_unresolved'`. Intentionally NOT defaulted to a
+   * fresh JsonWorkflowStore so the function stays hermetic for tests/programmatic callers.
+   */
+  workflowStore?: JsonWorkflowStore;
 }
+
+/**
+ * Diagnostic classification of `next_actions`:
+ * - `ok` — next_actions reflects what to do next (may be empty for a healthy run with only
+ *   downstream auto work that hasn't been triggered).
+ * - `auto_pending` — eligible steps exist but are all `auto` (buildNextActions drops them); the run
+ *   is making engine-side progress, not awaiting the agent.
+ * - `awaiting_human` — a human gate is open.
+ * - `workflow_unresolved` — no workflow store provided, or the workflow is not registered.
+ * - `skipped_terminal` — the run is terminal; nothing to do.
+ */
+export type NextActionsStatus =
+  | 'ok'
+  | 'auto_pending'
+  | 'awaiting_human'
+  | 'workflow_unresolved'
+  | 'skipped_terminal';
 
 export interface RunStateSummary {
   run_id: string;
@@ -33,6 +60,10 @@ export interface RunStateSummary {
     conditions?: Array<{ condition: string; resolved_value: unknown; passed: boolean }>;
     abort_message?: string;
   };
+  /** Eligible agent/handler steps for this run (empty unless `next_actions_status` is `'ok'`). */
+  next_actions: NextAction[];
+  /** Diagnostic classification — distinguishes a genuinely-stuck run from "nothing pending". */
+  next_actions_status: NextActionsStatus;
 }
 
 /**
@@ -45,6 +76,37 @@ export async function handleGetRunState(
 ): Promise<RunStateSummary> {
   const runStore = stores?.runStore ?? new JsonFileStore();
   const run = await runStore.get(args.run_id);
+
+  // Compute next_actions + diagnostic status (read-only). Precedence:
+  // terminal → skipped_terminal; gate open → awaiting_human; no/unresolved workflow →
+  // workflow_unresolved; else buildNextActions/findEligibleSteps → ok | auto_pending.
+  let nextActions: NextAction[] = [];
+  let nextActionsStatus: NextActionsStatus;
+  if (run.terminal_state) {
+    nextActionsStatus = 'skipped_terminal';
+  } else if (run.pending_gate !== undefined) {
+    nextActionsStatus = 'awaiting_human';
+  } else {
+    const definition =
+      stores?.workflowStore !== undefined
+        ? await stores.workflowStore.get(run.workflow_id).catch(() => undefined)
+        : undefined;
+    if (definition === undefined) {
+      nextActionsStatus = 'workflow_unresolved';
+    } else {
+      const na = buildNextActions(definition, run);
+      const eligible = findEligibleSteps(definition, run);
+      if (na.length > 0) {
+        nextActions = na;
+        nextActionsStatus = 'ok';
+      } else if (eligible.length > 0) {
+        // Eligible steps exist but are all auto (buildNextActions drops them).
+        nextActionsStatus = 'auto_pending';
+      } else {
+        nextActionsStatus = 'ok';
+      }
+    }
+  }
 
   return {
     run_id: run.id,
@@ -62,6 +124,8 @@ export async function handleGetRunState(
     updated_at: run.updated_at,
     params: run.params,
     ...(run.aborted_at !== undefined ? { abort_context: run.aborted_at } : {}),
+    next_actions: nextActions,
+    next_actions_status: nextActionsStatus,
   };
 }
 

--- a/packages/mcp-server/src/tools/run-recovery.test.ts
+++ b/packages/mcp-server/src/tools/run-recovery.test.ts
@@ -1,0 +1,192 @@
+// Tests for the 0.10.0 run-recovery surface: abandon_run MCP tool + get_run_state's
+// next_actions / next_actions_status.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore, JsonWorkflowStore, CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
+import type { WorkflowDefinition, PendingGate } from '@sensigo/realm';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client';
+import { handleAbandonRun, registerAbandonRun } from './abandon-run.js';
+import { handleGetRunState } from './get-run-state.js';
+
+const agentFirst: WorkflowDefinition = {
+  id: 'agentflow',
+  name: 'Agent First',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: { review: { description: 'Agent step', execution: 'agent', depends_on: [] } },
+};
+
+const autoFirst: WorkflowDefinition = {
+  id: 'autoflow',
+  name: 'Auto First',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: { compute: { description: 'Auto step', execution: 'auto', depends_on: [] } },
+};
+
+async function callRegisteredAbandon(
+  runStore: JsonFileStore,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const server = new McpServer({ name: 'test', version: '0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  registerAbandonRun(server, { runStore });
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test-client', version: '0' });
+  await client.connect(clientTransport);
+  const result = await client.callTool({ name: 'abandon_run', arguments: args });
+  const text = (result.content as Array<{ type: string; text: string }>)[0]!.text;
+  await client.close();
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('abandon_run MCP tool', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    runStore = new JsonFileStore(await mkdtemp(join(tmpdir(), 'rec-run-')));
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'rec-wf-')));
+    await workflowStore.register(agentFirst);
+  });
+
+  it('success: abandons a running run, returns a terminal summary', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const summary = await handleAbandonRun({ run_id: run.id, reason: 'stale' }, { runStore });
+    expect(summary.run_phase).toBe('abandoned');
+    expect(summary.terminal_state).toBe(true);
+    expect(summary.terminal_reason).toBe('stale');
+  });
+
+  it('error envelope: missing run → STATE_RUN_NOT_FOUND', async () => {
+    const env = await callRegisteredAbandon(runStore, { run_id: 'no-such-run' });
+    expect(env['status']).toBe('error');
+    expect(env['error_code']).toBe('STATE_RUN_NOT_FOUND');
+    expect(env['command']).toBe('abandon_run');
+  });
+
+  it('error envelope: terminal run → STATE_RUN_TERMINAL', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    await runStore.update({
+      ...run,
+      completed_steps: ['review'],
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+    });
+    const env = await callRegisteredAbandon(runStore, { run_id: run.id });
+    expect(env['status']).toBe('error');
+    expect(env['error_code']).toBe('STATE_RUN_TERMINAL');
+  });
+
+  it('error envelope: gate_waiting run → STATE_TRANSITION_DENIED', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const gate: PendingGate = {
+      gate_id: 'g1',
+      step_name: 'review',
+      choices: ['approve'],
+      opened_at: new Date().toISOString(),
+      preview: {},
+    };
+    await runStore.update({ ...run, pending_gate: gate });
+    const env = await callRegisteredAbandon(runStore, { run_id: run.id });
+    expect(env['status']).toBe('error');
+    expect(env['error_code']).toBe('STATE_TRANSITION_DENIED');
+  });
+});
+
+describe('get_run_state — next_actions_status', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    runStore = new JsonFileStore(await mkdtemp(join(tmpdir(), 'nas-run-')));
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'nas-wf-')));
+    await workflowStore.register(agentFirst);
+    await workflowStore.register(autoFirst);
+  });
+
+  it('ok: running with an eligible agent step → next_actions non-empty', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.next_actions_status).toBe('ok');
+    expect(state.next_actions.length).toBeGreaterThan(0);
+  });
+
+  it('auto_pending: running with only an auto step eligible → empty next_actions', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'autoflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.next_actions_status).toBe('auto_pending');
+    expect(state.next_actions).toEqual([]);
+  });
+
+  it('awaiting_human: a gate is open', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const gate: PendingGate = {
+      gate_id: 'g1',
+      step_name: 'review',
+      choices: ['approve'],
+      opened_at: new Date().toISOString(),
+      preview: {},
+    };
+    await runStore.update({ ...run, pending_gate: gate });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.next_actions_status).toBe('awaiting_human');
+    expect(state.next_actions).toEqual([]);
+  });
+
+  it('skipped_terminal: terminal run', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    await runStore.update({
+      ...run,
+      completed_steps: ['review'],
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+    });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.next_actions_status).toBe('skipped_terminal');
+    expect(state.next_actions).toEqual([]);
+  });
+
+  it('workflow_unresolved: no workflow store provided', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore }); // no workflowStore
+    expect(state.next_actions_status).toBe('workflow_unresolved');
+    expect(state.next_actions).toEqual([]);
+  });
+});

--- a/packages/mcp-server/src/tools/server-default-workflowstore.test.ts
+++ b/packages/mcp-server/src/tools/server-default-workflowstore.test.ts
@@ -1,0 +1,67 @@
+// Correction (0.10.0): createRealmMcpServer() with no options must still let get_run_state compute
+// next_actions — i.e. the factory defaults a workflowStore (parity with the `realm mcp` path).
+// JsonFileStore/JsonWorkflowStore compute their default dirs at module load, so $HOME is set BEFORE
+// the first `@sensigo/realm` / server import (no static realm imports here; load them lazily).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client';
+
+describe('createRealmMcpServer — default workflowStore enables get_run_state next_actions', () => {
+  let home: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'realm-srv-default-'));
+    await mkdir(join(home, '.realm', 'runs'), { recursive: true });
+    await mkdir(join(home, '.realm', 'workflows'), { recursive: true });
+    originalHome = process.env['HOME'];
+    process.env['HOME'] = home;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = originalHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('option-less server resolves next_actions (not workflow_unresolved)', async () => {
+    const { JsonFileStore, JsonWorkflowStore, CURRENT_WORKFLOW_SCHEMA_VERSION } =
+      await import('@sensigo/realm');
+
+    // Seed a workflow + a running run into the default ($HOME) dirs the factory will also use.
+    const workflowStore = new JsonWorkflowStore();
+    await workflowStore.register({
+      id: 'agentflow',
+      name: 'Agent First',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      steps: { review: { description: 'Agent step', execution: 'agent', depends_on: [] } },
+    });
+    const runStore = new JsonFileStore();
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    // Build the server with NO options — it must default the workflowStore internally.
+    const { createRealmMcpServer } = await import('../server.js');
+    const server = createRealmMcpServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test-client', version: '0' });
+    await client.connect(clientTransport);
+
+    const result = await client.callTool({ name: 'get_run_state', arguments: { run_id: run.id } });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]!.text;
+    const state = JSON.parse(text) as Record<string, unknown>;
+    await client.close();
+
+    // An eligible agent step is pending → 'ok' with non-empty next_actions (NOT 'workflow_unresolved').
+    expect(state['next_actions_status']).toBe('ok');
+    expect((state['next_actions'] as unknown[]).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -211,6 +211,37 @@ describe('InMemoryStore', () => {
 // InMemoryStore re-encounter policy parity (#92 PR 2)
 // ---------------------------------------------------------------------------
 
+describe('abandonRun parity (InMemoryStore)', () => {
+  it('running → abandoned (abandoned_at set, phase abandoned), even with failed_steps', async () => {
+    const { abandonRun } = await import('@sensigo/realm');
+    const store = new InMemoryStore();
+    const { run } = await store.create({ workflowId: 'wf', workflowVersion: 1, params: {} });
+    await store.update({ ...run, failed_steps: ['step_a'] }); // running, carries a failed step
+    const result = await abandonRun(store, run.id);
+    expect(result.abandoned_at).toBeDefined();
+    expect(result.terminal_state).toBe(true);
+    expect(result.run_phase).toBe('abandoned'); // authoritative marker beats failed_steps
+  });
+
+  it('already abandoned → idempotent no-op; terminal → STATE_RUN_TERMINAL', async () => {
+    const { abandonRun } = await import('@sensigo/realm');
+    const store = new InMemoryStore();
+    const { run } = await store.create({ workflowId: 'wf', workflowVersion: 1, params: {} });
+    const first = await abandonRun(store, run.id);
+    const second = await abandonRun(store, run.id);
+    expect(second.version).toBe(first.version); // no second write
+
+    const { run: done } = await store.create({ workflowId: 'wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...done,
+      completed_steps: ['s'],
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+    });
+    await expect(abandonRun(store, done.id)).rejects.toMatchObject({ code: 'STATE_RUN_TERMINAL' });
+  });
+});
+
 describe('InMemoryStore re-encounter policy', () => {
   async function seedTerminal(
     store: InMemoryStore,


### PR DESCRIPTION
## Context

A "stuck running runs" incident (CS1 fit_check) surfaced that Realm's run-recovery model, while present, was thin on the MCP surface and under-documented. Converged via a full Master-Architect design debate (Peer + Design Reviewer), which also caught a blocking defect in the first-pass design (naive `update({run_phase:'abandoned'})` is reverted by `deriveRunPhase`).

## Motivation

Give operators/runners a sound, targeted way to close a stuck run, see pending work, and recover — additively, without changing existing behavior.

## Changes (one additive bundle → 0.10.0)

- **`abandoned_at` authoritative marker** — new optional `RunRecord` field, checked first in `deriveRunPhase`, so `abandoned` derives correctly regardless of `failed_steps`/`pending_gate`/`terminal_reason` (mirrors the shipped `aborted_at` promotion). Also repairs a latent `cleanup` mislabel (idle `running`+`failed_steps` → was `failed`, now `abandoned`).
- **Shared core `abandonRun(store, runId, reason?)`** — idempotent if already abandoned; refuses `gate_waiting` (`STATE_TRANSITION_DENIED` — resolve via `submit_human_response` first); rejects terminal (`STATE_RUN_TERMINAL`); else stamps the marker. Concurrency: on `STATE_SNAPSHOT_MISMATCH`, reloads once → idempotent success if now abandoned, else propagates (a live writer wins).
- **`abandon_run` MCP tool** (10th tool) + **`realm run abandon <run-id> [--reason]` CLI** over the shared primitive.
- **`get_run_state` → `next_actions` + `next_actions_status`** (`ok`/`auto_pending`/`awaiting_human`/`workflow_unresolved`/`skipped_terminal`) — read-only recovery diagnostics that distinguish a parked run from one with no pending agent action. Hermetic handler; the server factory defaults a `workflowStore` so it works on every entrypoint.
- **`submit_human_response` defensive terminal guard** — rejects a gate response on a terminal run (`STATE_RUN_TERMINAL`), so a late response can't re-drive a finished run.
- **`realm run list --stuck`** — lists advanced-but-parked runs (`running` + no claimed step) with idle age.
- **`cleanup` sets `abandoned_at`** (authoritative phase).
- **Docs:** new `docs/reference/operating-runs.md` (recovery decision table + loop), `mcp-protocol.md`/`cli-commands.md`/README updates, MCP tool count → 10.

## Verification

```bash
npm run lint     # clean
npm run test     # core 1289 / cli 352 / testing 56 / mcp 96 — all green
npm run build    # tsc --build 4/4
node scripts/check-versions.mjs   # consistent, no bump
```
Key tests: `abandoned_at` outranks `failed_steps`/`completed`-reason; `abandonRun` full matrix incl. **running-with-failed_steps→abandoned** and the concurrency CAS reload path; all five `next_actions_status` values; `submitHumanResponse` terminal rejection; `cleanup` now stamps the marker; `list --stuck` filters correctly; option-less server resolves `next_actions`.

## Rollback

```bash
git revert <merge-commit>
```
Purely additive — reverting removes the new surfaces; `abandoned_at` is an optional field with no readers after revert. No data migration.

## Related

Detection + recovery for stuck runs. Excluded by design: automatic stuck-run timeout (mutate-on-read hazard; `cleanup`-on-cron is the mechanism); gate abandonment (deferred — needs gate snapshot/clear). Preventive runner liveness/capability handshake tracked in #101. The incident's root-cause runner soft-skip is a bradley-max (consumer) fix.
