### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
-
-> **Version intent: 0.11.0** (additive). Version constants are bumped at release time.
+## [0.11.0] — 2026-06-27
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.10.1');
+program.name('realm').description('Realm workflow engine CLI').version('0.11.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.10.1';
+export const VERSION = '0.11.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.10.1';
+export const VERSION = '0.11.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -60,7 +60,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.10.1',
+    version: '0.11.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.10.1';
+export const VERSION = '0.11.0';


### PR DESCRIPTION
## Context

Release **v0.11.0** — the failed-agent-attempt observability feature (Phases P2 + P3), shipped together as one minor release. Both phases were design-debated (Peer + Reviewer ×2), implemented, MA-reviewed, and merged to `main` (#108, #109).

## Motivation

Pre-claim `execute_step` schema-validation rejections are returned on a write-free path — nothing was persisted or logged, so operators had no post-mortem trail. This release adds structured, metadata-only telemetry for those rejections via two sinks (ephemeral stderr + durable per-run sidecar) plus a CLI reader.

## Changes

Additive, backwards-compatible (minor bump). From `[Unreleased]` → `[0.11.0]`:

- **`agent_step_attempt_failed` stderr telemetry** (P2) — structured, metadata-only MCP-server stderr event on the three `VALIDATION_*` rejection codes; pure `buildFailedAttemptRecord` / `serializeFailedAttemptLine` exported from `@sensigo/realm`; core stays I/O-free; live `execute_step` response unchanged.
- **Durable failed-attempt sidecar + `realm run attempts <run-id>` CLI** (P3) — co-located `<runsDir>/<run-id>.attempts.jsonl`, lock-free single-`O_APPEND` writes (≤PIPE_BUF), `stat`-based append-and-stop ceiling (~256 KB), `.jsonl`-invisible to `JsonFileStore.list()`, operator-managed retention; new `FailedAttemptStore` exported. Pure side-channel; best-effort.

This PR is the release commit (`chore: release v0.11.0`): version bumped to `0.11.0` across all four `package.json` files + the five source `VERSION` constants, and the CHANGELOG dated.

## Verification

```bash
# On main after merge + tag push:
node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"  # → 0.11.0
```

Pre-release gates (green on the feature PRs and on this branch's build): lint clean; full suite core 1312 / cli 356 / testing 56 / mcp 103; `tsc --build` 4/4; `npm audit --omit=dev` 0 vulnerabilities; engine untouched.

## Rollback

If the publish workflow fails partway, re-push the tag (already-published packages skip with `EPUBLISHCONFLICT`). If a broken artifact ships, cut a patch release (0.11.1) via the same Part B sequence.

## Related

- #108 (P2), #109 (P3) — the feature PRs merged into this release.
- #107 — engine run-purge / retention (separate tracked follow-up).
