### PR TITLE
fix(adapters): AirtableAdapter.upsert_record uses PATCH (was POST)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+> **Version intent: 0.10.1** (patch — a `### Fixed` defect, no API or behaviour change to any other op).
+
+### Fixed
+
+- **`AirtableAdapter.upsert_record` now uses `PATCH` (was `POST`)** — Airtable's `performUpsert` is only valid on the PATCH records endpoint, so every `update('upsert_record', …)` previously returned HTTP 422 (`"Invalid request: parameter validation failed."`). Body, validation, and response handling are unchanged. Adapter op tests now also assert the HTTP method for every operation, closing the gap that let the wrong verb ship.
+
+---
+
 ## [0.10.0] — 2026-06-26
 
 ### Added

--- a/packages/core/src/adapters/airtable-adapter.test.ts
+++ b/packages/core/src/adapters/airtable-adapter.test.ts
@@ -68,6 +68,18 @@ function respondText(statusCode: number, text: string): void {
   });
 }
 
+// Captures the HTTP method of the next request, then responds with JSON (mirrors `respond`).
+// Used to assert each op uses the correct verb — the gap that let the upsert POST→422 bug ship.
+let capturedMethod = '';
+function respondCapturingMethod(statusCode: number, body: unknown): void {
+  capturedMethod = '';
+  handlers.push((req, res) => {
+    capturedMethod = req.method ?? '';
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Adapter factory
 // ---------------------------------------------------------------------------
@@ -147,15 +159,18 @@ describe('AirtableAdapter auth header', () => {
 // ---------------------------------------------------------------------------
 
 describe('AirtableAdapter get_record', () => {
-  it('uses correct URL path: /v0/{base_id}/{table}/{record_id}', async () => {
+  it('uses GET to the correct URL path: /v0/{base_id}/{table}/{record_id}', async () => {
     let capturedUrl = '';
+    let capturedMethod = '';
     handlers.push((req, res) => {
       capturedUrl = req.url ?? '';
+      capturedMethod = req.method ?? '';
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(RECORD_FIXTURE));
     });
     const adapter = makeAdapter();
     await adapter.fetch('get_record', { table: 'Tickets', record_id: 'recABC' }, {});
+    expect(capturedMethod).toBe('GET');
     expect(capturedUrl).toBe('/v0/appXXXXXXXXXXXXXX/Tickets/recABC');
   });
 
@@ -190,10 +205,11 @@ describe('AirtableAdapter get_record', () => {
 // ---------------------------------------------------------------------------
 
 describe('AirtableAdapter list_records', () => {
-  it('returns records array and passes offset through when present', async () => {
-    respond(200, RECORDS_WITH_OFFSET_FIXTURE);
+  it('uses GET; returns records array and passes offset through when present', async () => {
+    respondCapturingMethod(200, RECORDS_WITH_OFFSET_FIXTURE);
     const adapter = makeAdapter();
     const result = await adapter.fetch('list_records', { table: 'Tickets' }, {});
+    expect(capturedMethod).toBe('GET');
     const data = result.data as typeof RECORDS_WITH_OFFSET_FIXTURE;
     expect(Array.isArray(data.records)).toBe(true);
     expect(data.offset).toBe('nextPageToken123');
@@ -322,19 +338,22 @@ describe('AirtableAdapter list_records', () => {
 // ---------------------------------------------------------------------------
 
 describe('AirtableAdapter search_records', () => {
-  function captureQuery(): { get: (key: string) => string | null } {
+  function captureQuery(): { get: (key: string) => string | null; method: () => string } {
     let capturedUrl = '';
+    let capturedMethod = '';
     handlers.push((req, res) => {
       capturedUrl = req.url ?? '';
+      capturedMethod = req.method ?? '';
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(RECORDS_FIXTURE));
     });
     return {
       get: (key: string) => new URLSearchParams(capturedUrl.split('?')[1] ?? '').get(key),
+      method: () => capturedMethod,
     };
   }
 
-  it('single field → filterByFormula is FIND("term", {field})', async () => {
+  it('uses GET; single field → filterByFormula is FIND("term", {field})', async () => {
     const query = captureQuery();
     const adapter = makeAdapter();
     await adapter.fetch(
@@ -342,6 +361,7 @@ describe('AirtableAdapter search_records', () => {
       { table: 'Tickets', search_term: 'x', fields: ['Name'] },
       {},
     );
+    expect(query.method()).toBe('GET');
     expect(query.get('filterByFormula')).toBe('FIND("x", {Name})');
   });
 
@@ -536,8 +556,10 @@ describe('AirtableAdapter list_records fetch_all', () => {
 // ---------------------------------------------------------------------------
 
 describe('AirtableAdapter create_record', () => {
-  it('request body contains fields key; response has data.id', async () => {
-    handlers.push((_req, res, body) => {
+  it('uses POST; request body contains fields key; response has data.id', async () => {
+    let capturedMethod = '';
+    handlers.push((req, res, body) => {
+      capturedMethod = req.method ?? '';
       const parsed = JSON.parse(body) as { fields?: unknown };
       if (parsed.fields === undefined) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -553,6 +575,7 @@ describe('AirtableAdapter create_record', () => {
       { table: 'Tickets', fields: { Name: 'New ticket' } },
       {},
     );
+    expect(capturedMethod).toBe('POST');
     expect(result.status).toBe(200);
     const data = result.data as typeof RECORD_FIXTURE;
     expect(data.id).toBe('recXXXXXXXXXXXXXX');
@@ -604,8 +627,8 @@ describe('AirtableAdapter upsert_record', () => {
     updatedRecords: [],
   };
 
-  it('request body contains records and performUpsert; createdRecords/updatedRecords passed through', async () => {
-    respond(200, UPSERT_RESPONSE);
+  it('uses PATCH (performUpsert is only valid on PATCH); body contains records and performUpsert; createdRecords/updatedRecords passed through', async () => {
+    respondCapturingMethod(200, UPSERT_RESPONSE);
     const adapter = makeAdapter();
     const result = await adapter.update(
       'upsert_record',
@@ -616,6 +639,8 @@ describe('AirtableAdapter upsert_record', () => {
       },
       {},
     );
+    // Method assertion catches the POST→422 bug: fails on the old 'POST', passes on 'PATCH'.
+    expect(capturedMethod).toBe('PATCH');
     expect(result.status).toBe(200);
     const data = result.data as typeof UPSERT_RESPONSE;
     expect(Array.isArray(data.records)).toBe(true);

--- a/packages/core/src/adapters/airtable-adapter.ts
+++ b/packages/core/src/adapters/airtable-adapter.ts
@@ -47,7 +47,7 @@ interface AirtableRecord {
  *   fetch('list_records', { table, ...query })       — GET  /v0/{base}/{table}
  *   fetch('search_records', { table, search_term, fields, ... }) — GET via filterByFormula
  *   create('create_record', { table, fields, ... })  — POST /v0/{base}/{table}
- *   update('upsert_record', { table, fields, ... })  — POST /v0/{base}/{table} (upsert)
+ *   update('upsert_record', { table, fields, ... })  — PATCH /v0/{base}/{table} (upsert via performUpsert)
  *   update('update_record', { table, record_id, fields, ... }) — PATCH /v0/{base}/{table}/{id}
  *   delete('delete_records', { table, record_ids })  — DELETE /v0/{base}/{table}?records[]=…
  */
@@ -705,7 +705,8 @@ export class AirtableAdapter implements ServiceAdapter {
       }
 
       const url = this.buildUrl(table);
-      const response = await this.executeRequest(url, 'POST', body, signal);
+      // Airtable accepts `performUpsert` ONLY on PATCH /v0/{base}/{table}; POST returns HTTP 422.
+      const response = await this.executeRequest(url, 'PATCH', body, signal);
 
       if (!response.ok) {
         await this.throwHttpError(response, 'upsert_record');


### PR DESCRIPTION
## Context

CS1's `record_ticket_outcome` step has written **zero records since 2026-06-24** — every `AirtableAdapter.update('upsert_record', …)` call returned HTTP 422. Root-caused by the bradley-max architect, confirmed against source by the Master Architect.

## Root Cause

`AirtableAdapter`'s `upsert_record` branch builds `performUpsert: { fieldsToMergeOn }` and sent it via **`POST`**. Airtable accepts `performUpsert` **only** on `PATCH /v0/{base}/{table}` — `POST` + `performUpsert` → `422 "parameter validation failed."` The op has been `POST` since introduction; it never wrote a record. It shipped green because the `upsert_record` tests asserted the request *body* but never the HTTP method.

## Changes

- **`airtable-adapter.ts`**: `upsert_record` HTTP verb `POST`→`PATCH` (one line + explanatory comment); corrected the stale doc comment (line 50). Body shape, `fields_to_merge_on` validation, response parsing, and error handling are unchanged (all correct for PATCH). No other op touched (`update_record`/`create_record` byte-identical).
- **`airtable-adapter.test.ts`**: closed the method-assertion gap across **every** op — `get`/`list`/`search`→GET, `create`→POST, `upsert`/`update`→PATCH, `delete`→DELETE. The new upsert PATCH assertion fails on the old `POST` and passes on `PATCH` (demonstrated).

## Verification

```bash
npm run lint     # clean
npm run test     # core 1289 / cli 352 / testing 56 / mcp 96 — all green
npm run build    # tsc --build 4/4
node scripts/check-versions.mjs   # consistent
```
Op→method map now fully asserted in tests; a wrong verb can no longer silently ship in this adapter.

## Rollback

```bash
git revert <merge-commit>
```
One-verb fix; reverting restores the (broken) `POST`. No data migration.

## Related

Fixes the Airtable upsert 422. Patch release **0.10.1** (`### Fixed`, no API/behaviour change to any other op). Consumer (bradley-max) can drop its raw-fetch workaround once 0.10.1 ships. Cross-adapter test-gap audit (other adapters' tests also assert body-not-method) recommended as a separate tracked item.
