### PR TITLE
fix(mcp): resolve bin-shim symlink in entry-point guard

### DIFF
--- a/packages/mcp-server/src/server.entry.test.ts
+++ b/packages/mcp-server/src/server.entry.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, symlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The compiled entry point — turbo runs test after build, so dist/ exists.
+const DIST_SERVER = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'server.js');
+
+const INITIALIZE_REQUEST = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'entry-test', version: '0.0.0' },
+  },
+});
+
+/**
+ * Spawns `node <entryPath>`, sends an initialize request over stdio, and resolves
+ * with the first response line. Rejects immediately if the process exits without
+ * responding — the silent-exit failure mode this test suite exists to catch.
+ */
+function initializeVia(entryPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entryPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let settled = false;
+    let stdout = '';
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill();
+      reject(new Error('no initialize response within 8s'));
+    }, 8000);
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const newline = stdout.indexOf('\n');
+      if (newline !== -1 && !settled) {
+        settled = true;
+        clearTimeout(timer);
+        child.kill();
+        resolve(stdout.slice(0, newline));
+      }
+    });
+    child.on('exit', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`server exited (code ${String(code)}) without responding to initialize`));
+    });
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.stdin.write(INITIALIZE_REQUEST + '\n');
+  });
+}
+
+describe('server entry point', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'realm-mcp-entry-'));
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('responds to initialize when run directly', async () => {
+    const line = await initializeVia(DIST_SERVER);
+    const response = JSON.parse(line) as { result?: { serverInfo?: { name?: string } } };
+    expect(response.result?.serverInfo?.name).toBe('realm');
+  }, 15000);
+
+  it('responds to initialize when invoked through a bin-shim symlink', async () => {
+    // npm/npx expose bin entries as symlinks (node_modules/.bin/realm-mcp -> dist/server.js);
+    // process.argv[1] is then the symlink path while import.meta.url is the resolved target.
+    const shim = join(tempDir, 'realm-mcp');
+    symlinkSync(DIST_SERVER, shim);
+    const line = await initializeVia(shim);
+    const response = JSON.parse(line) as { result?: { serverInfo?: { name?: string } } };
+    expect(response.result?.serverInfo?.name).toBe('realm');
+  }, 15000);
+
+  it('does not start the stdio server when imported as a module', async () => {
+    // Importing under vitest means argv[1] is the test runner, not server.js —
+    // the entry guard must stay false and the import must not hijack stdio.
+    const mod = await import('./server.js');
+    expect(typeof mod.createRealmMcpServer).toBe('function');
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 // realm-mcp — MCP server exposing the Realm workflow engine to AI agents.
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -106,10 +108,20 @@ export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer
 }
 
 // Entry point: start the MCP server on stdio when run directly.
-if (
-  process.argv[1] !== undefined &&
-  import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'))
-) {
+// argv[1] is realpath-resolved because npm/npx bin shims invoke this file through
+// a symlink (node_modules/.bin/realm-mcp), while import.meta.url holds the resolved
+// target path — a plain string comparison never matches and the process would exit
+// silently without connecting the transport.
+function isRunDirectly(): boolean {
+  if (process.argv[1] === undefined) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isRunDirectly()) {
   const server = createRealmMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Context

Found during MCP consumption setup (2026-07-03/04): configuring Claude Code to launch the published server via the standard pattern (`npx -y @sensigo/realm-mcp`) fails — the client reports the server as unresponsive. Running `node …/dist/server.js` directly works, which is why every existing setup (pointing at the dist path) never hit it. This blocks the documented consumption path for any external consumer of the published package.

## Root Cause

The entry-point guard in `packages/mcp-server/src/server.ts` decided "am I being run directly?" with:

```ts
import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'))
```

npm/npx expose bin entries as **symlinks** (`node_modules/.bin/realm-mcp` → `…/dist/server.js`). Under a bin-shim invocation, `process.argv[1]` holds the symlink path while `import.meta.url` holds the resolved target path (Node's ESM loader realpath-resolves the main entry). The `endsWith` comparison never matches, the guard stays false, the module loads and the process **exits 0 without ever connecting the stdio transport** — a silent failure with no error output for the MCP client to surface.

## Changes

- `server.ts`: replaced the string-suffix check with an `isRunDirectly()` helper comparing `realpathSync(process.argv[1])` against `realpathSync(fileURLToPath(import.meta.url))`, try/catch-wrapped (a nonexistent `argv[1]` path degrades to "not run directly" instead of throwing). Direct invocation, bin-shim symlink invocation, and Windows path separators all resolve to the same real path.
- `server.entry.test.ts` (new): spawn-based regression tests for all three invocation modes:
  - direct `node dist/server.js` → answers `initialize`
  - **through a temp-dir symlink named `realm-mcp`** (exact bin-shim shape) → answers `initialize`; the helper rejects immediately with "server exited without responding" if the silent-exit mode regresses
  - `import`-as-library → must NOT start the stdio server

Mutation-probe verified: reverting the guard to the old `endsWith` logic turns the symlink test red while the other two stay green.

## Verification

```bash
npm run build
TURBO_FORCE=true npx vitest run packages/mcp-server/src/server.entry.test.ts
# → 3 passed

# end-to-end, the exact npx failure shape:
ln -sf "$PWD/packages/mcp-server/dist/server.js" /tmp/realm-mcp-shim
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' | node /tmp/realm-mcp-shim
# → {"result":{"protocolVersion":"2024-11-05",…,"serverInfo":{"name":"realm","version":"0.12.0"}},…}
# (before this fix: empty output, exit 0)
```

Full gates: `npm run lint` clean, `npm run build` 4/4, `TURBO_FORCE=true npm run test` — core 1360 / cli 356 / mcp 106 / testing 56, all passed.

## Rollback

```bash
git revert HEAD
```

No data mutations; single-commit code change.

## Related

Ships as patch release v0.12.1 (npx consumption is broken in 0.12.0 and every earlier published version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
