### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
-
-> **Version intent: 0.10.0.** Additive run-recovery surface; defaults preserve current behavior, no breaking changes.
+## [0.10.0] — 2026-06-26
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.9.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.10.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.9.0';
+export const VERSION = '0.10.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.9.0';
+export const VERSION = '0.10.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -59,7 +59,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.9.0',
+    version: '0.10.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.9.0';
+export const VERSION = '0.10.0';


### PR DESCRIPTION
## Context

Release **v0.10.0** — additive run-lifecycle recovery surface. Cuts PR #102 to npm. All four packages bumped 0.9.0 → 0.10.0.

## Motivation

Ship the run-recovery bundle (abandon_run MCP tool + CLI, abandoned_at authoritative marker, get_run_state next_actions/next_actions_status diagnostics, submit_human_response terminal guard, realm run list --stuck, operating-runs docs). Minor bump — additive, no breaking changes.

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.10.0] — 2026-06-26` (version-intent note removed).
- Version bumped to `0.10.0` across all four `package.json` files + the five source `VERSION` constants (via `scripts/release.mjs`).

Release commit is tagged `v0.10.0`. **Merge with a merge commit** so the tagged SHA stays reachable from `main` (publish workflow depends on it).

## Verification

```bash
node scripts/check-versions.mjs   # all 0.10.0
npm run test                      # core 1289 / cli 352 / testing 56 / mcp 96 — green (verified on #102 + pre-release)
```
After merge + tag push, `publish.yml` publishes all four packages via OIDC. Post-publish: `npm install @sensigo/realm@0.10.0` + ESM `import { VERSION }` → `0.10.0`.

## Rollback

If publish fails partway, re-push the tag (already-published packages skip with `EPUBLISHCONFLICT`). If an artifact is broken, cut 0.10.1 via the same Part B sequence.

## Related

Cuts #102 to npm. No breaking changes. Preventive follow-up tracked in #101.
