### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-07-07
+
 ### Added
 
 - **`execution: finalizer` step class — a workflow-level try/catch/finally.** A finalizer is an engine-run step the engine drains as the final steps before it seals a run, matched to the run's terminal outcome via a required `on_outcome:` matcher (`FinalizerTrigger | FinalizerTrigger[]`, where `FinalizerTrigger = 'complete' | 'fail' | 'abort' | 'always'`, OR-membership). `complete` = the success/`try` arm, `fail`/`abort` = the `catch` arm, `always` = the `finally` arm. At each terminal transition the engine drains the matching finalizers **in-memory** — outcome-specific finalizers first (declaration order), then `always` finalizers (declaration order, so `finally` runs last) — each **at most once per run**, then performs the run's existing single seal write. Realm owns only _which_ finalizers run, _when_, in what _order_, and _once_; what a finalizer does internally is the workflow developer's business (it runs its `handler` through the injected registry exactly like any other handler step).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.14.1');
+program.name('realm').description('Realm workflow engine CLI').version('0.15.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.14.1';
+export const VERSION = '0.15.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.14.1';
+export const VERSION = '0.15.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.14.1',
+    version: '0.15.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.14.1';
+export const VERSION = '0.15.0';


### PR DESCRIPTION
## Context

Cuts the **v0.15.0** release: the `execution: finalizer` feature (PR #128, merged in `529cb3a`) plus the coordinated version bump. Additive, backward-compatible minor release.

## Motivation

Package the merged finalizer feature (workflow try/catch/finally) for npm. A new `execution: finalizer` step class is additive — no breaking changes — so this is a **minor** bump `0.14.1 → 0.15.0`.

## Changes

- `0b46b49` `docs: changelog for v0.15.0` — moves the `[Unreleased]` block to `## [0.15.0] — 2026-07-07`.
- `fa09324` `chore: release v0.15.0` — bumps all four packages + the five source version strings to `0.15.0` via `scripts/release.mjs`. Tag `v0.15.0` was created on this commit locally and will be pushed after merge.

## Verification

```bash
git fetch origin && git checkout release/v0.15.0
npm ci
npm run check:versions          # all strings match 0.15.0
TURBO_FORCE=true npm run test   # core 1453, cli 513, mcp 116, testing 74
npm run build
```

After merge, pushing the `v0.15.0` tag triggers `.github/workflows/publish.yml` (OIDC trusted publish of all four packages).

## Rollback

- **Pre-publish:** close without merge, and/or `git tag -d v0.15.0` (the tag is not pushed until after merge).
- **Post-publish:** npm disallows unpublish after 72h; the forward fix is a `v0.15.1` patch. `git revert fa09324` to unbump the version strings.

## Related

- Feature: #128 (merged).
- Follow-up: #101 (claim-lease / TTL reaper).
