### PR TITLE
fix(cli): loud error for orphaned deployment manifests (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
-- **Orphaned deployment manifest is now a loud error** (#123). A `realm.yaml` placed in the span `[source_dir, trust_root)` — the workflow directory or an intermediate directory below the resolved deployment root — was silently ignored (manifests load only from `<trust_root>/realm.yaml`), giving a confusing downstream `adapter 'X' not registered` at execution time and no signal at all under validate/sentinel/fixture paths. The loader now scans that span and throws before run creation, naming the orphaned path(s), the resolved trust root, and the fix. Detection-only: manifest loading stays strict-single-location. A manifest _above_ the trust root (monorepo-root case) is intentionally not scanned.
+- **Orphaned deployment manifest is now a loud error** (#123). A `realm.yaml` placed in the span `[source_dir, trust_root)` — the workflow directory or an intermediate directory below the resolved deployment root — was silently ignored (manifests load only from `<trust_root>/realm.yaml`), giving a confusing downstream `adapter 'X' not registered` at execution time and no signal at all under validate/sentinel/fixture paths. Every workflow-loading command now scans that span and throws before run creation, naming the orphaned path(s), the resolved trust root, and the fix. Detection-only: manifest loading stays strict-single-location. A manifest _above_ the trust root (monorepo-root case) is intentionally not scanned. **`realm workflow validate` now also surfaces this** — a misplaced `realm.yaml` may turn a previously-green validate red; that is correct topology reporting (the manifest was never being loaded), not a regression.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Orphaned deployment manifest is now a loud error** (#123). A `realm.yaml` placed in the span `[source_dir, trust_root)` — the workflow directory or an intermediate directory below the resolved deployment root — was silently ignored (manifests load only from `<trust_root>/realm.yaml`), giving a confusing downstream `adapter 'X' not registered` at execution time and no signal at all under validate/sentinel/fixture paths. The loader now scans that span and throws before run creation, naming the orphaned path(s), the resolved trust root, and the fix. Detection-only: manifest loading stays strict-single-location. A manifest _above_ the trust root (monorepo-root case) is intentionally not scanned.
+
+---
+
 ## [0.14.0] — 2026-07-05
 
 ### BREAKING

--- a/packages/cli/src/commands/validate-internal-error.test.ts
+++ b/packages/cli/src/commands/validate-internal-error.test.ts
@@ -1,0 +1,58 @@
+// #123 correction, test 3 — genuine-bug-still-loud. validate's from-string branch catches
+// ONLY `WorkflowError` (→ `Invalid:` + exit 1) and MUST rethrow anything else, so a real
+// internal defect surfaces as a loud stack trace, never mislabeled as `Invalid`. If a future
+// change broadens the catch to `catch (err)`, this test goes red. In-process (mocked) because
+// a plain (non-WorkflowError) throw cannot be induced through the real from-string loader.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Make loadWorkflowFromString throw a PLAIN Error (an "internal bug"); keep everything else
+// (WorkflowError, findTrustRoot, …) real.
+vi.mock('@sensigo/realm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sensigo/realm')>();
+  return {
+    ...actual,
+    loadWorkflowFromString: () => {
+      throw new Error('internal bug — not a WorkflowError');
+    },
+  };
+});
+
+import { validateCommand } from './validate.js';
+
+describe('validate — non-WorkflowError is NOT swallowed as Invalid', () => {
+  let dir: string;
+  let wfPath: string;
+
+  beforeEach(() => {
+    // A real, extension-free workflow file so readFileSync succeeds and the from-string
+    // branch is reached (where the mocked loadWorkflowFromString throws its plain Error).
+    dir = mkdtempSync(join(tmpdir(), 'realm-validate-internal-'));
+    wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(wfPath, 'id: x\nname: X\nversion: 1\nsteps: {}\n', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('rethrows a plain Error from the from-string branch (loud), never printing Invalid or exiting 1', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called — should not happen for an internal bug');
+    }) as never);
+
+    // parseAsync must REJECT with the plain Error (the `else throw err`), not resolve via
+    // the Invalid+exit path.
+    await expect(validateCommand.parseAsync([wfPath], { from: 'user' })).rejects.toThrow(
+      'internal bug — not a WorkflowError',
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const logged = errSpy.mock.calls.flat().map(String).join(' ');
+    expect(logged).not.toContain('Invalid:');
+  });
+});

--- a/packages/cli/src/commands/validate-orphan-manifest.test.ts
+++ b/packages/cli/src/commands/validate-orphan-manifest.test.ts
@@ -9,6 +9,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { workflowCommands } from '../commands-registry.js';
 
 const CLI_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const DIST_CLI = join(CLI_DIR, 'dist', 'index.js');
@@ -119,4 +120,29 @@ describe('every workflow-loading command rejects an orphaned manifest (behaviora
     },
     25_000,
   );
+
+  // ENFORCED enumeration (not comment-discipline): this feature was bitten twice by
+  // coverage gaps (#123 missed validate; the coverage correction fixed it). Partition
+  // `workflowCommands` into behaviorally-COVERED (derived from `cases` above — never a second
+  // hand-list) vs explicitly-EXCLUDED-with-reason, and fail if any command is neither. A
+  // newly-added workflow-loading command then cannot silently escape the guard's test net —
+  // its author must add it to `cases` or justify it here.
+  const ORPHAN_GUARD_EXCLUDED: Record<string, string> = {
+    init: 'scaffolds a new workflow; loads no existing definition',
+    migrate: 'rewrites a workflow file in place; does not load-to-run',
+    watch:
+      'long-running watcher; loads via register.ts (covered through register), not spawn-testable here',
+  };
+
+  it('every workflow-loading command is either behaviorally covered or explicitly excluded', () => {
+    // COVERED is the subcommand encoded at args(...)[1] of each behavioral case — dummy
+    // inputs are fine, we only read the subcommand slot (e.g. ['workflow','validate','x'][1]).
+    const covered = new Set(cases.map((c) => c.args('x', 'y')[1]));
+    const unclassified = workflowCommands
+      .map((c) => c.name())
+      .filter((n) => !covered.has(n) && !(n in ORPHAN_GUARD_EXCLUDED));
+    // A new `realm workflow` command MUST be added to `cases` (behaviorally exercised
+    // against the orphan) or to ORPHAN_GUARD_EXCLUDED (with a reason).
+    expect(unclassified).toEqual([]);
+  });
 });

--- a/packages/cli/src/commands/validate-orphan-manifest.test.ts
+++ b/packages/cli/src/commands/validate-orphan-manifest.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { workflowCommands } from '../commands-registry.js';
+import { workflowCommands, topLevelCommands } from '../commands-registry.js';
 
 const CLI_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const DIST_CLI = join(CLI_DIR, 'dist', 'index.js');
@@ -122,27 +122,51 @@ describe('every workflow-loading command rejects an orphaned manifest (behaviora
   );
 
   // ENFORCED enumeration (not comment-discipline): this feature was bitten twice by
-  // coverage gaps (#123 missed validate; the coverage correction fixed it). Partition
-  // `workflowCommands` into behaviorally-COVERED (derived from `cases` above — never a second
-  // hand-list) vs explicitly-EXCLUDED-with-reason, and fail if any command is neither. A
-  // newly-added workflow-loading command then cannot silently escape the guard's test net —
-  // its author must add it to `cases` or justify it here.
-  const ORPHAN_GUARD_EXCLUDED: Record<string, string> = {
+  // coverage gaps (#123 missed validate; the coverage correction fixed it). Every command
+  // group that can load a workflow — `workflowCommands` AND the top-level daemons
+  // (`topLevelCommands`) — is partitioned into behaviorally-COVERED (derived from `cases`
+  // above — never a second hand-list) or one of two EXCLUDED categories, and the test fails
+  // if any command is unclassified. A newly-added loading command in EITHER array then
+  // forces a conscious classification.
+  //
+  // The two exclusion categories mean DIFFERENT things — do not conflate them:
+  //   GUARD_NOT_APPLICABLE — the command does not load a workflow-from-path to run, so the
+  //     orphan guard genuinely never fires for it.
+  //   GUARDED_VIA_CHOKEPOINT_NOT_SPAWN_TESTED — the command DOES load workflows and IS
+  //     functionally guarded (it reaches loadProjectExtensions → loadManifestContext), but is
+  //     not spawn-exercised here because it needs a daemon harness (provider keys / triggers /
+  //     request drivers). Excluded from the BEHAVIORAL cases, NOT from the guard.
+  const GUARD_NOT_APPLICABLE: Record<string, string> = {
     init: 'scaffolds a new workflow; loads no existing definition',
     migrate: 'rewrites a workflow file in place; does not load-to-run',
-    watch:
-      'long-running watcher; loads via register.ts (covered through register), not spawn-testable here',
+    webhook: "removed alias (use 'realm listen'); loads no workflow",
+  };
+  const GUARDED_VIA_CHOKEPOINT_NOT_SPAWN_TESTED: Record<string, string> = {
+    watch: 'loads via register.ts (functionally guarded through register); not spawn-tested here',
+    agent:
+      'reaches the orphan guard via the loadProjectExtensions chokepoint (functionally guarded); not spawn-exercised here — needs a daemon harness',
+    listen:
+      'reaches the orphan guard via the loadProjectExtensions chokepoint (functionally guarded); not spawn-exercised here — needs a daemon harness',
+    serve:
+      'reaches the orphan guard via the loadProjectExtensions chokepoint (functionally guarded); not spawn-exercised here — needs a daemon harness',
+    mcp: 'reaches the orphan guard via the loadProjectExtensions chokepoint (functionally guarded); not spawn-exercised here — needs a daemon harness',
   };
 
-  it('every workflow-loading command is either behaviorally covered or explicitly excluded', () => {
+  it('every workflow-loading command (workflow + top-level) is behaviorally covered or explicitly excluded', () => {
     // COVERED is the subcommand encoded at args(...)[1] of each behavioral case — dummy
     // inputs are fine, we only read the subcommand slot (e.g. ['workflow','validate','x'][1]).
     const covered = new Set(cases.map((c) => c.args('x', 'y')[1]));
-    const unclassified = workflowCommands
+    const unclassified = [...workflowCommands, ...topLevelCommands]
       .map((c) => c.name())
-      .filter((n) => !covered.has(n) && !(n in ORPHAN_GUARD_EXCLUDED));
-    // A new `realm workflow` command MUST be added to `cases` (behaviorally exercised
-    // against the orphan) or to ORPHAN_GUARD_EXCLUDED (with a reason).
+      .filter(
+        (n) =>
+          !covered.has(n) &&
+          !(n in GUARD_NOT_APPLICABLE) &&
+          !(n in GUARDED_VIA_CHOKEPOINT_NOT_SPAWN_TESTED),
+      );
+    // A new command in either array MUST be added to `cases` (behaviorally exercised against
+    // the orphan) or to one of the two exclusion maps (with a reason that states WHICH kind
+    // of exclusion it is).
     expect(unclassified).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/validate-orphan-manifest.test.ts
+++ b/packages/cli/src/commands/validate-orphan-manifest.test.ts
@@ -1,0 +1,122 @@
+// Command-level tests (#123 correction): the orphaned-manifest guard must fire on the
+// EXTENSION-FREE `realm workflow validate` path — the from-string branch that #123's guard
+// bypassed — and on every other workflow-loading command. These spawn the built dist CLI
+// (NOT a loadProjectExtensions unit call): the #123 meta-lesson is that a unit call passed
+// while the command path stayed blind, so coverage is asserted at the command boundary.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CLI_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DIST_CLI = join(CLI_DIR, 'dist', 'index.js');
+
+function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(process.execPath, [DIST_CLI, ...args], { timeout: 20_000 }, (err, stdout, stderr) => {
+      const code = err !== null && typeof err.code === 'number' ? err.code : err !== null ? 1 : 0;
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+// Repo-subdir topology: <base> is the trust root (package.json); the workflow lives in a
+// nested dir with a STRAY realm.yaml in its own directory — the common misplacement.
+let base: string;
+let workflowDir: string;
+let workflowPath: string;
+
+const WORKFLOW_YAML = `id: orphan-wf
+name: Orphan WF
+version: 1
+steps:
+  s1:
+    description: a step
+    execution: agent
+`;
+
+const ORPHAN_MANIFEST = 'version: 1\nadapters:\n  fs2:\n    use: filesystem\n';
+
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'realm-validate-orphan-'));
+  writeFileSync(join(base, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+  workflowDir = join(base, 'workflows', 'wf');
+  mkdirSync(workflowDir, { recursive: true });
+  workflowPath = join(workflowDir, 'workflow.yaml');
+  writeFileSync(workflowPath, WORKFLOW_YAML, 'utf8');
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('realm workflow validate — orphaned-manifest guard (extension-free from-string path)', () => {
+  it('1. an orphaned realm.yaml in the workflow dir → Invalid: + non-zero exit', async () => {
+    const orphan = join(workflowDir, 'realm.yaml');
+    writeFileSync(orphan, ORPHAN_MANIFEST, 'utf8');
+    const { code, stdout, stderr } = await runCli(['workflow', 'validate', workflowPath]);
+    expect(code).toBe(1);
+    expect(stdout).not.toContain('Valid:');
+    const out = stdout + stderr;
+    expect(out).toContain('Invalid:');
+    expect(out).toContain(orphan);
+    expect(out).toContain('will NOT be loaded');
+    expect(out).toContain(join(base, 'realm.yaml')); // names the resolved trust root
+  }, 25_000);
+
+  it('2. byte-identical happy path: no orphan → exactly the Valid line, exit 0', async () => {
+    const { code, stdout, stderr } = await runCli(['workflow', 'validate', workflowPath]);
+    expect(stderr).toBe('');
+    expect(stdout).toBe('Valid: orphan-wf v1 (1 steps)\n');
+    expect(code).toBe(0);
+  }, 25_000);
+});
+
+// #123's structural test was source-text string-matching — exactly the style that let the
+// per-branch bypass through. This is BEHAVIORAL: every workflow-loading command in the
+// `realm workflow` group that loads a definition for validation/execution is invoked against
+// the orphan fixture and MUST reject it. The list is derived from commands-registry.ts's
+// workflowCommands, minus the ones that do not load-a-workflow-to-run (init scaffolds,
+// migrate rewrites, watch is a long-running watcher). ANY new step-executing / preflight
+// command MUST either appear here or be justified — a silent per-branch bypass is the bug
+// this test exists to prevent.
+describe('every workflow-loading command rejects an orphaned manifest (behavioral enumeration)', () => {
+  interface CommandCase {
+    name: string;
+    args: (wfPath: string, fixturesDir: string) => string[];
+  }
+  const cases: CommandCase[] = [
+    { name: 'workflow validate', args: (wf) => ['workflow', 'validate', wf] },
+    { name: 'workflow register', args: (wf) => ['workflow', 'register', wf] },
+    { name: 'workflow run', args: (wf) => ['workflow', 'run', wf] },
+    { name: 'workflow test', args: (wf, fx) => ['workflow', 'test', wf, '-f', fx] },
+  ];
+
+  it.each(cases)(
+    '$name → non-zero exit + orphan message',
+    async ({ args }) => {
+      const orphan = join(workflowDir, 'realm.yaml');
+      writeFileSync(orphan, ORPHAN_MANIFEST, 'utf8');
+      // `test` needs an existing fixtures dir (checked before the load); its contents never
+      // run because the guard throws first.
+      const fixturesDir = join(workflowDir, 'fixtures');
+      mkdirSync(fixturesDir, { recursive: true });
+      writeFileSync(
+        join(fixturesDir, 'f.yaml'),
+        'name: f\nexpected:\n  final_state: completed\n',
+        'utf8',
+      );
+
+      // `run` reads stdin after loading — close it immediately so it can never hang; the guard
+      // fires before the readline loop regardless.
+      const { code, stdout, stderr } = await runCli(args(workflowPath, fixturesDir));
+      const out = stdout + stderr;
+      expect(code).not.toBe(0);
+      expect(out).toContain('will NOT be loaded');
+      expect(out).toContain(orphan);
+    },
+    25_000,
+  );
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -6,11 +6,19 @@
 // file-based loading so extension modules can be resolved, then a SECOND pass validates
 // step `config` against each resolved adapter's `config_schema` (two-pass).
 import { Command } from 'commander';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { load } from 'js-yaml';
-import { loadWorkflowFromString, loadWorkflowFromFile, WorkflowError } from '@sensigo/realm';
-import { loadProjectExtensions } from '../extensions/load-project-extensions.js';
+import {
+  loadWorkflowFromString,
+  loadWorkflowFromFile,
+  findTrustRoot,
+  WorkflowError,
+} from '@sensigo/realm';
+import {
+  loadProjectExtensions,
+  checkForOrphanedManifests,
+} from '../extensions/load-project-extensions.js';
 
 /** Pre-scan: does the YAML carry a top-level `extensions` key? (Parse errors → false; the
  *  real loader below reports them with its existing error surface.) */
@@ -52,9 +60,17 @@ export const validateCommand = new Command('validate')
     }
 
     if (!hasTopLevelExtensions(content) && opts.extensionsModule === undefined) {
-      // Extension-free: the exact current from-string path — byte-identical behavior.
+      // Extension-free: the exact current from-string path — byte-identical behavior,
+      // plus the orphaned-manifest guard (#123). The from-string loader stamps no
+      // source_dir/trust_root, so resolve the same trust root the file-based path would
+      // (findTrustRoot walks package.json/.git from the workflow dir) and run the guard
+      // structural-first — after the workflow parses, before the `Valid:` print. It throws
+      // WorkflowError, which the catch below renders as `Invalid:` + exit(1). resolve()
+      // before dirname so a relative `workflow.yaml` doesn't collapse the walk to '.'.
       try {
         const definition = loadWorkflowFromString(content);
+        const workflowDir = dirname(resolve(filePath));
+        checkForOrphanedManifests(workflowDir, findTrustRoot(workflowDir));
         console.log(
           `Valid: ${definition.id} v${definition.version} (${Object.keys(definition.steps).length} steps)`,
         );

--- a/packages/cli/src/extensions/load-project-extensions.ts
+++ b/packages/cli/src/extensions/load-project-extensions.ts
@@ -25,6 +25,7 @@ import { load as loadYaml } from 'js-yaml';
 import {
   createDefaultRegistry,
   ExtensionRegistry,
+  WorkflowError,
   validateDeploymentManifest,
   collectManifestSecretRefs,
   interpolateConfigTree,
@@ -186,23 +187,21 @@ interface ManifestContext {
 
 /**
  * Orphaned-manifest guard (#123): throws when a `realm.yaml` sits anywhere in the span
- * `[source_dir, trust_root)` — from the workflow directory walking UP to, but NOT
- * including, the resolved trust_root. Such a manifest is silently ignored by the
- * strict-single-location loader, so surfacing it loudly before run creation turns a
- * confusing downstream `adapter 'X' not registered` (or total silence under
- * validate/sentinel/fixture paths) into an actionable placement error.
+ * `[sourceDir, trustRoot)` — from the workflow directory walking UP to, but NOT including,
+ * the trust root. Such a manifest is silently ignored by the strict-single-location loader,
+ * so surfacing it loudly turns a confusing downstream `adapter 'X' not registered` (or total
+ * silence under validate/sentinel/fixture paths) into an actionable placement error.
  *
- * No-op unless the definition carries BOTH `source_dir` and `trust_root` and they differ
- * (agent-origin / from-string definitions have no source_dir; a workflow dir that is its
- * own trust_root has an empty span). Never scans at or above trust_root — a stray at
+ * Path-keyed (takes the two directories, NOT a definition) so callers that don't stamp a
+ * definition — `realm workflow validate` on an extension-free workflow — can reuse it with a
+ * `findTrustRoot(workflowDir)` result. Callers guarantee both paths are known: the loader
+ * calls it only when a definition carries both source_dir and trust_root (agent-origin /
+ * from-string definitions have no source_dir → never scanned). A workflow dir that is its
+ * own trust root has an empty span (no-op). Never scans at or above trust_root — a stray at
  * trust_root IS the loaded manifest; Case C (above trust_root) is deliberately out of #123.
  */
-function checkForOrphanedManifests(definition: WorkflowDefinition, root: string): void {
-  const sourceDir = definition.source_dir;
-  const trustRoot = definition.trust_root;
-  // Only meaningful for file-loaded definitions whose trust_root is the resolved root.
-  if (sourceDir === undefined || trustRoot === undefined || trustRoot !== root) return;
-  if (sourceDir === trustRoot) return;
+export function checkForOrphanedManifests(sourceDir: string, trustRoot: string): void {
+  if (sourceDir === trustRoot) return; // empty span
 
   const orphans: string[] = [];
   let current = sourceDir;
@@ -222,11 +221,21 @@ function checkForOrphanedManifests(definition: WorkflowDefinition, root: string)
       ? `Deployment manifest at '${orphans[0]!}'`
       : `Deployment manifests at ${orphans.map((o) => `'${o}'`).join(', ')}`;
   const nearest = orphans[0]!;
-  throw new Error(
+  // Throw WorkflowError (VALIDATION class — the same class the yaml-loader raises for
+  // structural validation failures) so `realm workflow validate`'s existing
+  // `if (err instanceof WorkflowError)` handler renders it as `Invalid:` rather than a stack
+  // trace, and every execution/registration path treats it as a load failure.
+  throw new WorkflowError(
     `${found} will NOT be loaded — manifests are read only from the deployment root ` +
       `'${join(trustRoot, 'realm.yaml')}'. Move it to '${join(trustRoot, 'realm.yaml')}' ` +
       `(the nearest package.json/.git ancestor of the workflow), or add a package.json/.git ` +
       `at '${dirname(nearest)}' to make that the deployment root.`,
+    {
+      code: 'VALIDATION_WORKFLOW_SCHEMA',
+      category: 'VALIDATION',
+      agentAction: 'report_to_user',
+      retryable: false,
+    },
   );
 }
 
@@ -251,7 +260,15 @@ function loadManifestContext(
   // manifest does NOT excuse a stray one below it (the stray is still ignored, still
   // operator error). Detection-only — LOADING semantics stay strict-single-location.
   // Case C (realm.yaml ABOVE trust_root) is deliberately NOT scanned (see #123).
-  checkForOrphanedManifests(definition, root);
+  //
+  // Scan only when the definition carries both source_dir and trust_root: agent-origin /
+  // from-string definitions have no source_dir (and reach the manifest via `--project`),
+  // and `root === trust_root` here whenever trust_root is defined (root = trust_root ??
+  // projectDir), so passing definition.trust_root preserves the previous trust_root===root
+  // gate — the `--project`-fallback path never scans.
+  if (definition.source_dir !== undefined && definition.trust_root !== undefined) {
+    checkForOrphanedManifests(definition.source_dir, definition.trust_root);
+  }
 
   const manifestPath = join(root, 'realm.yaml');
   let bytes: Buffer;

--- a/packages/cli/src/extensions/load-project-extensions.ts
+++ b/packages/cli/src/extensions/load-project-extensions.ts
@@ -18,7 +18,7 @@
 // module paths and manifest `use:` refs originate ONLY from operator-registered definitions,
 // the operator's deployment root, or operator-typed flags — never from request data.
 import { createRequire } from 'node:module';
-import { readFileSync, realpathSync } from 'node:fs';
+import { readFileSync, realpathSync, existsSync } from 'node:fs';
 import { dirname, join, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { load as loadYaml } from 'js-yaml';
@@ -185,6 +185,52 @@ interface ManifestContext {
 }
 
 /**
+ * Orphaned-manifest guard (#123): throws when a `realm.yaml` sits anywhere in the span
+ * `[source_dir, trust_root)` — from the workflow directory walking UP to, but NOT
+ * including, the resolved trust_root. Such a manifest is silently ignored by the
+ * strict-single-location loader, so surfacing it loudly before run creation turns a
+ * confusing downstream `adapter 'X' not registered` (or total silence under
+ * validate/sentinel/fixture paths) into an actionable placement error.
+ *
+ * No-op unless the definition carries BOTH `source_dir` and `trust_root` and they differ
+ * (agent-origin / from-string definitions have no source_dir; a workflow dir that is its
+ * own trust_root has an empty span). Never scans at or above trust_root — a stray at
+ * trust_root IS the loaded manifest; Case C (above trust_root) is deliberately out of #123.
+ */
+function checkForOrphanedManifests(definition: WorkflowDefinition, root: string): void {
+  const sourceDir = definition.source_dir;
+  const trustRoot = definition.trust_root;
+  // Only meaningful for file-loaded definitions whose trust_root is the resolved root.
+  if (sourceDir === undefined || trustRoot === undefined || trustRoot !== root) return;
+  if (sourceDir === trustRoot) return;
+
+  const orphans: string[] = [];
+  let current = sourceDir;
+  // Walk [source_dir, trust_root): stop BEFORE trust_root; guard against a source_dir that
+  // is not actually under trust_root (never terminates otherwise).
+  while (current !== trustRoot) {
+    const candidate = join(current, 'realm.yaml');
+    if (existsSync(candidate)) orphans.push(candidate);
+    const parent = dirname(current);
+    if (parent === current) break; // hit the filesystem root without meeting trust_root
+    current = parent;
+  }
+
+  if (orphans.length === 0) return;
+  const found =
+    orphans.length === 1
+      ? `Deployment manifest at '${orphans[0]!}'`
+      : `Deployment manifests at ${orphans.map((o) => `'${o}'`).join(', ')}`;
+  const nearest = orphans[0]!;
+  throw new Error(
+    `${found} will NOT be loaded — manifests are read only from the deployment root ` +
+      `'${join(trustRoot, 'realm.yaml')}'. Move it to '${join(trustRoot, 'realm.yaml')}' ` +
+      `(the nearest package.json/.git ancestor of the workflow), or add a package.json/.git ` +
+      `at '${dirname(nearest)}' to make that the deployment root.`,
+  );
+}
+
+/**
  * Resolves the deployment root and loads+validates the manifest document when present.
  * Definitions WITH trust_root anchor there; definitions WITHOUT it anchor at the daemon's
  * `--project` root (absent → no manifest, defaults only — NO walking, NO error).
@@ -195,6 +241,18 @@ function loadManifestContext(
 ): ManifestContext | undefined {
   const root = definition.trust_root ?? projectDir;
   if (root === undefined) return undefined;
+
+  // Orphaned-manifest guard (#123): manifests load ONLY from <trust_root>/realm.yaml.
+  // A realm.yaml placed anywhere in the span [source_dir, trust_root) — the workflow dir
+  // or an intermediate dir below the resolved trust_root — is silently ignored, which is
+  // the common misplacement (workflow in a repo subdir whose package.json/.git is an
+  // ancestor). Detect it and fail loud BEFORE loading, consistent with the invalid-YAML /
+  // schema-error throws below. Runs before the trust_root load: a correctly-placed
+  // manifest does NOT excuse a stray one below it (the stray is still ignored, still
+  // operator error). Detection-only — LOADING semantics stay strict-single-location.
+  // Case C (realm.yaml ABOVE trust_root) is deliberately NOT scanned (see #123).
+  checkForOrphanedManifests(definition, root);
+
   const manifestPath = join(root, 'realm.yaml');
   let bytes: Buffer;
   try {

--- a/packages/cli/src/extensions/load-project-manifest-orphan.test.ts
+++ b/packages/cli/src/extensions/load-project-manifest-orphan.test.ts
@@ -1,0 +1,126 @@
+// Tests for the orphaned-manifest guard (#123): a realm.yaml in the span
+// [source_dir, trust_root) is silently ignored by the strict-single-location loader, so
+// the guard fails loud before run creation. Detection-only — LOADING stays strict.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
+import type { WorkflowDefinition } from '@sensigo/realm';
+import { loadProjectExtensions, clearProjectExtensionsCache } from './load-project-extensions.js';
+
+// Topology (everything under `base`, so cleanup is total):
+//   base/                         ← "monorepo root" (Case-C's above-trust_root dir)
+//   base/project/                 ← trust_root (has package.json)
+//   base/project/workflows/       ← intermediate dir in the span
+//   base/project/workflows/wf/    ← source_dir (workflow dir)
+let base: string;
+let root: string;
+let intermediate: string;
+let workflowDir: string;
+let counter = 0;
+
+beforeEach(() => {
+  clearProjectExtensionsCache();
+  base = mkdtempSync(join(tmpdir(), 'realm-orphan-'));
+  root = join(base, 'project');
+  intermediate = join(root, 'workflows');
+  workflowDir = join(intermediate, 'wf');
+  mkdirSync(workflowDir, { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+const MINIMAL_MANIFEST = 'version: 1\nadapters:\n  fs2:\n    use: filesystem\n';
+
+function writeManifest(dir: string): string {
+  const path = join(dir, 'realm.yaml');
+  writeFileSync(path, MINIMAL_MANIFEST, 'utf8');
+  return path;
+}
+
+/** Definition anchored with an explicit source_dir/trust_root span (the file-loaded shape). */
+function def(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    id: `wf-${counter++}`,
+    name: 'Orphan WF',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    steps: { s1: { description: 'step', execution: 'agent' } },
+    origin: 'human',
+    source_dir: workflowDir,
+    trust_root: root,
+    ...overrides,
+  };
+}
+
+describe('orphaned-manifest guard (#123)', () => {
+  it('1. orphan at source_dir with a higher trust_root → throws, naming orphan + trust_root + fix', async () => {
+    const orphan = writeManifest(workflowDir);
+    const err = await loadProjectExtensions(def()).then(
+      () => undefined,
+      (e: Error) => e,
+    );
+    expect(err).toBeDefined();
+    expect(err!.message).toContain(orphan);
+    expect(err!.message).toContain(join(root, 'realm.yaml'));
+    expect(err!.message).toContain('will NOT be loaded');
+    expect(err!.message).toContain('Move it to');
+  });
+
+  it('2. orphan in an intermediate dir between source_dir and trust_root → throws (monorepo shape)', async () => {
+    const orphan = writeManifest(intermediate);
+    await expect(loadProjectExtensions(def())).rejects.toThrow(orphan);
+  });
+
+  it('3. correctly-placed <trust_root>/realm.yaml → loads, NO error', async () => {
+    writeManifest(root);
+    const { manifest } = await loadProjectExtensions(def());
+    expect(manifest.adapters).toEqual(['fs2']); // proves the trust_root manifest loaded
+  });
+
+  it('4. correct manifest at trust_root AND a stray one below → still throws (stray not excused)', async () => {
+    writeManifest(root);
+    const stray = writeManifest(workflowDir);
+    await expect(loadProjectExtensions(def())).rejects.toThrow(stray);
+  });
+
+  it('5. genuinely absent (no realm.yaml in span or at trust_root) → defaults, NO error', async () => {
+    const { manifest, registry } = await loadProjectExtensions(def());
+    expect(manifest.adapters).toEqual([]);
+    expect(registry.getAdapter('filesystem')).toBeDefined(); // default registry only
+  });
+
+  it('6. trust_root === source_dir → loads, no orphan false-positive', async () => {
+    // Workflow dir is its own deployment root (its own package.json).
+    writeFileSync(join(workflowDir, 'package.json'), '{}', 'utf8');
+    writeManifest(workflowDir);
+    const { manifest } = await loadProjectExtensions(
+      def({ source_dir: workflowDir, trust_root: workflowDir }),
+    );
+    expect(manifest.adapters).toEqual(['fs2']); // the workflow-dir manifest IS the loaded one
+  });
+
+  it('7. agent-origin / from-string definition (no source_dir) → guard is a no-op; --project still reaches the manifest', async () => {
+    writeManifest(root);
+    const agentDef = def({ source_dir: undefined, trust_root: undefined, origin: 'agent' });
+    // No source_dir → no span → no error, and no manifest without --project.
+    const bare = await loadProjectExtensions(agentDef);
+    expect(bare.manifest.adapters).toEqual([]);
+    // --project anchors the manifest explicitly, and the guard does not fire (no source_dir).
+    const anchored = await loadProjectExtensions(agentDef, { projectDir: root });
+    expect(anchored.manifest.adapters).toEqual(['fs2']);
+  });
+
+  it('8. Case C control: realm.yaml ABOVE trust_root + valid one AT trust_root → loads trust_root, no error on the one above', async () => {
+    // A manifest above the trust root (the monorepo root `base`) must be IGNORED, not
+    // errored — Case C is deliberately out of scope.
+    writeManifest(base);
+    writeManifest(root);
+    const { manifest } = await loadProjectExtensions(def());
+    expect(manifest.adapters).toEqual(['fs2']); // trust_root manifest, no throw
+  });
+});

--- a/packages/cli/src/extensions/load-project-manifest-orphan.test.ts
+++ b/packages/cli/src/extensions/load-project-manifest-orphan.test.ts
@@ -123,4 +123,15 @@ describe('orphaned-manifest guard (#123)', () => {
     const { manifest } = await loadProjectExtensions(def());
     expect(manifest.adapters).toEqual(['fs2']); // trust_root manifest, no throw
   });
+
+  it('9. M1 regression — agent-origin (no source_dir) never scans, even with a stray manifest in the subtree', async () => {
+    // A stray realm.yaml sits where a span scan would trip — but an agent-origin definition
+    // has no source_dir, so the loader must never invoke the guard. Loads the --project
+    // root manifest cleanly.
+    writeManifest(root);
+    writeManifest(workflowDir); // would be an orphan for a file-loaded def; ignored here
+    const agentDef = def({ source_dir: undefined, trust_root: undefined, origin: 'agent' });
+    const loaded = await loadProjectExtensions(agentDef, { projectDir: root });
+    expect(loaded.manifest.adapters).toEqual(['fs2']); // no throw, root manifest loaded
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,7 @@ export { validateInputSchema } from './validation/input-schema.js';
 export {
   loadWorkflowFromFile,
   loadWorkflowFromString,
+  findTrustRoot,
   CURRENT_WORKFLOW_SCHEMA_VERSION,
 } from './workflow/yaml-loader.js';
 export { JsonWorkflowStore } from './workflow/registrar.js';

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -179,8 +179,11 @@ function validateExtensionsDeclaration(rawExtensions: unknown): string[] {
  * Finds the trust root for extension resolution: the nearest ancestor of `dir` (inclusive)
  * containing `package.json` or `.git`; falls back to `dir` itself when no such ancestor exists.
  * Derived once, at registration time, from an operator-given path — never at execution time.
+ * Exported so CLI paths that don't stamp a definition (e.g. `realm workflow validate` on an
+ * extension-free workflow) can resolve the same trust root for the orphaned-manifest guard.
+ * Pure `package.json`/`.git` walk — zero manifest knowledge.
  */
-function findTrustRoot(dir: string): string {
+export function findTrustRoot(dir: string): string {
   let current = dir;
   for (;;) {
     if (existsSync(join(current, 'package.json')) || existsSync(join(current, '.git'))) {


### PR DESCRIPTION
## Context

Issue #123. The deployment manifest loads only from `<trust_root>/realm.yaml` (`loadManifestContext`). A `realm.yaml` placed anywhere in the span `[source_dir, trust_root)` — the workflow directory, or an intermediate directory below the resolved trust root — is silently ignored (absent-manifest = defaults-only, indistinguishable from misplaced). This is the *common* topology (a workflow in a repo subdirectory whose `package.json`/`.git` is an ancestor) and it silently bit example 08 for an entire implementation round, masked by fixture mocks. At real execution the operator gets a confusing `adapter 'X' not registered` while staring at a `realm.yaml` that declares X; under validate/sentinel/fixture and filesystem-only workflows there is no signal at all.

## Root Cause

Strict-single-location manifest resolution has no detection of the near-miss. A misplaced manifest and a genuinely absent one are indistinguishable, so the misplacement never surfaces.

## Changes

`packages/cli/src/extensions/load-project-extensions.ts` — new `checkForOrphanedManifests(definition, root)`, called at the top of `loadManifestContext` **before** the trust_root load (a correctly-placed manifest does not excuse a stray one below it — the stray is still ignored, still operator error, so still an error):

- No-op unless the definition carries BOTH `source_dir` and `trust_root`, they differ, and `trust_root === root` (agent-origin / from-string definitions have no `source_dir`; a workflow dir that is its own trust root has an empty span).
- Walks `[source_dir, trust_root)` — from `source_dir` up to but NOT including `trust_root` — collecting every existing `realm.yaml` (`existsSync`), with a `parent === current` termination guard for definitions whose `source_dir` is not actually under `trust_root`.
- Any found → **throws** before run creation (consistent with the existing invalid-YAML / schema-error throws in this function). All orphans are named; the message names the resolved trust root and the fix. Implemented text (single-orphan form):

  > Deployment manifest at '<orphan>/realm.yaml' will NOT be loaded — manifests are read only from the deployment root '<trust_root>/realm.yaml'. Move it to '<trust_root>/realm.yaml' (the nearest package.json/.git ancestor of the workflow), or add a package.json/.git at '<orphan>' to make that the deployment root.

**Detection-only** — manifest LOADING semantics are unchanged (strict single location at `<trust_root>/realm.yaml`). **Case C** (a `realm.yaml` *above* trust_root, e.g. a monorepo root) is deliberately NOT scanned and NOT warned — it is ambiguous and deferred to its own debate (per #123).

Companion verbose line: **skipped** — `realm workflow validate` has no existing verbose/`-v` flag, and the prompt says not to add a new flag surface in this pass.

## Verification

```bash
# guard tests (8) — orphan at source_dir / intermediate / stray-below-valid all throw;
# correct placement, absent, trust_root===source_dir, agent-origin, and the Case-C
# control all load/no-op without error
cd packages/cli && npx vitest run src/extensions/load-project-manifest-orphan.test.ts   # 8 passed

# full gates
npm run lint                              # 4/4, 0 errors 0 warnings
npm run build                             # 4/4
TURBO_FORCE=true npm run test             # 2089 tests, 0 failed, 0 skipped (core 1406, cli 501, mcp 112, testing 70)
npm audit --omit=dev --audit-level=high   # 0 vulnerabilities
npm run check:versions                    # all match
```

Mutation probe (reported): disabling the span scan (`return` before the orphan check) turns tests 1/2/4 red; restored → 8/8 green.

## Rollback

```bash
git revert 3855cee
```

Detection-only, no persisted state, no migration — a plain revert fully removes the guard.

## Related

Closes #123
