### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.21.0] — 2026-07-12
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.20.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.21.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,7 +81,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.20.0';
+export const VERSION = '0.21.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.20.0';
+export const VERSION = '0.21.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.20.0',
+    version: '0.21.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.20.0';
+export const VERSION = '0.21.0';


### PR DESCRIPTION
## Context

Cuts **v0.21.0** — a minor release. Minor bump: the single `[Unreleased]` entry is `### Added` (`realm run export`, #159). (`realm run gc`, #160, already shipped in v0.20.0.)

## Motivation

Ship the read-only evidence-export companion (`realm run export`) so operators can preserve a run's evidence before purging or hand it off for a bug report — npm still shows 0.20.0 until tagged.

## Changes

Release mechanics only — no product code:

- `docs: update changelog for v0.21.0` (`618dd59`) — rename `## [Unreleased]` → `## [0.21.0] — 2026-07-12`.
- `chore: release v0.21.0` (`8e4e884`, via `scripts/release.mjs`) — bump `version` in all 4 `package.json` + 5 source `VERSION` constants to 0.21.0; tag `v0.21.0` on this commit.

Shipped content (previously merged + reviewed by value):
- **Added** — `realm run export`, the read-only evidence bundle (#159, PR #167), backed by `TraceBufferStore.readAllForRun`.

## Verification

```bash
git checkout release/v0.21.0
npm run check:versions   # all strings match at 0.21.0
```
The release script ran lint + format + build clean before committing. Tag `v0.21.0` points at `8e4e884` (confirmed via `git show-ref`). Post-merge, `git push --tags` triggers `publish.yml` (OIDC); artifact verified by clean-install `import { VERSION }` = 0.21.0 and live `npx @sensigo/realm-cli@0.21.0 --version`.

## Rollback

If verification reveals a broken artifact after publish, cut a patch (v0.21.1) via the full Part B sequence. Pre-merge, close the branch and delete the local tag (`git tag -d v0.21.0`, unpushed).

## Related

Bundles #159 (merged as #167). Merge with a **merge commit** (not rebase/squash) — the tag is on the release commit; a rewrite would orphan it and break the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
