### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
-
-> **Version intent: 0.12.0** (a breaking change on a 0.x line bumps the minor segment). Version constants are bumped at release time.
+## [0.12.0] — 2026-06-30
 
 ### Changed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.11.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.12.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.11.0';
+export const VERSION = '0.12.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.11.0';
+export const VERSION = '0.12.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -60,7 +60,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.11.0',
+    version: '0.12.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.11.0';
+export const VERSION = '0.12.0';


### PR DESCRIPTION
## Context

Release of `@sensigo/realm` **0.12.0** — the `when`-clause soundness + bounded-composition work (feature PR #113, merged to `main`).

## Motivation

Cut a published release so consumers can adopt the corrected `when` semantics and `when: string[]` composition. Minor bump because the change is breaking on a 0.x line (corrected absent-operand semantics + compound-`when` load rejection).

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `[0.12.0] — 2026-06-30`.
- `npm run release -- --version 0.12.0`: bumped `version` in all four `package.json` files and the five source `VERSION` constants to `0.12.0`; created the `chore: release v0.12.0` commit and the `v0.12.0` tag.

No source/behavior changes beyond the version bump — the engine changes landed in #113.

## Verification

```bash
node scripts/check-versions.mjs     # all 0.12.0
npm run build                       # tsc --build 4/4
npm run test                        # 8/8 green
```

After tag push, confirm the **Publish** workflow is green on `v0.12.0` and:

```bash
mkdir /tmp/verify-0120 && cd /tmp/verify-0120 && npm init -y
npm install @sensigo/realm@0.12.0
node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"   # 0.12.0
```

## Rollback

```bash
git revert <merge-commit>
```

If a broken artifact is published, cut a patch release (0.12.1) following the same Part B sequence. npm versions are immutable; do not attempt to unpublish.

## Related

Releases #113 (when-clause soundness + bounded composition).
