### PR TITLE
feat(cli): sweep orphaned atomic-write temps via realm run gc (#160, phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Orphaned atomic-write temp sweep — `realm run gc` (issue #160, Phase 1).** The shared atomic-write primitive (`atomicWriteFile`, used for run records and idempotency-key pointers) writes a unique `.tmp` sibling then renames it over the target; a process dying mid-write orphans that temp permanently — and, for a key-pointer temp (`keys/<hash>.json.<pid>.*.tmp`), it isn't runId-keyed at all, so `realm run purge` can never reach it. `realm run gc --older-than <dur> [--force]` is a new, **CLI-only**, **dry-run-by-default** sweep that reaps them: top-level `runsDir/*.tmp` plus one level into `runsDir/keys/*.tmp`. `--older-than` has **no default** (omitting it is an error) and a **1-hour floor** enforced inside the pure `sweepOrphans` function itself, so no caller can reach a delete below it. Per-candidate handling is `lstat`-typed and conservative: a symlink is never unlinked or followed; a `*.tmp` that turns out to be a directory (or other non-regular entry) is reported as a loud failure, never silently swallowed; a benign vanish (ENOENT, e.g. a concurrent sweep) is bucketed `already_gone`, never `failed`; a future mtime is skipped. Reaping a `.tmp` is unconditionally safe by construction — an interrupted `rename` on an unlinked temp only ever produces a spurious write error, never a torn target file. The report always names the residue classes `gc` deliberately does **not** reap — orphaned `.lock` dirs (deferred, issue #164) and run-less `trace-buffer-*.jsonl` WAL files (issue #163) — so their presence isn't mistaken for a bug. A documented no-op on Windows (`atomicWriteFile` never produces a temp there). `cleanup`/`purge`/`gc` are now the three hygiene verbs under `realm run`. See [docs/reference/operating-runs.md](docs/reference/operating-runs.md#garbage-collection-orphaned-atomic-write-temps).
+
 ## [0.19.0] — 2026-07-12
 
 ### Added

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -539,6 +539,31 @@ purging one destroys that path permanently.
 
 ---
 
+### `realm run gc`
+
+Sweeps orphaned atomic-write `.tmp` files — crash residue from a process that died between writing a
+temp and renaming it over the target (a run record or an idempotency-key pointer). Unlike `purge`,
+which acts by runId, `gc` cleans up files that belong to no specific run at all. See
+[Garbage collection](operating-runs.md#garbage-collection-orphaned-atomic-write-temps) for the full
+picture, including what it deliberately does NOT reap.
+
+```bash
+realm run gc --older-than 1h            # dry-run: report what WOULD be reaped
+realm run gc --older-than 1h --force    # actually delete it
+```
+
+`--older-than` is **required** (no default — omitting it is an error, not "reap everything") and has a
+**1-hour floor**: a smaller value is rejected outright, even with `--force`. Accepts the same duration
+format as `cleanup`/`purge`: `Nd` (days), `Nh` (hours), `Nm` (minutes). Dry-run by default; `--force` to
+actually delete.
+
+Reaps top-level `*.tmp` files in `runsDir` and one level into `runsDir/keys/*.tmp`. Does **not** reap
+orphaned `.lock` directories (deferred — issue #164) or run-less `trace-buffer-*.jsonl` WAL files
+(issue #163) — the report always names both so you don't mistake their presence for a bug. A no-op on
+Windows (no temp files are ever produced there).
+
+---
+
 ### `realm run attempts <run-id>`
 
 Shows failed agent-step validation attempts recorded for a run (the durable `<id>.attempts.jsonl`

--- a/docs/reference/operating-runs.md
+++ b/docs/reference/operating-runs.md
@@ -14,6 +14,7 @@ is the source of truth. Recovery is therefore about the **record**, not about ki
 | Stuck and dead        | A run is `running` with no claimed step (`in_progress_steps: []`) and no agent is coming back for it | `realm run abandon <run-id> [--reason …]` (or the `abandon_run` MCP tool), then re-run (see [Recovery loop](#recovery-loop)).                        |
 | Bulk idle             | Many old non-terminal runs left parked                                                               | `realm run cleanup --older-than 30d` — abandons idle non-terminal runs (skips `gate_waiting`).                                                       |
 | Disk cleanup          | Old terminal runs (and their artifacts) should be permanently removed                                | `realm run purge --older-than 30d [--force]` — see [Purging runs](#purging-runs-permanent-deletion). **Irreversible.**                               |
+| Crash residue         | `runsDir` has leftover `*.tmp` files from a process that died mid-write                              | `realm run gc --older-than 1h [--force]` — see [Garbage collection](#garbage-collection-orphaned-atomic-write-temps). **Irreversible.**              |
 | Fleet visibility      | "Which runs are stuck right now?"                                                                    | `realm run list --stuck` (running ∧ no claimed step, with idle age) and `get_run_state` → `next_actions_status`.                                     |
 | Awaiting a human      | A run is `gate_waiting`                                                                              | Resolve it via `submit_human_response` (the `respond` MCP tool / `realm run respond`). **Do NOT abandon a gated run** — abandon refuses it.          |
 
@@ -120,9 +121,54 @@ this version — size- or count-based retention (e.g. "keep the last N" or "cap 
 deferred fast-follow, not yet implemented. Retention is entirely operator-managed: you decide when
 and what to purge, and the command tells you exactly what it did.
 
-Purge does **not** sweep orphaned `.tmp`/`.lock` crash-residue files — a live-held lockfile could be
-corrupted by an unconditional sweep, so that cleanup has its own dedicated safety design and ships
-separately.
+Purge does **not** sweep orphaned `.tmp`/`.lock` crash-residue files — see
+[Garbage collection](#garbage-collection-orphaned-atomic-write-temps) below for the `.tmp` half
+(`realm run gc`); `.lock` reaping is a separate, deferred safety design (a live-held lockfile could be
+corrupted by an unconditional sweep) and orphaned WAL cleanup is its own separate follow-up too.
+
+---
+
+## Garbage collection (orphaned atomic-write temps)
+
+Every store write that must be torn-read-safe against a concurrent unlocked reader (run records, the
+idempotency-key pointer index) goes through a shared **atomic-write** primitive: it writes a unique
+sibling temp file (`${path}.<pid>.<counter>.tmp`) and POSIX-`rename`s it over the target. If the
+process dies between the write and the rename, that temp is orphaned — forever, since nothing
+automatically reclaims it. `realm run purge` (above) cannot help: it acts **by runId**, and a
+key-pointer temp (`keys/<hash>.json.<pid>.*.tmp`) isn't runId-keyed at all. `realm run gc` is the
+operator-invoked sweep for exactly this residue.
+
+```bash
+realm run gc --older-than 1h            # dry-run: report what WOULD be reaped
+realm run gc --older-than 1h --force    # actually delete it
+realm run gc --older-than 24h --force   # a more conservative age, for a cron-style sweep
+```
+
+Together, `cleanup` / `purge` / `gc` are the three **hygiene verbs** under `realm run`: `cleanup` marks
+idle runs abandoned, `purge` permanently deletes a terminal run's own artifacts, and `gc` reaps
+crash-residue temp files that belong to no specific run at all.
+
+**What it reaps:** `.tmp` files at the top level of `runsDir` (orphaned run-record writes) and one
+level into `runsDir/keys/` (orphaned key-pointer writes) — `keys/` is the only subdirectory any store
+ever creates there, so the sweep does not recurse further.
+
+**What it does NOT reap** (and says so in its own report, every time, so you don't mistake either for
+a bug):
+
+- Orphaned `.lock` directories — `proper-lockfile` self-heals a lock on a live path; only a lock
+  belonging to an already-purged target can linger, which is low-value enough to defer (issue #164).
+- Run-less `trace-buffer-*.jsonl` WAL files with no owning run at all — a separate follow-up (issue
+  #163).
+
+**Safety:** reaping a `.tmp` is unconditionally safe — if the sweep unlinks a temp mid-`rename`, the
+pending `rename` gets `ENOENT`, and `atomicWriteFile`'s own cleanup best-effort-unlinks its temp and
+rethrows; the **target** file is never touched (worst case is a spurious write error, never a torn
+file). On top of that, `gc` enforces a **1-hour floor** on `--older-than` — there is no default, and a
+value below the floor is rejected outright, even with `--force` — so an in-flight write's temp is
+never even a candidate. Like `purge`, `gc` is **dry-run by default**; `--force` is required to delete.
+
+**Windows note:** `atomicWriteFile` falls back to a plain `writeFile` (no temp) on `win32`, so `gc` is
+a documented no-op there — there is nothing for it to find.
 
 ---
 

--- a/packages/cli/src/commands-registry.ts
+++ b/packages/cli/src/commands-registry.ts
@@ -9,6 +9,7 @@ import { abandonCommand } from './commands/abandon.js';
 import { reclaimCommand } from './commands/reclaim.js';
 import { cleanupCommand } from './commands/cleanup.js';
 import { purgeCommand } from './commands/purge.js';
+import { gcCommand } from './commands/gc.js';
 import { reconcileCommand } from './commands/reconcile.js';
 import { attemptsCommand } from './commands/attempts.js';
 import { respondCommand } from './commands/respond.js';
@@ -49,6 +50,7 @@ export const runCommands = [
   respondCommand,
   cleanupCommand,
   purgeCommand,
+  gcCommand,
   reconcileCommand,
   attemptsCommand,
 ];

--- a/packages/cli/src/commands/gc.test.ts
+++ b/packages/cli/src/commands/gc.test.ts
@@ -1,0 +1,304 @@
+// Tests for sweepOrphans — the pure orphaned-.tmp reaper behind `realm run gc` (issue #160).
+//
+// Mirrors purge.test.ts's style: the exported LOGIC is tested directly against a real, isolated
+// tmp directory (NEVER `~/.realm/runs`) with an injected `now` and real `utimes` backdating — no
+// console/exit-code assertions (the command's thin report-formatting layer isn't unit-tested here
+// either, consistent with cleanup.ts/reclaim.ts/purge.ts). The CLI wiring itself (--help, a
+// non-destructive dry-run, the not-reaped footer) is smoke-tested against the built binary — see
+// the implementation report — mirroring how purge.ts's own `.action()` has no dedicated test file.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir, symlink, utimes, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sweepOrphans } from './gc.js';
+
+/** Matches the module-private `FLOOR_MS` in gc.ts (1 hour) — not imported (sweepOrphans is the
+ *  ONLY export; the floor is enforced inside it, per the design's "reap logic module-private"). */
+const ONE_HOUR_MS = 3_600_000;
+const FIVE_MIN_MS = 5 * 60_000; // margin, chosen in MINUTES per the WSL mtime-granularity trap
+
+async function makeTmpRunsDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'gc-test-'));
+}
+
+/** Writes a file and backdates its mtime (and atime, for good measure) by `ageMs` relative to
+ *  `now`. Uses real `utimes` — no fake timers — so the on-disk mtime genuinely reflects the age. */
+async function seedTemp(path: string, now: Date, ageMs: number, content = 'x'): Promise<void> {
+  await writeFile(path, content);
+  const backdated = new Date(now.getTime() - ageMs);
+  await utimes(path, backdated, backdated);
+}
+
+describe('sweepOrphans', () => {
+  it('boundary: a temp older than the floor by a margin (minutes) IS reaped; one younger by the same margin is NOT', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const oldEnough = join(dir, 'old-run.json.111.0.tmp');
+      const tooFresh = join(dir, 'fresh-run.json.222.0.tmp');
+      await seedTemp(oldEnough, now, ONE_HOUR_MS + FIVE_MIN_MS);
+      await seedTemp(tooFresh, now, ONE_HOUR_MS - FIVE_MIN_MS);
+
+      const result = await sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: false, now });
+
+      expect(result.reaped).toEqual([oldEnough]);
+      expect(result.failed).toEqual([]);
+      expect(result.already_gone).toEqual([]);
+      expect(existsSync(oldEnough)).toBe(false);
+      expect(existsSync(tooFresh)).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('floor-rejection: a parseable but sub-floor --older-than (59m, 1m) is rejected with the FLOOR message, not a parse error, and reaps nothing', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      // Seed a temp that would be trivially eligible if the floor didn't block the call outright.
+      const ancient = join(dir, 'ancient-run.json.1.0.tmp');
+      await seedTemp(ancient, now, 365 * 24 * ONE_HOUR_MS); // ~1 year old
+
+      const subFloorValuesMs = [59 * 60_000, 1 * 60_000]; // '59m' and '1m' — both parse fine
+      for (const olderThanMs of subFloorValuesMs) {
+        await expect(sweepOrphans(dir, { olderThanMs, dryRun: false, now })).rejects.toMatchObject({
+          message: expect.stringMatching(/at least 1h/),
+        });
+      }
+
+      // The throw happens before any filesystem access — nothing was ever examined or touched.
+      expect(existsSync(ancient)).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('floor-rejection error does NOT read like parseDuration\'s "Invalid duration" message', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      await expect(
+        sweepOrphans(dir, { olderThanMs: 60_000, dryRun: true, now: new Date() }),
+      ).rejects.toMatchObject({
+        message: expect.not.stringMatching(/Invalid duration/),
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('recurses into keys/ — a keys/<hash>.json.*.tmp is discovered and reaped (guards the top-level-only-readdir trap)', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      await mkdir(join(dir, 'keys'), { recursive: true });
+      const keyTemp = join(dir, 'keys', 'deadbeefhash.json.999.0.tmp');
+      await seedTemp(keyTemp, now, ONE_HOUR_MS + FIVE_MIN_MS);
+
+      const result = await sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: false, now });
+
+      expect(result.reaped).toEqual([keyTemp]);
+      expect(existsSync(keyTemp)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('tolerates a missing keys/ subdirectory entirely (no crash, zero candidates from it)', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      // No keys/ dir created at all.
+      const result = await sweepOrphans(dir, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: true,
+        now: new Date(),
+      });
+      expect(result).toEqual({ reaped: [], already_gone: [], failed: [] });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('tolerates a missing runsDir entirely (no crash, zero candidates)', async () => {
+    const dir = join(await makeTmpRunsDir(), 'does', 'not', 'exist');
+    const result = await sweepOrphans(dir, {
+      olderThanMs: ONE_HOUR_MS,
+      dryRun: true,
+      now: new Date(),
+    });
+    expect(result).toEqual({ reaped: [], already_gone: [], failed: [] });
+  });
+
+  it('dry-run-default: leaves every temp intact and reports it in `reaped` (the would-reap list)', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const p = join(dir, 'ancient-run.json.1.0.tmp');
+      await seedTemp(p, now, ONE_HOUR_MS + FIVE_MIN_MS, 'some run json content');
+
+      const result = await sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: true, now });
+
+      expect(result.reaped).toEqual([p]);
+      expect(result.already_gone).toEqual([]);
+      expect(result.failed).toEqual([]);
+      expect(existsSync(p)).toBe(true); // untouched
+      const info = await stat(p);
+      expect(info.size).toBeGreaterThan(0); // still fully intact and statable
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ENOENT-tolerance: a temp vanishing mid-sweep (a concurrent competing sweep) is bucketed already_gone, never failed', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const paths: string[] = [];
+      for (let i = 0; i < 12; i++) {
+        const p = join(dir, `run-${i}.json.${1000 + i}.0.tmp`);
+        await seedTemp(p, now, ONE_HOUR_MS + FIVE_MIN_MS);
+        paths.push(p);
+      }
+
+      // Race two force-mode sweeps against the SAME candidate set. Both readdir() near-
+      // simultaneously (before either has deleted anything), so both see the full set; unlink is
+      // atomic at the OS level, so for each file exactly one call's unlink succeeds and the other
+      // hits ENOENT (at lstat or unlink time) — which must land in already_gone, never failed.
+      const [r1, r2] = await Promise.all([
+        sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: false, now }),
+        sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: false, now }),
+      ]);
+
+      expect(r1.failed).toEqual([]);
+      expect(r2.failed).toEqual([]);
+
+      for (const p of paths) {
+        expect(existsSync(p)).toBe(false); // reaped by exactly one of the two racing sweeps
+      }
+
+      // every file is accounted for in at least one of the two results' reaped/already_gone
+      const accountedFor = new Set([
+        ...r1.reaped,
+        ...r1.already_gone,
+        ...r2.reaped,
+        ...r2.already_gone,
+      ]);
+      for (const p of paths) {
+        expect(accountedFor.has(p)).toBe(true);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('symlink skip: a symlinked *.tmp is never unlinked or followed, even when it would otherwise be selected', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const target = join(dir, 'real-target.txt');
+      await writeFile(target, 'do not touch me');
+      const symlinkPath = join(dir, 'sneaky-run.json.1.0.tmp');
+      await symlink(target, symlinkPath);
+
+      // Inject a `now` far in the future so a freshly-created symlink would look ancient by age
+      // math alone — proving the skip is TYPE-based (isSymbolicLink), not staleness-based.
+      const farFutureNow = new Date(Date.now() + 10 * ONE_HOUR_MS);
+
+      const result = await sweepOrphans(dir, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: false,
+        now: farFutureNow,
+      });
+
+      expect(existsSync(symlinkPath)).toBe(true);
+      expect(existsSync(target)).toBe(true);
+      expect(result.reaped).toEqual([]);
+      expect(result.already_gone).toEqual([]);
+      expect(result.failed).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('type-mismatch: a directory unexpectedly named *.tmp is bucketed failed (loud), never silently skipped or ENOENT-swallowed', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const dirPath = join(dir, 'oops-a-directory.json.1.0.tmp');
+      await mkdir(dirPath);
+      const farFutureNow = new Date(Date.now() + 10 * ONE_HOUR_MS);
+
+      const result = await sweepOrphans(dir, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: false,
+        now: farFutureNow,
+      });
+
+      expect(result.failed.map((f) => f.path)).toEqual([dirPath]);
+      expect(result.reaped).toEqual([]);
+      expect(result.already_gone).toEqual([]);
+      expect(existsSync(dirPath)).toBe(true); // never touched
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('type-mismatch is surfaced in dry-run too (not deferred until --force)', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const dirPath = join(dir, 'oops-a-directory.json.1.0.tmp');
+      await mkdir(dirPath);
+      const farFutureNow = new Date(Date.now() + 10 * ONE_HOUR_MS);
+
+      const result = await sweepOrphans(dir, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: true,
+        now: farFutureNow,
+      });
+
+      expect(result.failed.map((f) => f.path)).toEqual([dirPath]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('future-mtime: a *.tmp whose mtime is after `now` (clock skew) is skipped, never reaped', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const p = join(dir, 'from-the-future.json.1.0.tmp');
+      await writeFile(p, 'x');
+      const future = new Date(Date.now() + 10 * ONE_HOUR_MS);
+      await utimes(p, future, future);
+      const now = new Date(); // now is BEFORE the file's own mtime
+
+      const result = await sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: false, now });
+
+      expect(existsSync(p)).toBe(true);
+      expect(result.reaped).toEqual([]);
+      expect(result.already_gone).toEqual([]);
+      expect(result.failed).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores non-.tmp files entirely (a run file, a sidecar, a WAL file all survive untouched)', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const runFile = join(dir, 'some-run.json');
+      const sidecar = join(dir, 'some-run.attempts.jsonl');
+      const wal = join(dir, 'trace-buffer-some-run-c3RlcA.jsonl');
+      for (const p of [runFile, sidecar, wal]) {
+        await seedTemp(p, now, 365 * ONE_HOUR_MS); // ancient — would be selected if the glob were wrong
+      }
+
+      const result = await sweepOrphans(dir, { olderThanMs: ONE_HOUR_MS, dryRun: false, now });
+
+      expect(result).toEqual({ reaped: [], already_gone: [], failed: [] });
+      for (const p of [runFile, sidecar, wal]) {
+        expect(existsSync(p)).toBe(true);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/gc.ts
+++ b/packages/cli/src/commands/gc.ts
@@ -1,0 +1,291 @@
+// gc command — sweep orphaned atomic-write temps (issue #160, Phase 1: .tmp only).
+//
+// atomicWriteFile (packages/core/src/store/atomic-write.ts) writes a unique sibling temp
+// (`${path}.<pid>.<counter>.tmp`) then POSIX-renames it over the target. A process dying between
+// the write and the rename orphans that temp forever — it is not runId-keyed for the key-pointer
+// case (`keys/<hash>.json.<pid>.*.tmp`), so `realm run purge` (#107), which acts by runId, can
+// never reach it. Temps are invisible to `list()` (no `.json` suffix) but accumulate on disk
+// regardless. Windows never produces a temp at all (`atomicWriteFile` falls back to plain
+// `writeFile` on win32) — this sweep is a documented no-op there, not a design driver.
+//
+// Reaping a `.tmp` is unconditionally safe: if the sweep unlinks a temp mid-rename, the pending
+// `rename` gets ENOENT, `atomicWriteFile`'s own catch best-effort-unlinks its temp + rethrows — the
+// TARGET file is never touched (worst case: a spurious write error surfaces to the writer, never a
+// torn file). Combined with the 1h floor below, an in-flight write's temp (age ≪ floor) is never
+// even selected.
+//
+// Phase 1 = `.tmp` only. `.lock` reaping is deliberately split to #164 (deferred — proper-lockfile
+// self-heals a live-path lock; only a purged-target's lock lingers, which is negligible). Run-less
+// `trace-buffer-*.jsonl` WAL cleanup is #163. Neither is this command's job — see the report footer.
+import { readdir, lstat, unlink, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { WorkflowError } from '@sensigo/realm';
+import { parseDuration } from '../lib/parse-duration.js';
+
+/**
+ * Minimum `--older-than` the sweep will ever honor (1 hour) — a conservative floor for hygiene of
+ * non-urgent crash residue, and, forward-consistency-wise, the safety guard the deferred `.lock`
+ * reaping (#164) will also require; enforcing it here means #164 inherits an already-tested guard.
+ * Temps themselves are safe to reap at any age past a few seconds (see the module doc above) — this
+ * floor is conservatism, not the temp-safety mechanism. Module-private: the only way to reach a
+ * delete is through `sweepOrphans`, which checks this FIRST, before any filesystem access.
+ */
+const FLOOR_MS = 3_600_000;
+
+export interface SweepOrphansOptions {
+  /** Minimum age (ms) a `.tmp` must have to be reaped. Rejected below `FLOOR_MS` — see above. */
+  olderThanMs: number;
+  /** true (default caller behavior): report only, never unlink. */
+  dryRun: boolean;
+  /** Injected clock for deterministic age math in tests; defaults to `new Date()`. */
+  now?: Date;
+}
+
+export interface SweepOrphansResult {
+  /** Reaped (force mode) or would-be-reaped (dry-run) `.tmp` paths. */
+  reaped: string[];
+  /** A candidate vanished on its own (lstat or unlink hit ENOENT) — benign, never a failure. */
+  already_gone: string[];
+  /** A candidate lstat'd to something other than ENOENT/regular-file/symlink (e.g. a directory
+   *  unexpectedly named `*.tmp`), or a genuine unlink error (permissions, I/O). Loud on purpose —
+   *  a type mismatch is never silently swallowed, in either dry-run or force mode. */
+  failed: Array<{ path: string; error: string }>;
+}
+
+/**
+ * Every top-level `*.tmp` in `runsDir`, plus one level of recursion into `runsDir/keys/*.tmp` —
+ * `keys/` is the ONLY subdirectory any store ever creates in `runsDir` (verified: `JsonFileStore`'s
+ * `keysDir()`/`mkdir` calls are the only subdirectory creation anywhere in this codebase's
+ * `runsDir` usage). A plain `readdir(runsDir)` sees the `keys` entry itself (no `.json`/`.tmp`
+ * suffix, so it's filtered out) but NOT what's inside it — hence the explicit second `readdir`.
+ * Nothing else is recursed into; nothing else is globbed (no `*.lock` — that's #164).
+ * Tolerates a missing `runsDir` or a missing `keys/` (a fresh install, or one that never wrote a
+ * keyed run, legitimately lacks either) — a missing directory yields zero candidates, not a throw.
+ */
+async function findTempCandidates(runsDir: string): Promise<string[]> {
+  const topLevel = await readdir(runsDir).catch(() => [] as string[]);
+  const paths = topLevel.filter((f) => f.endsWith('.tmp')).map((f) => join(runsDir, f));
+
+  const keysDir = join(runsDir, 'keys');
+  const keysEntries = await readdir(keysDir).catch(() => [] as string[]);
+  paths.push(...keysEntries.filter((f) => f.endsWith('.tmp')).map((f) => join(keysDir, f)));
+
+  return paths;
+}
+
+/**
+ * Reaps orphaned atomic-write `.tmp` files older than `options.olderThanMs`. `FLOOR_MS` is
+ * checked FIRST, before any filesystem access, so no caller — CLI action, test, or future
+ * consumer — can reach a delete without crossing it.
+ *
+ * Per-candidate rule (uses `lstat`, never `readdir({ withFileTypes: true })` — on WSL/9p
+ * `Dirent.d_type` can be `DT_UNKNOWN`, which would make every type check false and the sweep
+ * reap nothing):
+ *  - `lstat` ENOENT (vanished before we could even examine it, or during the later `unlink`) →
+ *    `already_gone`, in either mode — a benign race, never a failure.
+ *  - a **symlink** → skipped silently (appears in no bucket). Never `unlink`ed, never followed.
+ *  - anything else that is **not a regular file** (a directory unexpectedly named `*.tmp`, a
+ *    socket, …) → `failed`, loud, in either mode — a type mismatch is never an ENOENT-style
+ *    silent swallow, because it signals something anomalous in `runsDir` worth surfacing even
+ *    from a dry-run.
+ *  - a **future mtime** (negative age — clock skew) → skipped silently, never reaped.
+ *  - a regular file younger than `olderThanMs` → skipped silently (almost certainly an in-flight
+ *    write's temp).
+ *  - a regular file older than `olderThanMs` → a reap candidate: in dry-run, its path lands in
+ *    `reaped` (interpreted as "would reap") without any filesystem mutation; in force mode, it is
+ *    `unlink`ed — success → `reaped`; ENOENT → `already_gone`; anything else → `failed`.
+ */
+export async function sweepOrphans(
+  runsDir: string,
+  options: SweepOrphansOptions,
+): Promise<SweepOrphansResult> {
+  if (options.olderThanMs < FLOOR_MS) {
+    throw new WorkflowError(
+      `--older-than must resolve to at least 1h (got ${options.olderThanMs}ms) — gc refuses to ` +
+        `reap crash residue younger than that, even with --force.`,
+      {
+        code: 'VALIDATION_INPUT_SCHEMA',
+        category: 'VALIDATION',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: { olderThanMs: options.olderThanMs, floorMs: FLOOR_MS },
+      },
+    );
+  }
+
+  const now = options.now ?? new Date();
+  const candidatePaths = await findTempCandidates(runsDir);
+
+  const result: SweepOrphansResult = { reaped: [], already_gone: [], failed: [] };
+  const toReap: string[] = [];
+
+  for (const path of candidatePaths) {
+    let info;
+    try {
+      info = await lstat(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        result.already_gone.push(path); // vanished between readdir and lstat
+      } else {
+        result.failed.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+      continue;
+    }
+
+    if (info.isSymbolicLink()) continue; // never unlink or follow a symlink — silent skip
+
+    if (!info.isFile()) {
+      result.failed.push({
+        path,
+        error: 'expected a regular file but found a different type (unexpected for a *.tmp name)',
+      });
+      continue;
+    }
+
+    const ageMs = now.getTime() - info.mtime.getTime();
+    if (ageMs < 0) continue; // future mtime (clock skew) — skip, never reap
+    if (ageMs <= options.olderThanMs) continue; // too fresh — most likely an in-flight write's temp
+
+    toReap.push(path);
+  }
+
+  if (options.dryRun) {
+    result.reaped = toReap;
+    return result;
+  }
+
+  for (const path of toReap) {
+    try {
+      await unlink(path);
+      result.reaped.push(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        result.already_gone.push(path); // vanished between lstat and unlink
+      } else {
+        result.failed.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Best-effort total bytes for a known list of paths — reporting-only, never gates reaping.
+ *  Called against a fresh dry-run preview, so the paths are still on disk when stat'd. */
+async function statPathBytes(paths: readonly string[]): Promise<number> {
+  let total = 0;
+  await Promise.all(
+    paths.map(async (p) => {
+      try {
+        const info = await stat(p);
+        total += info.size;
+      } catch {
+        // vanished between the preview pass and this stat — best-effort, ignore.
+      }
+    }),
+  );
+  return total;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** So an operator doesn't distrust the tool when `runsDir` still holds residue gc deliberately
+ *  does not touch — printed on every report, dry-run or force, empty or not. */
+const NOT_REAPED_FOOTER =
+  'gc does NOT reap orphaned .lock dirs (deferred — issue #164) or run-less trace-buffer-*.jsonl ' +
+  'WAL files (issue #163). Their presence in runsDir is expected and not a sign gc is broken.';
+
+/** Prints the dry-run / force report shared by both code paths. `previewBytes` always comes from
+ *  the initial (always non-destructive) preview pass — see the action below for why. */
+function printGcReport(result: SweepOrphansResult, previewBytes: number, dryRun: boolean): void {
+  const nothingToReport =
+    result.reaped.length === 0 && result.already_gone.length === 0 && result.failed.length === 0;
+
+  if (nothingToReport) {
+    console.log('No orphaned .tmp files found to reap.');
+  } else if (dryRun) {
+    console.log(
+      `${result.reaped.length} orphaned .tmp file(s) WOULD be reaped (${formatBytes(previewBytes)} to free):`,
+    );
+    for (const p of result.reaped) console.log(`  • ${p}`);
+    if (result.already_gone.length > 0) {
+      console.log(`(${result.already_gone.length} candidate(s) already vanished on their own.)`);
+    }
+  } else {
+    console.log(
+      `Reaped ${result.reaped.length} orphaned .tmp file(s) (${formatBytes(previewBytes)} freed). ` +
+        `${result.already_gone.length} already gone, ${result.failed.length} failed.`,
+    );
+  }
+
+  for (const f of result.failed) {
+    console.error(`  ✗ ${f.path}: ${f.error}`);
+  }
+  if (dryRun && !nothingToReport) {
+    console.log('\nRe-run with --force to actually delete.');
+  }
+  console.log(`\n${NOT_REAPED_FOOTER}`);
+}
+
+export const gcCommand = new Command('gc')
+  .description(
+    'Sweep orphaned atomic-write .tmp files — crash residue from a process that died mid-write (dry-run by default)',
+  )
+  .requiredOption(
+    '--older-than <duration>',
+    'Reap temps idle at least this long (minimum 1h; e.g. 1h, 6h, 30d)',
+  )
+  .option('--force', 'Actually delete (without this, gc only reports what WOULD be reaped)')
+  .action(async (opts: { olderThan: string; force?: boolean }) => {
+    let olderThanMs: number;
+    try {
+      olderThanMs = parseDuration(opts.olderThan);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+      return;
+    }
+
+    // Defense-in-depth over sweepOrphans's own floor check — reject before touching the
+    // filesystem at all, with a CLI-friendly message naming the flag the operator just typed.
+    if (olderThanMs < FLOOR_MS) {
+      console.error(
+        `--older-than must be at least 1h (got '${opts.olderThan}'). gc refuses to reap crash ` +
+          `residue younger than that, even with --force.`,
+      );
+      process.exit(1);
+      return;
+    }
+
+    const { JsonFileStore } = await import('@sensigo/realm');
+    const runsDir = new JsonFileStore().runsDirPath;
+    const now = new Date();
+
+    try {
+      // Always preview first — this NEVER mutates, in either mode — because it is the only
+      // reliable moment to `stat()` the candidates for the report's byte total: a force-mode
+      // reap deletes the files before sweepOrphans returns, so statting them afterward is
+      // impossible. The preview and the (optional) real pass share the same olderThanMs/now, so
+      // the candidate set is consistent bar a narrow, benign concurrent-activity window — which
+      // already_gone exists to absorb.
+      const preview = await sweepOrphans(runsDir, { olderThanMs, dryRun: true, now });
+      const bytes = await statPathBytes(preview.reaped);
+
+      if (opts.force !== true) {
+        printGcReport(preview, bytes, true);
+        return;
+      }
+
+      const result = await sweepOrphans(runsDir, { olderThanMs, dryRun: false, now });
+      printGcReport(result, bytes, false);
+      if (result.failed.length > 0) process.exit(1);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  });


### PR DESCRIPTION
## Context

`realm run purge` (#107) deletes a terminal run's artifacts by runId. Atomic-write **temp files** (`atomicWriteFile` writes `${path}.<pid>.<ctr>.tmp` then POSIX-`rename`s over the target) are orphaned when a process dies mid-write — and the key-pointer temp (`keys/<hash>.json.*.tmp`) is hash-keyed, never runId-catchable — so no per-run purge reaches them. They're invisible to `list()` but accumulate. This adds `realm run gc` to reap them. Output of a design debate (Peer ×2 → 93%, Reviewer ×2 → CONVERGED) that concluded the residue sweep should be **phased**.

## Motivation

Operator-managed retention needs a residue reaper. The debate established that reaping `.tmp` is **unconditionally safe** (unlinking a temp mid-`rename` only ENOENTs the pending rename — the target is never touched) and is the real accumulation, whereas `.lock` reaping is low-value (proper-lockfile self-heals live-path locks) and carries the only residual risk — so `.lock` is deferred to #164 (full design banked there).

## Changes

Phase 1, CLI-only, no version bump (`[Unreleased] › Added`).

- **`realm run gc --older-than <dur> [--force]`** — sweeps orphaned `*.tmp` (top-level + one-level `keys/` recursion). **Dry-run by default**; `--force` to delete.
- **Pure `sweepOrphans(runsDir, {olderThanMs, dryRun, now})`** with **`FLOOR_MS = 1h` enforced first** (before any fs access; no-default `--older-than`, reject `<1h` — the CLI re-checks for defense-in-depth). `lstat`-typed **files-only** reap (skip symlinks, type-mismatch→`failed` loud, ENOENT→`already_gone`, future-mtime→skip). Explicit `lstat`, not `readdir({withFileTypes})` (WSL/9p `DT_UNKNOWN` trap).
- Report `{reaped, already_gone, failed}` + bytes + a **footer naming what gc does NOT reap** (`.lock`→#164, run-less WAL→#163). Registered in `runCommands` (the `cleanup`/`purge`/`gc` hygiene trio); CLI-only, no MCP tool.
- No `core`/`mcp-server`/store change — a pure CLI filesystem sweep. Windows: `atomicWriteFile` has no temp on win32, so gc is a documented no-op there.

## Verification

```bash
git checkout feat/cli/run-gc-orphan-temps
npm run lint && npm run build && npm run check:versions   # 0.19.0, no bump
npm audit --omit=dev --audit-level=high                    # 0 vulnerabilities
TURBO_FORCE=true npm run test                              # 8/8; gc.test.ts 13/13
```

13 tests: boundary, floor-rejection (parseable `59m`/`1m` → floor message, not a parse error), `keys/` recursion, missing-dir tolerance, dry-run-default, ENOENT-tolerance (concurrent double-sweep), symlink-skip, type-mismatch→failed, future-mtime, non-`.tmp` survival. Mutation-probe: `FLOOR_MS→0` reddens floor-rejection. Built-CLI end-to-end against a scratch `runsDir` confirmed reject/floor/dry-run/force + `keys/` recursion + fresh-and-run-file survival.

## Rollback

```bash
git revert c18b9c6
```
A new CLI command + docs; nothing else references it. Plain revert removes it cleanly. No data/migration impact.

## Related

Closes #160 (Phase 1, `.tmp`). Deferred/companions: #164 (`.lock` reaping — full design banked), #163 (run-less orphaned WAL), #159 (`realm run export`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
