### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.14.0] — 2026-07-05
 
 ### BREAKING
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.13.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.14.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.13.0';
+export const VERSION = '0.14.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.13.0';
+export const VERSION = '0.14.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.13.0',
+    version: '0.14.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.13.0';
+export const VERSION = '0.14.0';


### PR DESCRIPTION
## Context

Release PR for **v0.14.0** — a BREAKING minor. Headline: the **deployment manifest** (`realm.yaml`) becomes the single home for all deployment configuration (adapter/handler/processor construction, `${secret:NAME}` bindings with declared sources, gate notifiers), completing #120 (legacy env-tier removal). Converged through six design generations + three fresh-eyes probes + a top-down derivation; independently MA-verified including consumer-grade E2E from packed tarballs (secrets proven by value, hot rotation, sentinel-mode validate, `--check-drift` manifest coverage).

## Changes

- CHANGELOG: `[Unreleased]` → `[0.14.0] — 2026-07-05`.
- `chore: release v0.14.0` — version bump across all four `package.json` files and source `VERSION` constants (release script, 9 files ±9).

## Verification

```bash
git describe --exact-match v0.14.0          # tag on this branch's release commit
npm ci && npm run build && TURBO_FORCE=true npm run test    # 2,081 tests
```

CI must be green before merge. Merge with a **merge commit** (the tag points at the release commit on this branch; rebase/squash would orphan it). After merge + tag push, `publish.yml` publishes all four packages via OIDC Trusted Publishing.

## Rollback

Pre-publish: close PR, delete branch + tag. Post-publish: npm is immutable — ship a follow-up patch.

## Related

- Completes #120 (legacy env-tier removal, phase 2). Manifest feature PR #122.
- Deferred to v0.14.1: #123 (orphaned-manifest guard — additive hardening, feature correct as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
