### PR TITLE
fix(core): bound precondition/guard resolved values (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here.
 ### Fixed
 
 - **`depends_on` cycles are now rejected at load time (issue #153).** A transitive `depends_on` cycle (`a → b → a`, or longer) previously loaded successfully — the loader validated dependencies only one hop at a time, with no graph traversal. At runtime the cyclic steps were mutually ineligible forever, and once the acyclic steps finished, the run silently sealed `completed` with the stranded steps in no step set and zero evidence — a silent-wrong-completion bug. `realm workflow validate` (and every workflow-loading command) now fails loud with a clear error naming the participating steps, before a run is ever created. Detection-only — no runtime, eligibility, or seal behavior changed.
+- **Precondition and guard `resolved_value`s are now bounded and scrubbed like every other durable evidence value (issue #154).** `precondition_trace[].resolved_value` and guard `abort_unless` results (surfaced in `aborted_at.conditions` and a passing guard's recorded evidence) previously stored the raw comparison operand verbatim — a large or PII-bearing value landed unbounded in the durable, inspectable run record. Both now route through the same `boundResolvedValue` helper #111 introduced for the `when`-skip trace: oversized strings/objects are capped at 500 characters, emails are scrubbed to `[REDACTED_EMAIL]`, and scalars (numbers, booleans, `null`) pass through byte-unchanged. Consistency hardening only — no verdict, resolution-error, or pass/abort behavior changed.
 
 ## [0.17.0] — 2026-07-11
 

--- a/packages/core/src/engine/precondition.test.ts
+++ b/packages/core/src/engine/precondition.test.ts
@@ -9,7 +9,7 @@ import {
   evaluateAllPreconditions,
   evaluateGuardConditions,
 } from './precondition.js';
-import { executeStep } from './execution-loop.js';
+import { executeStep, executeChain } from './execution-loop.js';
 import { JsonFileStore } from '../store/json-file-store.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 
@@ -48,6 +48,27 @@ describe('checkPreconditions', () => {
     expect(result).not.toBeNull();
     expect(result!.expression).toBe('step_a.count > 0');
     expect(result!.passed).toBe(false);
+  });
+
+  // issue #154: the first-failure resolved_value (feeding the blocked-step suggestion string
+  // in execution-loop.ts) is now bounded/scrubbed too.
+  it('scrubs an email-bearing LHS in the first-failure result', () => {
+    const evidence = { step_a: { text: 'contact jane.doe@example.com' } };
+    const result = checkPreconditions(["step_a.text == 'irrelevant'"], evidence);
+    expect(result!.resolved_value).toBe('contact [REDACTED_EMAIL]');
+  });
+
+  it('caps an oversized LHS in the first-failure result', () => {
+    const long = 'x'.repeat(600);
+    const evidence = { step_a: { text: long } };
+    const result = checkPreconditions(["step_a.text == 'irrelevant'"], evidence);
+    expect(result!.resolved_value).toBe(`${'x'.repeat(500)}…[truncated]`);
+  });
+
+  it('leaves a scalar first-failure resolved_value byte-unchanged', () => {
+    const evidence = { step_a: { count: 0 } };
+    const result = checkPreconditions(['step_a.count > 5'], evidence);
+    expect(result!.resolved_value).toBe(0);
   });
 });
 
@@ -104,6 +125,55 @@ describe('executeStep blocks when precondition fails', () => {
     expect(envelope.blocked_reason?.suggestion).toContain('Precondition failed');
     expect(envelope.blocked_reason?.suggestion).toContain('step-a.result.count > 0');
   });
+
+  // issue #154: the suggestion string (execution-loop.ts, String(failed.resolved_value)) now
+  // reflects the bounded/scrubbed value end-to-end, since checkPreconditions produces it already
+  // bounded — no change needed in execution-loop.ts itself.
+  it('suggestion reflects a scrubbed email when the precondition LHS is email-bearing', async () => {
+    const preconditionDef: WorkflowDefinition = {
+      id: 'precond-email-wf',
+      name: 'Precondition Email Workflow',
+      version: 1,
+      steps: {
+        'step-a': {
+          description: 'Produces some output',
+          execution: 'auto',
+          depends_on: [],
+        },
+        'step-b': {
+          description: 'Requires step-a text to equal a literal it will not match',
+          execution: 'auto',
+          depends_on: ['step-a'],
+          preconditions: ["step-a.result.text == 'never-matches'"],
+        },
+      },
+    };
+
+    const store = new JsonFileStore(dir);
+    const { run: run } = await store.create({
+      workflowId: 'precond-email-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    await executeStep(store, preconditionDef, {
+      runId: run.id,
+      command: 'step-a',
+      input: {},
+      dispatcher: async () => ({ result: { text: 'contact jane.doe@example.com' } }),
+    });
+
+    const envelope = await executeStep(store, preconditionDef, {
+      runId: run.id,
+      command: 'step-b',
+      input: {},
+      dispatcher: async () => ({}),
+    });
+
+    expect(envelope.status).toBe('blocked');
+    expect(envelope.blocked_reason?.suggestion).toContain('[REDACTED_EMAIL]');
+    expect(envelope.blocked_reason?.suggestion).not.toContain('jane.doe@example.com');
+  });
 });
 
 describe('evaluateAllPreconditions', () => {
@@ -123,6 +193,41 @@ describe('evaluateAllPreconditions', () => {
     expect(results[0]!.passed).toBe(false);
     expect(results[1]!.expression).toBe('step_a.count >= 0');
     expect(results[1]!.passed).toBe(true);
+  });
+
+  // issue #154: precondition_trace's resolved_value is now bounded/scrubbed via
+  // boundResolvedValue — the same helper #111 introduced for the when-skip trace.
+  it('caps an oversized string LHS with the truncation marker', () => {
+    const long = 'x'.repeat(600);
+    const evidence = { step_a: { text: long } };
+    const results = evaluateAllPreconditions(["step_a.text == 'irrelevant'"], evidence);
+    expect(results[0]!.resolved_value).toBe(`${'x'.repeat(500)}…[truncated]`);
+  });
+
+  it('scrubs an email-bearing string LHS', () => {
+    const evidence = { step_a: { text: 'contact jane.doe@example.com for help' } };
+    const results = evaluateAllPreconditions(["step_a.text == 'irrelevant'"], evidence);
+    expect(results[0]!.resolved_value).toBe('contact [REDACTED_EMAIL] for help');
+  });
+
+  it('JSON-stringifies and caps an object LHS', () => {
+    const evidence = { step_a: { obj: { email: 'jane.doe@example.com', ok: true } } };
+    const results = evaluateAllPreconditions(["step_a.obj == 'irrelevant'"], evidence);
+    const value = results[0]!.resolved_value as string;
+    expect(value).toContain('[REDACTED_EMAIL]');
+    expect(value).not.toContain('jane.doe@example.com');
+    expect(value).toContain('"ok":true');
+  });
+
+  it('leaves a scalar LHS byte-unchanged (type-faithful)', () => {
+    const evidence = { step_a: { count: 5, flag: true, short: 'ok' } };
+    expect(evaluateAllPreconditions(['step_a.count > 0'], evidence)[0]!.resolved_value).toBe(5);
+    expect(evaluateAllPreconditions(['step_a.flag == true'], evidence)[0]!.resolved_value).toBe(
+      true,
+    );
+    expect(evaluateAllPreconditions(["step_a.short == 'ok'"], evidence)[0]!.resolved_value).toBe(
+      'ok',
+    );
   });
 });
 
@@ -219,5 +324,112 @@ describe('evaluateGuardConditions', () => {
     if (result.kind === 'abort') {
       expect(result.conditions[0]!.resolved_value).toBe(0);
     }
+  });
+
+  // issue #154: GuardConditionResult.resolved_value is now bounded/scrubbed at the SAME two
+  // production sites (comparison-leaf L198, bare-path L205) regardless of outcome — the abort
+  // path and the pass path both flow through evaluateGuardConditions, so bounding here covers
+  // aborted_at.conditions AND the passing guard's recorded evidence uniformly.
+  it('abort path: scrubs an email-bearing LHS on a false comparison condition', () => {
+    const evidenceByStep = { step_a: { text: 'contact jane.doe@example.com' } };
+    const result = evaluateGuardConditions(["step_a.text == 'never-matches'"], evidenceByStep);
+    expect(result.kind).toBe('abort');
+    if (result.kind === 'abort') {
+      expect(result.conditions[0]!.resolved_value).toBe('contact [REDACTED_EMAIL]');
+    }
+  });
+
+  it('abort path: caps an oversized LHS on a false comparison condition', () => {
+    const long = 'x'.repeat(600);
+    const evidenceByStep = { step_a: { text: long } };
+    const result = evaluateGuardConditions(["step_a.text == 'never-matches'"], evidenceByStep);
+    expect(result.kind).toBe('abort');
+    if (result.kind === 'abort') {
+      expect(result.conditions[0]!.resolved_value).toBe(`${'x'.repeat(500)}…[truncated]`);
+    }
+  });
+
+  it('pass path: scrubs an email-bearing LHS on a bare-path truthy condition that passes', () => {
+    const evidenceByStep = { step_a: { text: 'contact jane.doe@example.com' } };
+    const result = evaluateGuardConditions(['step_a.text'], evidenceByStep);
+    expect(result.kind).toBe('pass');
+    if (result.kind === 'pass') {
+      expect(result.conditions[0]!.resolved_value).toBe('contact [REDACTED_EMAIL]');
+    }
+  });
+
+  it('pass path: caps an oversized LHS on a passing comparison condition', () => {
+    const long = 'x'.repeat(600);
+    const evidenceByStep = { step_a: { text: long } };
+    const result = evaluateGuardConditions([`step_a.text == '${long}'`], evidenceByStep);
+    expect(result.kind).toBe('pass');
+    if (result.kind === 'pass') {
+      expect(result.conditions[0]!.resolved_value).toBe(`${'x'.repeat(500)}…[truncated]`);
+    }
+  });
+
+  it('leaves a scalar guard-condition resolved_value byte-unchanged (pass and abort)', () => {
+    const passResult = evaluateGuardConditions(['step_a.count >= 10'], { step_a: { count: 10 } });
+    expect(passResult.kind).toBe('pass');
+    if (passResult.kind === 'pass') {
+      expect(passResult.conditions[0]!.resolved_value).toBe(10);
+    }
+
+    const abortResult = evaluateGuardConditions(['step_a.count > 5'], { step_a: { count: 0 } });
+    expect(abortResult.kind).toBe('abort');
+    if (abortResult.kind === 'abort') {
+      expect(abortResult.conditions[0]!.resolved_value).toBe(0);
+    }
+  });
+});
+
+// issue #154 — full end-to-end proof: a real guard-triggered abort stores the bounded/scrubbed
+// value in the durable RunRecord's aborted_at.conditions (not just in the pure evaluator's return).
+describe('guard abort — aborted_at.conditions is bounded end-to-end (issue #154)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-guard-bound-'));
+  });
+
+  it('a guard condition with an email-bearing LHS stores the scrubbed value in aborted_at.conditions', async () => {
+    const guardDef: WorkflowDefinition = {
+      id: 'guard-bound-wf',
+      name: 'Guard Bound Workflow',
+      version: 1,
+      steps: {
+        'step-a': {
+          description: 'Agent step',
+          execution: 'agent',
+          depends_on: [],
+        },
+        'guard-b': {
+          description: 'Guard step',
+          execution: 'guard',
+          depends_on: ['step-a'],
+          abort_unless: ["step-a.text == 'never-matches'"],
+        },
+      },
+    };
+
+    const store = new JsonFileStore(dir);
+    const { run: run } = await store.create({
+      workflowId: 'guard-bound-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    await executeChain(store, guardDef, {
+      runId: run.id,
+      command: 'step-a',
+      input: {},
+      dispatcher: async () => ({ text: 'contact jane.doe@example.com' }),
+    });
+
+    const savedRun = await store.get(run.id);
+    expect(savedRun.run_phase).toBe('aborted');
+    const conditions = savedRun.aborted_at?.conditions;
+    expect(conditions).toHaveLength(1);
+    expect(conditions![0]!.resolved_value).toBe('contact [REDACTED_EMAIL]');
   });
 });

--- a/packages/core/src/engine/precondition.ts
+++ b/packages/core/src/engine/precondition.ts
@@ -1,6 +1,7 @@
 // Precondition evaluator — evaluates step precondition expressions against
 // the run's collected evidence map before allowing a step to execute.
 import { splitComparison } from './comparison-expr.js';
+import { boundResolvedValue } from '../utils/redaction.js';
 
 /**
  * Resolves a dot-separated path into a nested object.
@@ -108,7 +109,7 @@ export function checkPreconditions(
       const split = splitComparison(expression);
       const resolvedValue: unknown =
         split.kind === 'comparison' ? resolvePath(evidenceByStep, split.lhsPath) : undefined;
-      return { expression, passed: false, resolved_value: resolvedValue };
+      return { expression, passed: false, resolved_value: boundResolvedValue(resolvedValue) };
     }
   }
   return null;
@@ -128,7 +129,7 @@ export function evaluateAllPreconditions(
     const split = splitComparison(expression);
     const resolvedValue: unknown =
       split.kind === 'comparison' ? resolvePath(evidenceByStep, split.lhsPath) : undefined;
-    return { expression, passed, resolved_value: resolvedValue };
+    return { expression, passed, resolved_value: boundResolvedValue(resolvedValue) };
   });
 }
 
@@ -195,14 +196,18 @@ export function evaluateGuardConditions(
       }
 
       const passed = compare(lhsValue, op, rhsValue);
-      results.push({ condition, resolved_value: lhsValue, passed });
+      results.push({ condition, resolved_value: boundResolvedValue(lhsValue), passed });
     } else if (split.kind === 'path') {
       // Bare path — truthy/falsy check.
       const value = resolvePath(root, split.path);
       if (value === undefined) {
         return { kind: 'resolution_error', condition, unresolvable_path: split.path };
       }
-      results.push({ condition, resolved_value: value, passed: Boolean(value) });
+      results.push({
+        condition,
+        resolved_value: boundResolvedValue(value),
+        passed: Boolean(value),
+      });
     } else {
       // Compound/malformed leaf is rejected at load; if one reaches runtime, treat as unresolvable.
       return { kind: 'resolution_error', condition, unresolvable_path: condition };


### PR DESCRIPTION
## Context

#111 introduced `boundResolvedValue` (scalars type-faithful; strings/objects capped at 500 chars + email-scrubbed) for the `when`-skip `resolved_value` it records. Two pre-existing durable resolved-value surfaces predate that helper and stored their values **unbounded and unscrubbed**: `precondition_trace[].resolved_value` and guard `abort_unless` results (surfaced in `aborted_at.conditions` and a passing guard's recorded evidence).

## Root Cause

The precondition and guard evaluators recorded the raw comparison operand verbatim, so a large or PII-bearing value landed unbounded in the durable, inspectable run record — an inconsistency where the newest field (when-skip) was stricter than its own precedents.

## Changes

Consistency hardening, detection/storage-only, no version bump (rides `[Unreleased] › Fixed`). One file of production code.

- **`engine/precondition.ts`** — one added import + four `boundResolvedValue(...)` wraps at the resolved-value production sites: `checkPreconditions` (first-failure result → the blocked-step suggestion), `evaluateAllPreconditions` (→ `precondition_trace`), and the two `evaluateGuardConditions` pushes (comparison + bare-path → `GuardConditionResult`, which flows into `aborted_at.conditions` on abort and the guard's evidence on pass). Bounding at the *production* site covers both pass and abort outcomes uniformly, so `execution-loop.ts` needs no change (it forwards already-bounded conditions).

No verdict, `resolution_error`, comparison, or pass/abort logic changed; the `PreconditionResult`/`GuardConditionResult` shapes are unchanged. Scalars (numbers, booleans, `null`) pass through byte-unchanged.

## Verification

```bash
git checkout fix/core/bound-precondition-guard-resolved-values
npm run lint && npm run build && npm run check:versions   # 0.17.0, no bump
npm audit --omit=dev --audit-level=high                    # 0 vulnerabilities
TURBO_FORCE=true npm run test                              # 8/8; precondition.test.ts 32/32
```

14 new tests cover precondition_trace, the `checkPreconditions` suggestion, guard pass/abort conditions, a scalar-unchanged assertion in both surfaces, and an **end-to-end guard abort** asserting the persisted `RunRecord.aborted_at.conditions[].resolved_value` is scrubbed. Mutation-probe: reverting the guard comparison site to the raw value reddens the four affected tests (incl. the durable `aborted_at` one), restored clean. Every `resolved_value` producer in the repo is now bounded.

## Rollback

```bash
git revert d92107c
```
Purely a value-bounding wrap at four sites; plain revert restores the prior (unbounded) storage. No data/migration impact.

## Related

Closes #154. Reuses the `boundResolvedValue` helper introduced by #111; completes the durable-evidence redaction-consistency arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
