### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-07-10
+
 ### Added
 
 - **Runner-liveness reclaim recovery — Phase 1 (issue #101).** Closes the _after-claim wedge_: a step pinned in `in_progress_steps` because its runner died after `claimStep` but before settling (the v0.15.0 finalizer crash-wedge is an instance). Every wedge is now **always detectable** and **recoverable by a deliberate per-step act** — no new run phase, no daemon, no background sweep.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.15.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.16.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,7 +79,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.15.0';
+export const VERSION = '0.16.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.15.0';
+export const VERSION = '0.16.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.15.0',
+    version: '0.16.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.15.0';
+export const VERSION = '0.16.0';


### PR DESCRIPTION
## Context

Cut **v0.16.0**. Seven merged PRs have accumulated under `CHANGELOG.md`'s `[Unreleased]` since v0.15.0; npm still shows 0.15.0 until a tag is pushed. This is the release PR (version bump + CHANGELOG rename) produced by `scripts/release.mjs`.

## Motivation

Publish the staged engine-robustness and adapter work to npm as a backwards-compatible **minor** (new `Added` capabilities dominate; no breaking changes). Bundled PRs:

- **#132** flaky-suite trio (vitest config + Slack-gate drain + JsonFileStore atomic writes)
- **#133** runner-liveness reclaim — #101 Phase 1 + Phase 2
- **#135** recoverable incapability + start-time capability warning — #134
- **#136** robust built-in Anthropic provider (submit tool + tolerant extractor)
- **#137** Gorgias adapter reliability (per-ticket endpoint, full thread, honest `truncated`, error-body redaction)
- **#138** default execution timeout for `auto` steps — A3
- **#143** claim-deadline horizon accounts for `max_attempts` — #101 follow-up

## Changes

- `CHANGELOG.md`: renamed `## [Unreleased]` → `## [0.16.0] — 2026-07-10` (fresh empty `[Unreleased]` left on top); entries unchanged.
- Version bump `0.15.0` → `0.16.0` across all four `package.json` files and the five source `VERSION` constants (`core`/`cli`/`mcp-server` index + `mcp-server` server + `testing` index), via `npm run release -- --version 0.16.0`.

## Verification

```bash
git checkout release/v0.16.0
npm run check:versions          # All version strings match. (0.16.0)
npm run lint && npm run build    # clean
npm audit --omit=dev --audit-level=high   # 0 vulnerabilities
TURBO_FORCE=true npm run test    # 8/8 tasks (verified on main pre-cut)
```

Publish is **not** manual: after this PR merges (**merge commit — not squash/rebase**, so the `v0.16.0` tag stays reachable), pushing the tag triggers `.github/workflows/publish.yml` (OIDC Trusted Publishing, all four packages). Then verify by value:

```bash
npm install @sensigo/realm@0.16.0
node --input-type=module -e "import { VERSION } from '@sensigo/realm'; console.log(VERSION);"   # 0.16.0
```

## Rollback

If the publish workflow partially fails, re-push the tag (`npm publish` skips already-published packages with `EPUBLISHCONFLICT`). If a published artifact is broken, cut a patch release (v0.16.1) via the same Part-B sequence. Pre-publish, this PR is a plain `git revert` of the two commits (CHANGELOG + version bump).

## Related

- Release process: `.github/instructions/pre-publication.instructions.md` (Part B).
- Prior release: v0.15.0 (tag `fa09324`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
