### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.22.0] — 2026-07-13
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.21.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.22.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,7 +81,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.21.0';
+export const VERSION = '0.22.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.21.0';
+export const VERSION = '0.22.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.21.0',
+    version: '0.22.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.21.0';
+export const VERSION = '0.22.0';


### PR DESCRIPTION
## Context

Release **v0.22.0** (minor). Ships the #144 family already merged to `main` and sitting in `[Unreleased]`. No new code — this PR only finalizes the CHANGELOG heading and bumps the four `package.json` versions + five `VERSION` constants via `scripts/release.mjs`.

## Motivation

Publish the workflow-authoring coherence work (#144) and the de-flake (#172) that have accumulated since v0.21.0.

## Changes

Contents of this release (all landed via #171 / #173):

- **Added** — workflow-level `description` is now a first-class field: declarative "what this workflow is for" (distinct from the imperative `protocol.quick_start`, no synthesized default), drives the agent protocol (`get_workflow_protocol`), settable via `create_workflow` `metadata.description`, echoed by `validate`/`register`.
- **Changed** — `realm init` scaffold now sequences its two steps with `depends_on` (previously the second step ran concurrently); vestigial `initial_state`/`allowed_from_states`/`produces_state` removed.
- **Fixed** — the YAML loader now warns on an unknown workflow/step key instead of silently dropping it (two allow-lists + compile-time partition drift-guard; non-breaking `console.warn`).

Follow-ups tracked separately: #170 (hard-reject at next major), #169 (structured warnings channel + `--strict`).

## Verification

- `npm run lint` · `npm run build` · `npm audit --omit=dev --audit-level=high` (0) — green.
- `TURBO_FORCE=true npm run test` — 8/8 tasks: core 66/1643, mcp 18/155, testing 4/77, cli 59/654; zero failures.
- `scripts/release.mjs` bumped all 4 `package.json` + 5 `VERSION` to 0.22.0 and tagged `v0.22.0` on `b98d37a` (build sanity-check passed inside the script).

## Rollback

Standard release rollback (pre-publication Part B step 8): if the publish workflow half-completes, re-push the tag; if a broken artifact ships, cut a patch release. No runtime/schema/data migration in this release.

## Related

Releases #144 (PR #171) + #172 (PR #173). Merge with a **merge commit** (not squash/rebase) so the `v0.22.0` tag stays reachable from `main`.
