### PR TITLE
feat(core): Gorgias adapter hardening — has_more, non-scalar reject, write-redirect refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`GorgiasAdapter` list results now include `has_more`.** `list_tickets`/`list_customers` responses carry a derived `has_more` boolean (from `meta.next_cursor`) alongside the raw `data`/`meta`, so callers can detect further pages without hand-parsing the cursor.
+
+### Changed
+
+- **`GorgiasAdapter` list ops reject a non-scalar filter param.** Passing an array/object as a `list_tickets`/`list_customers` query param was silently dropped (a silently-lost filter → over-broad results); it now throws `ADAPTER_VALIDATION_FAILED`. `null`/`undefined` still omit the param.
+
+### Fixed
+
+- **`GorgiasAdapter` surfaces a redirect on a write.** A 301/302 on a `POST`/`PUT` could silently downgrade the method to GET; write ops now refuse an unexpected redirect loudly. GET ops still follow redirects (unchanged).
+
 ## [0.16.0] — 2026-07-10
 
 ### Added

--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -1031,7 +1031,7 @@ describe("GorgiasAdapter create('create_ticket')", () => {
     const adapter = makeAdapter();
     await expect(
       adapter.create('create_ticket', { messages: [{ channel: 'email', from_agent: false }] }, {}),
-    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX', retryable: false });
+    ).rejects.toMatchObject({ code: 'SERVICE_UNEXPECTED_REDIRECT', retryable: false });
   });
 
   it('a normal 201 write still succeeds unchanged (redirect: manual does not affect non-redirect responses)', async () => {

--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -343,6 +343,27 @@ describe("GorgiasAdapter fetch('list_tickets')", () => {
     expect(lastRequestMethod).toBe('GET');
     expect(capturedUrl).toBe('/tickets');
   });
+
+  it('has_more is true when meta.next_cursor is present (issue A5)', async () => {
+    respond(200, { data: [{ id: 1, status: 'open' }], meta: { next_cursor: 'abc123' } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_tickets', {}, {});
+    const data = result.data as { data: unknown[]; meta: unknown; has_more: boolean };
+    expect(data.has_more).toBe(true);
+    // data.data and data.meta are preserved untouched (additive field only).
+    expect(data.data).toEqual([{ id: 1, status: 'open' }]);
+    expect(data.meta).toEqual({ next_cursor: 'abc123' });
+  });
+
+  it('has_more is false when meta.next_cursor is null (issue A5)', async () => {
+    respond(200, { data: [{ id: 1, status: 'open' }], meta: { next_cursor: null } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_tickets', {}, {});
+    const data = result.data as { data: unknown[]; meta: unknown; has_more: boolean };
+    expect(data.has_more).toBe(false);
+    expect(data.data).toEqual([{ id: 1, status: 'open' }]);
+    expect(data.meta).toEqual({ next_cursor: null });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -777,6 +798,27 @@ describe("GorgiasAdapter fetch('list_customers')", () => {
     const adapter = makeAdapter();
     await adapter.fetch('list_customers', {}, {});
     expect(capturedUrl).toBe('/customers');
+  });
+
+  it('has_more is true when meta.next_cursor is present (issue A5)', async () => {
+    respond(200, { data: [{ id: 1, email: 'a@example.com' }], meta: { next_cursor: 'xyz789' } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_customers', {}, {});
+    const data = result.data as { data: unknown[]; meta: unknown; has_more: boolean };
+    expect(data.has_more).toBe(true);
+    // data.data and data.meta are preserved untouched (additive field only).
+    expect(data.data).toEqual([{ id: 1, email: 'a@example.com' }]);
+    expect(data.meta).toEqual({ next_cursor: 'xyz789' });
+  });
+
+  it('has_more is false when meta.next_cursor is null (issue A5)', async () => {
+    respond(200, { data: [{ id: 1, email: 'a@example.com' }], meta: { next_cursor: null } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('list_customers', {}, {});
+    const data = result.data as { data: unknown[]; meta: unknown; has_more: boolean };
+    expect(data.has_more).toBe(false);
+    expect(data.data).toEqual([{ id: 1, email: 'a@example.com' }]);
+    expect(data.meta).toEqual({ next_cursor: null });
   });
 });
 

--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -331,6 +331,30 @@ describe("GorgiasAdapter fetch('list_tickets')", () => {
     expect(capturedUrl).toContain('limit=10');
   });
 
+  it('rejects a non-scalar param (array) with ADAPTER_VALIDATION_FAILED (issue A6)', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_tickets', { limit: 10, tags: ['vip', 'new'] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    await expect(
+      adapter.fetch('list_tickets', { limit: 10, tags: ['vip', 'new'] }, {}),
+    ).rejects.toBeInstanceOf(WorkflowError);
+  });
+
+  it('null/undefined params are still omitted (not thrown) alongside scalar params', async () => {
+    let capturedUrl = '';
+    handlers.push((req, res) => {
+      capturedUrl = req.url ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
+    });
+    const adapter = makeAdapter();
+    await adapter.fetch('list_tickets', { limit: 10, order_by: undefined, cursor: null }, {});
+    expect(capturedUrl).toContain('limit=10');
+    expect(capturedUrl).not.toContain('order_by=');
+    expect(capturedUrl).not.toContain('cursor=');
+  });
+
   it('no params: URL path has no query string', async () => {
     let capturedUrl = '';
     handlers.push((req, res) => {
@@ -770,7 +794,24 @@ describe("GorgiasAdapter fetch('list_customers')", () => {
     expect(capturedUrl).toContain('limit=5');
   });
 
-  it('skips non-scalar params (arrays, objects) from query string', async () => {
+  it('rejects a non-scalar param (array) with ADAPTER_VALIDATION_FAILED (issue A6)', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_customers', { limit: 10, tags: ['vip', 'new'] }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+    await expect(
+      adapter.fetch('list_customers', { limit: 10, tags: ['vip', 'new'] }, {}),
+    ).rejects.toBeInstanceOf(WorkflowError);
+  });
+
+  it('rejects a non-scalar param (object) with ADAPTER_VALIDATION_FAILED (issue A6)', async () => {
+    const adapter = makeAdapter();
+    await expect(
+      adapter.fetch('list_customers', { limit: 10, nested: { key: 'val' } }, {}),
+    ).rejects.toMatchObject({ code: 'ADAPTER_VALIDATION_FAILED' });
+  });
+
+  it('null/undefined params are still omitted (not thrown) alongside scalar params', async () => {
     let capturedUrl = '';
     handlers.push((req, res) => {
       capturedUrl = req.url ?? '';
@@ -778,14 +819,10 @@ describe("GorgiasAdapter fetch('list_customers')", () => {
       res.end(JSON.stringify({ data: [], meta: { next_cursor: null } }));
     });
     const adapter = makeAdapter();
-    await adapter.fetch(
-      'list_customers',
-      { limit: 10, tags: ['vip', 'new'], nested: { key: 'val' } },
-      {},
-    );
+    await adapter.fetch('list_customers', { limit: 10, email: undefined, tags: null }, {});
     expect(capturedUrl).toContain('limit=10');
+    expect(capturedUrl).not.toContain('email=');
     expect(capturedUrl).not.toContain('tags=');
-    expect(capturedUrl).not.toContain('nested=');
   });
 
   it('no params: URL path has no query string', async () => {

--- a/packages/core/src/adapters/gorgias-adapter.test.ts
+++ b/packages/core/src/adapters/gorgias-adapter.test.ts
@@ -730,6 +730,26 @@ describe("GorgiasAdapter fetch('get_messages')", () => {
     expect(data.messages).toHaveLength(0);
     expect(data.truncated).toBe(false);
   });
+
+  it('GET still follows a redirect (issue A7 — GET keeps the default follow, unchanged)', async () => {
+    // First response: a real 301 pointing back at this same mock server. Since GET's
+    // fetchOptions still use the default redirect: 'follow' (unlike POST/PUT), the underlying
+    // fetch() transparently issues the follow-up GET itself — the adapter only sees the final
+    // response. Two handlers are queued: one for the 301, one for the followed request.
+    handlers.push((_req, res) => {
+      res.writeHead(301, {
+        'Content-Type': 'application/json',
+        Location: `http://127.0.0.1:${port}/tickets/10/messages?redirected=true`,
+      });
+      res.end(JSON.stringify({ moved: true }));
+    });
+    respond(200, { data: [makeMsg(1)], meta: { next_cursor: null } });
+    const adapter = makeAdapter();
+    const result = await adapter.fetch('get_messages', { ticket_id: 10 }, {});
+    const data = result.data as { messages: unknown[]; truncated: boolean };
+    expect(data.messages).toHaveLength(1);
+    expect(data.truncated).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1004,6 +1024,27 @@ describe("GorgiasAdapter create('create_ticket')", () => {
       subject: 'Help needed',
       status: 'open',
     });
+  });
+
+  it('a 301 on POST throws a non-retryable redirect error instead of following (issue A7)', async () => {
+    respond(301, { moved: true }, { Location: 'https://test.gorgias.com/api/tickets/123' });
+    const adapter = makeAdapter();
+    await expect(
+      adapter.create('create_ticket', { messages: [{ channel: 'email', from_agent: false }] }, {}),
+    ).rejects.toMatchObject({ code: 'SERVICE_HTTP_4XX', retryable: false });
+  });
+
+  it('a normal 201 write still succeeds unchanged (redirect: manual does not affect non-redirect responses)', async () => {
+    respond(201, { id: 100, status: 'open', channel: 'email' });
+    const adapter = makeAdapter();
+    const result = await adapter.create(
+      'create_ticket',
+      { messages: [{ channel: 'email', from_agent: false }] },
+      {},
+    );
+    expect(result.status).toBe(201);
+    const data = result.data as Record<string, unknown>;
+    expect(data['id']).toBe(100);
   });
 });
 

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -87,9 +87,10 @@ interface GorgiasMessage {
  *   update('update_ticket',   { ticket_id, ...ticketFields })        — PUT  /tickets/{id}
  *   update('update_customer', { customer_id, ...customerFields })    — PUT  /customers/{id}
  *
- * list_tickets and list_customers return a single page; pass cursor from response meta
- * to retrieve subsequent pages. Scalar params (string | number | boolean) are forwarded
- * as query params. Non-scalar values (arrays, objects) are silently skipped.
+ * list_tickets and list_customers return a single page — data.data/data.meta passthrough plus
+ * an additive data.has_more (derived from meta.next_cursor; no auto-pagination); pass cursor
+ * from response meta to retrieve subsequent pages. Scalar params (string | number | boolean) are
+ * forwarded as query params. Non-scalar values (arrays, objects) are silently skipped.
  */
 export class GorgiasAdapter implements ServiceAdapter {
   readonly id: string;
@@ -376,13 +377,23 @@ export class GorgiasAdapter implements ServiceAdapter {
         }
       }
       const queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
-      return this.executeRequest(
+      const res = await this.executeRequest(
         'GET',
         `${this.baseUrl}/tickets${queryString}`,
         'list_tickets',
         undefined,
         signal,
       );
+      // A5: additive has_more convenience signal derived from meta.next_cursor — data.data and
+      // data.meta are preserved untouched; no auto-pagination.
+      const meta = (res.data as { meta?: { next_cursor?: string | null } }).meta;
+      return {
+        ...res,
+        data: {
+          ...(res.data as Record<string, unknown>),
+          has_more: (meta?.next_cursor ?? null) !== null,
+        },
+      };
     }
 
     if (operation === 'get_customer') {
@@ -406,13 +417,23 @@ export class GorgiasAdapter implements ServiceAdapter {
         }
       }
       const queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
-      return this.executeRequest(
+      const res = await this.executeRequest(
         'GET',
         `${this.baseUrl}/customers${queryString}`,
         'list_customers',
         undefined,
         signal,
       );
+      // A5: additive has_more convenience signal derived from meta.next_cursor — data.data and
+      // data.meta are preserved untouched; no auto-pagination.
+      const meta = (res.data as { meta?: { next_cursor?: string | null } }).meta;
+      return {
+        ...res,
+        data: {
+          ...(res.data as Record<string, unknown>),
+          has_more: (meta?.next_cursor ?? null) !== null,
+        },
+      };
     }
 
     throw new WorkflowError(`GorgiasAdapter: unsupported fetch operation '${operation}'`, {

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -90,7 +90,8 @@ interface GorgiasMessage {
  * list_tickets and list_customers return a single page — data.data/data.meta passthrough plus
  * an additive data.has_more (derived from meta.next_cursor; no auto-pagination); pass cursor
  * from response meta to retrieve subsequent pages. Scalar params (string | number | boolean) are
- * forwarded as query params. Non-scalar values (arrays, objects) are silently skipped.
+ * forwarded as query params; null/undefined are omitted ("not set"). A non-scalar value (array,
+ * object) throws ADAPTER_VALIDATION_FAILED — a dropped filter would silently over-broaden results.
  */
 export class GorgiasAdapter implements ServiceAdapter {
   readonly id: string;
@@ -371,9 +372,24 @@ export class GorgiasAdapter implements ServiceAdapter {
     if (operation === 'list_tickets') {
       this.checkAborted(signal);
       const queryParts: string[] = [];
+      // A6: fail loud on a non-scalar param instead of silently dropping it — a dropped filter
+      // yields silently-wrong (over-broad) results. null/undefined mean "not set" and still omit;
+      // core stays I/O-free, so a console.warn is not an option here.
       for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue;
         if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
           queryParts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+        } else {
+          throw new WorkflowError(
+            `GorgiasAdapter: list param '${key}' must be a scalar (string, number, or boolean); got ${Array.isArray(value) ? 'array' : typeof value}`,
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+              details: { key, type: Array.isArray(value) ? 'array' : typeof value },
+            },
+          );
         }
       }
       const queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
@@ -411,9 +427,24 @@ export class GorgiasAdapter implements ServiceAdapter {
     if (operation === 'list_customers') {
       this.checkAborted(signal);
       const queryParts: string[] = [];
+      // A6: fail loud on a non-scalar param instead of silently dropping it — a dropped filter
+      // yields silently-wrong (over-broad) results. null/undefined mean "not set" and still omit;
+      // core stays I/O-free, so a console.warn is not an option here.
       for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue;
         if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
           queryParts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+        } else {
+          throw new WorkflowError(
+            `GorgiasAdapter: list param '${key}' must be a scalar (string, number, or boolean); got ${Array.isArray(value) ? 'array' : typeof value}`,
+            {
+              code: 'ADAPTER_VALIDATION_FAILED',
+              category: 'ENGINE',
+              agentAction: 'provide_input',
+              retryable: false,
+              details: { key, type: Array.isArray(value) ? 'array' : typeof value },
+            },
+          );
         }
       }
       const queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -153,9 +153,9 @@ export class GorgiasAdapter implements ServiceAdapter {
             body: JSON.stringify(body),
             signal: signal ?? null,
             // A7: a redirect on a write would silently downgrade POST/PUT → GET (dropping the
-            // body). 'manual' surfaces the redirect as an opaque response instead of following
-            // it. GET keeps the default 'follow' — the get_messages per-ticket endpoint
-            // legitimately 301s and must keep working unchanged.
+            // body). 'manual' makes Node's fetch return the real 3xx status without following
+            // it (see the check below). GET keeps the default 'follow' — the get_messages
+            // per-ticket endpoint legitimately 301s and must keep working unchanged.
             redirect: 'manual',
           };
 
@@ -181,15 +181,15 @@ export class GorgiasAdapter implements ServiceAdapter {
     }
 
     // A7: surface a redirect on a write rather than silently downgrading POST/PUT → GET (which
-    // would drop the request body). GET is unaffected (redirect stays 'follow' above).
-    if (
-      method !== 'GET' &&
-      (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400))
-    ) {
+    // would drop the request body). GET is unaffected (redirect stays 'follow' above). Node's
+    // redirect: 'manual' returns the real 3xx status directly without following it — no
+    // opaqueredirect check needed (that response type is a browser/CORS-only concept and never
+    // occurs for a plain server-side fetch).
+    if (method !== 'GET' && response.status >= 300 && response.status < 400) {
       throw new WorkflowError(
         `GorgiasAdapter: unexpected redirect (HTTP ${response.status}) on ${method} ${operation} — refusing to silently downgrade the request`,
         {
-          code: 'SERVICE_HTTP_4XX',
+          code: 'SERVICE_UNEXPECTED_REDIRECT',
           category: 'SERVICE',
           agentAction: 'stop',
           retryable: false,

--- a/packages/core/src/adapters/gorgias-adapter.ts
+++ b/packages/core/src/adapters/gorgias-adapter.ts
@@ -152,6 +152,11 @@ export class GorgiasAdapter implements ServiceAdapter {
             headers: this.buildHeaders(),
             body: JSON.stringify(body),
             signal: signal ?? null,
+            // A7: a redirect on a write would silently downgrade POST/PUT → GET (dropping the
+            // body). 'manual' surfaces the redirect as an opaque response instead of following
+            // it. GET keeps the default 'follow' — the get_messages per-ticket endpoint
+            // legitimately 301s and must keep working unchanged.
+            redirect: 'manual',
           };
 
     let response: Response;
@@ -173,6 +178,24 @@ export class GorgiasAdapter implements ServiceAdapter {
         agentAction: 'wait_for_human',
         retryable: true,
       });
+    }
+
+    // A7: surface a redirect on a write rather than silently downgrading POST/PUT → GET (which
+    // would drop the request body). GET is unaffected (redirect stays 'follow' above).
+    if (
+      method !== 'GET' &&
+      (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400))
+    ) {
+      throw new WorkflowError(
+        `GorgiasAdapter: unexpected redirect (HTTP ${response.status}) on ${method} ${operation} — refusing to silently downgrade the request`,
+        {
+          code: 'SERVICE_HTTP_4XX',
+          category: 'SERVICE',
+          agentAction: 'stop',
+          retryable: false,
+          details: { status: response.status, operation, method },
+        },
+      );
     }
 
     if (!response.ok) {

--- a/packages/core/src/types/workflow-error.ts
+++ b/packages/core/src/types/workflow-error.ts
@@ -23,6 +23,8 @@ export type ErrorCode =
   | 'SERVICE_AUTH_FAILED'
   | 'SERVICE_NOT_FOUND'
   | 'SERVICE_RESPONSE_INVALID'
+  // a 3xx redirect where a direct response was required (e.g. on a write) — non-retryable
+  | 'SERVICE_UNEXPECTED_REDIRECT'
   // STATE
   | 'STATE_BLOCKED'
   | 'STATE_PRECONDITION_FAILED'


### PR DESCRIPTION
## Context

Three deferred findings from the Gorgias whole-adapter audit (filed as #145/#146/#147), batched — all small, all in `gorgias-adapter.ts`. Low risk: the downstream consumer reaches Gorgias via a separate Python MCP client, not this adapter, so the only affected callers are this adapter's own tests.

## Motivation

Harden the adapter's list and write paths against three silent footguns:
- **A5 (#145):** `list_tickets`/`list_customers` gave no "more pages exist" signal.
- **A6 (#146):** a non-scalar list filter param was silently dropped → silently over-broad results.
- **A7 (#147):** a 301/302 on a write could silently downgrade POST/PUT → GET (dropping the body).

## Changes

Five commits.

- **`feat` A5** — list results carry an additive `has_more` (derived from `meta.next_cursor`); `data.data`/`data.meta` preserved, no auto-pagination.
- **`fix` A6** — a non-scalar (array/object) list param now throws `ADAPTER_VALIDATION_FAILED` instead of being dropped; `null`/`undefined` still omit ("not set"). Fail-loud (core stays I/O-free, so no `console.warn`).
- **`fix` A7** — write ops (`POST`/`PUT`) use `redirect: 'manual'` and refuse an unexpected 3xx with a dedicated, non-retryable `SERVICE_UNEXPECTED_REDIRECT`. **GET keeps `follow`** — the `get_messages` per-ticket endpoint legitimately 301s (verified still-follows).
- **`docs`** — CHANGELOG (`Added` has_more · `Changed` non-scalar reject · `Fixed` write-redirect refuse).
- **`refactor`** — minted the dedicated `SERVICE_UNEXPECTED_REDIRECT` code (clean `ErrorCode` union add, no exhaustive consumer) and dropped the inert `opaqueredirect` clause (Node's `redirect:'manual'` returns the real 3xx status; that response type is browser-only).

## Verification

```bash
git checkout fix/core/gorgias-adapter-hardening
npm run lint && npm run build && npm run check:versions   # 0.16.0
npm audit --omit=dev --audit-level=high                    # 0 vulnerabilities
TURBO_FORCE=true npm run test                              # 8/8; core 1563
cd packages/core && npx vitest run src/adapters/gorgias-adapter.test.ts   # 79 passed
```
Mutation-probes run during review (each restored): A6 → revert to silent-skip reddens the 3 reject tests; A7 → disable the redirect check reddens the write-redirect test (falls through to `SERVICE_HTTP_5XX`). Build/type-check proves the `ErrorCode` union add is non-cascading.

## Rollback

```bash
git revert 8f9fbf7 25b3cc3 d3afe05 f08958b 14328c6
```
Code-only; additive `has_more` and the new error code are non-breaking; A6's throw is the only behaviour change (no realm consumer relies on the old silent-drop). Plain revert restores prior behaviour.

## Related

Closes #145
Closes #146
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
