### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ---
 
+## [0.12.1] — 2026-07-04
+
+### Fixed
+
+- **`realm-mcp` bin entry exited silently when invoked via npm/npx bin shims** (`npx @sensigo/realm-mcp`, `node_modules/.bin/realm-mcp`). The entry-point guard compared `import.meta.url` against `process.argv[1]` with a string-suffix check; bin shims are symlinks, so `argv[1]` held the symlink path while `import.meta.url` held the resolved target — the guard never matched and the process exited 0 without connecting the stdio transport. The guard now realpath-resolves both sides. Direct `node dist/server.js` invocation and library import behavior are unchanged; all three invocation modes are covered by spawn-based regression tests. (PR #115)
+
+---
+
 ## [0.12.0] — 2026-06-30
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.12.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.12.1');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.12.0';
+export const VERSION = '0.12.1';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.12.0';
+export const VERSION = '0.12.1';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -62,7 +62,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.12.0',
+    version: '0.12.1',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.12.0';
+export const VERSION = '0.12.1';


### PR DESCRIPTION
## Context

Release PR for patch **v0.12.1**. The only change since v0.12.0 is PR #115: the `realm-mcp` bin entry exited silently when invoked through npm/npx bin shims, which broke the standard `npx @sensigo/realm-mcp` consumption path in every published version to date.

## Changes

- CHANGELOG: new `[0.12.1]` section (Fixed).
- `chore: release v0.12.1` — version bump in all four `package.json` files and the source `VERSION` constants (release script output, 9 files, +9/−9).

## Verification

```bash
git describe --exact-match v0.12.1   # tag points at the release commit on this branch
npm run build && TURBO_FORCE=true npm run test
```

CI must be green before merge. After merge + tag push, `publish.yml` publishes all four packages via OIDC Trusted Publishing.

## Rollback

Pre-publish: close PR, delete branch and tag. Post-publish: npm packages are immutable — ship a follow-up patch per the release process.

## Related

- PR #115 (the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
