### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.17.0] — 2026-07-11
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.16.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.17.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,7 +80,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.16.0';
+export const VERSION = '0.17.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.16.0';
+export const VERSION = '0.17.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.16.0',
+    version: '0.17.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.16.0';
+export const VERSION = '0.17.0';


### PR DESCRIPTION
## Context

Cuts **v0.17.0** — a minor release bundling all `[Unreleased]` work merged since v0.16.0 (2026-07-10). Minor bump because `### Added` (Gorgias `has_more`) introduces a new backwards-compatible feature.

## Motivation

`[Unreleased]` had accumulated one `Added`, one `Changed`, and four `Fixed` entries across five merged PRs; per the release policy, ship rather than let it keep growing (npm shows the prior version until a tag is pushed).

## Changes

Release mechanics only — no product code changes in this PR:

- `docs: update changelog for v0.17.0` (`c61c675`) — rename `## [Unreleased]` → `## [0.17.0] — 2026-07-11`.
- `chore: release v0.17.0` (`75aff61`, via `scripts/release.mjs`) — bump `version` in all 4 `package.json` + 5 source `VERSION` constants to 0.17.0; tag `v0.17.0` created on this commit.

Shipped content (all previously merged + reviewed):
- **Added** — `GorgiasAdapter` list results include `has_more` (#145).
- **Changed** — `GorgiasAdapter` list ops reject a non-scalar filter param (#146).
- **Fixed** — Gorgias write-redirect refusal (#147); atomic workflow-registry writes (#130); `JsonFileStore.save()` file-path lock (#131); `NotionAdapter` rate-limit/`retry_after` contract alignment (#15).

## Verification

```bash
git checkout release/v0.17.0
npm run check:versions   # all strings match at 0.17.0
npm run lint && npm run build && TURBO_FORCE=true npm run test   # lint/format/build ran clean in the release script; CI re-runs all
```
The release script ran lint + format + build clean before committing. Tag `v0.17.0` points at the release commit `75aff61` (confirmed via `git show-ref`). Post-merge, `git push --tags` triggers `publish.yml` (OIDC); artifact verified by clean-install `import { VERSION }` = 0.17.0.

## Rollback

Release PR — if verification reveals a broken artifact after publish, cut a patch (v0.17.1) following the full Part B sequence. Pre-merge, the branch can simply be closed and the local tag deleted (`git tag -d v0.17.0`) since the tag has not been pushed.

## Related

Bundles #145, #146, #147, #130, #131, #15 (all merged). Merge with a **merge commit** (not rebase/squash) — the tag is on the release commit and a rewrite would orphan it and break the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
