### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.14.1] — 2026-07-06
 
 ### Fixed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.14.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.14.1');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.14.0';
+export const VERSION = '0.14.1';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.14.0';
+export const VERSION = '0.14.1';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.14.0',
+    version: '0.14.1',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.14.0';
+export const VERSION = '0.14.1';


### PR DESCRIPTION
## Context

Release PR for **v0.14.1** — a patch hardening the v0.14.0 deployment manifest. Closes #123: an orphaned `realm.yaml` (placed in `[source_dir, trust_root)`, below the deployment root where manifests are actually read) was silently ignored. Now every workflow-loading command throws loudly before run creation, naming the orphan, the trust root, and the fix — including `realm workflow validate` (the coverage gap MA verification caught: extension-free workflows bypassed the guard via the from-string path).

## Changes

- CHANGELOG: `[Unreleased]` → `[0.14.1] — 2026-07-06`.
- `chore: release v0.14.1` — version bump across all four `package.json` files and source `VERSION` constants (release script, 9 files ±9).

Guard is detection-only (manifest loading stays strict-single-location; the monorepo-root "Case C" is intentionally out — tracked in #125). An enforced enumeration test partitions all workflow-loading commands (workflowCommands ∪ topLevelCommands) into covered/excluded so a new loading command cannot silently escape the guard's test net.

## Verification

```bash
git describe --exact-match v0.14.1
npm ci && npm run build && TURBO_FORCE=true npm run test    # 2,098 tests
```

CI must be green before merge. Merge with a **merge commit** (the tag points at the release commit on this branch). Tag push triggers `publish.yml` (OIDC Trusted Publishing).

## Rollback

Pre-publish: close PR, delete branch + tag. Post-publish: npm is immutable — ship a follow-up patch.

## Related

- Closes #123. Feature baseline v0.14.0 (#122). Deferred: #125 (monorepo config compose-up — Case C, debate-worthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
