### PR TITLE
feat(core): when-skip observability — reason-carrying skip_details (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`when`-driven and cascade step skips are now observable (issue #111).** Runs record a `skip_details` map explaining every skipped step — a false `when` (with the expression, each leaf, and its resolved value, so a field-name typo that silently resolved to `undefined` is now visible), an unsatisfiable `trigger_rule` (the rule + the blocking deps), or a handler/guard abort. Surfaced via `get_run_state` and `realm inspect`. Additive and back-compatible: `skipped_steps` is unchanged, legacy runs read fine, and a false `when` still completes the run (observability, not a new failure).
+
 ## [0.17.0] — 2026-07-11
 
 ### Added

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -638,3 +638,58 @@ describe('--check-drift manifest hash (v0.14 hardening)', () => {
     }
   });
 });
+
+describe('inspectRun — skip_details surfacing (issue #111)', () => {
+  it('renders a when_false reason inline for a skipped step', async () => {
+    const run = makeRun([], {
+      skipped_steps: ['route_billing'],
+      skip_details: {
+        route_billing: {
+          kind: 'when_false',
+          expression: 'classify.category == billing',
+          leaves: [
+            {
+              leaf: 'classify.category == billing',
+              lhs_present: true,
+              resolved_value: 'bug',
+              passed: false,
+            },
+          ],
+        },
+      },
+    });
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Skipped: route_billing');
+    expect(result).toContain(
+      'route_billing: when_false: classify.category == billing [lhs → "bug"]',
+    );
+  });
+
+  it('renders a trigger_rule_unsatisfiable reason inline for a skipped step', async () => {
+    const run = makeRun([], {
+      skipped_steps: ['b'],
+      skip_details: {
+        b: {
+          kind: 'trigger_rule_unsatisfiable',
+          rule: 'all_success',
+          blocking_deps: [{ dep: 'a', state: 'failed' }],
+        },
+      },
+    });
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('b: trigger_rule_unsatisfiable: all_success, dep a failed');
+  });
+
+  it('renders "skipped (reason unavailable)" for a skipped step with no detail (legacy run)', async () => {
+    const run = makeRun([], { skipped_steps: ['legacy_step'] }); // no skip_details at all
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('legacy_step: skipped (reason unavailable)');
+  });
+
+  it('renders nothing extra when there are no skipped steps', async () => {
+    const run = makeRun([]);
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Skipped: (none)');
+    expect(result).not.toContain('reason unavailable');
+  });
+});

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -13,8 +13,37 @@ import type {
   EvidenceSnapshot,
   StepDiagnostics,
   ExtensionIdentityEntry,
+  SkipDetail,
 } from '@sensigo/realm';
 import { recomputeIdentity } from '../extensions/extension-identity.js';
+
+/**
+ * Renders one skipped step's reason inline (issue #111) — kind plus the salient detail.
+ * A step lacking a detail (legacy run, or a skip family not yet carrying one) is the caller's
+ * responsibility to fall back on; `skipped_steps` stays authoritative regardless.
+ */
+function formatSkipDetail(detail: SkipDetail): string {
+  switch (detail.kind) {
+    case 'when_false': {
+      const falsy = detail.leaves.find((l) => !l.passed);
+      const valueDisplay =
+        falsy === undefined || !falsy.lhs_present
+          ? 'undefined'
+          : JSON.stringify(falsy.resolved_value);
+      const leafTag = detail.leaves.length > 1 && falsy !== undefined ? ` '${falsy.leaf}'` : '';
+      return `when_false: ${detail.expression} [lhs${leafTag} → ${valueDisplay}]`;
+    }
+    case 'trigger_rule_unsatisfiable': {
+      const label = detail.blocking_deps.length === 1 ? 'dep' : 'deps';
+      const depsText = detail.blocking_deps.map((b) => `${b.dep} ${b.state}`).join(', ');
+      return `trigger_rule_unsatisfiable: ${detail.rule}, ${label} ${depsText}`;
+    }
+    case 'handler_abort':
+      return 'handler_abort';
+    case 'guard_abort':
+      return 'guard_abort';
+  }
+}
 
 /**
  * Renders the run's extension-code identity history (drift evidence, issue #119) plus,
@@ -207,6 +236,12 @@ export async function inspectRun(
   lines.push(`In Progress: ${run.in_progress_steps.join(', ') || '(none)'}`);
   lines.push(`Failed: ${run.failed_steps.join(', ') || '(none)'}`);
   lines.push(`Skipped: ${run.skipped_steps.join(', ') || '(none)'}`);
+  for (const stepName of run.skipped_steps) {
+    const detail = run.skip_details?.[stepName];
+    lines.push(
+      `  ${stepName}: ${detail !== undefined ? formatSkipDetail(detail) : 'skipped (reason unavailable)'}`,
+    );
+  }
   lines.push(`Created: ${run.created_at}`);
   lines.push(`Updated: ${run.updated_at}`);
 

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -147,4 +147,38 @@ describe('resumeRun', () => {
     // The re-enabled step is now eligible (proving the run is genuinely runnable again).
     expect(findEligibleSteps(redriveWorkflow, resumed)).toContain('step-a');
   });
+
+  it('clean-slate recompute (issue #111): a stale skip_details entry does not survive resume for a step that is now re-eligible', async () => {
+    await workflowStore.register(redriveWorkflow);
+    const { run: run } = await runStore.create({
+      workflowId: 'resume-redrive-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    // step-a failed → step-b was skipped (all_success unsatisfiable) with a recorded reason →
+    // run terminal failed. This mirrors the real shape execution-loop.ts would have written.
+    await runStore.update({
+      ...run,
+      run_phase: 'failed',
+      failed_steps: ['step-a'],
+      skipped_steps: ['step-b'],
+      skip_details: {
+        'step-b': {
+          kind: 'trigger_rule_unsatisfiable',
+          rule: 'all_success',
+          blocking_deps: [{ dep: 'step-a', state: 'failed' }],
+        },
+      },
+      terminal_state: true,
+      terminal_reason: 'step-a failed',
+    });
+
+    await resumeRun(run.id, 'step-a', runStore, workflowStore);
+
+    const resumed = await runStore.get(run.id);
+    // step-b is re-eligible again — its stale detail must not survive (would otherwise violate
+    // Object.keys(skip_details) ⊆ skipped_steps AND show a misleading reason for a live step).
+    expect(resumed.skip_details?.['step-b']).toBeUndefined();
+    expect(resumed.skipped_steps).not.toContain('step-b');
+  });
 });

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -60,16 +60,25 @@ export async function resumeRun(
   // terminal_reason (destructure-and-omit to honour exactOptionalPropertyTypes), re-derive
   // skipped_steps from scratch so steps skipped only because of this failure become eligible again,
   // and reset terminal_state to false. update() recomputes run_phase → 'running'.
+  //
+  // #111 clean slate: `...rest` still carries the run's stale `skip_details` — it MUST be reset
+  // to `{}` alongside `skipped_steps: []`, or an orphaned detail would survive for a step that is
+  // now re-eligible (violating `Object.keys(skip_details) ⊆ skipped_steps` isn't the risk here —
+  // the risk is a STALE-but-still-valid-looking reason for a step that no longer has one).
+  // No handler/guard-abort detail is re-mintable by this propagateSkips-only recompute — that is
+  // fine and unreachable: resume is gated to failed/abandoned phases (RESUMABLE_PHASES), never
+  // the aborted phase a handler/guard abort produces.
   const { terminal_reason: _terminalReason, ...rest } = run;
   const failedSteps = rest.failed_steps.filter((s) => s !== stepName);
-  const skippedSteps = propagateSkips(
-    { ...rest, failed_steps: failedSteps, skipped_steps: [] as string[] },
+  const { skipped: skippedSteps, details: skipDetails } = propagateSkips(
+    { ...rest, failed_steps: failedSteps, skipped_steps: [] as string[], skip_details: {} },
     workflow,
   );
   await runStore.update({
     ...rest,
     failed_steps: failedSteps,
     skipped_steps: skippedSteps,
+    skip_details: skipDetails,
     terminal_state: false,
   });
 }

--- a/packages/core/src/adapters/adapter-utils.ts
+++ b/packages/core/src/adapters/adapter-utils.ts
@@ -1,3 +1,5 @@
+import { scrubEmail, capText } from '../utils/redaction.js';
+
 /**
  * Bounds and redacts an adapter error body before it is attached to a WorkflowError's
  * `details` (which surfaces in the user-facing envelope as error_details). Caps length and
@@ -14,8 +16,7 @@ export function redactErrorBody(body: unknown): string {
       text = String(body);
     }
   }
-  const capped = text.length > 500 ? `${text.slice(0, 500)}…[truncated]` : text;
-  return capped.replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, '[REDACTED_EMAIL]');
+  return scrubEmail(capText(text));
 }
 
 /**

--- a/packages/core/src/engine/eligibility.test.ts
+++ b/packages/core/src/engine/eligibility.test.ts
@@ -1,7 +1,7 @@
 // Unit tests for findEligibleSteps, triggerRuleSatisfied, evaluateWhenCondition,
 // and deriveRunPhase — the DAG eligibility predicates.
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtemp } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -13,6 +13,7 @@ import {
   deriveRunPhase,
   propagateSkips,
   isWorkflowComplete,
+  buildEvidenceByStep,
 } from './eligibility.js';
 import { JsonFileStore } from '../store/json-file-store.js';
 import type { WorkflowDefinition, StepDefinition } from '../types/workflow-definition.js';
@@ -597,13 +598,17 @@ describe('findEligibleSteps — skip propagation', () => {
 // ---------------------------------------------------------------------------
 
 describe('propagateSkips', () => {
+  // NOTE (issue #111): propagateSkips' return shape changed from string[] to
+  // { skipped, details } — every assertion below reads `.skipped` now. This is a stale-not-
+  // regression update to the RETURN-SHAPE ONLY; the underlying skip-computation behavior these
+  // tests pin is unchanged (confirmed: every test below still passes with the same semantics).
   it('marks a downstream all_success step as skipped when its dep fails', () => {
     const definition = makeWorkflow({
       a: { depends_on: [] },
       b: { depends_on: ['a'], trigger_rule: 'all_success' },
     });
     const run = makeRun({ failed_steps: ['a'] });
-    expect(propagateSkips(run, definition)).toContain('b');
+    expect(propagateSkips(run, definition).skipped).toContain('b');
   });
 
   it('marks a downstream none_failed step as skipped when its dep fails', () => {
@@ -612,7 +617,7 @@ describe('propagateSkips', () => {
       b: { depends_on: ['a'], trigger_rule: 'none_failed' },
     });
     const run = makeRun({ failed_steps: ['a'] });
-    expect(propagateSkips(run, definition)).toContain('b');
+    expect(propagateSkips(run, definition).skipped).toContain('b');
   });
 
   it('marks a downstream all_failed step as skipped when its dep completes', () => {
@@ -621,7 +626,7 @@ describe('propagateSkips', () => {
       b: { depends_on: ['a'], trigger_rule: 'all_failed' },
     });
     const run = makeRun({ completed_steps: ['a'] });
-    expect(propagateSkips(run, definition)).toContain('b');
+    expect(propagateSkips(run, definition).skipped).toContain('b');
   });
 
   it('marks a downstream one_failed step as skipped when all deps complete', () => {
@@ -631,7 +636,7 @@ describe('propagateSkips', () => {
       c: { depends_on: ['a', 'b'], trigger_rule: 'one_failed' },
     });
     const run = makeRun({ completed_steps: ['a', 'b'] });
-    expect(propagateSkips(run, definition)).toContain('c');
+    expect(propagateSkips(run, definition).skipped).toContain('c');
   });
 
   it('marks a downstream one_success step as skipped when all deps fail', () => {
@@ -641,7 +646,7 @@ describe('propagateSkips', () => {
       c: { depends_on: ['a', 'b'], trigger_rule: 'one_success' },
     });
     const run = makeRun({ failed_steps: ['a', 'b'] });
-    expect(propagateSkips(run, definition)).toContain('c');
+    expect(propagateSkips(run, definition).skipped).toContain('c');
   });
 
   it('does not skip an all_done step — all_done is always eventually satisfiable', () => {
@@ -650,7 +655,7 @@ describe('propagateSkips', () => {
       b: { depends_on: ['a'], trigger_rule: 'all_done' },
     });
     const run = makeRun({ failed_steps: ['a'] });
-    expect(propagateSkips(run, definition)).not.toContain('b');
+    expect(propagateSkips(run, definition).skipped).not.toContain('b');
   });
 
   it('cascades: skipping B causes C (all_success on [B]) to also be skipped', () => {
@@ -660,7 +665,7 @@ describe('propagateSkips', () => {
       c: { depends_on: ['b'], trigger_rule: 'all_success' },
     });
     const run = makeRun({ failed_steps: ['a'] });
-    const result = propagateSkips(run, definition);
+    const result = propagateSkips(run, definition).skipped;
     expect(result).toContain('b');
     expect(result).toContain('c');
   });
@@ -671,7 +676,7 @@ describe('propagateSkips', () => {
       b: { depends_on: ['a'], trigger_rule: 'all_success' },
     });
     const run = makeRun({ failed_steps: ['a'], skipped_steps: ['b'] });
-    const result = propagateSkips(run, definition);
+    const result = propagateSkips(run, definition).skipped;
     expect(result.filter((s) => s === 'b')).toHaveLength(1);
   });
 
@@ -681,7 +686,7 @@ describe('propagateSkips', () => {
       b: { depends_on: [] },
     });
     const run = makeRun({ completed_steps: ['a'], failed_steps: ['b'] });
-    const result = propagateSkips(run, definition);
+    const result = propagateSkips(run, definition).skipped;
     expect(result).not.toContain('a');
     expect(result).not.toContain('b');
   });
@@ -694,7 +699,7 @@ describe('propagateSkips', () => {
     });
     // a completed, b is still pending and might yet fail
     const run = makeRun({ completed_steps: ['a'] });
-    expect(propagateSkips(run, definition)).not.toContain('c');
+    expect(propagateSkips(run, definition).skipped).not.toContain('c');
   });
 
   it('preserves existing skipped_steps in the returned array', () => {
@@ -704,7 +709,7 @@ describe('propagateSkips', () => {
       c: { depends_on: [] },
     });
     const run = makeRun({ failed_steps: ['a'], skipped_steps: ['c'] });
-    const result = propagateSkips(run, definition);
+    const result = propagateSkips(run, definition).skipped;
     expect(result).toContain('b');
     expect(result).toContain('c');
   });
@@ -717,7 +722,7 @@ describe('propagateSkips', () => {
     });
     // a completed — one_success is already satisfiable
     const run = makeRun({ completed_steps: ['a'], failed_steps: ['b'] });
-    expect(propagateSkips(run, definition)).not.toContain('c');
+    expect(propagateSkips(run, definition).skipped).not.toContain('c');
   });
 
   it('skips a routing step when its dep completes and the when-condition is false', () => {
@@ -743,7 +748,7 @@ describe('propagateSkips', () => {
         },
       ],
     });
-    expect(propagateSkips(run, definition)).toContain('route_billing');
+    expect(propagateSkips(run, definition).skipped).toContain('route_billing');
   });
 
   it('does not skip a routing step when the when-condition is true', () => {
@@ -769,7 +774,7 @@ describe('propagateSkips', () => {
         },
       ],
     });
-    expect(propagateSkips(run, definition)).not.toContain('route_billing');
+    expect(propagateSkips(run, definition).skipped).not.toContain('route_billing');
   });
 
   it('does not skip a routing step when its dep is still in-progress', () => {
@@ -782,7 +787,7 @@ describe('propagateSkips', () => {
     });
     // classify is in-progress — deps are not settled, condition cannot be evaluated yet
     const run = makeRun({ in_progress_steps: ['classify'] });
-    expect(propagateSkips(run, definition)).not.toContain('route_billing');
+    expect(propagateSkips(run, definition).skipped).not.toContain('route_billing');
   });
 
   it('cascade: skipping a when-condition step causes its downstream all_success step to also skip', () => {
@@ -812,9 +817,425 @@ describe('propagateSkips', () => {
         },
       ],
     });
-    const result = propagateSkips(run, definition);
+    const result = propagateSkips(run, definition).skipped;
     expect(result).toContain('route_billing');
     expect(result).toContain('notify_billing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// propagateSkips — trigger_rule_unsatisfiable witness (issue #111)
+// canTriggerRuleEverBeSatisfied is module-private; its witness is exercised through
+// propagateSkips' returned `details[stepName].blocking_deps`, its only caller.
+// ---------------------------------------------------------------------------
+
+describe('propagateSkips — trigger_rule_unsatisfiable witness (issue #111)', () => {
+  it('all_success: blocking_deps names exactly the failed-or-skipped deps, not the completed one', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: [] },
+      c: { depends_on: [] },
+      d: { depends_on: ['a', 'b', 'c'], trigger_rule: 'all_success' },
+    });
+    const run = makeRun({ failed_steps: ['a'], skipped_steps: ['b'], completed_steps: ['c'] });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['d'];
+    if (detail?.kind !== 'trigger_rule_unsatisfiable')
+      throw new Error('expected trigger_rule_unsatisfiable');
+    expect(detail.rule).toBe('all_success');
+    expect(detail.blocking_deps).toEqual(
+      expect.arrayContaining([
+        { dep: 'a', state: 'failed' },
+        { dep: 'b', state: 'skipped' },
+      ]),
+    );
+    expect(detail.blocking_deps).toHaveLength(2);
+  });
+
+  it('all_failed: blocking_deps names the completed-or-skipped deps', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: [] },
+      c: { depends_on: ['a', 'b'], trigger_rule: 'all_failed' },
+    });
+    const run = makeRun({ completed_steps: ['a'], skipped_steps: ['b'] });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['c'];
+    if (detail?.kind !== 'trigger_rule_unsatisfiable')
+      throw new Error('expected trigger_rule_unsatisfiable');
+    expect(detail.rule).toBe('all_failed');
+    expect(detail.blocking_deps).toEqual(
+      expect.arrayContaining([
+        { dep: 'a', state: 'completed' },
+        { dep: 'b', state: 'skipped' },
+      ]),
+    );
+    expect(detail.blocking_deps).toHaveLength(2);
+  });
+
+  it('all_done: never unsatisfiable — no skip_details entry is ever created for it', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: ['a'], trigger_rule: 'all_done' },
+    });
+    const run = makeRun({ failed_steps: ['a'] });
+    const { details } = propagateSkips(run, definition);
+    expect(details['b']).toBeUndefined();
+  });
+
+  it('one_failed: unsatisfiable witness names ALL deps (collective exhaustion), never a subset', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: [] },
+      c: { depends_on: ['a', 'b'], trigger_rule: 'one_failed' },
+    });
+    const run = makeRun({ completed_steps: ['a'], skipped_steps: ['b'] });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['c'];
+    if (detail?.kind !== 'trigger_rule_unsatisfiable')
+      throw new Error('expected trigger_rule_unsatisfiable');
+    expect(detail.rule).toBe('one_failed');
+    expect(detail.blocking_deps).toEqual(
+      expect.arrayContaining([
+        { dep: 'a', state: 'completed' },
+        { dep: 'b', state: 'skipped' },
+      ]),
+    );
+    expect(detail.blocking_deps).toHaveLength(2); // ALL deps, not a subset
+  });
+
+  it('one_success: unsatisfiable witness names ALL deps (collective exhaustion), never a subset', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: [] },
+      c: { depends_on: ['a', 'b'], trigger_rule: 'one_success' },
+    });
+    const run = makeRun({ failed_steps: ['a'], skipped_steps: ['b'] });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['c'];
+    if (detail?.kind !== 'trigger_rule_unsatisfiable')
+      throw new Error('expected trigger_rule_unsatisfiable');
+    expect(detail.rule).toBe('one_success');
+    expect(detail.blocking_deps).toEqual(
+      expect.arrayContaining([
+        { dep: 'a', state: 'failed' },
+        { dep: 'b', state: 'skipped' },
+      ]),
+    );
+    expect(detail.blocking_deps).toHaveLength(2);
+  });
+
+  it('none_failed: blocking_deps names only the failed dep, not an unsettled one', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: [] },
+      c: { depends_on: ['a', 'b'], trigger_rule: 'none_failed' },
+    });
+    // a failed (blocks it); b is still unsettled — none_failed only cares about failures.
+    const run = makeRun({ failed_steps: ['a'] });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['c'];
+    if (detail?.kind !== 'trigger_rule_unsatisfiable')
+      throw new Error('expected trigger_rule_unsatisfiable');
+    expect(detail.rule).toBe('none_failed');
+    expect(detail.blocking_deps).toEqual([{ dep: 'a', state: 'failed' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// propagateSkips — when_false trace (issue #111)
+// traceWhenCondition is module-private; exercised through propagateSkips' returned
+// `details[stepName].leaves`, its only call site.
+// ---------------------------------------------------------------------------
+
+describe('propagateSkips — when_false trace (issue #111)', () => {
+  const classifyEvidence = (output: Record<string, unknown>) => [
+    {
+      step_id: 'classify',
+      started_at: '',
+      completed_at: '',
+      duration_ms: 0,
+      input_summary: {},
+      output_summary: output,
+      status: 'success' as const,
+      evidence_hash: 'abc',
+    },
+  ];
+
+  it('multi-leaf AND: records EVERY leaf, not just the first false one (false leaf is in the MIDDLE, proving no short-circuit)', () => {
+    const definition = makeWorkflow({
+      classify: { depends_on: [] },
+      route: {
+        depends_on: ['classify'],
+        when: [
+          'classify.category == billing',
+          'classify.priority == high', // the false leaf — NOT the last one
+          'classify.region == us',
+        ],
+      },
+    });
+    const run = makeRun({
+      completed_steps: ['classify'],
+      evidence: classifyEvidence({ category: 'billing', priority: 'low', region: 'us' }),
+    });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['route'];
+    if (detail?.kind !== 'when_false') throw new Error('expected when_false');
+    // A short-circuit-at-first-false implementation would stop after leaf[1] and never
+    // record leaf[2] — asserting length 3 (and leaf[2]'s content) is what catches that.
+    expect(detail.leaves).toHaveLength(3);
+    expect(detail.leaves[0]).toEqual({
+      leaf: 'classify.category == billing',
+      lhs_present: true,
+      resolved_value: 'billing',
+      passed: true,
+    });
+    expect(detail.leaves[1]).toEqual({
+      leaf: 'classify.priority == high',
+      lhs_present: true,
+      resolved_value: 'low',
+      passed: false,
+    });
+    expect(detail.leaves[2]).toEqual({
+      leaf: 'classify.region == us',
+      lhs_present: true,
+      resolved_value: 'us',
+      passed: true,
+    });
+  });
+
+  it('a field-name typo (path miss) records lhs_present:false with resolved_value OMITTED, not undefined', () => {
+    const definition = makeWorkflow({
+      classify: { depends_on: [] },
+      route: { depends_on: ['classify'], when: 'classify.tcuont >= 0.8' }, // typo'd field
+    });
+    const run = makeRun({
+      completed_steps: ['classify'],
+      evidence: classifyEvidence({ count: 0.9 }),
+    });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['route'];
+    if (detail?.kind !== 'when_false') throw new Error('expected when_false');
+    expect(detail.leaves).toHaveLength(1);
+    const leaf = detail.leaves[0]!;
+    expect(leaf.lhs_present).toBe(false);
+    expect(leaf.passed).toBe(false);
+    expect('resolved_value' in leaf).toBe(false);
+    // The absence must survive a JSON round-trip — this is the durable typo signal.
+    expect(JSON.parse(JSON.stringify(leaf))).not.toHaveProperty('resolved_value');
+  });
+
+  it('a present scalar LHS records lhs_present:true with the resolved value', () => {
+    const definition = makeWorkflow({
+      classify: { depends_on: [] },
+      route: { depends_on: ['classify'], when: 'classify.category == billing' },
+    });
+    const run = makeRun({
+      completed_steps: ['classify'],
+      evidence: classifyEvidence({ category: 'bug' }),
+    });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['route'];
+    if (detail?.kind !== 'when_false') throw new Error('expected when_false');
+    expect(detail.leaves[0]).toEqual({
+      leaf: 'classify.category == billing',
+      lhs_present: true,
+      resolved_value: 'bug',
+      passed: false,
+    });
+  });
+
+  it('a compound leaf reaching runtime (kind: invalid) records lhs_present:false, passed:false, no resolved_value', () => {
+    // Bypasses load-time rejection (makeWorkflow builds a raw definition, no yaml-loader pass).
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: ['a'], when: 'a.x == 1 and a.y == 2' },
+    });
+    const run = makeRun({
+      completed_steps: ['a'],
+      evidence: [
+        {
+          step_id: 'a',
+          started_at: '',
+          completed_at: '',
+          duration_ms: 0,
+          input_summary: {},
+          output_summary: { x: 1, y: 2 },
+          status: 'success',
+          evidence_hash: 'x',
+        },
+      ],
+    });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['b'];
+    if (detail?.kind !== 'when_false') throw new Error('expected when_false');
+    expect(detail.leaves[0]).toMatchObject({ lhs_present: false, passed: false });
+    expect('resolved_value' in detail.leaves[0]!).toBe(false);
+  });
+
+  it("every leaf's traced passed equals evaluateWhenCondition's own verdict for the same leaf", () => {
+    const definition = makeWorkflow({
+      classify: { depends_on: [] },
+      route: {
+        depends_on: ['classify'],
+        when: ['classify.category == billing', 'classify.amount > 100'],
+      },
+    });
+    const run = makeRun({
+      completed_steps: ['classify'],
+      evidence: classifyEvidence({ category: 'billing', amount: 50 }),
+    });
+    const { details } = propagateSkips(run, definition);
+    const detail = details['route'];
+    if (detail?.kind !== 'when_false') throw new Error('expected when_false');
+    const evidenceByStep = buildEvidenceByStep(run);
+    for (const leaf of detail.leaves) {
+      expect(leaf.passed).toBe(evaluateWhenCondition(leaf.leaf, evidenceByStep, run.params));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// propagateSkips — skip_details behavioral (issue #111)
+// ---------------------------------------------------------------------------
+
+describe('propagateSkips — skip_details behavioral (issue #111)', () => {
+  it('Object.keys(details) is always a subset of the returned skipped array', () => {
+    const definition = makeWorkflow({
+      classify: { depends_on: [] },
+      a: { depends_on: [] },
+      b: { depends_on: ['a'], trigger_rule: 'all_success' },
+      route: { depends_on: ['classify'], when: 'classify.category == billing' },
+    });
+    const run = makeRun({
+      failed_steps: ['a'],
+      completed_steps: ['classify'],
+      evidence: [
+        {
+          step_id: 'classify',
+          started_at: '',
+          completed_at: '',
+          duration_ms: 0,
+          input_summary: {},
+          output_summary: { category: 'bug' },
+          status: 'success',
+          evidence_hash: 'abc',
+        },
+      ],
+    });
+    const { skipped, details } = propagateSkips(run, definition);
+    for (const key of Object.keys(details)) {
+      expect(skipped).toContain(key);
+    }
+  });
+
+  it('carries forward run.skip_details across successive calls (does not drop prior detail)', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: ['a'], trigger_rule: 'all_success' },
+      c: { depends_on: [] },
+      d: { depends_on: ['c'], trigger_rule: 'all_success' },
+    });
+    const run1 = makeRun({ failed_steps: ['a'] });
+    const first = propagateSkips(run1, definition);
+    expect(first.details['b']?.kind).toBe('trigger_rule_unsatisfiable');
+
+    // A second call, seeded with the FIRST call's skipped_steps/skip_details (mirroring how a
+    // caller persists-then-recomputes), now also failing c.
+    const run2 = makeRun({
+      failed_steps: ['a', 'c'],
+      skipped_steps: first.skipped,
+      skip_details: first.details,
+    });
+    const second = propagateSkips(run2, definition);
+    expect(second.details['b']).toEqual(first.details['b']); // carried forward, unchanged
+    expect(second.details['d']?.kind).toBe('trigger_rule_unsatisfiable'); // newly added
+  });
+
+  it('produces a trigger_rule_unsatisfiable detail with the documented shape', () => {
+    const definition = makeWorkflow({
+      a: { depends_on: [] },
+      b: { depends_on: ['a'], trigger_rule: 'all_success' },
+    });
+    const run = makeRun({ failed_steps: ['a'] });
+    const { details } = propagateSkips(run, definition);
+    expect(details['b']).toEqual({
+      kind: 'trigger_rule_unsatisfiable',
+      rule: 'all_success',
+      blocking_deps: [{ dep: 'a', state: 'failed' }],
+    });
+  });
+
+  it('produces a when_false detail with the documented shape', () => {
+    const definition = makeWorkflow({
+      classify: { depends_on: [] },
+      route: { depends_on: ['classify'], when: 'classify.category == billing' },
+    });
+    const run = makeRun({
+      completed_steps: ['classify'],
+      evidence: [
+        {
+          step_id: 'classify',
+          started_at: '',
+          completed_at: '',
+          duration_ms: 0,
+          input_summary: {},
+          output_summary: { category: 'bug' },
+          status: 'success',
+          evidence_hash: 'abc',
+        },
+      ],
+    });
+    const { details } = propagateSkips(run, definition);
+    expect(details['route']).toEqual({
+      kind: 'when_false',
+      expression: 'classify.category == billing',
+      leaves: [
+        {
+          leaf: 'classify.category == billing',
+          lhs_present: true,
+          resolved_value: 'bug',
+          passed: false,
+        },
+      ],
+    });
+  });
+
+  it('5-path completeness (1/5): a freshly-created run (no skips yet) yields empty skipped/details — no detail for a step that never skipped', () => {
+    const definition = makeWorkflow({ a: { depends_on: [] } });
+    const run = makeRun(); // default: skipped_steps: [], no skip_details key at all
+    const { skipped, details } = propagateSkips(run, definition);
+    expect(skipped).toEqual([]);
+    expect(details).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural anti-recurrence guard (issue #111, S2) — models the atomicWriteFile grep-guard
+// from #132/#130: the set of source sites that GROW a persisted skipped_steps must equal the
+// sanctioned whitelist (2 abort direct-pushes in execution-loop.ts + propagateSkips' own 2
+// branches in eligibility.ts). A new grow-site outside this whitelist reddens this test.
+// ---------------------------------------------------------------------------
+
+describe('structural guard — skipped_steps grow-sites (issue #111)', () => {
+  it('eligibility.ts: exactly 2 skipped.push( grow-sites, both inside propagateSkips', async () => {
+    const src = await readFile(new URL('./eligibility.ts', import.meta.url), 'utf8');
+    const growSites = [...src.matchAll(/\bskipped\.push\(/g)];
+    expect(growSites).toHaveLength(2);
+    // The excluded, non-grow sites must remain present (seed + scratch, never appends):
+    expect(src).toContain('const skipped = [...run.skipped_steps];');
+    expect(src).toContain('const tempRun: RunRecord = { ...run, skipped_steps: skipped };');
+  });
+
+  it('execution-loop.ts: exactly 2 skipped_steps spread-append grow-sites — the handler-abort and guard-abort direct pushes', async () => {
+    const src = await readFile(new URL('./execution-loop.ts', import.meta.url), 'utf8');
+    const growSites = [...src.matchAll(/\[\.\.\.[\w.]+\.skipped_steps,\s*[^\]]+\]/g)];
+    expect(growSites).toHaveLength(2);
+    expect(src).toContain('skipped_steps: [...pendingRun.skipped_steps, options.command],');
+    expect(src).toContain('skipped_steps: [...run.skipped_steps, stepName],');
+    // No raw .push( on a skipped_steps-shaped array anywhere in this file — every mutation goes
+    // through the sanctioned spread-append above or through propagateSkips.
+    expect(src).not.toMatch(/skipped_steps\.push\(/);
   });
 });
 
@@ -1023,7 +1444,7 @@ describe('finalizer steps — held out of the DAG', () => {
       cleanup: { execution: 'finalizer', on_outcome: 'always', handler: 'do_cleanup' },
     });
     const run = makeRun({ failed_steps: ['a'] });
-    const skipped = propagateSkips(run, workflow);
+    const skipped = propagateSkips(run, workflow).skipped;
     expect(skipped).toContain('b');
     expect(skipped).not.toContain('cleanup');
   });

--- a/packages/core/src/engine/eligibility.ts
+++ b/packages/core/src/engine/eligibility.ts
@@ -6,10 +6,11 @@ import type {
   StepDefinition,
   TriggerRule,
 } from '../types/workflow-definition.js';
-import type { RunRecord } from '../types/run-record.js';
+import type { RunRecord, SkipDetail } from '../types/run-record.js';
 import type { RunPhase } from '../types/run-record.js';
 import { resolvePath } from './render-template.js';
 import { splitComparison, type ComparisonOp } from './comparison-expr.js';
+import { boundResolvedValue } from '../utils/redaction.js';
 
 /**
  * Derives the run_phase from the run record fields.
@@ -128,6 +129,23 @@ function compareNumeric(op: ComparisonOp, lhs: unknown, rhs: unknown): boolean {
 }
 
 /**
+ * Builds the root object `when`-condition paths resolve against: step outputs directly
+ * (`"step_id.field"`), plus `run.params.field` for run start params. Extracted (issue #111) so
+ * both {@link evaluateWhenCondition} and the traced evaluator ({@link traceWhenCondition}) resolve
+ * against the exact same shape — a pure extraction, byte-identical to the previous inline object.
+ *
+ * Scoped to the when-root ONLY — do NOT reuse this for the input_map root (`execution-loop.ts`)
+ * or the template root (`render-template.ts`); those are a different nested `context.resources`
+ * shape and unifying them would corrupt path resolution.
+ */
+function buildWhenRoot(
+  evidenceByStep: Record<string, Record<string, unknown>>,
+  runParams: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...evidenceByStep, run: { params: runParams } };
+}
+
+/**
  * Evaluates a single `when`-condition LEAF against prior step evidence (per-leaf; the array-AND
  * folding lives in {@link evaluateWhen}). Splitting is quote-aware via the shared splitter, so the
  * leaf is split the same way at load and at runtime (no validate/eval divergence).
@@ -145,9 +163,7 @@ export function evaluateWhenCondition(
   evidenceByStep: Record<string, Record<string, unknown>>,
   runParams: Record<string, unknown> = {},
 ): boolean {
-  // when-condition paths are relative to step outputs: "step_id.field" resolves directly against
-  // evidenceByStep; "run.params.field" resolves against run start params.
-  const root: Record<string, unknown> = { ...evidenceByStep, run: { params: runParams } };
+  const root = buildWhenRoot(evidenceByStep, runParams);
 
   const split = splitComparison(expr);
 
@@ -207,6 +223,56 @@ export function evaluateWhen(
 ): boolean {
   const leaves = Array.isArray(clause) ? clause : [clause];
   return leaves.every((leaf) => evaluateWhenCondition(leaf, evidenceByStep, runParams));
+}
+
+/**
+ * Traced `when`-evaluator (issue #111) — used ONLY at propagateSkips' when-branch, built once at
+ * the moment a step is pushed to `skipped_steps`. Unlike {@link evaluateWhen} (which short-circuits
+ * via `.every` at the first false leaf), this iterates EVERY leaf and records its resolved LHS —
+ * the signal that catches a field-name typo (a mistyped `when` leaf resolves to `undefined` → false
+ * → the step silently skips; recording `lhs_present: false` makes that visible).
+ *
+ * Each leaf's `passed` REUSES {@link evaluateWhenCondition} — never re-implemented — so the trace
+ * can never drift from the actual verdict that caused the skip. By construction,
+ * `evaluateWhen(clause, ...) === trace.every((l) => l.passed)` for the same inputs.
+ */
+function traceWhenCondition(
+  clause: string | string[],
+  evidenceByStep: Record<string, Record<string, unknown>>,
+  runParams: Record<string, unknown>,
+): Array<{ leaf: string; lhs_present: boolean; resolved_value?: unknown; passed: boolean }> {
+  const leaves = Array.isArray(clause) ? clause : [clause];
+  const root = buildWhenRoot(evidenceByStep, runParams);
+
+  return leaves.map((leaf) => {
+    // Reuse the real evaluator for `passed` — the trace must never compute a second, divergent
+    // boolean path.
+    const passed = evaluateWhenCondition(leaf, evidenceByStep, runParams);
+
+    const split = splitComparison(leaf);
+    // A compound/malformed leaf reaching runtime (load-time validation normally rejects it):
+    // no LHS to resolve. `passed` is already false here (evaluateWhenCondition returns false for
+    // `kind: 'invalid'`), consistent with the reused-verdict rule above.
+    if (split.kind === 'invalid') {
+      return { leaf, lhs_present: false, passed };
+    }
+
+    const lhsPath = split.kind === 'path' ? split.path : split.lhsPath;
+    let value: unknown;
+    try {
+      value = resolvePath(lhsPath, root);
+    } catch {
+      return { leaf, lhs_present: false, passed };
+    }
+
+    // A path miss (commonly a field-name typo) resolves to undefined — omit resolved_value
+    // entirely (not `undefined`) so its ABSENCE is the JSON-durable typo signal.
+    if (value === undefined) {
+      return { leaf, lhs_present: false, passed };
+    }
+
+    return { leaf, lhs_present: true, resolved_value: boundResolvedValue(value), passed };
+  });
 }
 
 /**
@@ -342,55 +408,123 @@ export function isWorkflowComplete(run: RunRecord, definition: WorkflowDefinitio
   );
 }
 
+/** A dep's settled state, as witnessed by {@link canTriggerRuleEverBeSatisfied}. */
+type DepState = 'completed' | 'failed' | 'skipped';
+
+/** The result of {@link canTriggerRuleEverBeSatisfied}: a verdict plus, when unsatisfiable, a witness. */
+interface SatisfiabilityResult {
+  satisfiable: boolean;
+  /** The deps whose settled state makes the rule provably unsatisfiable. Only present when unsatisfiable. */
+  blocking_deps?: Array<{ dep: string; state: DepState }>;
+}
+
 /**
- * Returns false if a step's trigger_rule can provably never be satisfied given the
- * current settled state. Called by propagateSkips to determine which steps to skip.
+ * Returns false (plus a witness — issue #111) if a step's trigger_rule can provably never be
+ * satisfied given the current settled state. Called by propagateSkips to determine which steps
+ * to skip. Verdict and witness are computed together at the SAME membership tests, per rule arm,
+ * so they cannot drift from each other.
  *
  * "Settled" means the step is in completed_steps, failed_steps, or skipped_steps.
  * In-progress and unsettled steps are treated as potentially resolving either way.
+ *
+ * Only caller: propagateSkips.
  */
-function canTriggerRuleEverBeSatisfied(step: StepDefinition, run: RunRecord): boolean {
+function canTriggerRuleEverBeSatisfied(step: StepDefinition, run: RunRecord): SatisfiabilityResult {
   const deps = step.depends_on ?? [];
-  if (deps.length === 0) return true;
+  if (deps.length === 0) return { satisfiable: true };
 
   const rule: TriggerRule = step.trigger_rule ?? 'all_success';
 
   switch (rule) {
-    case 'all_success':
+    case 'all_success': {
       // Needs every dep to succeed — impossible if any dep already failed or is skipped.
-      return deps.every((d) => !run.failed_steps.includes(d) && !run.skipped_steps.includes(d));
+      const blocking_deps = deps
+        .filter((d) => run.failed_steps.includes(d) || run.skipped_steps.includes(d))
+        .map((d) => ({
+          dep: d,
+          state: (run.failed_steps.includes(d) ? 'failed' : 'skipped') as DepState,
+        }));
+      return blocking_deps.length === 0
+        ? { satisfiable: true }
+        : { satisfiable: false, blocking_deps };
+    }
 
-    case 'all_failed':
+    case 'all_failed': {
       // Needs every dep to fail — impossible if any dep already completed or is skipped.
-      return deps.every((d) => !run.completed_steps.includes(d) && !run.skipped_steps.includes(d));
+      const blocking_deps = deps
+        .filter((d) => run.completed_steps.includes(d) || run.skipped_steps.includes(d))
+        .map((d) => ({
+          dep: d,
+          state: (run.completed_steps.includes(d) ? 'completed' : 'skipped') as DepState,
+        }));
+      return blocking_deps.length === 0
+        ? { satisfiable: true }
+        : { satisfiable: false, blocking_deps };
+    }
 
     case 'all_done':
       // Always eventually satisfiable — all deps will settle (complete, fail, or be skipped)
       // and all_done treats skipped as settled, so this can always fire.
-      return true;
+      return { satisfiable: true };
 
-    case 'one_failed':
+    case 'one_failed': {
       // Needs at least one dep to fail — impossible if all deps are completed or skipped
       // (none can ever fail). A dep that is still unsettled might yet fail.
-      return deps.some(
+      const satisfiable = deps.some(
         (d) =>
           run.failed_steps.includes(d) || // already satisfied
           (!run.completed_steps.includes(d) && !run.skipped_steps.includes(d)), // might still fail
       );
+      if (satisfiable) return { satisfiable: true };
+      // Unsatisfiable here means EVERY dep is provably completed or skipped (none failed, none
+      // unsettled) — collective exhaustion, so the witness names ALL deps; a subset would
+      // misattribute cause.
+      return {
+        satisfiable: false,
+        blocking_deps: deps.map((d) => ({
+          dep: d,
+          state: (run.completed_steps.includes(d) ? 'completed' : 'skipped') as DepState,
+        })),
+      };
+    }
 
-    case 'one_success':
+    case 'one_success': {
       // Needs at least one dep to succeed — impossible if all deps are failed or skipped
       // (none can ever succeed). A dep that is still unsettled might yet succeed.
-      return deps.some(
+      const satisfiable = deps.some(
         (d) =>
           run.completed_steps.includes(d) || // already satisfied
           (!run.failed_steps.includes(d) && !run.skipped_steps.includes(d)), // might still succeed
       );
+      if (satisfiable) return { satisfiable: true };
+      // Unsatisfiable here means EVERY dep is provably failed or skipped — collective exhaustion,
+      // same rationale as one_failed above.
+      return {
+        satisfiable: false,
+        blocking_deps: deps.map((d) => ({
+          dep: d,
+          state: (run.failed_steps.includes(d) ? 'failed' : 'skipped') as DepState,
+        })),
+      };
+    }
 
-    case 'none_failed':
+    case 'none_failed': {
       // Needs no dep to fail — impossible if any dep already failed.
-      return deps.every((d) => !run.failed_steps.includes(d));
+      const blocking_deps = deps
+        .filter((d) => run.failed_steps.includes(d))
+        .map((d) => ({ dep: d, state: 'failed' as DepState }));
+      return blocking_deps.length === 0
+        ? { satisfiable: true }
+        : { satisfiable: false, blocking_deps };
+    }
   }
+}
+
+/** Return shape of {@link propagateSkips} — the skip set plus a reason for each newly-added entry. */
+export interface PropagateSkipsResult {
+  skipped: string[];
+  /** Reason detail per skipped step (issue #111). Carries forward `run.skip_details`; grows only. */
+  details: Record<string, SkipDetail>;
 }
 
 /**
@@ -398,11 +532,18 @@ function canTriggerRuleEverBeSatisfied(step: StepDefinition, run: RunRecord): bo
  * may have trigger_rules that can never be satisfied. This function marks those steps
  * as skipped and iterates until no new skips can be derived (fixed-point).
  *
- * Returns the updated skipped_steps array, which may be larger than run.skipped_steps.
- * Does not mutate the run record — callers apply the result before writing.
+ * Returns the updated skipped_steps array (which may be larger than run.skipped_steps) plus a
+ * `details` map explaining why each step was added (issue #111) — `details` seeds from
+ * `run.skip_details` (mirroring how `skipped` seeds from `run.skipped_steps`) and grows only for
+ * steps this call itself adds; already-settled steps are skipped via the continue above and never
+ * touch `details`. Does not mutate the run record — callers apply the result before writing.
  */
-export function propagateSkips(run: RunRecord, definition: WorkflowDefinition): string[] {
+export function propagateSkips(
+  run: RunRecord,
+  definition: WorkflowDefinition,
+): PropagateSkipsResult {
   const skipped = [...run.skipped_steps];
+  const details: Record<string, SkipDetail> = { ...run.skip_details };
   let changed = true;
 
   while (changed) {
@@ -425,8 +566,14 @@ export function propagateSkips(run: RunRecord, definition: WorkflowDefinition): 
 
       // Use the growing skipped set so cascading skips are detected in one pass.
       const tempRun: RunRecord = { ...run, skipped_steps: skipped };
-      if (!canTriggerRuleEverBeSatisfied(step, tempRun)) {
+      const satisfiability = canTriggerRuleEverBeSatisfied(step, tempRun);
+      if (!satisfiability.satisfiable) {
         skipped.push(stepName);
+        details[stepName] = {
+          kind: 'trigger_rule_unsatisfiable',
+          rule: step.trigger_rule ?? 'all_success',
+          blocking_deps: satisfiability.blocking_deps ?? [],
+        };
         changed = true;
         continue;
       }
@@ -443,11 +590,19 @@ export function propagateSkips(run: RunRecord, definition: WorkflowDefinition): 
         );
         if (allDepsSettled && !evaluateWhen(step.when, buildEvidenceByStep(run), run.params)) {
           skipped.push(stepName);
+          // Build the trace once, at the moment the step is pushed to skipped — not per
+          // fixed-point iteration.
+          const evidenceByStep = buildEvidenceByStep(run);
+          details[stepName] = {
+            kind: 'when_false',
+            expression: Array.isArray(step.when) ? step.when.join(' && ') : step.when,
+            leaves: traceWhenCondition(step.when, evidenceByStep, run.params),
+          };
           changed = true;
         }
       }
     }
   }
 
-  return skipped;
+  return { skipped, details };
 }

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -1180,6 +1180,54 @@ describe('executeStep', () => {
       expect(updatedRun.failed_steps).not.toContain('check');
     });
 
+    it('a handler abort records a handler_abort skip_details entry, plus a cascade detail for the downstream step (issue #111)', async () => {
+      const twoStepHandlerDef: WorkflowDefinition = {
+        id: 'two-step-handler-wf',
+        name: 'Two Step Handler Workflow',
+        version: 1,
+        steps: {
+          check: {
+            description: 'Guard-like check',
+            execution: 'auto',
+            depends_on: [],
+            handler: 'my_handler',
+          },
+          process: {
+            description: 'Downstream processing',
+            execution: 'agent',
+            depends_on: ['check'],
+          },
+        },
+      };
+
+      const handler: StepHandler = {
+        id: 'my_handler',
+        execute: vi.fn().mockResolvedValue({ abort: { message: 'Condition not met' } }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'my_handler', handler);
+
+      const { run: run } = await store.create({
+        workflowId: 'two-step-handler-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      await executeStep(store, twoStepHandlerDef, {
+        runId: run.id,
+        command: 'check',
+        input: {},
+        dispatcher: echoDispatcher,
+        registry,
+      });
+
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.skip_details?.['check']).toEqual({ kind: 'handler_abort' });
+      // The merge is load-bearing — the cascade detail for 'process' (skipped because its
+      // all_success dep 'check' never completed) must survive alongside 'check''s own tag.
+      expect(updatedRun.skip_details?.['process']?.kind).toBe('trigger_rule_unsatisfiable');
+    });
+
     it('abort evidence entry has status skipped and records the abort message', async () => {
       const handler: StepHandler = {
         id: 'my_handler',
@@ -3699,6 +3747,27 @@ describe('guard step execution', () => {
     expect(savedRun.skipped_steps).toContain('step_c');
   });
 
+  it('a guard abort records a guard_abort skip_details entry, plus a cascade detail for the downstream step (issue #111)', async () => {
+    const { run: run } = await store.create({
+      workflowId: 'guard-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    await executeChain(store, guardWorkflow, {
+      runId: run.id,
+      command: 'step_a',
+      input: {},
+      dispatcher: async () => ({ status: 'closed' }),
+    });
+
+    const savedRun = await store.get(run.id);
+    expect(savedRun.skip_details?.['guard_b']).toEqual({ kind: 'guard_abort' });
+    // The merge is load-bearing — the cascade detail for 'step_c' (skipped because its
+    // all_success dep 'guard_b' never completed) must survive alongside 'guard_b''s own tag.
+    expect(savedRun.skip_details?.['step_c']?.kind).toBe('trigger_rule_unsatisfiable');
+  });
+
   it('guard resolution error — run_phase becomes failed, guard in failed_steps', async () => {
     const { run: run } = await store.create({
       workflowId: 'guard-wf',
@@ -4085,6 +4154,8 @@ describe('when: run.params integration', () => {
     expect(savedRun.skipped_steps).toContain('post_action');
     expect(savedRun.terminal_state).toBe(true);
     expect(postHandler.execute).not.toHaveBeenCalled();
+    // issue #111: the regular (non-abort) complete path writes skip_details too.
+    expect(savedRun.skip_details?.['post_action']?.kind).toBe('when_false');
   });
 });
 

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -1091,9 +1091,16 @@ export async function executeStep(
           evidence: [...pendingRun.evidence, abortEvidence],
           skipped_steps: [...pendingRun.skipped_steps, options.command],
         };
+        // #111: merge is load-bearing — it preserves any cascade details propagateSkips derives
+        // for OTHER now-unreachable steps alongside this step's own handler_abort tag.
+        const handlerAbortPropagated = propagateSkips(withHandlerSkipped, definition);
         const withAllSkipped: RunRecord = {
           ...withHandlerSkipped,
-          skipped_steps: propagateSkips(withHandlerSkipped, definition),
+          skipped_steps: handlerAbortPropagated.skipped,
+          skip_details: {
+            ...handlerAbortPropagated.details,
+            [options.command]: { kind: 'handler_abort' },
+          },
         };
         const abortDraft: RunRecord = {
           ...withAllSkipped,
@@ -1343,9 +1350,11 @@ export async function executeStep(
       failed_steps: [...pendingRun.failed_steps, options.command],
     };
     // Propagate skips: mark steps whose trigger_rule can never be satisfied after this failure.
+    const failPropagated = propagateSkips(afterFail, definition);
     const withSkippedFail: RunRecord = {
       ...afterFail,
-      skipped_steps: propagateSkips(afterFail, definition),
+      skipped_steps: failPropagated.skipped,
+      skip_details: failPropagated.details,
     };
     // A run is terminal when all steps are settled OR when no step will ever become
     // eligible again (safety net for when-condition edge cases not covered by propagateSkips).
@@ -1619,9 +1628,11 @@ export async function executeStep(
   };
   // Propagate skips: completing this step may make some downstream steps permanently ineligible
   // (e.g. all_failed steps whose dep just succeeded, one_failed steps whose last unfailed dep just completed).
+  const completePropagated = propagateSkips(afterComplete, definition);
   const withSkippedComplete: RunRecord = {
     ...afterComplete,
-    skipped_steps: propagateSkips(afterComplete, definition),
+    skipped_steps: completePropagated.skipped,
+    skip_details: completePropagated.details,
   };
   // A run is terminal when all steps are settled OR when no step will ever become
   // eligible again (safety net for when-condition routing not fully covered by propagateSkips).
@@ -1817,9 +1828,11 @@ export async function submitHumanResponse(
   };
   // Propagate skips in case resolving the gate completes a dep that makes
   // some downstream trigger_rules permanently unsatisfiable.
+  const gatePropagated = propagateSkips(afterGate, definition);
   const withSkippedGate: RunRecord = {
     ...afterGate,
-    skipped_steps: propagateSkips(afterGate, definition),
+    skipped_steps: gatePropagated.skipped,
+    skip_details: gatePropagated.details,
   };
   // A run is terminal when all steps are settled OR when no step will ever become
   // eligible again (safety net for when-condition routing not fully covered by propagateSkips).
@@ -1935,9 +1948,11 @@ async function executeGuardStep(
       evidence: [...run.evidence, evidenceEntry],
       failed_steps: [...run.failed_steps, stepName],
     };
+    const resolutionErrorPropagated = propagateSkips(withFailed, definition);
     const withSkipped: RunRecord = {
       ...withFailed,
-      skipped_steps: propagateSkips(withFailed, definition),
+      skipped_steps: resolutionErrorPropagated.skipped,
+      skip_details: resolutionErrorPropagated.details,
     };
     return {
       ...withSkipped,
@@ -1961,9 +1976,11 @@ async function executeGuardStep(
       evidence: [...run.evidence, evidenceEntry],
       completed_steps: [...run.completed_steps, stepName],
     };
+    const guardPassPropagated = propagateSkips(withCompleted, definition);
     const withSkipped: RunRecord = {
       ...withCompleted,
-      skipped_steps: propagateSkips(withCompleted, definition),
+      skipped_steps: guardPassPropagated.skipped,
+      skip_details: guardPassPropagated.details,
     };
     const isComplete =
       isWorkflowComplete(withSkipped, definition) ||
@@ -1997,10 +2014,14 @@ async function executeGuardStep(
     // Guard that aborted goes into skipped_steps (not completed or failed).
     skipped_steps: [...run.skipped_steps, stepName],
   };
-  // Propagate skips for any downstream steps that can no longer fire.
+  // Propagate skips for any downstream steps that can no longer fire. The merge below is
+  // load-bearing (issue #111) — it preserves any cascade details for OTHER now-unreachable
+  // steps alongside this guard's own guard_abort tag.
+  const guardAbortPropagated = propagateSkips(withGuardSkipped, definition);
   const withAllSkipped: RunRecord = {
     ...withGuardSkipped,
-    skipped_steps: propagateSkips(withGuardSkipped, definition),
+    skipped_steps: guardAbortPropagated.skipped,
+    skip_details: { ...guardAbortPropagated.details, [stepName]: { kind: 'guard_abort' } },
   };
   return {
     ...withAllSkipped,

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -1,6 +1,7 @@
 // Types for an active or historical workflow run record stored on disk.
 import type { ToolCallRecord } from './mcp-types.js';
 import type { ExtensionIdentityEntry } from './extension-identity.js';
+import type { TriggerRule } from './workflow-definition.js';
 
 /**
  * A single trace entry submitted by the agent. Submitted as-is; the engine
@@ -209,6 +210,35 @@ export interface CapabilityBlock {
   at: string;
 }
 
+/**
+ * Reason a step landed in `skipped_steps` (issue #111), keyed by step name in
+ * {@link RunRecord.skip_details}. Additive-optional, definition-free surfacing metadata —
+ * `skipped_steps` stays the authoritative set; this only explains *why*.
+ */
+export type SkipDetail =
+  | {
+      kind: 'when_false';
+      /** The step's `when` clause, verbatim (a single leaf or the joined array). */
+      expression: string;
+      /** Every leaf's evaluation, in declaration order — not just the first false one. */
+      leaves: Array<{
+        leaf: string;
+        /** False when the LHS path resolved to `undefined` (a miss — commonly a field-name typo). */
+        lhs_present: boolean;
+        /** Omitted (not `undefined`) when `lhs_present` is false, so absence survives a JSON round-trip. */
+        resolved_value?: unknown;
+        passed: boolean;
+      }>;
+    }
+  | {
+      kind: 'trigger_rule_unsatisfiable';
+      rule: TriggerRule;
+      /** The deps whose settled state makes the rule provably unsatisfiable. */
+      blocking_deps: Array<{ dep: string; state: 'completed' | 'failed' | 'skipped' }>;
+    }
+  | { kind: 'handler_abort' }
+  | { kind: 'guard_abort' };
+
 export interface RunRecord {
   id: string;
   workflow_id: string;
@@ -231,6 +261,15 @@ export interface RunRecord {
   failed_steps: string[];
   /** Steps whose trigger_rule can no longer be satisfied; recorded for auditability. */
   skipped_steps: string[];
+
+  /**
+   * Reason detail for each skipped step (issue #111), keyed by step name. Additive-optional
+   * (the `claims`/`capability_blocks` precedent): absent on legacy records. `skipped_steps`
+   * stays authoritative — `Object.keys(skip_details) ⊆ skipped_steps` always, but a skipped step
+   * MAY lack a detail entry (surfacing renders "reason unavailable" for those). Never gate DAG
+   * logic on this field.
+   */
+  skip_details?: Record<string, SkipDetail>;
 
   /**
    * Per-claim liveness clock (issue #101), keyed by step name. Written ATOMICALLY in

--- a/packages/core/src/utils/redaction.test.ts
+++ b/packages/core/src/utils/redaction.test.ts
@@ -1,0 +1,87 @@
+// Unit tests for the shared redaction/bounding primitives (issue #111 extraction).
+// redactErrorBody's own behavior-unchanged coverage lives in adapter-utils.test.ts — unmodified
+// by this extraction, and still green, which is the proof of byte-identical behavior.
+import { describe, it, expect } from 'vitest';
+import { scrubEmail, capText, boundResolvedValue, REDACTION_CHAR_CAP } from './redaction.js';
+
+describe('scrubEmail', () => {
+  it('replaces an email address with [REDACTED_EMAIL]', () => {
+    expect(scrubEmail('contact jane.doe@example.com for help')).toBe(
+      'contact [REDACTED_EMAIL] for help',
+    );
+  });
+
+  it('leaves a string with no email unchanged', () => {
+    expect(scrubEmail('no email here')).toBe('no email here');
+  });
+});
+
+describe('capText', () => {
+  it('leaves a short string unchanged', () => {
+    expect(capText('short')).toBe('short');
+  });
+
+  it('caps an over-limit string and appends the truncation marker', () => {
+    const long = 'x'.repeat(600);
+    expect(capText(long)).toBe(`${'x'.repeat(REDACTION_CHAR_CAP)}…[truncated]`);
+  });
+});
+
+describe('boundResolvedValue (issue #111)', () => {
+  it('passes null through verbatim', () => {
+    expect(boundResolvedValue(null)).toBeNull();
+  });
+
+  it('passes undefined through verbatim', () => {
+    expect(boundResolvedValue(undefined)).toBeUndefined();
+  });
+
+  it('passes booleans through verbatim', () => {
+    expect(boundResolvedValue(true)).toBe(true);
+    expect(boundResolvedValue(false)).toBe(false);
+  });
+
+  it('passes numbers through verbatim (including 0 and negative)', () => {
+    expect(boundResolvedValue(0)).toBe(0);
+    expect(boundResolvedValue(-5)).toBe(-5);
+    expect(boundResolvedValue(3.14)).toBe(3.14);
+  });
+
+  it('passes a short string through, scrubbed of email addresses', () => {
+    expect(boundResolvedValue('jane.doe@example.com')).toBe('[REDACTED_EMAIL]');
+    expect(boundResolvedValue('plain string')).toBe('plain string');
+  });
+
+  it('caps a long string and appends the truncation marker, scrubbed', () => {
+    const long = 'x'.repeat(600);
+    expect(boundResolvedValue(long)).toBe(`${'x'.repeat(REDACTION_CHAR_CAP)}…[truncated]`);
+  });
+
+  it('caps a long string containing an email — scrub applies to the capped text', () => {
+    const long = `jane.doe@example.com${'x'.repeat(600)}`;
+    const result = boundResolvedValue(long) as string;
+    expect(result).toContain('[REDACTED_EMAIL]');
+    expect(result).not.toContain('jane.doe@example.com');
+    expect(result.endsWith('…[truncated]')).toBe(true);
+  });
+
+  it('stringifies, caps, and scrubs an object', () => {
+    const result = boundResolvedValue({ email: 'jane.doe@example.com', ok: true }) as string;
+    expect(result).toContain('[REDACTED_EMAIL]');
+    expect(result).not.toContain('jane.doe@example.com');
+    expect(result).toContain('"ok":true');
+  });
+
+  it('stringifies and caps a large array', () => {
+    const arr = Array.from({ length: 200 }, (_, i) => i);
+    const result = boundResolvedValue(arr) as string;
+    expect(result.length).toBeLessThanOrEqual(REDACTION_CHAR_CAP + '…[truncated]'.length);
+    expect(result.endsWith('…[truncated]')).toBe(true);
+  });
+
+  it('falls back to <unserializable> for a circular object (JSON.stringify throws)', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    expect(boundResolvedValue(circular)).toBe('<unserializable>');
+  });
+});

--- a/packages/core/src/utils/redaction.ts
+++ b/packages/core/src/utils/redaction.ts
@@ -1,0 +1,48 @@
+// Shared redaction/bounding primitives (issue #111 extraction — were inline in
+// adapters/adapter-utils.ts's redactErrorBody). Neutral module: no imports from engine/ or
+// adapters/, so both can depend on it without creating an import cycle between them.
+
+/** The realistic PII an API error body or a resolved evidence value echoes back: an email address. */
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+
+/** Scrubs email addresses from `s`, replacing each with `[REDACTED_EMAIL]`. */
+export function scrubEmail(s: string): string {
+  return s.replace(EMAIL_PATTERN, '[REDACTED_EMAIL]');
+}
+
+/** Shared length cap for a redacted/bounded string, in characters (before the truncation suffix). */
+export const REDACTION_CHAR_CAP = 500;
+
+/** Caps `text` at {@link REDACTION_CHAR_CAP} characters, appending a truncation marker if cut. */
+export function capText(text: string): string {
+  return text.length > REDACTION_CHAR_CAP
+    ? `${text.slice(0, REDACTION_CHAR_CAP)}…[truncated]`
+    : text;
+}
+
+/**
+ * Bounds an arbitrary resolved value (issue #111) for durable storage in a `SkipDetail`'s
+ * `resolved_value` — type-faithful for scalars (`null`/`undefined`/`boolean`/`number` pass
+ * through verbatim, so the typo case's "absent" vs. "present but falsy" distinction survives),
+ * length-capped and email-scrubbed for strings/objects (the same bounding discipline as
+ * `redactErrorBody`, applied to an evidence value instead of an error body).
+ */
+export function boundResolvedValue(v: unknown): unknown {
+  if (v === null || v === undefined || typeof v === 'boolean' || typeof v === 'number') {
+    return v;
+  }
+  if (typeof v === 'string') {
+    return v.length <= REDACTION_CHAR_CAP
+      ? scrubEmail(v)
+      : scrubEmail(v.slice(0, REDACTION_CHAR_CAP)) + '…[truncated]';
+  }
+  let s: string;
+  try {
+    s = JSON.stringify(v) ?? String(v);
+  } catch {
+    s = '<unserializable>';
+  }
+  return scrubEmail(
+    s.length <= REDACTION_CHAR_CAP ? s : s.slice(0, REDACTION_CHAR_CAP) + '…[truncated]',
+  );
+}

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -13,6 +13,7 @@ import {
   type RunPhase,
   type NextAction,
   type ClaimState,
+  type SkipDetail,
 } from '@sensigo/realm';
 import { sseJsonStringify } from '../sse-json.js';
 
@@ -102,6 +103,12 @@ export interface RunStateSummary {
     requirement: { kind: 'handler' | 'adapter'; name: string };
     code: string;
   }>;
+  /**
+   * Reason detail for each skipped step (issue #111) — present only when non-empty. Additive:
+   * `skipped_steps` above stays the authoritative set; a skipped step may still lack an entry
+   * here (a legacy run, or a skip family not yet carrying a detail).
+   */
+  skip_details?: Record<string, SkipDetail>;
 }
 
 /**
@@ -210,6 +217,9 @@ export async function handleGetRunState(
             code: b.code,
           })),
         }
+      : {}),
+    ...(run.skip_details !== undefined && Object.keys(run.skip_details).length > 0
+      ? { skip_details: run.skip_details }
       : {}),
   };
 }

--- a/packages/mcp-server/src/tools/run-recovery.test.ts
+++ b/packages/mcp-server/src/tools/run-recovery.test.ts
@@ -327,3 +327,51 @@ describe('get_run_state — gate_waiting + fan-out wedge (issue #101 gate/fan-ou
     expect(state.stuck_claims).toBeUndefined();
   });
 });
+
+describe('get_run_state — skip_details surfacing (issue #111)', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    runStore = new JsonFileStore(await mkdtemp(join(tmpdir(), 'skip-details-run-')));
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'skip-details-wf-')));
+    await workflowStore.register(agentFirst);
+  });
+
+  it('present when non-empty — a run with a recorded skip reason surfaces skip_details', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    await runStore.update({
+      ...run,
+      skipped_steps: ['review'],
+      skip_details: { review: { kind: 'handler_abort' } },
+    });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.skip_details).toEqual({ review: { kind: 'handler_abort' } });
+  });
+
+  it('omitted when empty — a run with no skips has no skip_details key at all', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.skip_details).toBeUndefined();
+  });
+
+  it('omitted when skipped_steps is non-empty but skip_details is absent (legacy run)', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'agentflow',
+      workflowVersion: 1,
+      params: {},
+    });
+    // A legacy record: skipped_steps populated, but skip_details never written.
+    await runStore.update({ ...run, skipped_steps: ['review'] });
+    const state = await handleGetRunState({ run_id: run.id }, { runStore, workflowStore });
+    expect(state.skip_details).toBeUndefined();
+  });
+});

--- a/packages/testing/src/runner/test-runner.ts
+++ b/packages/testing/src/runner/test-runner.ts
@@ -266,7 +266,14 @@ async function runSingleFixture(
           // failed_steps. Re-derive from scratch so steps that were only skipped
           // because of this failure become eligible again on the retry.
           const tempRun = { ...rest, failed_steps: newFailedSteps, skipped_steps: [] as string[] };
-          const newSkippedSteps = propagateSkips(tempRun, definition);
+          // #111: propagateSkips' return shape changed from string[] to { skipped, details } —
+          // this caller is outside the issue #111 prompt's stated damage rails (packages/testing
+          // is not in the touch-only file list) but was found to be a real 9th call site during
+          // implementation (grep found it; the prompt's anchors counted only 8: the 7 in
+          // execution-loop.ts + resume.ts). Left as a same-behavior destructure — no skip_details
+          // handling added here, since nothing in packages/testing reads that field. Flagged in
+          // the implementation report as a discovered anchor discrepancy.
+          const { skipped: newSkippedSteps } = propagateSkips(tempRun, definition);
           await store.update({
             ...rest,
             failed_steps: newFailedSteps,


### PR DESCRIPTION
## Context

A `when:`-false step — or a field-name typo in a `when` leaf that resolves (via realm's lenient path semantics) to `undefined`→false — was silently never run, landed in `skipped_steps` (a bare `string[]`, no reason/value), and the run reported `completed` with the intended work omitted and no operator-facing trace. `when`-false, `trigger_rule`-unsatisfiable, and handler/guard-abort skips were indistinguishable. For an evidence-first engine, a skip that leaves no evidence is a core-promise failure (issue #111). Output of a full two-phase design debate (Peer ×2 → Reviewer ×3, converged with zero open findings).

## Motivation

Make every skip **observable and attributable** — durably, inspectably, and *without* violating the I/O-free-core invariant — including the resolved LHS values that surface the motivating typo. The key insight from the debate: `propagateSkips` is pure and already *returns* data every caller persists, so the reason rides that return into the record with **zero new I/O**.

## Changes

Additive, back-compatible, no migration, no version bump (rides `[Unreleased]`). One commit.

- **`run-record.ts`** — new optional `skip_details?: Record<step_id, SkipDetail>` (discriminated union: `when_false` with per-leaf `{lhs_present, resolved_value?, passed}`, `trigger_rule_unsatisfiable` with `rule` + `blocking_deps`, `handler_abort`, `guard_abort`). `skipped_steps` stays authoritative; invariant `Object.keys(skip_details) ⊆ skipped_steps`, **test-enforced (no runtime assertion)**.
- **`eligibility.ts`** — `canTriggerRuleEverBeSatisfied` now returns `{satisfiable, blocking_deps?}` with per-arm inline witnesses (no predicate/reason drift); shared `buildWhenRoot` (pure extraction) + a traced when-evaluator that iterates all leaves and reuses `evaluateWhenCondition` for `passed`; `propagateSkips` returns `{skipped, details}` (seeds from `run.skip_details`, grows only for steps it adds).
- **`utils/redaction.ts` (new)** — `boundResolvedValue` (scalars type-faithful; strings/objects capped@500 + email-scrubbed) sharing `scrubEmail`/`capText` extracted from `redactErrorBody` (behavior byte-identical). `lhs_present:false` makes a typo's `undefined` JSON-durable.
- **`execution-loop.ts`** — all 7 `propagateSkips` callers thread `{skipped, details}`; the 2 abort sites merge their `handler_abort`/`guard_abort` tag (preserving cascade details).
- **`resume.ts`** — clean-slate recompute (`skip_details: {}`) + explicit write (no orphan details on `--from`).
- **Surfacing** — `get_run_state` (present-when-non-empty) + `realm inspect` (inline reason, "reason unavailable" fallback).
- **`packages/testing/test-runner.ts`** — one-line `.skipped` destructure (a 9th `propagateSkips` caller found during implementation, outside the issue's stated file list; behavior-preserving, keeps the monorepo build compiling; flagged in the report).

`run_phase: completed` is unchanged (observability ≠ anomaly); a `when` typo stays a silent-observable skip, never a hard error.

## Verification

```bash
git checkout feat/core/when-skip-observability
npm run lint && npm run build && npm run check:versions   # 0.17.0, no bump
npm audit --omit=dev --audit-level=high                    # 0 vulnerabilities
TURBO_FORCE=true npm run test                              # 8/8 (core 1600, mcp 136, cli 580, testing 77)
```

Five mutation-probes (each reverted after): short-circuit the traced evaluator → "records EVERY leaf" reddens; record `undefined` verbatim → typo `lhs_present` test reddens; `one_failed` witness names a subset → "names ALL deps" reddens; drop a caller's `skip_details` write → shadow-mode `when_false` test reddens; add a raw `skipped_steps` grow-site → structural anti-recurrence guard reddens. The `buildWhenRoot` extraction flips no `when` verdict (99 pre-existing evaluator tests green through it).

## Rollback

```bash
git revert f01c410
```
Additive field + pure-return threading; plain revert restores prior behaviour. No data migration (legacy runs simply lack the field).

## Related

Closes #111. Out-of-scope spinoffs filed during the debate: #153 (reject `depends_on` cycles at load time — a proven silent-completion bug), #154 (retrofit `boundResolvedValue` to `precondition_trace`/`aborted_at`, depends on this). `skip_details` added to the realm-cloud Postgres round-trip backlog (evidence-priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
