### PR TITLE
feat(observability): agent_step_attempt_failed stderr telemetry (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+> **Version intent: 0.11.0** (additive). Version constants are bumped at release time.
+
+### Added
+
+- **`agent_step_attempt_failed` stderr telemetry** — when an agent's `execute_step` output fails pre-claim schema validation (`VALIDATION_INPUT_SCHEMA` / `VALIDATION_OUTPUT_SCHEMA` / `VALIDATION_TRACE_SCHEMA`), the MCP server now emits a structured, **metadata-only** stderr event (filter by `event`). The record carries Ajv error metadata (offending-value echoes dropped), submitted key _names_ (capped), counts, and byte size — never raw model output. This gives operators a post-mortem trail for rejections that are otherwise write-free (never reach `failed_steps[]`, never bump `version`). Exposes pure `buildFailedAttemptRecord` / `serializeFailedAttemptLine` helpers from `@sensigo/realm`. Core stays I/O-free; the live `execute_step` response is unchanged.
+
+---
+
 ## [0.10.1] — 2026-06-26
 
 ### Fixed

--- a/docs/reference/mcp-protocol.md
+++ b/docs/reference/mcp-protocol.md
@@ -136,6 +136,8 @@ When the engine opens a gate:
 
 When `agent_action` is `provide_input` or `resolve_precondition` and `next_actions` is non-empty, follow the first item exactly as after a successful step.
 
+A `provide_input` rejection (the agent's `execute_step` output failed schema validation) is a **pre-claim, write-free** path: nothing is persisted to the run record and `version` is not bumped, so it leaves no run-record trail. The MCP server emits a metadata-only `agent_step_attempt_failed` stderr event for these rejections so operators retain a post-mortem trail — see [Operating & recovering runs → Failed agent attempts](operating-runs.md#failed-agent-attempts-agent_step_attempt_failed-telemetry).
+
 ---
 
 ## `start_run_batch`

--- a/docs/reference/operating-runs.md
+++ b/docs/reference/operating-runs.md
@@ -63,3 +63,49 @@ abandoned run instead of starting fresh. To actually re-run, either:
 - start with a **new idempotency key**.
 
 See the idempotency re-encounter policy in [mcp-protocol.md](mcp-protocol.md#idempotency-re-encounter-policy).
+
+---
+
+## Failed agent attempts (`agent_step_attempt_failed` telemetry)
+
+When an agent calls `execute_step` with output that fails schema validation, the engine rejects it
+**before the step is claimed** — a write-free path: nothing is persisted to the run record and
+`version` is not bumped. The validation error is returned live to the caller (`error_details.errors`)
+but is otherwise ephemeral, so there is no post-mortem trail of _what the agent submitted_ or _which
+rule failed_.
+
+To give operators that trail, the MCP server emits a structured **stderr** event on each such
+rejection:
+
+```json
+{
+  "event": "agent_step_attempt_failed",
+  "run_id": "...",
+  "workflow_id": "...",
+  "step_id": "...",
+  "ts": "...",
+  "error_code": "VALIDATION_OUTPUT_SCHEMA",
+  "validation_error_summary": [
+    { "instancePath": "/category", "schemaPath": "...", "keyword": "required", "message": "..." }
+  ],
+  "submitted_key_count": 1,
+  "submitted_keys": ["ticket_body"],
+  "submitted_bytes": 48,
+  "trace_entry_count": 0
+}
+```
+
+- **Filter by `event`** (`agent_step_attempt_failed`) — stderr also carries other structured events
+  (e.g. `idempotency_dedup`).
+- Emitted only for the three pre-claim validation codes: `VALIDATION_INPUT_SCHEMA`,
+  `VALIDATION_OUTPUT_SCHEMA`, `VALIDATION_TRACE_SCHEMA`. Not for `blocked`, other errors, or success.
+- **Metadata-only — never raw model output.** The record carries Ajv error metadata (with the
+  offending-value echoes dropped), submitted key _names_ (capped), counts, and byte size — never
+  submitted values or trace content. (Key names are leak-resistant, not leak-proof — a hard cap
+  applies; a durable opt-in sidecar follows in a later phase.)
+
+**Pre-claim vs post-claim — the load-bearing distinction:** a pre-claim _validation_ rejection
+(this event) never reaches `failed_steps[]` and never bumps `version` — it is invisible on the run
+record, which is exactly why this telemetry exists. A post-claim _execution_ failure (the step
+claimed, then its handler/adapter failed) **does** land in `failed_steps[]`, bumps `version`, and is
+visible via `get_run_state` / `realm run inspect`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,15 @@ export { decideIdempotencyPolicy } from './store/idempotency-policy.js';
 export type { IdempotencyDecision } from './store/idempotency-policy.js';
 export { executeStep } from './engine/execution-loop.js';
 export { abandonRun } from './engine/abandon-run.js';
+export {
+  buildFailedAttemptRecord,
+  serializeFailedAttemptLine,
+} from './observability/failed-attempt-record.js';
+export type {
+  BuildFailedAttemptInput,
+  FailedAttemptRecord,
+  ValidationErrorSummaryEntry,
+} from './observability/failed-attempt-record.js';
 export type { StepDispatcher, ExecuteStepOptions } from './engine/execution-loop.js';
 export {
   submitHumanResponse,

--- a/packages/core/src/observability/failed-attempt-record.test.ts
+++ b/packages/core/src/observability/failed-attempt-record.test.ts
@@ -1,0 +1,240 @@
+// Tests for the pure failed-attempt record builder + serializer (P2 observability).
+import { describe, it, expect } from 'vitest';
+import { buildFailedAttemptRecord, serializeFailedAttemptLine } from './failed-attempt-record.js';
+import type { BuildFailedAttemptInput } from './failed-attempt-record.js';
+
+function baseInput(over: Partial<BuildFailedAttemptInput> = {}): BuildFailedAttemptInput {
+  return {
+    run_id: 'run-1',
+    workflow_id: 'wf-1',
+    step_id: 'classify',
+    ts: '2026-06-27T00:00:00.000Z',
+    error_code: 'VALIDATION_OUTPUT_SCHEMA',
+    ajv_errors: [],
+    params: {},
+    trace_entry_count: 0,
+    ...over,
+  };
+}
+
+describe('buildFailedAttemptRecord', () => {
+  it('copies the scalar metadata fields verbatim', () => {
+    const rec = buildFailedAttemptRecord(
+      baseInput({
+        run_id: 'r',
+        workflow_id: 'w',
+        step_id: 's',
+        ts: 'T',
+        error_code: 'VALIDATION_INPUT_SCHEMA',
+        trace_entry_count: 3,
+      }),
+    );
+    expect(rec).toMatchObject({
+      run_id: 'r',
+      workflow_id: 'w',
+      step_id: 's',
+      ts: 'T',
+      error_code: 'VALIDATION_INPUT_SCHEMA',
+      trace_entry_count: 3,
+    });
+  });
+
+  it('whitelists Ajv fields and DROPS the params/data value echoes (leak vector)', () => {
+    const rec = buildFailedAttemptRecord(
+      baseInput({
+        ajv_errors: [
+          {
+            instancePath: '/status',
+            schemaPath: '#/properties/status/enum',
+            keyword: 'enum',
+            message: 'must be equal to one of the allowed values',
+            params: { allowedValues: ['open', 'closed'] },
+            data: 'SECRET_CUSTOMER_VALUE',
+          },
+        ],
+      }),
+    );
+    expect(rec.validation_error_summary).toEqual([
+      {
+        instancePath: '/status',
+        schemaPath: '#/properties/status/enum',
+        keyword: 'enum',
+        message: 'must be equal to one of the allowed values',
+      },
+    ]);
+    // The offending value echo must not appear anywhere in the serialized record.
+    expect(JSON.stringify(rec)).not.toContain('SECRET_CUSTOMER_VALUE');
+    expect(JSON.stringify(rec)).not.toContain('allowedValues');
+  });
+
+  it('truncates instancePath/schemaPath/message to 200 chars', () => {
+    const long = 'x'.repeat(500);
+    const rec = buildFailedAttemptRecord(
+      baseInput({
+        ajv_errors: [{ instancePath: long, schemaPath: long, keyword: 'type', message: long }],
+      }),
+    );
+    const e = rec.validation_error_summary[0]!;
+    expect(e.instancePath).toHaveLength(200);
+    expect(e.schemaPath).toHaveLength(200);
+    expect(e.message).toHaveLength(200);
+  });
+
+  it('caps validation_error_summary at the first 10 entries', () => {
+    const errs = Array.from({ length: 25 }, (_, i) => ({
+      instancePath: `/f${i}`,
+      schemaPath: '#/x',
+      keyword: 'type',
+      message: 'bad',
+    }));
+    const rec = buildFailedAttemptRecord(baseInput({ ajv_errors: errs }));
+    expect(rec.validation_error_summary).toHaveLength(10);
+    expect(rec.validation_error_summary[0]!.instancePath).toBe('/f0');
+  });
+
+  it('submitted_keys are truncated to 100 chars and capped at 50; submitted_key_count is the full count', () => {
+    const params: Record<string, unknown> = {};
+    for (let i = 0; i < 120; i++) params[`k${i}`] = i;
+    const longKey = 'L'.repeat(300);
+    params[longKey] = 1;
+    const rec = buildFailedAttemptRecord(baseInput({ params }));
+    expect(rec.submitted_key_count).toBe(121); // full count
+    expect(rec.submitted_keys).toHaveLength(50); // capped
+    expect(rec.submitted_keys.every((k) => k.length <= 100)).toBe(true);
+  });
+
+  it('submitted_bytes equals the UTF-8 byte length of JSON.stringify(params)', () => {
+    const params = { a: 'hello', b: 2 };
+    const rec = buildFailedAttemptRecord(baseInput({ params }));
+    expect(rec.submitted_bytes).toBe(Buffer.byteLength(JSON.stringify(params), 'utf8'));
+  });
+
+  it('never includes raw submitted VALUES — only key names', () => {
+    const rec = buildFailedAttemptRecord(
+      baseInput({ params: { ticket_body: 'PII: jane@example.com ordered 3 widgets' } }),
+    );
+    const serialized = JSON.stringify(rec);
+    expect(serialized).toContain('ticket_body'); // key name is allowed
+    expect(serialized).not.toContain('jane@example.com'); // value is not
+    expect(rec.submitted_keys).toEqual(['ticket_body']);
+  });
+
+  it('is defensive: non-array ajv_errors yields an empty summary, no throw', () => {
+    expect(() =>
+      buildFailedAttemptRecord(baseInput({ ajv_errors: 'not-an-array' as unknown as unknown[] })),
+    ).not.toThrow();
+    const rec = buildFailedAttemptRecord(
+      baseInput({ ajv_errors: 'not-an-array' as unknown as unknown[] }),
+    );
+    expect(rec.validation_error_summary).toEqual([]);
+  });
+
+  it('is defensive: malformed entries (non-objects, missing fields) are skipped/coerced without throwing', () => {
+    const rec = buildFailedAttemptRecord(
+      baseInput({
+        ajv_errors: [
+          null,
+          42,
+          'string-entry',
+          { keyword: 'required' }, // missing instancePath/schemaPath/message
+          { instancePath: 99, message: { nested: 'obj' } }, // non-string fields → ''
+        ],
+      }),
+    );
+    // null/42/'string-entry' skipped; the two objects kept.
+    expect(rec.validation_error_summary).toHaveLength(2);
+    expect(rec.validation_error_summary[0]).toEqual({
+      instancePath: '',
+      schemaPath: '',
+      keyword: 'required',
+      message: '',
+    });
+    // Non-string instancePath/message coerced to '' (no object leak via String()).
+    expect(rec.validation_error_summary[1]).toEqual({
+      instancePath: '',
+      schemaPath: '',
+      keyword: '',
+      message: '',
+    });
+  });
+
+  it('does not throw on unstringifiable params (circular) — submitted_bytes falls back to 0', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    const rec = buildFailedAttemptRecord(baseInput({ params: circular }));
+    expect(rec.submitted_bytes).toBe(0);
+    expect(rec.submitted_key_count).toBe(1);
+  });
+});
+
+describe('serializeFailedAttemptLine', () => {
+  it('a small record returns truncated:false and is unchanged', () => {
+    const rec = buildFailedAttemptRecord(baseInput({ params: { a: 1 } }));
+    const { line, truncated } = serializeFailedAttemptLine({
+      event: 'agent_step_attempt_failed',
+      ...rec,
+    });
+    expect(truncated).toBe(false);
+    expect(JSON.parse(line)).toEqual({ event: 'agent_step_attempt_failed', ...rec });
+  });
+
+  it('preserves wrapper keys (event) on a small record', () => {
+    const rec = buildFailedAttemptRecord(baseInput());
+    const { line } = serializeFailedAttemptLine({
+      event: 'agent_step_attempt_failed',
+      dropped_attempts: 7,
+      ...rec,
+    });
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed['event']).toBe('agent_step_attempt_failed');
+    expect(parsed['dropped_attempts']).toBe(7);
+  });
+
+  it('an oversized record is reduced to <= maxBytes with truncated:true (drops summary, then keys)', () => {
+    const longMsg = 'm'.repeat(180);
+    const summary = Array.from({ length: 100 }, (_, i) => ({
+      instancePath: `/field${i}`,
+      schemaPath: '#/properties/x',
+      keyword: 'type',
+      message: longMsg,
+    }));
+    const submitted_keys = Array.from({ length: 500 }, (_, i) => `key_number_${i}`);
+    const obj = {
+      event: 'agent_step_attempt_failed',
+      run_id: 'r',
+      workflow_id: 'w',
+      step_id: 's',
+      ts: 'T',
+      error_code: 'VALIDATION_OUTPUT_SCHEMA',
+      validation_error_summary: summary,
+      submitted_key_count: 500,
+      submitted_keys,
+      submitted_bytes: 1234,
+      trace_entry_count: 0,
+    };
+    const { line, truncated } = serializeFailedAttemptLine(obj);
+    expect(truncated).toBe(true);
+    expect(line.length).toBeLessThanOrEqual(3072);
+    expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(3072);
+  });
+
+  it('respects a custom maxBytes and still guarantees the bound (hard-substring fallback)', () => {
+    // A single field too large to fit even after dropping summary + keys → hard substring.
+    const obj = {
+      event: 'agent_step_attempt_failed',
+      run_id: 'r'.repeat(5000),
+      workflow_id: 'w',
+      step_id: 's',
+      ts: 'T',
+      error_code: 'VALIDATION_OUTPUT_SCHEMA',
+      validation_error_summary: [],
+      submitted_key_count: 0,
+      submitted_keys: [],
+      submitted_bytes: 0,
+      trace_entry_count: 0,
+    };
+    const { line, truncated } = serializeFailedAttemptLine(obj, 256);
+    expect(truncated).toBe(true);
+    expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(256);
+  });
+});

--- a/packages/core/src/observability/failed-attempt-record.ts
+++ b/packages/core/src/observability/failed-attempt-record.ts
@@ -1,0 +1,198 @@
+// Pure, I/O-free builder + serializer for failed agent-step validation telemetry.
+//
+// When an agent's execute_step output fails pre-claim schema validation, the engine returns an
+// error envelope on a WRITE-FREE path (nothing persisted, nothing logged). These helpers turn that
+// ephemeral rejection into a structured, METADATA-ONLY record for stderr emission (P2) and a durable
+// sidecar (P3, which reuses this exact builder/serializer).
+//
+// PII guard: the record never contains raw model output values — only Ajv error metadata (whitelisted
+// fields, with offending-value echoes dropped), submitted key NAMES (capped), counts, and byte size.
+//
+// Determinism: no Date.now()/Math.random()/I/O here — the timestamp is supplied by the caller — so
+// these functions are deterministic and unit-testable.
+
+/** Input to {@link buildFailedAttemptRecord}. */
+export interface BuildFailedAttemptInput {
+  run_id: string;
+  workflow_id: string;
+  step_id: string;
+  /** ISO timestamp; supplied by the caller (e.g. `new Date().toISOString()`). */
+  ts: string;
+  /** One of the three VALIDATION_* error codes. */
+  error_code: string;
+  /** The raw `error_details.errors` array (may be anything — coerced defensively). */
+  ajv_errors: unknown[];
+  /** The agent's submitted output (`args.params`). */
+  params: Record<string, unknown>;
+  /** `args.trace?.length ?? 0`. */
+  trace_entry_count: number;
+}
+
+/** A single whitelisted Ajv error — value echoes (`params`/`data`) are intentionally excluded. */
+export interface ValidationErrorSummaryEntry {
+  instancePath: string;
+  schemaPath: string;
+  keyword: string;
+  message: string;
+}
+
+/** Metadata-only record describing a failed agent-step validation attempt. */
+export interface FailedAttemptRecord {
+  run_id: string;
+  workflow_id: string;
+  step_id: string;
+  ts: string;
+  error_code: string;
+  validation_error_summary: ValidationErrorSummaryEntry[];
+  submitted_key_count: number;
+  submitted_keys: string[];
+  submitted_bytes: number;
+  trace_entry_count: number;
+}
+
+const MAX_SUMMARY_ENTRIES = 10;
+const MAX_FIELD_CHARS = 200;
+const MAX_KEYS = 50;
+const MAX_KEY_CHARS = 100;
+const DEFAULT_MAX_BYTES = 3072;
+
+/** Coerce to a string ONLY when already a string; otherwise '' (never leak objects via String()). */
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Byte length of a string, guarded so it never throws. */
+function byteLength(value: string): number {
+  try {
+    return Buffer.byteLength(value, 'utf8');
+  } catch {
+    return value.length;
+  }
+}
+
+/** JSON.stringify guarded against circular refs / throwers; returns '{}' on failure. */
+function safeStringify(value: unknown): string {
+  try {
+    const s = JSON.stringify(value);
+    return typeof s === 'string' ? s : '{}';
+  } catch {
+    return '{}';
+  }
+}
+
+/**
+ * Map raw Ajv errors to the whitelisted summary. Drops `params`/`data` (Ajv embeds offending VALUES
+ * there — a leak vector). Skips non-object entries, caps at the first 10, truncates path/message
+ * fields to 200 chars. Never throws.
+ */
+function summarizeAjvErrors(ajvErrors: unknown[]): ValidationErrorSummaryEntry[] {
+  if (!Array.isArray(ajvErrors)) return [];
+  const out: ValidationErrorSummaryEntry[] = [];
+  for (const entry of ajvErrors) {
+    if (out.length >= MAX_SUMMARY_ENTRIES) break;
+    if (entry === null || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    out.push({
+      instancePath: truncate(asString(e['instancePath']), MAX_FIELD_CHARS),
+      schemaPath: truncate(asString(e['schemaPath']), MAX_FIELD_CHARS),
+      keyword: truncate(asString(e['keyword']), MAX_FIELD_CHARS),
+      message: truncate(asString(e['message']), MAX_FIELD_CHARS),
+    });
+  }
+  return out;
+}
+
+/**
+ * Build a metadata-only {@link FailedAttemptRecord}. Pure and deterministic — no timestamps or I/O
+ * generated here. Never throws on malformed input.
+ */
+export function buildFailedAttemptRecord(input: BuildFailedAttemptInput): FailedAttemptRecord {
+  const params = input.params !== null && typeof input.params === 'object' ? input.params : {};
+  const allKeys = Object.keys(params);
+
+  let submittedBytes = 0;
+  try {
+    const s = JSON.stringify(params);
+    if (typeof s === 'string') submittedBytes = byteLength(s);
+  } catch {
+    submittedBytes = 0;
+  }
+
+  return {
+    run_id: input.run_id,
+    workflow_id: input.workflow_id,
+    step_id: input.step_id,
+    ts: input.ts,
+    error_code: input.error_code,
+    validation_error_summary: summarizeAjvErrors(input.ajv_errors),
+    submitted_key_count: allKeys.length,
+    submitted_keys: allKeys.slice(0, MAX_KEYS).map((k) => truncate(k, MAX_KEY_CHARS)),
+    submitted_bytes: submittedBytes,
+    trace_entry_count: typeof input.trace_entry_count === 'number' ? input.trace_entry_count : 0,
+  };
+}
+
+/** Byte-safe truncation: returns the longest prefix of `value` whose UTF-8 length is ≤ maxBytes. */
+function byteTruncate(value: string, maxBytes: number): string {
+  if (byteLength(value) <= maxBytes) return value;
+  let lo = 0;
+  let hi = value.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (byteLength(value.slice(0, mid)) <= maxBytes) lo = mid;
+    else hi = mid - 1;
+  }
+  return value.slice(0, lo);
+}
+
+/**
+ * Serialize a failed-attempt record (optionally wrapped with extra keys like `event`) to a single
+ * JSON line guaranteed to be ≤ `maxBytes`. When the serialized form (plus a 1-byte newline budget)
+ * exceeds the limit, reduce progressively and set `truncated: true`:
+ *   1. drop `validation_error_summary` entries from the end (down to empty);
+ *   2. if still over, replace `submitted_keys` with `[]` (keeping `submitted_key_count`);
+ *   3. if still over, hard byte-truncate the JSON string to `maxBytes` as a final guarantee.
+ * Wrapper keys (e.g. `event`, `dropped_attempts`) are preserved; only the known record fields are
+ * reduced. The returned `line` is ALWAYS ≤ `maxBytes` (verified on the serialized string).
+ *
+ * This is the single source of truth for line size — P3's atomic append reuses it verbatim (where
+ * ≤PIPE_BUF matters for lock-free atomicity).
+ */
+export function serializeFailedAttemptLine(
+  obj: Record<string, unknown>,
+  maxBytes: number = DEFAULT_MAX_BYTES,
+): { line: string; truncated: boolean } {
+  // Fits if the serialized bytes plus a 1-byte newline budget stay within the limit.
+  const fits = (s: string): boolean => byteLength(s) + 1 <= maxBytes;
+
+  let line = safeStringify(obj);
+  if (fits(line)) return { line, truncated: false };
+
+  let work: Record<string, unknown> = { ...obj };
+
+  // Step 1: drop validation_error_summary entries from the end.
+  if (Array.isArray(work['validation_error_summary'])) {
+    const arr = [...(work['validation_error_summary'] as unknown[])];
+    while (arr.length > 0 && !fits(safeStringify({ ...work, validation_error_summary: arr }))) {
+      arr.pop();
+    }
+    work = { ...work, validation_error_summary: arr };
+    line = safeStringify(work);
+    if (fits(line)) return { line, truncated: true };
+  }
+
+  // Step 2: drop submitted_keys (keep submitted_key_count).
+  if ('submitted_keys' in work) {
+    work = { ...work, submitted_keys: [] };
+    line = safeStringify(work);
+    if (fits(line)) return { line, truncated: true };
+  }
+
+  // Step 3: hard byte-truncate as a final guarantee.
+  line = byteTruncate(line, maxBytes);
+  return { line, truncated: true };
+}

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -7,12 +7,63 @@ import {
   executeChain,
   WorkflowError,
   buildPreExecutionErrorEnvelope,
+  buildFailedAttemptRecord,
+  serializeFailedAttemptLine,
   type StepDispatcher,
   type ResponseEnvelope,
   type AgentTraceEntry,
 } from '@sensigo/realm';
 import type { HandleRunStores } from './start-run.js';
 import { sseJsonStringify } from '../sse-json.js';
+
+/**
+ * Pre-claim validation rejections carry one of these error codes (claimStep runs strictly after all
+ * three schema gates, so they never reach failed_steps[] / never bump version — a write-free path).
+ * Failed agent attempts on these codes are surfaced as stderr telemetry below.
+ */
+const VALIDATION_TELEMETRY_CODES = new Set([
+  'VALIDATION_INPUT_SCHEMA',
+  'VALIDATION_OUTPUT_SCHEMA',
+  'VALIDATION_TRACE_SCHEMA',
+]);
+
+/**
+ * Best-effort, metadata-only stderr telemetry for a failed agent-step validation attempt. Emits a
+ * single structured `agent_step_attempt_failed` line iff the (pre-strip) envelope is a validation
+ * rejection. Never throws and never alters the execute_step response.
+ */
+function emitFailedAttemptTelemetry(
+  args: {
+    run_id: string;
+    command: string;
+    params?: Record<string, unknown>;
+    trace?: AgentTraceEntry[] | undefined;
+  },
+  workflowId: string,
+  result: ResponseEnvelope,
+): void {
+  try {
+    if (result.status !== 'error') return;
+    const code = result.error_code;
+    if (code === undefined || !VALIDATION_TELEMETRY_CODES.has(code)) return;
+    const ajvErrors = result.error_details?.['errors'];
+    const record = buildFailedAttemptRecord({
+      run_id: args.run_id,
+      workflow_id: workflowId,
+      step_id: args.command,
+      ts: new Date().toISOString(),
+      error_code: code,
+      ajv_errors: Array.isArray(ajvErrors) ? ajvErrors : [],
+      params: args.params ?? {},
+      trace_entry_count: args.trace?.length ?? 0,
+    });
+    console.error(
+      serializeFailedAttemptLine({ event: 'agent_step_attempt_failed', ...record }).line,
+    );
+  } catch {
+    // Best-effort: telemetry must never affect the execute_step response.
+  }
+}
 
 /** Zod schema for a single agent trace entry submitted to execute_step or append_trace. */
 export const traceEntrySchema = z.object({
@@ -47,7 +98,7 @@ export async function handleExecuteStep(
   const definition = await workflowStore.get(run.workflow_id);
   const params = args.params ?? {};
 
-  return executeChain(runStore, definition, {
+  const result = await executeChain(runStore, definition, {
     runId: args.run_id,
     command: args.command,
     input: params,
@@ -61,6 +112,12 @@ export async function handleExecuteStep(
       ? { traceBufferStore: stores.traceBufferStore }
       : {}),
   });
+
+  // P2 observability: emit metadata-only stderr telemetry on a pre-claim validation rejection.
+  // Reads the pre-strip envelope; best-effort (never throws, never alters the response).
+  emitFailedAttemptTelemetry(args, run.workflow_id, result);
+
+  return result;
 }
 
 /**

--- a/packages/mcp-server/src/tools/failed-attempt-telemetry.test.ts
+++ b/packages/mcp-server/src/tools/failed-attempt-telemetry.test.ts
@@ -1,0 +1,143 @@
+// P2 observability: the MCP execute_step handler emits a metadata-only `agent_step_attempt_failed`
+// stderr line on a pre-claim validation rejection (and nothing on success / blocked / other codes).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore, JsonWorkflowStore, CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
+import type { WorkflowDefinition } from '@sensigo/realm';
+import { handleExecuteStep, handleExecuteStepTool } from './execute-step.js';
+
+// First step is an agent step with an output_schema → a missing-field submission fails
+// VALIDATION_OUTPUT_SCHEMA on the write-free pre-claim path.
+const wf: WorkflowDefinition = {
+  id: 'classify-wf',
+  name: 'Classify',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    classify: {
+      description: 'Classify a ticket',
+      execution: 'agent',
+      depends_on: [],
+      output_schema: {
+        type: 'object',
+        required: ['category'],
+        properties: { category: { type: 'string' } },
+      },
+    },
+  },
+};
+
+describe('execute_step failed-attempt telemetry', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    runStore = new JsonFileStore(await mkdtemp(join(tmpdir(), 'fat-run-')));
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'fat-wf-')));
+    await workflowStore.register(wf);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  /** Lines emitted by the telemetry hook (filtered by event). */
+  function emittedEvents(): Array<Record<string, unknown>> {
+    return errSpy.mock.calls
+      .map((c) => String(c[0]))
+      .map((s) => {
+        try {
+          return JSON.parse(s) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .filter(
+        (o): o is Record<string, unknown> =>
+          o !== null && o['event'] === 'agent_step_attempt_failed',
+      );
+  }
+
+  it('emits exactly one agent_step_attempt_failed line with the right metadata and no raw output', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'classify-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const result = await handleExecuteStep(
+      {
+        run_id: run.id,
+        command: 'classify',
+        // Missing required 'category'; carries PII in another field.
+        params: { ticket_body: 'jane@example.com is furious' },
+      },
+      { runStore, workflowStore },
+    );
+    expect(result.status).toBe('error');
+    expect(result.error_code).toBe('VALIDATION_OUTPUT_SCHEMA');
+
+    const events = emittedEvents();
+    expect(events).toHaveLength(1);
+    const ev = events[0]!;
+    expect(ev['event']).toBe('agent_step_attempt_failed');
+    expect(ev['run_id']).toBe(run.id);
+    expect(ev['step_id']).toBe('classify');
+    expect(ev['error_code']).toBe('VALIDATION_OUTPUT_SCHEMA');
+    expect(ev['submitted_keys']).toEqual(['ticket_body']);
+    expect(ev['submitted_key_count']).toBe(1);
+    // Metadata-only: the raw PII value must never appear in the emitted line.
+    expect(JSON.stringify(ev)).not.toContain('jane@example.com');
+  });
+
+  it('emits nothing on a successful step', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'classify-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const result = await handleExecuteStep(
+      { run_id: run.id, command: 'classify', params: { category: 'billing' } },
+      { runStore, workflowStore },
+    );
+    expect(result.status).toBe('ok');
+    expect(emittedEvents()).toHaveLength(0);
+  });
+
+  it('emits nothing on a blocked result (wrong step for current state)', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'classify-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    // 'no_such_step' is not eligible → status 'blocked', not a VALIDATION_* error.
+    const result = await handleExecuteStep(
+      { run_id: run.id, command: 'no_such_step', params: {} },
+      { runStore, workflowStore },
+    );
+    expect(result.status).toBe('blocked');
+    expect(emittedEvents()).toHaveLength(0);
+  });
+
+  it('emits via the MCP tool wrapper too, reading the pre-strip envelope', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'classify-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await handleExecuteStepTool(
+      { run_id: run.id, command: 'classify', params: { wrong: 1 } },
+      { runStore, workflowStore },
+    );
+    const events = emittedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!['error_code']).toBe('VALIDATION_OUTPUT_SCHEMA');
+    // The summarized validation error is present (metadata), proving pre-strip error_details was read.
+    expect(Array.isArray(events[0]!['validation_error_summary'])).toBe(true);
+    expect((events[0]!['validation_error_summary'] as unknown[]).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Context

A bradley-max incident report surfaced that failed `execution: agent` step attempts leave no trace: when an agent calls the MCP `execute_step` tool with output that fails pre-claim schema validation, the engine rejects it via `makeErrorEnvelope` **before the step is claimed** — a write-free path. Nothing is persisted to the run record and nothing is logged, so operators cannot post-mortem *what the agent submitted* or *which validation rule failed* (the real error is returned live but is ephemeral). A full two-round design debate (Peer + Reviewer ×2) converged on a P2+P3 design shipping in one minor release.

## Motivation

This is **Phase P2 of 2**: the shared, pure record builder/serializer plus the ephemeral **stderr** sink. It gives operators real-time, metadata-only visibility into failed agent-step validation attempts, filterable by `event`. P3 (durable sidecar + `realm run attempts` CLI) will reuse this exact builder/serializer verbatim.

## Changes

- **New pure core module** `packages/core/src/observability/failed-attempt-record.ts` (exported from `@sensigo/realm`):
  - `buildFailedAttemptRecord(input)` → metadata-only `FailedAttemptRecord`. Whitelists Ajv errors to `{instancePath, schemaPath, keyword, message}` (truncated 200 chars, capped 10 entries) and **drops Ajv `params`/`data`** (the offending-value echo). Records `submitted_key_count`, length-bounded `submitted_keys` (50×100), `submitted_bytes` — **never raw output values**. Pure, deterministic (ts is a parameter), never throws.
  - `serializeFailedAttemptLine(obj, maxBytes=3072)` → guarantees the serialized line is ≤ maxBytes by progressive reduction (drop summary → drop keys → byte-truncate), setting `truncated`. Single source of truth for line size; reused by P3's atomic append.
- **MCP emit** (`packages/mcp-server/src/tools/execute-step.ts`): on the **pre-strip** envelope, when `status==='error'` and `error_code ∈ {VALIDATION_INPUT_SCHEMA, VALIDATION_OUTPUT_SCHEMA, VALIDATION_TRACE_SCHEMA}`, emit `console.error(JSON.stringify({event:'agent_step_attempt_failed', ...record}))`. Whole body is best-effort (`try/catch`) — never throws, never alters the response.
- **Docs**: `operating-runs.md` (event shape, filter-by-`event`, metadata-only guarantee, and the pre-claim-validation vs post-claim-`failed_steps[]` distinction) and `mcp-protocol.md` cross-link.
- **CHANGELOG**: `[Unreleased]` → `### Added` (0.11.0 intent). No version-constant bump.

Core stays pure (no I/O added); the engine failure path and the live error envelope are unchanged.

## Verification

```bash
npm run lint          # clean
npm run test          # core 1303 (+14), cli 352, testing 56, mcp 100 (+4)
npm run build         # tsc --build 4/4
node scripts/check-versions.mjs   # all 0.10.1, no bump

# Targeted (forced, no cache):
npx vitest run --no-cache \
  packages/core/src/observability/failed-attempt-record.test.ts \
  packages/mcp-server/src/tools/failed-attempt-telemetry.test.ts
# → 18 passed (builder/serializer PII + truncation; handler emits only on the 3 VALIDATION_* codes,
#   nothing on success/blocked, no raw PII in the line, reads pre-strip error_details)
```

Independently verified: engine failure path byte-untouched; no `console./process./appendFile` added to `packages/core`; PII-safety holds by construction (only whitelisted Ajv fields + key names, never values).

## Rollback

```bash
git revert HEAD
```

Pure additive change (new module + one guarded emit call); `git revert` fully reverts it. No data migrations, no out-of-band effects.

## Related

- Phase P3 (durable `*.attempts.jsonl` sidecar + `realm run attempts <id>` CLI) — follow-up PR, reuses this builder/serializer; both ship in 0.11.0.
- #107 — engine run-purge (retention lifecycle), the separate tracked fix for the pre-existing leak class.
