### PR TITLE
test(adapters): assert HTTP method for every Gorgias/ParcelPanel/Shopify op

### DIFF
--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -13,12 +13,16 @@ let port: number;
 let server: http.Server;
 const handlers: RequestHandler[] = [];
 
+// Captured on every request regardless of which response helper is used (see central handler).
+let lastRequestMethod = '';
+
 beforeAll(async () => {
   server = http.createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on('data', (chunk: Buffer) => chunks.push(chunk));
     req.on('end', () => {
       const body = Buffer.concat(chunks).toString('utf-8');
+      lastRequestMethod = req.method ?? '';
       const handler = handlers.shift();
       if (handler === undefined) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -163,6 +167,7 @@ describe("GorgiasAdapter fetch('get_ticket')", () => {
     respond(200, { id: 42, subject: 'Test ticket' });
     const adapter = makeAdapter();
     const result = await adapter.fetch('get_ticket', { ticket_id: 42 }, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(result.status).toBe(200);
     const data = result.data as Record<string, unknown>;
     expect(data['id']).toBe(42);
@@ -299,6 +304,7 @@ describe("GorgiasAdapter fetch('list_tickets')", () => {
     });
     const adapter = makeAdapter();
     await adapter.fetch('list_tickets', {}, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(capturedUrl).toBe('/tickets');
   });
 });
@@ -315,6 +321,7 @@ describe("GorgiasAdapter fetch('get_messages')", () => {
     });
     const adapter = makeAdapter();
     const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(result.status).toBe(200);
     const data = result.data as { messages: unknown[]; truncated: boolean };
     expect(data.truncated).toBe(false);
@@ -556,6 +563,7 @@ describe("GorgiasAdapter fetch('get_customer')", () => {
     respond(200, { id: 42, email: 'test@example.com', name: 'Test User' });
     const adapter = makeAdapter();
     const result = await adapter.fetch('get_customer', { customer_id: 42 }, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(result.status).toBe(200);
     const data = result.data as Record<string, unknown>;
     expect(data['id']).toBe(42);
@@ -603,6 +611,7 @@ describe("GorgiasAdapter fetch('list_customers')", () => {
     });
     const adapter = makeAdapter();
     await adapter.fetch('list_customers', { email: 'test@example.com', limit: 5 }, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(capturedUrl).toContain('email=test%40example.com');
     expect(capturedUrl).toContain('limit=5');
   });
@@ -658,6 +667,7 @@ describe("GorgiasAdapter create('create_message')", () => {
       { ticket_id: 42, body_html: '<p>hi</p>', channel: 'note', public: false, from_agent: true },
       {},
     );
+    expect(lastRequestMethod).toBe('POST');
     expect(result.status).toBe(201);
     const data = result.data as Record<string, unknown>;
     expect(data['id']).toBe(999);
@@ -754,6 +764,7 @@ describe("GorgiasAdapter create('create_ticket')", () => {
       { messages: [{ channel: 'email', from_agent: false }] },
       {},
     );
+    expect(lastRequestMethod).toBe('POST');
     expect(result.status).toBe(201);
     const data = result.data as Record<string, unknown>;
     expect(data['id']).toBe(100);
@@ -797,6 +808,7 @@ describe("GorgiasAdapter create('create_customer')", () => {
       { channels: [{ type: 'email', address: 'new@example.com' }] },
       {},
     );
+    expect(lastRequestMethod).toBe('POST');
     expect(result.status).toBe(201);
     const data = result.data as Record<string, unknown>;
     expect(data['id']).toBe(55);
@@ -846,6 +858,7 @@ describe("GorgiasAdapter update('update_ticket')", () => {
     respond(202, { id: 10, status: 'closed' });
     const adapter = makeAdapter();
     const result = await adapter.update('update_ticket', { ticket_id: 10, status: 'closed' }, {});
+    expect(lastRequestMethod).toBe('PUT');
     expect(result.status).toBe(202);
     const data = result.data as Record<string, unknown>;
     expect(data['status']).toBe('closed');
@@ -910,6 +923,7 @@ describe("GorgiasAdapter update('update_customer')", () => {
     });
     const adapter = makeAdapter();
     await adapter.update('update_customer', { customer_id: 42, name: 'Jane', language: 'fr' }, {});
+    expect(lastRequestMethod).toBe('PUT');
     expect(capturedBody).toEqual({ name: 'Jane', language: 'fr' });
     expect((capturedBody as Record<string, unknown>)['customer_id']).toBeUndefined();
   });

--- a/packages/core/src/adapters/parcelpanel-adapter.test.ts
+++ b/packages/core/src/adapters/parcelpanel-adapter.test.ts
@@ -17,6 +17,7 @@ const handlers: RequestHandler[] = [];
 
 // Last received request details for assertions
 let lastRequestHeaders: http.IncomingHttpHeaders = {};
+let lastRequestMethod = '';
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
@@ -25,6 +26,7 @@ beforeAll(async () => {
     req.on('end', () => {
       const body = Buffer.concat(chunks).toString('utf-8');
       lastRequestHeaders = req.headers;
+      lastRequestMethod = req.method ?? '';
       const handler = handlers.shift();
       if (handler === undefined) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -235,6 +237,7 @@ describe('ParcelPanelAdapter order_number normalization', () => {
     });
     const adapter = makeAdapter();
     await adapter.fetch('get_tracking', { store: 'mystore', order_number: '#1234' }, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(capturedUrl).toContain('order_number=1234');
     expect(capturedUrl).not.toContain('order_number=%231234');
   });
@@ -555,6 +558,7 @@ describe('ParcelPanelAdapter fetch(get_tracking_by_id)', () => {
     });
     const adapter = makeAdapter();
     await adapter.fetch('get_tracking_by_id', { store: 'mystore', order_id: 6140516335690 }, {});
+    expect(lastRequestMethod).toBe('GET');
     expect(capturedUrl).toContain('order_id=6140516335690');
     expect(capturedUrl).not.toContain('order_number');
   });

--- a/packages/core/src/adapters/shopify-adapter.test.ts
+++ b/packages/core/src/adapters/shopify-adapter.test.ts
@@ -17,6 +17,7 @@ const handlers: RequestHandler[] = [];
 // Last received request details for assertions
 let lastRequestHeaders: http.IncomingHttpHeaders = {};
 let lastRequestBody = '';
+let lastRequestMethod = '';
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
@@ -26,6 +27,7 @@ beforeAll(async () => {
       const body = Buffer.concat(chunks).toString('utf-8');
       lastRequestHeaders = req.headers;
       lastRequestBody = body;
+      lastRequestMethod = req.method ?? '';
       const handler = handlers.shift();
       if (handler === undefined) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -294,6 +296,7 @@ describe("ShopifyAdapter fetch('query') request forwarding", () => {
     respondWith(200, { data: { shop: { name: 'My Store' } } });
     const adapter = makeAdapter();
     await adapter.fetch('query', { store: 'mystore', query: gqlQuery }, {});
+    expect(lastRequestMethod).toBe('POST');
     const body = JSON.parse(lastRequestBody) as { query: string };
     expect(body.query).toBe(gqlQuery);
   });


### PR DESCRIPTION
## Context

The v0.10.1 P0 (`AirtableAdapter.upsert_record` sent `POST` where Airtable's `performUpsert` requires `PATCH` → HTTP 422) shipped green because the Airtable op tests asserted the request **body** but never the request **HTTP method** — the mock returned 200 regardless of verb, so the wrong verb passed CI. v0.10.1 closed that gap for the Airtable adapter only.

A follow-up cross-adapter audit (against source) then confirmed two things: (1) **no second wrong-verb bug exists** — every other adapter sends the correct verb; and (2) the same test-gap class is present in three adapters whose op tests assert body/URL/headers but never `req.method` — **Gorgias** (10 ops), **ParcelPanel** (2 ops), **Shopify** (1 op). Notion and GitHub already assert method and are the model.

## Motivation

Retrofit HTTP-method assertions onto those three adapters so a future verb regression (the Airtable class) fails CI instead of shipping green. This is **test-only hardening** — no production code, no behavior change, no verb change.

## Changes

One uniform pattern per file (the Notion gold standard): add a module-level `lastRequestMethod = req.method` capture in the central `http.createServer` handler (populates on every request regardless of which response helper is used), then add exactly one `expect(lastRequestMethod).toBe(<VERB>)` in place to an existing passing test for each op. No new `it()` cases, no restructure.

- `packages/core/src/adapters/gorgias-adapter.test.ts` (+14) — 10 ops: `get_ticket`/`get_messages`/`list_tickets`/`get_customer`/`list_customers` → `GET`; `create_message`/`create_ticket`/`create_customer` → `POST`; `update_ticket`/`update_customer` → `PUT`.
- `packages/core/src/adapters/parcelpanel-adapter.test.ts` (+4) — `get_tracking`/`get_tracking_by_id` → `GET`.
- `packages/core/src/adapters/shopify-adapter.test.ts` (+3) — `fetch('query')` → `POST`.

All 13 assertions pass against current code — confirming no verb is wrong. A future verb flip in any of these 13 op paths now fails CI.

## Verification

```bash
# The three adapter suites — all green (124 tests)
npx vitest run --no-cache \
  packages/core/src/adapters/gorgias-adapter.test.ts \
  packages/core/src/adapters/parcelpanel-adapter.test.ts \
  packages/core/src/adapters/shopify-adapter.test.ts
# → Test Files 3 passed (3) | Tests 124 passed (124)

# Full suite unchanged at baseline (core count unchanged — assertions added in place)
npm run lint     # exit 0
npm run test     # core 1289 / cli 352 / testing 56 / mcp 96
npm run build    # tsc --build 4/4
node scripts/check-versions.mjs   # all 0.10.1, no bump

# Proof the new guards bite (mutation probe): temporarily flip a verb in source and re-run —
# the corresponding method assertion fails (expected 'POST' to be 'PUT', etc.). Restore after.
```

Diff is exactly three test files, +21 insertions, 0 deletions — no production source, doc, or CHANGELOG change.

## Rollback

```bash
git revert HEAD
```

No out-of-band mutations (test-only change); `git revert` fully reverts it.
