### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.18.0] — 2026-07-11
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.17.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.18.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,7 +80,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.17.0';
+export const VERSION = '0.18.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,4 +3,4 @@ export { createRealmMcpServer, createDefaultRegistry } from './server.js';
 export type { RealmMcpServerOptions } from './server.js';
 export { generateProtocol } from './protocol/generator.js';
 export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
-export const VERSION = '0.17.0';
+export const VERSION = '0.18.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.17.0',
+    version: '0.18.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.17.0';
+export const VERSION = '0.18.0';


### PR DESCRIPTION
## Context

Cuts **v0.18.0** — a minor release bundling all `[Unreleased]` work merged since v0.17.0. Minor bump because `### Added` (`skip_details` observability, #111) introduces a new backwards-compatible capability. This closes the silent-completion + observability + durable-redaction arc.

## Motivation

`[Unreleased]` held one `Added` and two `Fixed` across three merged, individually-verified PRs; ship them as one coherent release rather than let the section accumulate.

## Changes

Release mechanics only — no product code in this PR:

- `docs: update changelog for v0.18.0` (`ebce360`) — rename `## [Unreleased]` → `## [0.18.0] — 2026-07-11`.
- `chore: release v0.18.0` (`78b6fa3`, via `scripts/release.mjs`) — bump `version` in all 4 `package.json` + 5 source `VERSION` constants to 0.18.0; tag `v0.18.0` on this commit.

Shipped content (all previously merged + reviewed by value):
- **Added** — `when`-driven and cascade step skips are observable via a durable `skip_details` map (#111).
- **Fixed** — `depends_on` cycles rejected at load time (#153); precondition/guard `resolved_value`s bounded + scrubbed uniformly (#154).

## Verification

```bash
git checkout release/v0.18.0
npm run check:versions   # all strings match at 0.18.0
```
The release script ran lint + format + build clean before committing. Tag `v0.18.0` points at `78b6fa3` (confirmed via `git show-ref`). Post-merge, `git push --tags` triggers `publish.yml` (OIDC); artifact verified by clean-install `import { VERSION }` = 0.18.0 and live `npx @sensigo/realm-cli@0.18.0 --version`.

## Rollback

Release PR — if verification reveals a broken artifact after publish, cut a patch (v0.18.1) via the full Part B sequence. Pre-merge, close the branch and delete the local tag (`git tag -d v0.18.0`, unpushed).

## Related

Bundles #111, #153, #154 (all merged). Merge with a **merge commit** (not rebase/squash) — the tag is on the release commit and a rewrite would orphan it and break the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
