### PR TITLE
feat(engine): when-clause soundness and bounded composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+> **Version intent: 0.12.0** (a breaking change on a 0.x line bumps the minor segment). Version constants are bumped at release time.
+
+### Changed
+
+- **BREAKING — corrected `when` absent-operand semantics.** When a `when` leaf's left-hand path is unresolved, the engine no longer lets `undefined` flow into the comparison (which made `undefined != null` → `true`, so a clause mis-fired). New per-operator behavior on an **absent** LHS: `== null` → **true**, `!= null` → **false** (presence tests, loose null), `!= '<non-null>'` → **false** (was `true`), relational `> < >= <=` → **false**; equality/relational on a **resolved** LHS is unchanged. A **present-`null`** LHS with a relational op is now **false** (numeric guard) instead of `true` (the old JS `null → 0` coercion). Symmetric `undefined → false` is deliberate. (External consequence: `run.params.mode != 'shadow'` now skips when `mode` is absent rather than firing — safe in practice; an external-workflow concern.)
+- **BREAKING — compound `when` strings are rejected at load.** `when:` never supported boolean composition; a compound string like `"A == x and B != y"` previously misparsed silently (latched a stray operator → always-true). It is now a loud, actionable load error pointing to the list form. The same load rejection now also applies to compound `abort_unless` / `preconditions` leaves (previously silently mis-evaluated; zero such clauses in known workflows).
+
+### Added
+
+- **`when: string[]` (implicit AND).** `when` is now `string | string[]`; an array ANDs its leaves (mirrors `abort_unless`). An empty array is a load error. `any`/OR is not added.
+- **Load-time condition validation across `when` / `abort_unless` / `preconditions`** via a shared zero-dependency quote-aware splitter (`comparison-expr.ts`): every leaf must be a single comparison (or, for `when`/`abort_unless`, a bare path) with a path-shaped LHS — compound / multi-operator / non-path leaves are rejected with actionable errors. The same splitter is used at runtime, so validation and evaluation never diverge.
+- **`when` direct-`depends_on` reference check (load-time).** A `when` leaf's `step.field` must reference `run.params.*` or a step in that step's direct `depends_on` (one-hop) — a mistyped/undeclared step name is now a load error.
+
+---
+
 ## [0.11.0] — 2026-06-27
 
 ### Added

--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -31,7 +31,7 @@ Complete reference for `workflow.yaml` fields. Every field documented here is va
 | `execution`       | `agent` \| `auto` \| `guard`                | Yes      | Who executes this step. See [Execution modes](#execution-modes).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `depends_on`      | string[]                                    | No       | Step IDs this step waits for. Empty array or omitted means eligible from run start.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `trigger_rule`    | string                                      | No       | When to evaluate dependency satisfaction. Default: `all_success`. See [`trigger_rule`](#trigger_rule).                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `when`            | string                                      | No       | Expression evaluated against prior step evidence. A step is ineligible until this is truthy. See [`when` condition](#when-condition).                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `when`            | string \| string[]                          | No       | Condition controlling step eligibility — a step is ineligible until truthy. A `string[]` is the implicit AND of its leaves. See [`when` condition](#when-condition).                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `uses_service`    | string                                      | No       | Name of a service declared in `services`. Only valid on `execution: auto` steps.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `service_method`  | `fetch` \| `create` \| `update` \| `delete` | No       | Adapter method to call. Defaults to `fetch`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `operation`       | string                                      | No       | Operation name passed to the adapter. Defaults to the step name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -243,11 +243,36 @@ steps:
     when: "classify_ticket.category == 'technical'"
 ```
 
-**Supported operators:** `==`, `!=`, `>`, `<`, `>=`, `<=`. The left side is a dot-path into prior step evidence (`step_name.field_name`). The right side is a quoted string, an unquoted number, `true`, `false`, or `null`.
+`when` is `string | string[]`. A single string is one leaf; **an array is the implicit AND of its leaves** (every leaf must hold). An empty array is a load error.
 
-`when` conditions are evaluated against each step's recorded `output_summary`. Comparison is strict — types must match (`"1"` does not equal `1`).
+```yaml
+when:
+  - 'extract_order.order_number_found == true'
+  - 'resolve_store.store_key != null'
+```
 
-Once all of a step's dependencies are settled, the engine evaluates the `when` condition. If it evaluates to false at that point, the step is moved to `skipped_steps` immediately — it does not remain indefinitely ineligible. In a mutual-exclusion pattern (two branches with opposite `when` conditions), the inactive branch is skipped as soon as the shared upstream step completes. No finalizer step is needed to close the run.
+**Leaf grammar:** `<path> <op> <literal>` or a bare `<path>` (truthy test). **Supported operators:** `==`, `!=`, `>`, `<`, `>=`, `<=`. The left side is a dot-path (`step_name.field_name`, or `run.params.field`). The right side is a quoted string, an unquoted number, `true`, `false`, or `null`. The split is quote-aware — an operator inside a quoted RHS (e.g. `subject == 'a >= b'`) does not mis-split.
+
+**Compound `and`/`or` inside a single string is rejected at load** — use the list form. The load error echoes the suggested list:
+
+```
+Step 'fetch_order': 'when' uses unsupported 'and' — write it as a list:
+  when:
+    - "extract_order.order_number_found == true"
+    - "resolve_store.store_key != null"
+```
+
+**Reference rule (load-time):** a `when` leaf's `step.field` must reference either `run.params.*` or a step in this step's **direct `depends_on`** (one-hop). Referencing a step not in `depends_on` is a load error (add it to `depends_on` or use `run.params.*`). Field names are not checked.
+
+**Comparison semantics.** A resolved LHS uses strict equality (`==`/`!=`; `"1"` does not equal `1`) and numeric-guarded relational comparison (`>` `<` `>=` `<=` require both operands to be numbers). When the LHS is **unresolved** (absent path):
+
+- `== null` / `!= null` are **presence tests** (loose null) — `== null` is true for a missing or present-`null` value; `!= null` is true only for a present non-null value.
+- relational ops (`> < >= <=`) → **false** (no `null → 0` coercion).
+- any other operator on an absent LHS → **false** (symmetric: a `!=` against a non-null literal does **not** fire when the path is absent).
+
+> **Field-name typo fire-direction (accepted residual).** Field names in a leaf are not statically checkable (agent-step outputs aren't declared). A typo'd field resolves as absent in **both** directions: `x.tcuont >= 0.8` → false → the step **skips**; but `x.tcuont == null` → "absent" → true → the step **fires**. This is consistent with Realm's lenient path resolution everywhere. The high-value typo (a mistyped **step name**) is caught loudly by the reference rule above; only field-name typos within a correctly-named dependency slip through.
+
+Once all of a step's dependencies are settled, the engine evaluates the `when` condition. If it is false at that point, the step is moved to `skipped_steps` immediately. In a mutual-exclusion pattern (two branches with opposite `when` conditions), the inactive branch is skipped as soon as the shared upstream step completes. No finalizer step is needed to close the run.
 
 ### Shadow mode via `run.params`
 

--- a/packages/core/src/engine/comparison-expr.test.ts
+++ b/packages/core/src/engine/comparison-expr.test.ts
@@ -1,0 +1,115 @@
+// Tests for the shared quote-aware comparison splitter (Change 1a).
+import { describe, it, expect } from 'vitest';
+import { splitComparison, isPathShaped, splitOnUnquotedDelimiter } from './comparison-expr.js';
+
+describe('splitComparison', () => {
+  it('splits a simple comparison', () => {
+    expect(splitComparison('a.b == 1')).toEqual({
+      kind: 'comparison',
+      lhsPath: 'a.b',
+      op: '==',
+      rhsRaw: '1',
+    });
+  });
+
+  it('handles all six operators (2-char before 1-char)', () => {
+    expect(splitComparison('x >= 1')).toMatchObject({ op: '>=' });
+    expect(splitComparison('x <= 1')).toMatchObject({ op: '<=' });
+    expect(splitComparison('x != 1')).toMatchObject({ op: '!=' });
+    expect(splitComparison('x == 1')).toMatchObject({ op: '==' });
+    expect(splitComparison('x > 1')).toMatchObject({ op: '>' });
+    expect(splitComparison('x < 1')).toMatchObject({ op: '<' });
+  });
+
+  it('is quote-aware: an operator inside the quoted RHS does not mis-split', () => {
+    // The first UNQUOTED operator is `==`; `>=` lives inside the quotes → part of the RHS.
+    expect(splitComparison("subject == 'a >= b'")).toEqual({
+      kind: 'comparison',
+      lhsPath: 'subject',
+      op: '==',
+      rhsRaw: "'a >= b'",
+    });
+  });
+
+  it('is quote-aware for double quotes too', () => {
+    expect(splitComparison('subject != "x == y"')).toEqual({
+      kind: 'comparison',
+      lhsPath: 'subject',
+      op: '!=',
+      rhsRaw: '"x == y"',
+    });
+  });
+
+  it('a bare path → kind path', () => {
+    expect(splitComparison('flags.enabled')).toEqual({ kind: 'path', path: 'flags.enabled' });
+  });
+
+  it('compound `and` (unquoted) → invalid with split parts', () => {
+    const r = splitComparison('a.x == true and b.y != null');
+    expect(r).toMatchObject({ kind: 'invalid', reason: 'compound_and' });
+    if (r.kind === 'invalid') expect(r.parts).toEqual(['a.x == true', 'b.y != null']);
+  });
+
+  it('compound `or` (unquoted) → invalid', () => {
+    expect(splitComparison('a == 1 or b == 2')).toMatchObject({
+      kind: 'invalid',
+      reason: 'compound_or',
+    });
+  });
+
+  it('`and` INSIDE quotes is not a compound', () => {
+    expect(splitComparison("subject == 'cats and dogs'")).toEqual({
+      kind: 'comparison',
+      lhsPath: 'subject',
+      op: '==',
+      rhsRaw: "'cats and dogs'",
+    });
+  });
+
+  it('multiple comparison operators → invalid', () => {
+    expect(splitComparison('a == b == c')).toMatchObject({
+      kind: 'invalid',
+      reason: 'multiple_operators',
+    });
+  });
+
+  it('empty → invalid', () => {
+    expect(splitComparison('   ')).toMatchObject({ kind: 'invalid', reason: 'empty' });
+  });
+
+  it('negative-number RHS is not mistaken for an operator', () => {
+    expect(splitComparison('score < -5')).toEqual({
+      kind: 'comparison',
+      lhsPath: 'score',
+      op: '<',
+      rhsRaw: '-5',
+    });
+  });
+
+  it('never throws on weird input', () => {
+    expect(() => splitComparison('=='.repeat(50))).not.toThrow();
+    expect(() => splitComparison("'unterminated")).not.toThrow();
+  });
+});
+
+describe('isPathShaped', () => {
+  it('accepts dot-paths and run.params', () => {
+    expect(isPathShaped('step.field')).toBe(true);
+    expect(isPathShaped('run.params.mode')).toBe(true);
+    expect(isPathShaped('a_b-c.d')).toBe(true);
+  });
+  it('rejects spaces, operators, quotes, leading digits/dots', () => {
+    expect(isPathShaped('a b')).toBe(false);
+    expect(isPathShaped('a == b')).toBe(false);
+    expect(isPathShaped("'x'")).toBe(false);
+    expect(isPathShaped('.a')).toBe(false);
+    expect(isPathShaped('')).toBe(false);
+  });
+});
+
+describe('splitOnUnquotedDelimiter (moved from render-template)', () => {
+  it('splits on unquoted delimiter only', () => {
+    expect(splitOnUnquotedDelimiter('a|b|c', '|')).toEqual(['a', 'b', 'c']);
+    expect(splitOnUnquotedDelimiter("a|'b|c'|d", '|')).toEqual(['a', "'b|c'", 'd']);
+  });
+});

--- a/packages/core/src/engine/comparison-expr.ts
+++ b/packages/core/src/engine/comparison-expr.ts
@@ -1,0 +1,176 @@
+// comparison-expr.ts — zero-dependency, quote-aware splitting for Realm's condition leaves.
+//
+// This module is the SINGLE source of truth for how a one-line condition leaf is split into a
+// comparison, a bare path, or an "invalid" verdict. It is used by:
+//   - load-time validation (yaml-loader) — to reject compound / malformed leaves with a loud error;
+//   - runtime evaluation (evaluateWhenCondition, evaluateGuardConditions, evaluatePrecondition) — so
+//     the split used to validate a leaf is the SAME split used to evaluate it (no validate/eval drift).
+//
+// It MUST stay zero-dependency (no import from render-template/eligibility/precondition) to avoid an
+// import cycle — those modules import FROM here.
+
+/** The comparison operators Realm understands, longest tokens first for greedy matching. */
+export type ComparisonOp = '==' | '!=' | '>=' | '<=' | '>' | '<';
+
+export type ComparisonInvalidReason =
+  | 'empty'
+  | 'compound_and'
+  | 'compound_or'
+  | 'multiple_operators';
+
+/** The result of splitting one condition leaf. Never thrown — malformed input returns `invalid`. */
+export type ComparisonSplit =
+  | { kind: 'comparison'; lhsPath: string; op: ComparisonOp; rhsRaw: string }
+  | { kind: 'path'; path: string }
+  | { kind: 'invalid'; reason: ComparisonInvalidReason; parts?: string[] };
+
+/**
+ * Splits `input` on every occurrence of single-character `delimiter` that is NOT inside a quoted
+ * string. Single or double quotes both open/close quote state; the other quote type is ignored while
+ * inside a quote. Returns raw substrings — no trimming, no quote stripping.
+ *
+ * (Moved here from render-template.ts so both template rendering and condition splitting share one
+ * quote-aware primitive; render-template imports it from this module.)
+ */
+export function splitOnUnquotedDelimiter(input: string, delimiter: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (const ch of input) {
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+      continue;
+    }
+    if (ch === delimiter && !inSingle && !inDouble) {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  segments.push(current);
+  return segments;
+}
+
+/**
+ * Returns `expr` with every character inside a quoted region (and the quote chars themselves)
+ * replaced by a space, preserving length so positions in the mask map 1:1 to the original. Used to
+ * find operators/keywords while ignoring quoted content.
+ */
+function maskQuoted(expr: string): string {
+  let out = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (const ch of expr) {
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      out += ' ';
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      out += ' ';
+      continue;
+    }
+    out += inSingle || inDouble ? ' ' : ch;
+  }
+  return out;
+}
+
+const TWO_CHAR_OPS: ComparisonOp[] = ['>=', '<=', '==', '!='];
+
+/** Find all unquoted comparison-operator occurrences in `mask` (2-char ops take precedence). */
+function findOperators(mask: string): Array<{ pos: number; op: ComparisonOp; len: number }> {
+  const found: Array<{ pos: number; op: ComparisonOp; len: number }> = [];
+  let i = 0;
+  while (i < mask.length) {
+    const two = mask.slice(i, i + 2);
+    if ((TWO_CHAR_OPS as string[]).includes(two)) {
+      found.push({ pos: i, op: two as ComparisonOp, len: 2 });
+      i += 2;
+      continue;
+    }
+    const one = mask[i];
+    if (one === '>' || one === '<') {
+      found.push({ pos: i, op: one, len: 1 });
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  return found;
+}
+
+/** Split `expr` on an unquoted whitespace-delimited keyword (e.g. `and`), using the mask. */
+function splitOnUnquotedKeyword(expr: string, mask: string, keyword: string): string[] {
+  const re = new RegExp(`\\s${keyword}\\s`, 'g');
+  const parts: string[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(mask)) !== null) {
+    parts.push(expr.slice(last, m.index).trim());
+    last = m.index + m[0].length;
+  }
+  parts.push(expr.slice(last).trim());
+  return parts;
+}
+
+/**
+ * Split one condition leaf, quote-aware, into a comparison `{ lhsPath, op, rhsRaw }`, a bare
+ * `{ path }`, or `{ invalid, reason }`. Operator tokens and `and`/`or` keywords inside quoted
+ * regions are ignored. Never throws.
+ *
+ * - `and`/`or` (unquoted) → `invalid` with `parts` (the split candidates, for an actionable error).
+ * - exactly one unquoted operator → `comparison`.
+ * - more than one → `invalid` (`multiple_operators`).
+ * - none → `path` (a bare path; the caller validates its shape with {@link isPathShaped}).
+ */
+export function splitComparison(input: string): ComparisonSplit {
+  const expr = input.trim();
+  if (expr === '') return { kind: 'invalid', reason: 'empty' };
+
+  const mask = maskQuoted(expr);
+
+  // Boolean composition keywords take priority — they produce the most actionable error.
+  if (/\sand\s/.test(mask)) {
+    return {
+      kind: 'invalid',
+      reason: 'compound_and',
+      parts: splitOnUnquotedKeyword(expr, mask, 'and'),
+    };
+  }
+  if (/\sor\s/.test(mask)) {
+    return {
+      kind: 'invalid',
+      reason: 'compound_or',
+      parts: splitOnUnquotedKeyword(expr, mask, 'or'),
+    };
+  }
+
+  const ops = findOperators(mask);
+  if (ops.length === 0) return { kind: 'path', path: expr };
+  if (ops.length > 1) return { kind: 'invalid', reason: 'multiple_operators' };
+
+  const { pos, op, len } = ops[0]!;
+  return {
+    kind: 'comparison',
+    lhsPath: expr.slice(0, pos).trim(),
+    op,
+    rhsRaw: expr.slice(pos + len).trim(),
+  };
+}
+
+/**
+ * True when `s` is a bare dot-path: starts with a letter/underscore and contains only word chars,
+ * `.`, or `-` (no spaces, no operators). Used to reject a non-path LHS at load time.
+ */
+export function isPathShaped(s: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_.-]*$/.test(s);
+}

--- a/packages/core/src/engine/eligibility.test.ts
+++ b/packages/core/src/engine/eligibility.test.ts
@@ -9,6 +9,7 @@ import {
   findEligibleGuardSteps,
   triggerRuleSatisfied,
   evaluateWhenCondition,
+  evaluateWhen,
   deriveRunPhase,
   propagateSkips,
 } from './eligibility.js';
@@ -320,6 +321,102 @@ describe('evaluateWhenCondition', () => {
   it('unquoted string rhs treated as bareword for equality', () => {
     const evidence = { step_a: { confidence: 'high' } };
     expect(evaluateWhenCondition('step_a.confidence == high', evidence)).toBe(true);
+  });
+
+  it('quote-aware: an operator inside the quoted RHS does not mis-split', () => {
+    const evidence = { step_a: { subject: 'a >= b' } };
+    expect(evaluateWhenCondition("step_a.subject == 'a >= b'", evidence)).toBe(true);
+    expect(evaluateWhenCondition("step_a.subject == 'a >= c'", evidence)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateWhenCondition — 1c absent/present-null truth-table (the corrected semantics)
+// ---------------------------------------------------------------------------
+
+describe('evaluateWhenCondition — 1c absent-LHS / present-null semantics', () => {
+  const absent = { step_a: {} }; // step_a.missing is absent
+  const presentNull = { step_a: { v: null } }; // step_a.v is present and null
+
+  // CHANGED rows (were untested; load-bearing)
+  it('absent == null → true (was false)', () => {
+    expect(evaluateWhenCondition('step_a.missing == null', absent)).toBe(true);
+  });
+  it('absent != null → false (was true — the incident)', () => {
+    expect(evaluateWhenCondition('step_a.missing != null', absent)).toBe(false);
+  });
+  it("absent != '<non-null literal>' → false (was true)", () => {
+    expect(evaluateWhenCondition("step_a.missing != 'shadow'", absent)).toBe(false);
+  });
+  it('present-null >= 0 / <= 0 / > / < → false (numeric guard; was true via null→0)', () => {
+    expect(evaluateWhenCondition('step_a.v >= 0', presentNull)).toBe(false);
+    expect(evaluateWhenCondition('step_a.v <= 0', presentNull)).toBe(false);
+    expect(evaluateWhenCondition('step_a.v > -1', presentNull)).toBe(false);
+    expect(evaluateWhenCondition('step_a.v < 1', presentNull)).toBe(false);
+  });
+
+  // UNCHANGED rows (regression guards)
+  it("absent == '<non-null literal>' → false (unchanged)", () => {
+    expect(evaluateWhenCondition("step_a.missing == 'shadow'", absent)).toBe(false);
+  });
+  it('absent relational (>= n etc.) → false (unchanged)', () => {
+    expect(evaluateWhenCondition('step_a.missing >= 1', absent)).toBe(false);
+    expect(evaluateWhenCondition('step_a.missing < 1', absent)).toBe(false);
+  });
+  it('present-null == null → true, != null → false (unchanged)', () => {
+    expect(evaluateWhenCondition('step_a.v == null', presentNull)).toBe(true);
+    expect(evaluateWhenCondition('step_a.v != null', presentNull)).toBe(false);
+  });
+  it("present-null == '<non-null>' → false, != '<non-null>' → true (unchanged)", () => {
+    expect(evaluateWhenCondition("step_a.v == 'x'", presentNull)).toBe(false);
+    expect(evaluateWhenCondition("step_a.v != 'x'", presentNull)).toBe(true);
+  });
+  it('resolved relational still works (present number)', () => {
+    expect(evaluateWhenCondition('step_a.n >= 3', { step_a: { n: 3 } })).toBe(true);
+    expect(evaluateWhenCondition('step_a.n >= 3', { step_a: { n: 2 } })).toBe(false);
+  });
+  it('bare path → Boolean(value), unchanged', () => {
+    expect(evaluateWhenCondition('step_a.flag', { step_a: { flag: true } })).toBe(true);
+    expect(evaluateWhenCondition('step_a.flag', { step_a: { flag: false } })).toBe(false);
+    expect(evaluateWhenCondition('step_a.flag', { step_a: {} })).toBe(false);
+  });
+
+  it("run.params.mode != 'shadow' SKIPS (false) when mode is absent (deliberate flip)", () => {
+    expect(evaluateWhenCondition("run.params.mode != 'shadow'", {}, {})).toBe(false);
+    // and still fires when mode is present and not 'shadow'
+    expect(evaluateWhenCondition("run.params.mode != 'shadow'", {}, { mode: 'live' })).toBe(true);
+  });
+
+  it('a compound string reaching runtime (load normally rejects it) → false', () => {
+    expect(
+      evaluateWhenCondition('step_a.x == 1 and step_a.y == 2', { step_a: { x: 1, y: 2 } }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateWhen — string[] implicit AND folding (Change 3)
+// ---------------------------------------------------------------------------
+
+describe('evaluateWhen — implicit AND folding', () => {
+  const evidence = { a: { ok: true }, b: { key: 'x' } };
+
+  it('a single string behaves as one leaf', () => {
+    expect(evaluateWhen('a.ok == true', evidence)).toBe(true);
+    expect(evaluateWhen('a.ok == false', evidence)).toBe(false);
+  });
+
+  it('an array ANDs its leaves (all true → true)', () => {
+    expect(evaluateWhen(['a.ok == true', 'b.key != null'], evidence)).toBe(true);
+  });
+
+  it('an array is false if any leaf is false', () => {
+    expect(evaluateWhen(['a.ok == true', "b.key == 'nope'"], evidence)).toBe(false);
+  });
+
+  it('a bare-path leaf inside an array is preserved', () => {
+    expect(evaluateWhen(['a.ok', 'b.key != null'], evidence)).toBe(true);
+    expect(evaluateWhen(['a.ok', 'b.missing'], evidence)).toBe(false);
   });
 });
 

--- a/packages/core/src/engine/eligibility.ts
+++ b/packages/core/src/engine/eligibility.ts
@@ -9,6 +9,7 @@ import type {
 import type { RunRecord } from '../types/run-record.js';
 import type { RunPhase } from '../types/run-record.js';
 import { resolvePath } from './render-template.js';
+import { splitComparison, type ComparisonOp } from './comparison-expr.js';
 
 /**
  * Derives the run_phase from the run record fields.
@@ -97,72 +98,115 @@ export function triggerRuleSatisfied(step: StepDefinition, run: RunRecord): bool
   }
 }
 
+/** Parse a `when` RHS literal, flagging the bare `null` token (drives the 1c presence-test). */
+function parseWhenRhs(rhs: string): { value: unknown; isBareNull: boolean } {
+  if ((rhs.startsWith("'") && rhs.endsWith("'")) || (rhs.startsWith('"') && rhs.endsWith('"'))) {
+    return { value: rhs.slice(1, -1), isBareNull: false };
+  }
+  if (rhs === 'true') return { value: true, isBareNull: false };
+  if (rhs === 'false') return { value: false, isBareNull: false };
+  if (rhs === 'null') return { value: null, isBareNull: true };
+  const n = Number(rhs);
+  return { value: Number.isNaN(n) ? rhs : n, isBareNull: false };
+}
+
+/** Relational comparison requiring both operands numeric (no JS null→0 coercion). */
+function compareNumeric(op: ComparisonOp, lhs: unknown, rhs: unknown): boolean {
+  if (typeof lhs !== 'number' || typeof rhs !== 'number') return false;
+  switch (op) {
+    case '>':
+      return lhs > rhs;
+    case '<':
+      return lhs < rhs;
+    case '>=':
+      return lhs >= rhs;
+    case '<=':
+      return lhs <= rhs;
+    default:
+      return false;
+  }
+}
+
 /**
- * Evaluates a when-condition expression against prior step evidence.
- * Supports: path == 'value', path != 'value', path > n, path < n, path >= n, path <= n.
- * Returns false on parse error or missing value.
+ * Evaluates a single `when`-condition LEAF against prior step evidence (per-leaf; the array-AND
+ * folding lives in {@link evaluateWhen}). Splitting is quote-aware via the shared splitter, so the
+ * leaf is split the same way at load and at runtime (no validate/eval divergence).
+ *
+ * Absent-LHS semantics (unique to `when`):
+ * - `== null` / `!= null` (bare null RHS) → loose presence test (`lhs == null` / `lhs != null`),
+ *   covering both a missing path and a present-`null` value uniformly.
+ * - relational `> < >= <=` → both operands must be numeric, else false (no `null→0` coercion).
+ * - any other operator with an undefined LHS → false (symmetric `undefined → false`).
+ * - bare path → `Boolean(resolved)`.
+ * A resolved LHS uses strict `===`/`!==` (equality) or numeric-guarded relational comparison.
  */
 export function evaluateWhenCondition(
   expr: string,
   evidenceByStep: Record<string, Record<string, unknown>>,
   runParams: Record<string, unknown> = {},
 ): boolean {
-  // when-condition paths are relative to step outputs: "step_id.field" resolves
-  // directly against evidenceByStep (e.g. step_a.confidence == high).
-  // "run.params.field" resolves against run start params.
+  // when-condition paths are relative to step outputs: "step_id.field" resolves directly against
+  // evidenceByStep; "run.params.field" resolves against run start params.
   const root: Record<string, unknown> = { ...evidenceByStep, run: { params: runParams } };
 
-  const operators: Array<[string, (a: unknown, b: unknown) => boolean]> = [
-    [' >= ', (a, b) => (a as number) >= (b as number)],
-    [' <= ', (a, b) => (a as number) <= (b as number)],
-    [' != ', (a, b) => a !== b],
-    [' == ', (a, b) => a === b],
-    [' > ', (a, b) => (a as number) > (b as number)],
-    [' < ', (a, b) => (a as number) < (b as number)],
-  ];
+  const split = splitComparison(expr);
 
-  for (const [op, compare] of operators) {
-    const idx = expr.indexOf(op);
-    if (idx === -1) continue;
+  // A compound/malformed leaf is rejected at load; if one reaches runtime it is never eligible.
+  if (split.kind === 'invalid') return false;
 
-    const lhsPath = expr.slice(0, idx).trim();
-    const rhs = expr.slice(idx + op.length).trim();
-
-    let leftVal: unknown;
+  if (split.kind === 'path') {
     try {
-      leftVal = resolvePath(lhsPath, root as Record<string, unknown>);
-    } catch {
-      return false;
-    }
-
-    let rightVal: unknown;
-    if ((rhs.startsWith("'") && rhs.endsWith("'")) || (rhs.startsWith('"') && rhs.endsWith('"'))) {
-      rightVal = rhs.slice(1, -1);
-    } else if (rhs === 'true') {
-      rightVal = true;
-    } else if (rhs === 'false') {
-      rightVal = false;
-    } else if (rhs === 'null') {
-      rightVal = null;
-    } else {
-      const n = Number(rhs);
-      rightVal = Number.isNaN(n) ? rhs : n;
-    }
-
-    try {
-      return compare(leftVal, rightVal);
+      return Boolean(resolvePath(split.path, root));
     } catch {
       return false;
     }
   }
 
-  // No operator: treat the path value as a truthy/falsy boolean.
+  const { lhsPath, op, rhsRaw } = split;
+  let lhs: unknown;
   try {
-    const val = resolvePath(expr.trim(), root as Record<string, unknown>);
-    return Boolean(val);
+    lhs = resolvePath(lhsPath, root);
   } catch {
     return false;
   }
+  const { value: rhs, isBareNull } = parseWhenRhs(rhsRaw);
+
+  if (lhs === undefined) {
+    // Presence test first (covers missing + present-null uniformly via loose null).
+    if ((op === '==' || op === '!=') && isBareNull) {
+      return op === '==' ? lhs == null : lhs != null;
+    }
+    // Relational on an absent LHS → false (numeric guard); any other op on absent → false.
+    return false;
+  }
+
+  switch (op) {
+    case '==':
+      return lhs === rhs;
+    case '!=':
+      return lhs !== rhs;
+    case '>':
+    case '<':
+    case '>=':
+    case '<=':
+      return compareNumeric(op, lhs, rhs);
+    default:
+      return false;
+  }
+}
+
+/**
+ * AND-folds a `when` clause (`string | string[]`) over the per-leaf {@link evaluateWhenCondition}.
+ * A bare string is a single leaf; an array is the implicit AND of its leaves. An array NEVER reaches
+ * the single-string evaluator — normalization happens here, in one place.
+ */
+export function evaluateWhen(
+  clause: string | string[],
+  evidenceByStep: Record<string, Record<string, unknown>>,
+  runParams: Record<string, unknown> = {},
+): boolean {
+  const leaves = Array.isArray(clause) ? clause : [clause];
+  return leaves.every((leaf) => evaluateWhenCondition(leaf, evidenceByStep, runParams));
 }
 
 /**
@@ -223,9 +267,9 @@ export function findEligibleSteps(definition: WorkflowDefinition, run: RunRecord
     // Trigger rule evaluation.
     if (!triggerRuleSatisfied(step, run)) continue;
 
-    // when-condition evaluation.
+    // when-condition evaluation (string | string[] implicit-AND).
     if (step.when !== undefined) {
-      if (!evaluateWhenCondition(step.when, evidenceByStep, run.params)) continue;
+      if (!evaluateWhen(step.when, evidenceByStep, run.params)) continue;
     }
 
     eligible.push(stepName);
@@ -264,10 +308,10 @@ export function findEligibleGuardSteps(definition: WorkflowDefinition, run: RunR
     // Trigger rule evaluation.
     if (!triggerRuleSatisfied(step, run)) continue;
 
-    // when-condition evaluation.
+    // when-condition evaluation (string | string[] implicit-AND).
     if (step.when !== undefined) {
       const evidenceByStep = buildEvidenceByStep(run);
-      if (!evaluateWhenCondition(step.when, evidenceByStep, run.params)) continue;
+      if (!evaluateWhen(step.when, evidenceByStep, run.params)) continue;
     }
 
     eligible.push(stepName);
@@ -386,10 +430,7 @@ export function propagateSkips(run: RunRecord, definition: WorkflowDefinition): 
             tempRun.failed_steps.includes(d) ||
             skipped.includes(d),
         );
-        if (
-          allDepsSettled &&
-          !evaluateWhenCondition(step.when, buildEvidenceByStep(run), run.params)
-        ) {
+        if (allDepsSettled && !evaluateWhen(step.when, buildEvidenceByStep(run), run.params)) {
           skipped.push(stepName);
           changed = true;
         }

--- a/packages/core/src/engine/precondition.ts
+++ b/packages/core/src/engine/precondition.ts
@@ -1,5 +1,6 @@
 // Precondition evaluator — evaluates step precondition expressions against
 // the run's collected evidence map before allowing a step to execute.
+import { splitComparison } from './comparison-expr.js';
 
 /**
  * Resolves a dot-separated path into a nested object.
@@ -71,22 +72,19 @@ export function evaluatePrecondition(
   expression: string,
   evidenceByStep: Record<string, Record<string, unknown>>,
 ): boolean {
-  const match = /^([\w-]+)\.([\w.]+)\s*(>=|<=|!=|>|<|==)\s*(\S.*)$/.exec(expression);
-  if (match === null) return false;
+  // Split via the shared quote-aware splitter (same split used at load) — see comparison-expr.ts.
+  // A precondition is a comparison only; a bare path / compound / malformed leaf → false (the old
+  // regex's no-match behavior). Absent LHS → false. Coercion is unchanged (compare/parseLiteral).
+  const split = splitComparison(expression);
+  if (split.kind !== 'comparison') return false;
 
-  const stepName = match[1]!;
-  const fieldPath = match[2]!;
-  const op = match[3]!;
-  const literalRaw = match[4]!;
-
-  const stepEvidence = evidenceByStep[stepName];
-  if (stepEvidence === undefined) return false;
-
-  const lhs = resolvePath(stepEvidence, fieldPath);
+  // resolvePath(evidenceByStep, "step.field") walks the dotted path — equivalent to the old
+  // two-step (evidenceByStep[step] then resolvePath of the field path).
+  const lhs = resolvePath(evidenceByStep, split.lhsPath);
   if (lhs === undefined) return false;
 
-  const rhs = parseLiteral(literalRaw);
-  return compare(lhs, op, rhs);
+  const rhs = parseLiteral(split.rhsRaw);
+  return compare(lhs, split.op, rhs);
 }
 
 export interface PreconditionResult {
@@ -106,15 +104,10 @@ export function checkPreconditions(
   for (const expression of preconditions) {
     const passed = evaluatePrecondition(expression, evidenceByStep);
     if (!passed) {
-      // Resolve the LHS value for the failure message.
-      const match = /^([\w-]+)\.([\w.]+)/.exec(expression);
-      let resolvedValue: unknown = undefined;
-      if (match !== null) {
-        const stepEvidence = evidenceByStep[match[1]!];
-        if (stepEvidence !== undefined) {
-          resolvedValue = resolvePath(stepEvidence, match[2]!);
-        }
-      }
+      // Resolve the LHS value for the failure message (shared splitter — see comparison-expr.ts).
+      const split = splitComparison(expression);
+      const resolvedValue: unknown =
+        split.kind === 'comparison' ? resolvePath(evidenceByStep, split.lhsPath) : undefined;
       return { expression, passed: false, resolved_value: resolvedValue };
     }
   }
@@ -132,14 +125,9 @@ export function evaluateAllPreconditions(
 ): PreconditionResult[] {
   return preconditions.map((expression) => {
     const passed = evaluatePrecondition(expression, evidenceByStep);
-    const match = /^([\w-]+)\.([\w.]+)/.exec(expression);
-    let resolvedValue: unknown = undefined;
-    if (match !== null) {
-      const stepEvidence = evidenceByStep[match[1]!];
-      if (stepEvidence !== undefined) {
-        resolvedValue = resolvePath(stepEvidence, match[2]!);
-      }
-    }
+    const split = splitComparison(expression);
+    const resolvedValue: unknown =
+      split.kind === 'comparison' ? resolvePath(evidenceByStep, split.lhsPath) : undefined;
     return { expression, passed, resolved_value: resolvedValue };
   });
 }
@@ -182,26 +170,20 @@ export function evaluateGuardConditions(
   const results: GuardConditionResult[] = [];
 
   for (const condition of conditions) {
-    const operators = ['>=', '<=', '!=', '==', '>', '<'] as const;
-    let matched = false;
+    // Split via the shared quote-aware splitter (same split used at load) — see comparison-expr.ts.
+    // Absent-policy and type-coercion are UNCHANGED from the original indexOf-scan: an unresolved
+    // LHS or a non-numeric relational comparison is a resolution_error; a bare path is a truthy test.
+    const split = splitComparison(condition);
 
-    for (const op of operators) {
-      const opWithSpaces = ` ${op} `;
-      const idx = condition.indexOf(opWithSpaces);
-      if (idx === -1) continue;
+    if (split.kind === 'comparison') {
+      const { lhsPath, op, rhsRaw } = split;
 
-      matched = true;
-      const lhsPath = condition.slice(0, idx).trim();
-      const rhs = condition.slice(idx + opWithSpaces.length).trim();
-
-      // Resolve LHS.
       const lhsValue = resolvePath(root, lhsPath);
       if (lhsValue === undefined) {
         return { kind: 'resolution_error', condition, unresolvable_path: lhsPath };
       }
 
-      // Parse RHS literal.
-      const rhsValue = parseLiteral(rhs);
+      const rhsValue = parseLiteral(rhsRaw);
 
       // Numeric operators require both sides to be numbers.
       if (
@@ -214,17 +196,16 @@ export function evaluateGuardConditions(
 
       const passed = compare(lhsValue, op, rhsValue);
       results.push({ condition, resolved_value: lhsValue, passed });
-      break;
-    }
-
-    if (!matched) {
+    } else if (split.kind === 'path') {
       // Bare path — truthy/falsy check.
-      const path = condition.trim();
-      const value = resolvePath(root, path);
+      const value = resolvePath(root, split.path);
       if (value === undefined) {
-        return { kind: 'resolution_error', condition, unresolvable_path: path };
+        return { kind: 'resolution_error', condition, unresolvable_path: split.path };
       }
       results.push({ condition, resolved_value: value, passed: Boolean(value) });
+    } else {
+      // Compound/malformed leaf is rejected at load; if one reaches runtime, treat as unresolvable.
+      return { kind: 'resolution_error', condition, unresolvable_path: condition };
     }
   }
 

--- a/packages/core/src/engine/render-template.ts
+++ b/packages/core/src/engine/render-template.ts
@@ -4,6 +4,7 @@
 // Unknown references are left as-is. Object/array values are JSON-stringified.
 import type { WorkflowContextSnapshot } from '../types/run-record.js';
 import type { ContextWrapperFormat } from '../types/workflow-definition.js';
+import { splitOnUnquotedDelimiter } from './comparison-expr.js';
 
 /**
  * Resolves a dot-path like "context.resources.review_security.findings"
@@ -391,36 +392,8 @@ function stripOuterQuotes(token: string): string {
   return token;
 }
 
-// Splits input on every occurrence of delimiter that is not inside a quoted string.
-// Single or double quotes both open/close quote state; the other quote type is ignored
-// while inside a quote. delimiter must be a single character.
-// Returns raw substrings — no trimming, no quote stripping.
-function splitOnUnquotedDelimiter(input: string, delimiter: string): string[] {
-  const segments: string[] = [];
-  let current = '';
-  let inSingle = false;
-  let inDouble = false;
-  for (const ch of input) {
-    if (ch === '"' && !inSingle) {
-      inDouble = !inDouble;
-      current += ch;
-      continue;
-    }
-    if (ch === "'" && !inDouble) {
-      inSingle = !inSingle;
-      current += ch;
-      continue;
-    }
-    if (ch === delimiter && !inSingle && !inDouble) {
-      segments.push(current);
-      current = '';
-      continue;
-    }
-    current += ch;
-  }
-  segments.push(current);
-  return segments;
-}
+// splitOnUnquotedDelimiter now lives in comparison-expr.ts (shared with condition splitting) and is
+// imported above — keeping one quote-aware primitive across template rendering and condition parsing.
 
 function splitOnUnquotedPipes(expr: string): string[] {
   return splitOnUnquotedDelimiter(expr, '|');

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -112,14 +112,21 @@ export interface StepDefinition {
    */
   trigger_rule?: TriggerRule;
   /**
-   * Optional condition expression evaluated against prior step evidence or run params.
-   * Step is ineligible until this expression is truthy.
+   * Optional condition controlling step eligibility — the step is ineligible until it is truthy.
+   * A single string is one comparison/bare-path leaf; a `string[]` is the **implicit AND** of its
+   * leaves (every leaf must hold). Compound `and`/`or` *inside a string* is rejected at load — use
+   * the array form instead. An empty array is rejected.
+   *
+   * Leaf grammar: `<path> <op> <literal>` (`op` ∈ `== != > >= < <=`) or a bare `<path>` (truthy test).
    * Path forms:
-   *   step_id.field        — prior step output (e.g. "classify.category == 'billing'")
-   *   run.params.field     — run start params (e.g. "run.params.mode == 'live'")
-   * Single expression only — compound conditions (AND/OR) are not supported.
+   *   step_id.field    — prior step output; the step must be in this step's `depends_on` (one-hop)
+   *   run.params.field — run start params (`when` only)
+   *
+   * Unresolved-LHS semantics: `== null` / `!= null` are presence tests (loose null, covering missing
+   * and present-null); relational ops require both operands numeric (else false); any other op on an
+   * absent LHS is false. A resolved LHS uses strict equality / numeric-guarded relational comparison.
    */
-  when?: string;
+  when?: string | string[];
   /**
    * Array of condition expressions evaluated against prior step evidence.
    * All conditions are evaluated; the run aborts (run_phase: 'aborted') if any is false.

--- a/packages/core/src/workflow/yaml-loader.test.ts
+++ b/packages/core/src/workflow/yaml-loader.test.ts
@@ -1892,3 +1892,157 @@ steps:
     expect(() => loadWorkflowFromString(wf(trigger))).toThrow(/unknown property|dedpu/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Condition leaf validation: when / abort_unless / preconditions (Change 1b/2/3)
+// ---------------------------------------------------------------------------
+
+describe('loadWorkflowFromString — when/abort_unless/preconditions validation', () => {
+  /** A two-step workflow where `gate`/`act` can carry a `when`/`preconditions` block. */
+  function wf(actBlock: string): string {
+    return `
+id: cond-wf
+name: Cond WF
+version: 1
+steps:
+  classify:
+    description: classify
+    execution: agent
+    depends_on: []
+  act:
+    description: act
+    execution: agent
+    depends_on: [classify]
+${actBlock}
+`;
+  }
+
+  // --- Change 3: when string | string[] ---
+  it('accepts a single-string when referencing a direct dependency', () => {
+    expect(() =>
+      loadWorkflowFromString(wf('    when: "classify.category == \'billing\'"')),
+    ).not.toThrow();
+  });
+
+  it('accepts a string[] when (implicit AND) of valid leaves', () => {
+    const block =
+      '    when:\n      - "classify.category == \'billing\'"\n      - "classify.confidence >= 0.8"';
+    expect(() => loadWorkflowFromString(wf(block))).not.toThrow();
+  });
+
+  it('rejects an empty when array', () => {
+    expect(() => loadWorkflowFromString(wf('    when: []'))).toThrow(
+      /'when' array must not be empty/,
+    );
+  });
+
+  it('preserves a bare-path leaf inside a when array', () => {
+    const block = '    when:\n      - "classify.ready"\n      - "classify.category == \'billing\'"';
+    expect(() => loadWorkflowFromString(wf(block))).not.toThrow();
+  });
+
+  // --- 1b: compound rejection with actionable echo ---
+  it('rejects a compound `and` when string with an actionable list-form message', () => {
+    let msg = '';
+    try {
+      loadWorkflowFromString(
+        wf('    when: "classify.category == \'billing\' and classify.confidence >= 0.8"'),
+      );
+    } catch (e) {
+      msg = (e as WorkflowError).message;
+    }
+    expect(msg).toContain("'when' uses unsupported 'and' — write it as a list:");
+    expect(msg).toContain('- "classify.category == \'billing\'"');
+    expect(msg).toContain('- "classify.confidence >= 0.8"');
+  });
+
+  it('rejects a compound `or` when string', () => {
+    expect(() =>
+      loadWorkflowFromString(wf('    when: "classify.a == 1 or classify.b == 2"')),
+    ).toThrow(/uses unsupported 'or'/);
+  });
+
+  it('rejects a when leaf with multiple comparison operators', () => {
+    expect(() => loadWorkflowFromString(wf('    when: "classify.a == classify.b == 1"'))).toThrow(
+      /multiple comparison operators/,
+    );
+  });
+
+  // --- 1a quote-aware: operator inside quotes does NOT trip compound/multi-op detection ---
+  it('accepts a when whose quoted RHS contains an operator', () => {
+    expect(() =>
+      loadWorkflowFromString(wf('    when: "classify.subject == \'a >= b\'"')),
+    ).not.toThrow();
+  });
+
+  // --- Change 2: direct-depends_on reference check (when only) ---
+  it('rejects a when referencing a step not in depends_on', () => {
+    expect(() => loadWorkflowFromString(wf('    when: "other_step.x == 1"'))).toThrow(
+      /references step 'other_step' which is not in its depends_on/,
+    );
+  });
+
+  it('accepts a when referencing run.params.*', () => {
+    expect(() =>
+      loadWorkflowFromString(wf('    when: "run.params.mode == \'live\'"')),
+    ).not.toThrow();
+  });
+
+  it('rejects a when referencing run.<not-params>', () => {
+    expect(() => loadWorkflowFromString(wf('    when: "run.something == 1"'))).toThrow(
+      /only 'run.params.\*' is available/,
+    );
+  });
+
+  // --- Scope B: preconditions ---
+  it('rejects a compound precondition', () => {
+    const block = '    preconditions:\n      - "classify.count > 0 and classify.ok == true"';
+    expect(() => loadWorkflowFromString(wf(block))).toThrow(
+      /'preconditions' uses unsupported 'and'/,
+    );
+  });
+
+  it('rejects a bare-path precondition (must be a comparison)', () => {
+    const block = '    preconditions:\n      - "classify.ready"';
+    expect(() => loadWorkflowFromString(wf(block))).toThrow(/must be a comparison/);
+  });
+
+  it('accepts a valid comparison precondition', () => {
+    const block = '    preconditions:\n      - "classify.count > 0"';
+    expect(() => loadWorkflowFromString(wf(block))).not.toThrow();
+  });
+
+  // --- Scope B: abort_unless (guard step) ---
+  function guardWf(abortBlock: string): string {
+    return `
+id: guard-wf
+name: Guard WF
+version: 1
+steps:
+  classify:
+    description: classify
+    execution: agent
+    depends_on: []
+  gate:
+    description: gate
+    execution: guard
+    depends_on: [classify]
+${abortBlock}
+`;
+  }
+
+  it('rejects a compound abort_unless', () => {
+    const block = '    abort_unless:\n      - "classify.a == 1 and classify.b == 2"';
+    expect(() => loadWorkflowFromString(guardWf(block))).toThrow(
+      /'abort_unless' uses unsupported 'and'/,
+    );
+  });
+
+  it('accepts a valid abort_unless (string and array)', () => {
+    expect(() =>
+      loadWorkflowFromString(guardWf('    abort_unless: "classify.a == 1"')),
+    ).not.toThrow();
+    const block = '    abort_unless:\n      - "classify.a == 1"\n      - "classify.b != null"';
+    expect(() => loadWorkflowFromString(guardWf(block))).not.toThrow();
+  });
+});

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -13,6 +13,96 @@ import { WorkflowError } from '../types/workflow-error.js';
 import { resolveTemplates } from './template-resolver.js';
 import type { ExtensionRegistry } from '../extensions/registry.js';
 import { normalizeTriggerFilter, validateTriggerStructure } from './trigger-schema.js';
+import { splitComparison, isPathShaped } from '../engine/comparison-expr.js';
+
+type ConditionSurface = 'when' | 'abort_unless' | 'preconditions';
+
+/**
+ * Validate one condition leaf at load time using the shared quote-aware splitter (the SAME split
+ * used at runtime). Rejects compound `and`/`or`, multiple operators, and non-path LHS. For `when`,
+ * also enforces the direct-`depends_on` reference check (Change 2). Pushes actionable errors.
+ */
+function validateConditionLeaf(
+  surface: ConditionSurface,
+  leaf: string,
+  stepName: string,
+  dependsOn: string[],
+  errors: string[],
+): void {
+  const split = splitComparison(leaf);
+
+  if (split.kind === 'invalid') {
+    if (split.reason === 'compound_and' || split.reason === 'compound_or') {
+      const kw = split.reason === 'compound_and' ? 'and' : 'or';
+      const listForm = (split.parts ?? [leaf]).map((p) => `    - "${p}"`).join('\n');
+      errors.push(
+        `Step '${stepName}': '${surface}' uses unsupported '${kw}' — write it as a list:\n` +
+          `  ${surface}:\n${listForm}`,
+      );
+    } else if (split.reason === 'multiple_operators') {
+      errors.push(
+        `Step '${stepName}': '${surface}' leaf '${leaf}' has multiple comparison operators — each leaf must be a single comparison.`,
+      );
+    } else {
+      errors.push(`Step '${stepName}': '${surface}' leaf must not be empty.`);
+    }
+    return;
+  }
+
+  if (split.kind === 'path') {
+    // A precondition is always a comparison; a bare path is not a valid precondition.
+    if (surface === 'preconditions') {
+      errors.push(
+        `Step '${stepName}': precondition '${leaf}' must be a comparison (e.g. "step.field >= 1").`,
+      );
+      return;
+    }
+    if (!isPathShaped(split.path)) {
+      errors.push(
+        `Step '${stepName}': '${surface}' leaf '${leaf}' is not a valid path or comparison.`,
+      );
+      return;
+    }
+    if (surface === 'when') validateWhenReference(split.path, stepName, dependsOn, errors);
+    return;
+  }
+
+  // comparison
+  if (!isPathShaped(split.lhsPath)) {
+    errors.push(
+      `Step '${stepName}': '${surface}' leaf '${leaf}' must have a path on the left-hand side (got '${split.lhsPath}').`,
+    );
+    return;
+  }
+  if (surface === 'when') validateWhenReference(split.lhsPath, stepName, dependsOn, errors);
+}
+
+/**
+ * Change 2 (when-only): a `when` leaf's `step.field` reference must resolve to `run.params.*` or to a
+ * step in this step's DIRECT `depends_on` (one-hop membership — no graph traversal). Field names are
+ * not checked (agent-step outputs aren't statically declared).
+ */
+function validateWhenReference(
+  path: string,
+  stepName: string,
+  dependsOn: string[],
+  errors: string[],
+): void {
+  const first = path.split('.')[0]!;
+  if (first === 'run') {
+    if (!(path === 'run.params' || path.startsWith('run.params.'))) {
+      errors.push(
+        `Step '${stepName}': 'when' references '${path}' — only 'run.params.*' is available from 'run'.`,
+      );
+    }
+    return;
+  }
+  if (!dependsOn.includes(first)) {
+    errors.push(
+      `Step '${stepName}': 'when' references step '${first}' which is not in its depends_on [${dependsOn.join(', ')}]. Add it to depends_on or use 'run.params.*'.`,
+    );
+  }
+}
 
 /** Bumped on every breaking change to WorkflowDefinition's serialized format. */
 export const CURRENT_WORKFLOW_SCHEMA_VERSION = 1;
@@ -467,10 +557,76 @@ export function loadWorkflowFromString(
       }
     }
 
-    // Validate when: must be a non-empty string.
+    // Validate when: string | string[] of single-comparison/bare-path leaves (implicit AND).
     if ('when' in step && step['when'] !== undefined) {
-      if (typeof step['when'] !== 'string' || step['when'].trim() === '') {
-        errors.push(`Step '${stepName}': 'when' must be a non-empty string`);
+      const rawWhen = step['when'];
+      const dependsOn = Array.isArray(step['depends_on'])
+        ? (step['depends_on'] as unknown[]).filter((d): d is string => typeof d === 'string')
+        : [];
+      if (typeof rawWhen === 'string') {
+        if (rawWhen.trim() === '') {
+          errors.push(`Step '${stepName}': 'when' must be a non-empty string`);
+        } else {
+          validateConditionLeaf('when', rawWhen, stepName, dependsOn, errors);
+        }
+      } else if (Array.isArray(rawWhen)) {
+        if (rawWhen.length === 0) {
+          errors.push(`Step '${stepName}': 'when' array must not be empty`);
+        } else {
+          for (const leaf of rawWhen) {
+            if (typeof leaf !== 'string' || leaf.trim() === '') {
+              errors.push(`Step '${stepName}': 'when' array entries must be non-empty strings`);
+            } else {
+              validateConditionLeaf('when', leaf, stepName, dependsOn, errors);
+            }
+          }
+        }
+      } else {
+        errors.push(`Step '${stepName}': 'when' must be a string or an array of strings`);
+      }
+    }
+
+    // Validate abort_unless leaf shape (guard steps only; reference check is when-only).
+    if (step['abort_unless'] !== undefined && step['execution'] === 'guard') {
+      const rawAbort = step['abort_unless'];
+      if (typeof rawAbort === 'string') {
+        if (rawAbort.trim() === '') {
+          errors.push(`Step '${stepName}': 'abort_unless' must be a non-empty string`);
+        } else {
+          validateConditionLeaf('abort_unless', rawAbort, stepName, [], errors);
+        }
+      } else if (Array.isArray(rawAbort)) {
+        if (rawAbort.length === 0) {
+          errors.push(`Step '${stepName}': 'abort_unless' array must not be empty`);
+        } else {
+          for (const leaf of rawAbort) {
+            if (typeof leaf !== 'string' || leaf.trim() === '') {
+              errors.push(
+                `Step '${stepName}': 'abort_unless' array entries must be non-empty strings`,
+              );
+            } else {
+              validateConditionLeaf('abort_unless', leaf, stepName, [], errors);
+            }
+          }
+        }
+      } else {
+        errors.push(`Step '${stepName}': 'abort_unless' must be a string or an array of strings`);
+      }
+    }
+
+    // Validate preconditions leaf shape (each must be a single comparison).
+    if (step['preconditions'] !== undefined) {
+      const rawPre = step['preconditions'];
+      if (!Array.isArray(rawPre)) {
+        errors.push(`Step '${stepName}': 'preconditions' must be an array of strings`);
+      } else {
+        for (const leaf of rawPre) {
+          if (typeof leaf !== 'string' || leaf.trim() === '') {
+            errors.push(`Step '${stepName}': 'preconditions' entries must be non-empty strings`);
+          } else {
+            validateConditionLeaf('preconditions', leaf, stepName, [], errors);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Context

A CS1 workflow used `when: "extract_order_number.order_number_found == true and resolve_shopify_store.store_key != null"` expecting boolean AND. The step ran even when both operands should have gated it off, and `ShopifyAdapter` crashed on the empty store. Investigation found this was not a one-off: **all three** compound `when` clauses in the production `cs1-ticket-classifier` workflow were silently mis-evaluating — two always-running, one always-skipping.

## Motivation

Realm's `when:` expression language never supported boolean operators. `evaluateWhenCondition` scanned a fixed operator table first-match-wins via `indexOf`, so a compound `A and B` latched onto a stray operator, built a garbage left-hand path that `resolvePath` resolved to `undefined`, and — uniquely among the three condition evaluators — let `undefined` flow into the comparison, so `undefined != null` → `true`. A false `when` then drives `propagateSkips` to silently skip the step and cascade to completion. The loader only checked that `when` was a non-empty string, so every misparse was silent. This change makes the condition language sound across all three surfaces, corrects the operand semantics, and adds bounded composition.

## Changes

**1. Comparison soundness.**
- New zero-dependency `comparison-expr.ts` — a quote-aware splitter that is the single source of truth for how a condition leaf is split (used by load validation *and* runtime, so they never diverge). Never throws; `and`/`or` and multi-operator leaves return an `invalid` verdict.
- Load-time leaf-shape validation across `when` / `abort_unless` / `preconditions`: compound `a and b`, multiple operators, and non-path left-hand sides are now loud, actionable load errors (the `and`/`or` error echoes the suggested list form).
- `when` absent-LHS semantics corrected: `== null` / `!= null` are presence tests (loose null, covering missing and present-`null`); relational `> < >= <=` require both operands numeric (no JS `null → 0` coercion); any other operator on an unresolved LHS → `false`; a resolved LHS uses strict equality. Per-surface absent-policy for `abort_unless` (resolution_error) and `preconditions` (false) is unchanged — only the split is shared.

**2. `when` reference check (load-time).** A `when` leaf's `step.field` reference must resolve to `run.params.*` or a step in that step's direct `depends_on` (one-hop; no graph traversal). A mistyped or undeclared step name is now a load error.

**3. `when: string[]` (implicit AND).** `when` is now `string | string[]`; an array ANDs its leaves (mirrors the existing `abort_unless` shape). Empty arrays are rejected at load. The three runtime consumers route through an `evaluateWhen` AND-folding wrapper; the per-leaf `evaluateWhenCondition` never receives an array. `any`/OR is not added.

**Breaking:** the corrected absent-operand semantics and the compound-`when` load rejection are behavior changes (documented in `CHANGELOG.md`, version intent 0.12.0). `execution-loop`, the `RunRecord`, and the stores are untouched; `when` is not serialized.

## Verification

```bash
npm run lint                         # exit 0, 4/4 clean
npm run build                        # exit 0, tsc --build 4/4
node scripts/check-versions.mjs      # all 0.11.0, no bump
npm run test                         # 8/8 green; core/cli/mcp/testing all pass, zero skipped

# the corrected truth-table + load validation:
npx vitest run --dir packages/core src/engine/comparison-expr.test.ts \
  src/engine/eligibility.test.ts src/workflow/yaml-loader.test.ts   # 222 passed
```

Mutation probe: flipping the 1c presence-test operator (`==`↔`!=`) turns `absent == null → true` and `absent != null → false` red, confirming the guards bite.

## Rollback

```bash
git revert <merge-commit>
```

No out-of-band mutations — engine-only change, no data writes, no external calls. `when` is not persisted, so reverting restores the prior eligibility behavior on the next driver tick with no migration.

## Related

- Follow-ups (not closed by this PR): #111 (when-skip observability), #112 (ShopifyAdapter typed-error hardening).
