### PR TITLE
fix(core): registry atomic writes + save() lock, and bare-auto docs (#130, #131, #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project are documented here.
 ### Fixed
 
 - **`GorgiasAdapter` surfaces a redirect on a write.** A 301/302 on a `POST`/`PUT` could silently downgrade the method to GET; write ops now refuse an unexpected redirect loudly. GET ops still follow redirects (unchanged).
+- **Atomic writes now cover the workflow registry (issue #130).** `registrar` (`register()`) and the `migrate` command wrote the registry with non-atomic `writeFileSync` (truncate-then-write), so a concurrent unlocked reader (`get`/`list`/`loadWorkflow`) could tear-read a half-written registry file — the same class as the v0.16.0 run-store fix, for `~/.realm/workflows/`. Both now write via the shared `atomicWriteFile` (unique temp + POSIX `rename`; win32 passthrough), extracted to `store/atomic-write.ts` and covered by a structural anti-recurrence guard.
+- **`JsonFileStore.save()` now holds the file-path lock (issue #131).** `save()` was the only run writer not acquiring the `proper-lockfile` per-path lock that `update()`/`claimStep()` hold; its create-if-absent contract made a lost-update unreachable today, but the asymmetry was a latent trap. Its read-check-write is now serialized under the same lock. No behaviour change to `save()`'s create-if-absent / version-conflict semantics.
 
 ## [0.16.0] — 2026-07-10
 

--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -99,6 +99,37 @@ The engine pauses and returns `next_actions` containing this step. The AI agent 
 
 The engine executes this step immediately without returning to the caller. If the step declares `uses_service`, the engine calls the registered adapter. If it declares `handler`, the engine calls the registered `StepHandler`. Auto steps chain automatically: after any step completes, if the next step is `auto`, the engine runs it immediately and repeats until it reaches an agent step, a human gate, or a terminal state.
 
+#### The bare `auto` step
+
+An `execution: auto` step may declare **none** of `uses_service`, `handler`, or a human `trust` gate. This is valid — not a loader error — and is an intentional pattern for a step whose role is purely structural: a place in the DAG, typically the run's last step, that requires no adapter/handler computation and no human review.
+
+**What it is.** With none of `uses_service` / `handler` / `trust` set, the engine has nothing to compute for this step: no adapter is called, no handler runs, no gate opens. It is still sequenced by `depends_on` / `trigger_rule` / `when` like any other step, and it still produces an evidence entry and moves to `completed_steps` when it settles.
+
+**What its output actually is.** Whatever value is already in flight on the underlying `execute_step` / auto-chain call becomes this step's recorded output — an empty object if it's the first thing a fresh call reaches, or, when it is auto-chained immediately after another step within the same call, **a copy of that other step's own submitted output** (one dispatcher serves an entire auto-chain hop; the engine does not solicit separate input per bare step). **Treat a bare `auto` step's own output as inconsequential — never reference it (`context.resources.<step>.*`) from a downstream step.** Its value is a byproduct of chaining, not an authored result; what matters is that the step — and with it, the run — completed.
+
+**When to use it.** A terminal "record/checkpoint" step: the last node of the DAG, whose completion is what marks the run done, not whatever data lands in its evidence. Give it a correct `depends_on` naming its real predecessor(s) so it cannot become eligible — and therefore run — before the actual work finishes.
+
+```yaml
+steps:
+  do_the_work:
+    description: Perform the real work
+    execution: agent
+    depends_on: []
+
+  finalize:
+    description: Terminal checkpoint — no output of its own
+    execution: auto
+    depends_on: [do_the_work]
+```
+
+**How it differs:**
+
+- From a **handler/adapter** step (`handler` / `uses_service` set): those have the engine compute a real, meaningful output.
+- From a **gate** (`trust: human_confirmed` / `human_reviewed`): a gate pauses the run for an explicit human decision; a bare step never pauses — it settles the instant it's reached.
+- From `execution: agent`: an agent step is surfaced in `next_actions` and requires an explicit `execute_step` call carrying agent-authored params; a bare `auto` step is never surfaced in `next_actions` and settles automatically as part of the auto-chain.
+
+This is intentional, not an authoring error.
+
 ### `execution: guard`
 
 The engine evaluates one or more boolean expressions declared in `abort_unless` against the run's current evidence. The evaluation happens inline, as part of the auto-chain — the guard is never returned to the agent as a step to execute.

--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+
+describe('migrate command — structural guard (issue #130)', () => {
+  it('T3 — no raw writeFileSync of a workflow file outside atomicWriteFile', async () => {
+    // Anti-recurrence, same class as json-file-store.ts's / registrar.ts's T3: the migrate
+    // back-fill write must route through the shared atomicWriteFile helper, not a raw sync
+    // writer — a raw writeFileSync reintroduces a torn read for a concurrent unlocked reader.
+    const src = await readFile(new URL('./migrate.ts', import.meta.url), 'utf8');
+
+    expect(src).not.toMatch(/writeFileSync\(/);
+    expect(src).not.toMatch(/\bwriteFile\(/);
+    expect(src).toContain("import { atomicWriteFile } from '@sensigo/realm';");
+
+    const atomicIdx = [...src.matchAll(/\batomicWriteFile\(/g)];
+    expect(atomicIdx).toHaveLength(1); // the one write path: the origin back-fill
+  });
+});

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,14 +1,15 @@
 // realm workflow migrate — back-fills origin: 'human' on local workflow JSON files.
 import { Command } from 'commander';
-import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { atomicWriteFile } from '@sensigo/realm';
 
 export const migrateCommand = new Command('migrate')
   .description(
     'Back-fill origin field on local workflow definitions that predate provenance tracking',
   )
-  .action(() => {
+  .action(async () => {
     const workflowsDir = join(homedir(), '.realm', 'workflows');
     if (!existsSync(workflowsDir)) {
       console.log('No local workflow store found. Nothing to migrate.');
@@ -42,7 +43,7 @@ export const migrateCommand = new Command('migrate')
       }
 
       definition.origin = 'human';
-      writeFileSync(filePath, JSON.stringify(definition, null, 2), 'utf8');
+      await atomicWriteFile(filePath, JSON.stringify(definition, null, 2));
       console.log(`Migrated: ${file}`);
       migrated++;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './types/workflow-definition.js';
 export * from './store/store-interface.js';
 export { JsonFileStore } from './store/json-file-store.js';
 export type { ReconcileSummary } from './store/json-file-store.js';
+export { atomicWriteFile } from './store/atomic-write.js';
 export { hashParams, canonicalJson } from './store/params-hash.js';
 export { decideIdempotencyPolicy } from './store/idempotency-policy.js';
 export type { IdempotencyDecision } from './store/idempotency-policy.js';

--- a/packages/core/src/store/atomic-write.ts
+++ b/packages/core/src/store/atomic-write.ts
@@ -1,0 +1,51 @@
+// Shared atomic-write primitive (issue #130 extraction — was module-private in
+// json-file-store.ts). Used by every store/registry writer that must be torn-read-safe
+// against a concurrent unlocked reader.
+import { writeFile, rename, unlink } from 'node:fs/promises';
+
+let atomicWriteCounter = 0;
+
+/**
+ * Torn-read-safe write for a JSON file (run records, key pointers, registry entries, …).
+ *
+ * POSIX (Linux/macOS): writes a unique sibling temp then rename(2)s it over the
+ * target. rename-over-existing is atomic on POSIX within one filesystem, so any
+ * concurrent unlocked reader (get/list/readPointer) sees the complete old file
+ * XOR the complete new file — never a truncated buffer. The temp is a path
+ * sibling (`${path}.<pid>.<counter>.tmp`), so it is guaranteed same-directory /
+ * same-filesystem (rename never EXDEV) and is excluded from directory listings
+ * that filter on a specific suffix (e.g. `.json`) — it ends in `.tmp`.
+ *
+ * Windows (win32): rename-over-an-open-file throws EPERM/EBUSY — exactly the
+ * concurrent-reader case this helper exists for — so on win32 we fall back to the
+ * pre-existing plain writeFile (status quo: racy but non-throwing). Real Windows
+ * atomicity is deferred to a follow-up (write-file-atomic in its own PR).
+ *
+ * fsync is intentionally omitted: the bug this fixes is a live-process page-cache
+ * truncation read, which rename fixes by construction; fsync would only add
+ * power-loss durability, a contract this store does not hold (durable tier =
+ * realm-cloud/Postgres). Add fsync(temp)+fsync(dir) here if durability ever
+ * becomes a requirement.
+ *
+ * INVARIANT: every JSON file a caller reads without holding a lock (run/pointer files in
+ * JsonFileStore, registry entries in JsonWorkflowStore, …) MUST be written through this
+ * helper. A raw writeFile of such a file reintroduces the torn read. (Enforced by
+ * structural tests in each writer's own test file.)
+ */
+export async function atomicWriteFile(path: string, data: string): Promise<void> {
+  if (process.platform === 'win32') {
+    await writeFile(path, data, 'utf8');
+    return;
+  }
+  // pid separates processes; atomicWriteCounter separates concurrent in-process
+  // writers (counter++ is atomic in the single-threaded event loop — no await
+  // between read and increment). Sufficient for uniqueness; no randomBytes.
+  const tmp = `${path}.${process.pid}.${atomicWriteCounter++}.tmp`;
+  try {
+    await writeFile(tmp, data, 'utf8');
+    await rename(tmp, path);
+  } catch (err) {
+    await unlink(tmp).catch(() => {}); // best-effort cleanup of our own temp only
+    throw err;
+  }
+}

--- a/packages/core/src/store/json-file-store.test.ts
+++ b/packages/core/src/store/json-file-store.test.ts
@@ -273,6 +273,45 @@ describe('JsonFileStore.save()', () => {
     });
   });
 
+  it('issue #131 AC#4: two concurrent save() calls on the same absent id cannot interleave to a partial/duplicate write', async () => {
+    // Two racing imports of the same run id, DIFFERING versions (a genuine divergence) — the
+    // id does not exist on disk yet, so both calls race the create-if-absent path. Without the
+    // #131 lock, both could pass existsSync() seeing "absent" and both write, silently masking
+    // the divergence (whichever write lands last wins with no error). With the lock, the two
+    // read-check-write critical sections are fully serialized: exactly one call observes "absent"
+    // and writes; the other, now serialized behind it, observes the just-written file under the
+    // SAME lock and correctly throws STATE_RUN_DIVERGED — never both succeeding, never a torn file.
+    const recordA = makeRunRecord({
+      id: 'concurrent-save-race',
+      workflow_id: 'wf-race',
+      version: 1,
+      params: { source: 'A' },
+    });
+    const recordB = makeRunRecord({
+      id: 'concurrent-save-race',
+      workflow_id: 'wf-race',
+      version: 2,
+      params: { source: 'B' },
+    });
+
+    const results = await Promise.allSettled([store.save(recordA), store.save(recordB)]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      code: 'STATE_RUN_DIVERGED',
+    });
+
+    // The on-disk file is a complete, valid record matching EXACTLY one of the two inputs —
+    // never a torn/mixed write.
+    const finalRun = await store.get('concurrent-save-race');
+    expect([1, 2]).toContain(finalRun.version);
+    const winner = finalRun.version === 1 ? recordA : recordB;
+    expect(finalRun.params).toEqual(winner.params);
+  });
+
   it('cleanup', async () => {
     await rm(dir, { recursive: true, force: true });
   });

--- a/packages/core/src/store/json-file-store.test.ts
+++ b/packages/core/src/store/json-file-store.test.ts
@@ -1030,28 +1030,35 @@ describe('JsonFileStore — atomic writes (torn-read safety)', () => {
   }, 20_000); // per-test: concurrent list() over a padded corpus legitimately exceeds the 5s default
 
   it('T3 — structural guard: no raw writeFile of a run/pointer file outside atomicWriteFile', async () => {
-    // Anti-recurrence (#123-style): every run/pointer write MUST route through atomicWriteFile.
-    // The only raw writeFile( calls allowed are the two INSIDE the helper (win32 passthrough + the
-    // temp write). A future dev adding a raw writeFile of a '.json' run/pointer file — reintroducing
-    // the torn read — makes this test fail loudly.
+    // Anti-recurrence (#123-style): every run/pointer write MUST route through the shared
+    // atomicWriteFile helper (issue #130 extracted it to atomic-write.ts, so this file now only
+    // IMPORTS it — no local definition). A future dev adding a raw writeFile of a '.json'
+    // run/pointer file — reintroducing the torn read — makes this test fail loudly.
     const src = await readFile(new URL('./json-file-store.ts', import.meta.url), 'utf8');
 
     expect(src).not.toMatch(/writeFileSync\(/); // no sync writer sneaks in either
+    expect(src).not.toMatch(/\bwriteFile\(/); // no raw async writer either — the helper moved out
+    expect(src).toContain("import { atomicWriteFile } from './atomic-write.js';");
+    expect(src).not.toContain('async function atomicWriteFile('); // no local re-definition
 
-    const helperStart = src.indexOf('async function atomicWriteFile(');
-    const classStart = src.indexOf('export class JsonFileStore');
-    expect(helperStart).toBeGreaterThan(-1);
-    expect(classStart).toBeGreaterThan(helperStart); // helper is module-scope, before the class
-
-    const writeFileIdx = [...src.matchAll(/\bwriteFile\(/g)].map((m) => m.index ?? -1);
-    expect(writeFileIdx).toHaveLength(2); // exactly two — both inside the helper
-    for (const idx of writeFileIdx) {
-      expect(idx).toBeGreaterThan(helperStart);
-      expect(idx).toBeLessThan(classStart); // → inside the helper, never in a class method
-    }
-
-    // 6 occurrences of atomicWriteFile( = 1 definition + 5 call-sites (the 5 write paths).
+    // 5 occurrences of atomicWriteFile( = the 5 write paths (writePointer, writeFreshRun,
+    // update, claimStep, save). The import statement itself has no trailing '(' so it doesn't
+    // inflate this count.
     const atomicIdx = [...src.matchAll(/\batomicWriteFile\(/g)];
-    expect(atomicIdx).toHaveLength(6);
+    expect(atomicIdx).toHaveLength(5);
+  });
+
+  it('T3b — structural guard: the atomicWriteFile primitive itself has exactly one definition and two raw writeFile( calls', async () => {
+    // Sanity-checks the shared primitive's own internal shape (win32 passthrough + the temp
+    // write) hasn't drifted since the #130 extraction.
+    const src = await readFile(new URL('./atomic-write.ts', import.meta.url), 'utf8');
+
+    expect(src).not.toMatch(/writeFileSync\(/);
+
+    const defIdx = [...src.matchAll(/export async function atomicWriteFile\(/g)];
+    expect(defIdx).toHaveLength(1);
+
+    const writeFileIdx = [...src.matchAll(/\bwriteFile\(/g)];
+    expect(writeFileIdx).toHaveLength(2); // win32 passthrough + the temp write
   });
 });

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -421,27 +421,41 @@ export class JsonFileStore implements RunStore {
   async save(record: RunRecord): Promise<void> {
     await this.ensureDir();
     const path = this.filePath(record.id);
-    if (existsSync(path)) {
-      const raw = await readFile(path, 'utf8');
-      const stored = JSON.parse(raw) as RunRecord;
-      if (stored.version === record.version) return;
-      throw new WorkflowError(
-        `Run '${record.id}' exists locally with a different version (local: ${stored.version}, incoming: ${record.version}). Manual resolution required.`,
-        {
-          code: 'STATE_RUN_DIVERGED',
-          category: 'STATE',
-          agentAction: 'report_to_user',
-          retryable: false,
-          details: {
-            runId: record.id,
-            localVersion: stored.version,
-            incomingVersion: record.version,
+
+    // #131: the read-check-write critical section now holds the same per-path lock
+    // update()/claimStep() use, closing the one run-writer that previously raced unlocked.
+    // realpath: false (like create()'s key lock) — save()'s whole point is create-if-absent,
+    // so the target file legitimately may not exist yet; the default realpath resolution
+    // would throw ENOENT locking a path with nothing there.
+    const release = await lockfile.lock(path, {
+      realpath: false,
+      retries: { retries: 3, minTimeout: 50 },
+    });
+    try {
+      if (existsSync(path)) {
+        const raw = await readFile(path, 'utf8');
+        const stored = JSON.parse(raw) as RunRecord;
+        if (stored.version === record.version) return;
+        throw new WorkflowError(
+          `Run '${record.id}' exists locally with a different version (local: ${stored.version}, incoming: ${record.version}). Manual resolution required.`,
+          {
+            code: 'STATE_RUN_DIVERGED',
+            category: 'STATE',
+            agentAction: 'report_to_user',
+            retryable: false,
+            details: {
+              runId: record.id,
+              localVersion: stored.version,
+              incomingVersion: record.version,
+            },
           },
-        },
-      );
+        );
+      }
+      // Run file FIRST (consistent with create()), then register the key pointer.
+      await atomicWriteFile(path, JSON.stringify(record, null, 2));
+    } finally {
+      await release();
     }
-    // Run file FIRST (consistent with create()), then register the key pointer.
-    await atomicWriteFile(path, JSON.stringify(record, null, 2));
     await this.registerImportedKey(record);
   }
 

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -1,6 +1,6 @@
 // Local file-backed run store. Stores each run as a JSON file in ~/.realm/runs/.
 // Uses proper-lockfile to prevent concurrent writes.
-import { mkdir, readFile, writeFile, readdir, rename, unlink } from 'node:fs/promises';
+import { mkdir, readFile, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
@@ -15,57 +15,12 @@ import { findEligibleSteps, deriveRunPhase } from '../engine/eligibility.js';
 import { computeClaimDeadline } from '../engine/claim-liveness.js';
 import { hashParams } from './params-hash.js';
 import { decideIdempotencyPolicy } from './idempotency-policy.js';
+import { atomicWriteFile } from './atomic-write.js';
 
 const DEFAULT_RUNS_DIR = join(homedir(), '.realm', 'runs');
 
 /** Bounded per-key lock retry policy — used for the resolve-or-claim critical section. */
 const KEY_LOCK_RETRIES = { retries: 10, minTimeout: 50 } as const;
-
-let atomicWriteCounter = 0;
-
-/**
- * Torn-read-safe write for JsonFileStore run and key-pointer files.
- *
- * POSIX (Linux/macOS): writes a unique sibling temp then rename(2)s it over the
- * target. rename-over-existing is atomic on POSIX within one filesystem, so any
- * concurrent unlocked reader (get/list/readPointer) sees the complete old file
- * XOR the complete new file — never a truncated buffer. The temp is a path
- * sibling (`${path}.<pid>.<counter>.tmp`), so it is guaranteed same-directory /
- * same-filesystem (rename never EXDEV) and is excluded from list()'s `.json`
- * scan (it ends in `.tmp`).
- *
- * Windows (win32): rename-over-an-open-file throws EPERM/EBUSY — exactly the
- * concurrent-reader case this store lives in — so on win32 we fall back to the
- * pre-existing plain writeFile (status quo: racy but non-throwing). Real Windows
- * atomicity is deferred to a follow-up (write-file-atomic in its own PR).
- *
- * fsync is intentionally omitted: the bug is a live-process page-cache
- * truncation read, which rename fixes by construction; fsync would only add
- * power-loss durability, a contract this store does not hold (durable tier =
- * realm-cloud/Postgres). Add fsync(temp)+fsync(dir) here if durability ever
- * becomes a requirement.
- *
- * INVARIANT: every `.json` file written into the runs/keys directories MUST go
- * through this helper. A raw writeFile of a run/pointer file reintroduces the
- * torn read in list()/get()/readPointer. (Enforced by a structural test.)
- */
-async function atomicWriteFile(path: string, data: string): Promise<void> {
-  if (process.platform === 'win32') {
-    await writeFile(path, data, 'utf8');
-    return;
-  }
-  // pid separates processes; atomicWriteCounter separates concurrent in-process
-  // writers (counter++ is atomic in the single-threaded event loop — no await
-  // between read and increment). Sufficient for uniqueness; no randomBytes.
-  const tmp = `${path}.${process.pid}.${atomicWriteCounter++}.tmp`;
-  try {
-    await writeFile(tmp, data, 'utf8');
-    await rename(tmp, path);
-  } catch (err) {
-    await unlink(tmp).catch(() => {}); // best-effort cleanup of our own temp only
-    throw err;
-  }
-}
 
 /**
  * A pointer file: the authoritative, deterministic index entry for one idempotency key.

--- a/packages/core/src/workflow/registrar.test.ts
+++ b/packages/core/src/workflow/registrar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { JsonWorkflowStore } from './registrar.js';
@@ -88,5 +88,19 @@ describe('JsonWorkflowStore', () => {
     await expect(store.get('wf-old')).rejects.toMatchObject({
       code: 'STATE_LEGACY_FORMAT',
     });
+  });
+
+  it('T3 — structural guard: no raw writeFileSync of a registry file outside atomicWriteFile (issue #130)', async () => {
+    // Anti-recurrence, same class as json-file-store.ts's T3: register() must route through the
+    // shared atomicWriteFile helper, not a raw sync writer — a raw writeFileSync reintroduces a
+    // torn read for a concurrent unlocked reader (get()/list()).
+    const src = await readFile(new URL('./registrar.ts', import.meta.url), 'utf8');
+
+    expect(src).not.toMatch(/writeFileSync\(/);
+    expect(src).not.toMatch(/\bwriteFile\(/);
+    expect(src).toContain("import { atomicWriteFile } from '../store/atomic-write.js';");
+
+    const atomicIdx = [...src.matchAll(/\batomicWriteFile\(/g)];
+    expect(atomicIdx).toHaveLength(1); // the one write path: register()
   });
 });

--- a/packages/core/src/workflow/registrar.ts
+++ b/packages/core/src/workflow/registrar.ts
@@ -1,10 +1,11 @@
 // JsonWorkflowStore — persists registered WorkflowDefinition objects to ~/.realm/workflows/.
-import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { readFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import { CURRENT_WORKFLOW_SCHEMA_VERSION } from './yaml-loader.js';
+import { atomicWriteFile } from '../store/atomic-write.js';
 
 export interface WorkflowRegistrar {
   /** Persist a WorkflowDefinition under its id, overwriting any previous registration. */
@@ -27,10 +28,9 @@ export class JsonWorkflowStore implements WorkflowRegistrar {
   }
 
   async register(definition: WorkflowDefinition): Promise<void> {
-    writeFileSync(
+    await atomicWriteFile(
       join(this.dir, `${definition.id}.json`),
       JSON.stringify(definition, null, 2),
-      'utf8',
     );
   }
 


### PR DESCRIPTION
## Context

Three contained Tier-1 backlog items, batched into one PR with focused commits (+ a CHANGELOG commit). All ride `[Unreleased]` (post-v0.16.0); no version bump.

## Motivation

Finish the store/registry write-path hardening that v0.16.0 (#132) started for the run store, and document a pattern that was nearly mis-reject-ruled:
- **#130** — the workflow **registry** (`registrar`/`migrate`) still wrote non-atomically → a concurrent reader could tear-read (same class as #132's run-store fix).
- **#131** — `JsonFileStore.save()` was the lone run-writer not holding the file-path lock (latent trap; benign today).
- **#142** — the bare `execution: auto` step is a real pattern but undocumented, which led to a nearly-shipped reject rule (#139 closed-invalid).

## Changes

Four commits.

- **`fix(core)` #130** — extract `atomicWriteFile` to a shared `store/atomic-write.ts` (exported from the core index; run-store's 5 sites byte-unchanged); `registrar.register()` and the `migrate` command now write atomically; #132's "no raw write" structural guard extended to `registrar` + a new `migrate` guard.
- **`fix(core)` #131** — `save()`'s read-check-write now runs under the same `proper-lockfile` lock as `update()`/`claimStep()` (`realpath: false`, since `save` is create-if-absent — matches `create()`'s key-lock precedent). Semantics unchanged.
- **`docs` #142** — document the bare `auto` step in `yaml-schema.md`, written to **verified engine reality**: it's a structural/terminal step whose recorded output is a byproduct of auto-chaining (a chained bare step inherits the caller's params) — so the doc teaches a real `depends_on`, says treat the output as inconsequential, and clarifies it vs handler/gate/agent. Not the flawed "driver deliberately supplies output" model.
- **`docs`** — CHANGELOG `[Unreleased] › Fixed` entries for #130 + #131.

## Verification

```bash
git checkout chore/tier1-backlog-cleanup
npm run lint && npm run build && npm run check:versions   # 0.16.0
npm audit --omit=dev --audit-level=high                    # 0 vulnerabilities
TURBO_FORCE=true npm run test                              # 8/8 tasks
```
Mutation-probes run during review (each restored): #130 → `registrar`→`writeFileSync` reddens the structural guard; #131 → lock disabled → both concurrent `save()`s fulfill (masking the version divergence). The #142 doc's engine claims were verified by value (`makeParamsDispatcher` + `executeChainInternal`'s `...options` dispatcher reuse; `start-run.ts:114` drives the first eligible auto step at creation).

## Rollback

```bash
git revert 7d8a0da ea24f6c 3ea4f8b 2178a6f
```
Code-only; the `atomicWriteFile` extraction is a pure move (behavior-identical), `save()`'s lock is additive, the doc/CHANGELOG are text. Plain revert restores prior behaviour.

## Related

Closes #130
Closes #131
Closes #142

Surfaced during this work (not fixed here): the `realm init` scaffold's `finalize` step runs at run-creation rather than last, because the vestigial `initial_state`/`allowed_from_states`/`produces_state` fields leave it without a real `depends_on` — a concrete consequence captured on #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
