### PR TITLE
feat(core): structured loader-warning channel + validate/register --strict + agent diagnostics (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Structured loader-warning channel (issue #169).** The YAML loader's warnings — an unknown workflow/step key, an idempotent-but-inert flag, dual schema declarations — are now typed, code-tagged data (`LoaderWarning { code, severity, message, scope, key?, did_you_mean? }`) resolved through a code→severity policy, instead of fire-and-forget `console.warn`. This is what powers `--strict`, agent-facing diagnostics, and (as a tracked follow-up, issue #170) a future hard-reject expressed as a single, already-wired policy flip.
+- **New public exports from `@sensigo/realm` (additive — nothing removed or changed).** `loadWorkflowFromFileWithDiagnostics` / `loadWorkflowFromStringWithDiagnostics` return `{ definition, warnings }` and print nothing, for callers that want to surface warnings themselves. Also exported: the diagnostics module itself — `DEFAULT_POLICY`, `resolveSeverity`, `findUnknownKeys`, `renderLoaderWarning`, and the `WarningCode` / `LoaderWarning` types. **Non-breaking guarantee:** `loadWorkflowFromFile` / `loadWorkflowFromString` keep their exact signatures and default `console.warn` behavior — existing callers need no change.
+- **`realm workflow validate --strict` and `realm workflow register --strict` (issue #169).** Exit non-zero when any loader warning is present (unknown keys, a retry-without-timeout advisory, a sentinel-credential fallback); `register --strict` additionally refuses to persist the workflow. Opt-in CI enforcement — default (non-strict) behavior is unchanged: warnings still print, the command still succeeds.
+- **"Did you mean…" suggestions on unknown keys (issue #169).** A close typo now gets a targeted suggestion — e.g. a mistyped `dependson` prints `⚠ step 'x': unknown key 'dependson' — ignored (did you mean 'depends_on'?)` — instead of just "ignored." Helps humans fix workflow YAML faster and lets an authoring agent self-correct.
+- **Agent-facing structured diagnostics on `create_workflow` (issue #169).** The response envelope gains an additive `diagnostics?: LoaderWarning[]` field alongside the unchanged `warnings: string[]` — an authoring agent can now branch on `code`/`key`/`did_you_mean` instead of parsing warning text. An unrecognized step key is still only ever dropped and warned, never rejected; the workflow is created either way.
+
+### Changed
+
+- The YAML loader's internal parser is now pure — warnings are collected as data and handed to the caller, which decides whether to print them (the default, byte-identical behavior) or surface them structurally instead. No observable behavior change for existing callers.
+
+---
+
 ## [0.22.0] — 2026-07-13
 
 ### Added

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -83,6 +83,7 @@ and invalid `depends_on` references.
 
 ```bash
 realm workflow validate ./my-workflow
+realm workflow validate ./my-workflow --strict   # fail (exit 1) if any warning is present
 ```
 
 Workflows declaring `extensions:` (or validated with `--extensions-module <path>`) are loaded
@@ -90,6 +91,23 @@ file-based, their extension modules are loaded, and step `config` is then valida
 resolved adapter's `config_schema` (two-pass). Extension-free workflows keep the historical
 string-based validation surface — a deliberate strictness asymmetry (file-context checks like
 agent-profile resolution only run for declaring workflows).
+
+**`--strict` (issue #169):** by default, a non-fatal loader warning (an unknown workflow/step key,
+a retry-without-timeout advisory, a sentinel-credential fallback) is printed but the command still
+exits `0` — the workflow is `Valid:` regardless. `--strict` changes that: if **any** warning is
+present, the summary line names the count and the command exits `1` instead. Nothing is checked
+that isn't already checked without the flag — `--strict` only changes what counts as success, so
+it's meant for CI gates that want to catch a typo before it reaches `register`.
+
+```bash
+$ realm workflow validate ./my-workflow --strict
+⚠ step 'sync_data': unknown key 'dependson' — ignored (did you mean 'depends_on'?)
+Valid: my-workflow v1 (3 steps) — 1 warning(s); failing due to --strict
+$ echo $?
+1
+```
+
+Without `--strict`, the same workflow prints the identical warning but exits `0`.
 
 ---
 
@@ -101,12 +119,19 @@ on each call. Fails immediately if any agent profile declared in the workflow is
 
 ```bash
 realm workflow register ./my-workflow
+realm workflow register ./my-workflow --strict   # refuse to persist if any warning is present
 ```
 
 Registering **mints the trust decision** for project extensions: when the workflow declares
 `extensions:`, the modules are fully loaded and duck-validated and step `config` gets the
 `config_schema` two-pass — all **before** anything is persisted. See the
 [Project extensions guide](project-extensions.md).
+
+**`--strict` (issue #169):** same warning surface as `validate --strict` (see above), but the
+consequence is stronger — a warning-bearing workflow is never written to the store at all
+(`store.register` is not called), and the command exits `1`. Without `--strict`, registration
+proceeds as always: the workflow is persisted and every warning is printed alongside the
+`Registered:` line.
 
 ---
 

--- a/docs/reference/mcp-protocol.md
+++ b/docs/reference/mcp-protocol.md
@@ -53,21 +53,22 @@ action. See [Operating & recovering runs](operating-runs.md).
 
 Every tool call returns a `ResponseEnvelope`:
 
-| Field                | Type     | Description                                                                                                             |
-| -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `command`            | string   | The step name that was executed.                                                                                        |
-| `run_id`             | string   | Stable run identifier.                                                                                                  |
-| `run_version`        | number   | Integer version of the run record. Observability only — not required as input to any tool.                              |
-| `status`             | string   | `ok`, `error`, `blocked`, or `confirm_required`.                                                                        |
-| `data`               | object   | Step output from the handler or adapter.                                                                                |
-| `evidence`           | array    | Evidence snapshots produced by this call.                                                                               |
-| `warnings`           | string[] | Non-fatal notices (e.g. a recovery path was taken — check `context_hint` for details).                                  |
-| `errors`             | string[] | Error messages when `status` is `error` or `blocked`.                                                                   |
-| `context_hint`       | string   | Human-readable description of what just happened and the current run state. Present on every response including errors. |
-| `next_actions`       | array    | Steps available for execution. Empty on terminal or unrecoverable states. Multiple items signal parallel fan-out.       |
-| `agent_action`       | string   | Error recovery instruction. Present only when `status` is `error` or `blocked`.                                         |
-| `chained_auto_steps` | array    | Ordered record of auto steps the engine ran silently in this call. Omitted when no auto steps were chained.             |
-| `gate`               | object   | Gate data. Present only when `status` is `confirm_required`.                                                            |
+| Field                | Type     | Description                                                                                                                                                                                                                                                                                                           |
+| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`            | string   | The step name that was executed.                                                                                                                                                                                                                                                                                      |
+| `run_id`             | string   | Stable run identifier.                                                                                                                                                                                                                                                                                                |
+| `run_version`        | number   | Integer version of the run record. Observability only — not required as input to any tool.                                                                                                                                                                                                                            |
+| `status`             | string   | `ok`, `error`, `blocked`, or `confirm_required`.                                                                                                                                                                                                                                                                      |
+| `data`               | object   | Step output from the handler or adapter.                                                                                                                                                                                                                                                                              |
+| `evidence`           | array    | Evidence snapshots produced by this call.                                                                                                                                                                                                                                                                             |
+| `warnings`           | string[] | Non-fatal notices (e.g. a recovery path was taken — check `context_hint` for details).                                                                                                                                                                                                                                |
+| `diagnostics`        | array    | Structured, code-tagged counterpart to `warnings` — `{ code, severity, message, scope, key?, did_you_mean? }` per entry. Additive-optional; only `create_workflow` populates it today (see below), every other tool omits it. Lets an agent branch on `code`/`key`/`did_you_mean` instead of parsing `warnings` text. |
+| `errors`             | string[] | Error messages when `status` is `error` or `blocked`.                                                                                                                                                                                                                                                                 |
+| `context_hint`       | string   | Human-readable description of what just happened and the current run state. Present on every response including errors.                                                                                                                                                                                               |
+| `next_actions`       | array    | Steps available for execution. Empty on terminal or unrecoverable states. Multiple items signal parallel fan-out.                                                                                                                                                                                                     |
+| `agent_action`       | string   | Error recovery instruction. Present only when `status` is `error` or `blocked`.                                                                                                                                                                                                                                       |
+| `chained_auto_steps` | array    | Ordered record of auto steps the engine ran silently in this call. Omitted when no auto steps were chained.                                                                                                                                                                                                           |
+| `gate`               | object   | Gate data. Present only when `status` is `confirm_required`.                                                                                                                                                                                                                                                          |
 
 ---
 
@@ -254,6 +255,12 @@ Use `create_workflow` when no registered workflow matches the task. It registers
 | `depends_on`      | No       | Array with at most one step ID this step depends on. Controls execution order. Omit for the first step.    |
 | `input_schema`    | No       | JSON Schema for the fields this step's `params` must include. Used to validate `execute_step` submissions. |
 | `timeout_seconds` | No       | Positive integer. If the step is not completed within this time, the run enters an error state.            |
+
+An unrecognized step key (e.g. a typo like `dependson`) is never rejected — the field is dropped
+and the workflow is still created. It's surfaced both in `warnings` (the rendered text, e.g.
+`⚠ step 'x': unknown key 'dependson' — ignored (did you mean 'depends_on'?)`) and as a structured
+entry (`code: "UNKNOWN_CREATE_WORKFLOW_KEY"`) in `diagnostics` — an authoring agent can self-correct
+on the next call instead of repeating the same typo.
 
 ### Metadata fields
 

--- a/docs/reference/mcp-protocol.md
+++ b/docs/reference/mcp-protocol.md
@@ -264,10 +264,14 @@ on the next call instead of repeating the same typo.
 
 ### Metadata fields
 
-| Field              | Required | Description                                           |
-| ------------------ | -------- | ----------------------------------------------------- |
-| `name`             | No       | Short kebab-case slug used to derive the workflow ID. |
-| `task_description` | No       | Human-readable description of the overall task.       |
+| Field              | Required | Description                                                                                                                                                                                                                                                                                                    |
+| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`             | No       | Short kebab-case slug used to derive the workflow ID.                                                                                                                                                                                                                                                          |
+| `description`      | No       | **Declarative** — what this workflow is for / when to use it. Becomes the workflow's `description`, surfaced in the agent protocol (`get_workflow_protocol`) and echoed by `realm workflow validate`/`register`. No synthesized default: omit it (or submit only whitespace) and the workflow simply has none. |
+| `task_description` | No       | **Imperative** — how to begin driving this run (the quick-start instruction). Becomes `protocol.quick_start`. Distinct from `description` above — one says what the workflow is, this says how to start it.                                                                                                    |
+
+`description` and `task_description` map to different places and are never blurred: `description` is
+the declarative "what it's for," `task_description` is the imperative "how to begin."
 
 ### Response and continuation
 

--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -2,6 +2,14 @@
 
 Complete reference for `workflow.yaml` fields. Every field documented here is validated at `realm workflow register` time — errors include the field name and expected type.
 
+An unrecognized top-level or step key (a typo, or a field from a removed feature) is never a hard
+error — it's dropped and a warning is printed, e.g. `⚠ step 'sync_data': unknown key 'dependson' —
+ignored (did you mean 'depends_on'?)`, with the **did-you-mean** suggestion appearing only when
+the key is a close match of a real one. `realm workflow validate --strict` (or `register --strict`)
+turns these warnings into a failure, for CI. A future major version will hard-reject unrecognized
+keys outright (tracked in [issue #170](https://github.com/sensigo-hq/realm/issues/170)) — until
+then, leaving one in place while you fix it is safe.
+
 ---
 
 ## Top-level fields

--- a/packages/cli/src/commands/dormant-reject.test.ts
+++ b/packages/cli/src/commands/dormant-reject.test.ts
@@ -1,0 +1,139 @@
+// The dormant issue #170 boundary-reject hook (issue #169): inert today because every
+// DEFAULT_POLICY entry is 'warn'. This test proves the mechanism is REAL and correctly wired by
+// mutating the shared, exported DEFAULT_POLICY object directly — flipping UNKNOWN_WORKFLOW_KEY /
+// UNKNOWN_STEP_KEY to 'error' — then observing validate/register actually refuse an
+// unknown-key workflow, and restoring the original values afterward. This is the sanctioned
+// #170-flip simulation (see the prompt's own "Mutation-probe" verification step); DEFAULT_POLICY
+// is a plain mutable Record specifically so this technique works.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_POLICY } from '@sensigo/realm';
+import { validateCommand } from './validate.js';
+import { registerCommand } from './register.js';
+
+describe('dormant #170 boundary-reject — selective policy flip (issue #169)', () => {
+  let originalWorkflowKeyPolicy: 'warn' | 'error';
+  let originalStepKeyPolicy: 'warn' | 'error';
+
+  beforeEach(() => {
+    originalWorkflowKeyPolicy = DEFAULT_POLICY.UNKNOWN_WORKFLOW_KEY;
+    originalStepKeyPolicy = DEFAULT_POLICY.UNKNOWN_STEP_KEY;
+  });
+
+  afterEach(() => {
+    DEFAULT_POLICY.UNKNOWN_WORKFLOW_KEY = originalWorkflowKeyPolicy;
+    DEFAULT_POLICY.UNKNOWN_STEP_KEY = originalStepKeyPolicy;
+  });
+
+  it('with the default (unflipped) policy, validate and register only WARN on an unknown step key', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'realm-dormant-reject-warn-'));
+    const wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: unflipped-wf
+name: Unflipped WF
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+
+    await validateCommand.parseAsync([wfPath], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join('\n')).toContain('Valid: unflipped-wf');
+
+    vi.restoreAllMocks();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('flipping DEFAULT_POLICY.UNKNOWN_STEP_KEY to "error" makes validate REFUSE the same workflow', async () => {
+    DEFAULT_POLICY.UNKNOWN_STEP_KEY = 'error';
+
+    const dir = mkdtempSync(join(tmpdir(), 'realm-dormant-reject-flip-validate-'));
+    const wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: flipped-wf
+name: Flipped WF
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+
+    await expect(validateCommand.parseAsync([wfPath], { from: 'user' })).rejects.toThrow(
+      'process.exit',
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.map((c) => String(c[0])).join('\n')).toContain('Invalid:');
+
+    vi.restoreAllMocks();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('flipping DEFAULT_POLICY.UNKNOWN_STEP_KEY to "error" makes register refuse-to-register the same workflow', async () => {
+    DEFAULT_POLICY.UNKNOWN_STEP_KEY = 'error';
+
+    const home = mkdtempSync(join(tmpdir(), 'realm-dormant-reject-flip-register-home-'));
+    mkdirSync(join(home, '.realm', 'workflows'), { recursive: true });
+    const originalHome = process.env['HOME'];
+    process.env['HOME'] = home;
+
+    const wfDir = mkdtempSync(join(tmpdir(), 'realm-dormant-reject-flip-register-wf-'));
+    writeFileSync(
+      join(wfDir, 'workflow.yaml'),
+      `id: flipped-reg-wf
+name: Flipped Reg WF
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+
+    await expect(registerCommand.parseAsync([wfDir], { from: 'user' })).rejects.toThrow(
+      'process.exit',
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.map((c) => String(c[0])).join('\n')).toContain('refusing to register');
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('Registered:');
+
+    if (originalHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = originalHome;
+    vi.restoreAllMocks();
+    rmSync(home, { recursive: true, force: true });
+    rmSync(wfDir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/src/commands/register-extensions.test.ts
+++ b/packages/cli/src/commands/register-extensions.test.ts
@@ -41,7 +41,7 @@ function writeWorkflow(content: string): string {
 
 describe('loadWorkflowForRegistration', () => {
   it('extension-free workflows load exactly as before (no loader involvement)', async () => {
-    const definition = await loadWorkflowForRegistration(writeWorkflow(BASE_YAML));
+    const { definition } = await loadWorkflowForRegistration(writeWorkflow(BASE_YAML));
     expect(definition.id).toBe('reg-wf');
     expect(definition.extensions).toBeUndefined();
   });
@@ -52,7 +52,7 @@ describe('loadWorkflowForRegistration', () => {
       `export default { handlers: { h1: { id: 'h1', execute: async () => ({ data: {} }) } } };`,
       'utf8',
     );
-    const definition = await loadWorkflowForRegistration(
+    const { definition } = await loadWorkflowForRegistration(
       writeWorkflow(`${BASE_YAML}extensions: ../../dist/registry.js\n`),
     );
     expect(definition.extensions).toEqual(['../../dist/registry.js']);

--- a/packages/cli/src/commands/register-strict.test.ts
+++ b/packages/cli/src/commands/register-strict.test.ts
@@ -1,0 +1,115 @@
+// register --strict tests (issue #169). registerCommand constructs `new JsonWorkflowStore()`
+// with no injectable directory — its default resolves via node:os homedir() at construction
+// time (inside the command's own action, not at import time), so pointing $HOME at a temp dir
+// before parseAsync isolates it safely (same technique as abandon.test.ts /
+// register-description-echo.test.ts).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerCommand } from './register.js';
+
+describe('register --strict (issue #169)', () => {
+  let home: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'realm-register-strict-'));
+    mkdirSync(join(home, '.realm', 'workflows'), { recursive: true });
+    originalHome = process.env['HOME'];
+    process.env['HOME'] = home;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = originalHome;
+    vi.restoreAllMocks();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('registers normally and exits 0 when --strict is set but there are no warnings', async () => {
+    const wfDir = mkdtempSync(join(tmpdir(), 'realm-register-strict-wf-'));
+    writeFileSync(
+      join(wfDir, 'workflow.yaml'),
+      `id: clean-reg
+name: Clean Reg
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+`,
+      'utf8',
+    );
+
+    await registerCommand.parseAsync([wfDir, '--strict'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('Registered: clean-reg v1 (1 steps)');
+    rmSync(wfDir, { recursive: true, force: true });
+  });
+
+  it('refuses to register and exits 1 when --strict is set and a warning is present', async () => {
+    const wfDir = mkdtempSync(join(tmpdir(), 'realm-register-strict-wf-'));
+    writeFileSync(
+      join(wfDir, 'workflow.yaml'),
+      `id: typo-reg
+name: Typo Reg
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+
+    await expect(registerCommand.parseAsync([wfDir, '--strict'], { from: 'user' })).rejects.toThrow(
+      'process.exit',
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errored = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(errored).toContain('refusing to register due to --strict');
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('Registered:');
+    rmSync(wfDir, { recursive: true, force: true });
+  });
+
+  it('without --strict, the same warning-bearing workflow registers and still prints the warning', async () => {
+    const wfDir = mkdtempSync(join(tmpdir(), 'realm-register-strict-wf-'));
+    writeFileSync(
+      join(wfDir, 'workflow.yaml'),
+      `id: typo-reg-lenient
+name: Typo Reg Lenient
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+
+    await registerCommand.parseAsync([wfDir], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('Registered: typo-reg-lenient v1 (1 steps)');
+    const warned = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain("unknown key 'dependson'");
+    rmSync(wfDir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -4,21 +4,42 @@
 // against the resolved adapters' config_schema (two-pass) BEFORE anything is persisted.
 import { Command } from 'commander';
 import { join } from 'node:path';
-import { loadWorkflowFromFile, JsonWorkflowStore } from '@sensigo/realm';
-import type { WorkflowDefinition } from '@sensigo/realm';
+import {
+  loadWorkflowFromFileWithDiagnostics,
+  JsonWorkflowStore,
+  resolveSeverity,
+} from '@sensigo/realm';
+import type { WorkflowDefinition, LoaderWarning } from '@sensigo/realm';
 import {
   loadProjectExtensions,
   type LoadedProjectExtensions,
 } from '../extensions/load-project-extensions.js';
 import { ManifestSecretsError } from '../extensions/manifest-secrets.js';
+import { printLoaderWarnings, rejectOnErrorSeverity, failsStrict } from '../lib/loader-warnings.js';
+
+/** Wraps loadProjectExtensions' sentinel-credential warnings as LoaderWarning (issue #169). */
+function wrapSentinelWarnings(sentinelWarnings: string[] | undefined): LoaderWarning[] {
+  return (sentinelWarnings ?? []).map((message) => ({
+    code: 'EXTENSION_SENTINEL' as const,
+    severity: resolveSeverity('EXTENSION_SENTINEL'),
+    scope: 'workflow' as const,
+    message: `⚠  ${message}`,
+  }));
+}
 
 /**
  * Loads and validates a workflow for registration. Extension-declaring workflows get the
  * full extension load + config_schema two-pass; extension-free workflows are untouched.
+ * Returns the definition alongside every accumulated LoaderWarning (issue #169) — pass-1's
+ * structural warnings plus the sentinel-credential warnings, if any. Prints NOTHING itself;
+ * both callers (register's action, watch's registerFile) decide how to surface/act on warnings
+ * (register supports `--strict` + the dormant #170 reject; watch just prints and continues).
  * @throws on any validation or extension-load failure — nothing is persisted on throw.
  */
-export async function loadWorkflowForRegistration(filePath: string): Promise<WorkflowDefinition> {
-  const definition = loadWorkflowFromFile(filePath);
+export async function loadWorkflowForRegistration(
+  filePath: string,
+): Promise<{ definition: WorkflowDefinition; warnings: LoaderWarning[] }> {
+  const { definition, warnings: pass1Warnings } = loadWorkflowFromFileWithDiagnostics(filePath);
   // Full module load + duck validation + manifest construction + config_schema two-pass
   // BEFORE persisting. Secret sources may be unavailable at provisioning time: degrade to
   // SENTINEL construction with a loud WARN (never silent, never a registration blocker);
@@ -34,26 +55,56 @@ export async function loadWorkflowForRegistration(filePath: string): Promise<Wor
     );
     loaded = await loadProjectExtensions(definition, { secretMode: 'sentinel' });
   }
-  for (const warning of loaded.sentinelWarnings ?? []) console.warn(`⚠  ${warning}`);
   // Two-pass: re-validate with the resolved registry so step config is checked against
-  // each adapter's config_schema before the definition is persisted.
-  loadWorkflowFromFile(filePath, loaded.registry);
-  return definition;
+  // each adapter's config_schema before the definition is persisted. Its warnings are proven
+  // identical to pass-1's (same content, registry only adds config_schema checks) — discarded
+  // here to avoid double-counting the same unknown key twice.
+  loadWorkflowFromFileWithDiagnostics(filePath, loaded.registry);
+
+  return {
+    definition,
+    warnings: [...pass1Warnings, ...wrapSentinelWarnings(loaded.sentinelWarnings)],
+  };
 }
 
 export const registerCommand = new Command('register')
   .argument('<path>', 'Path to workflow directory or workflow.yaml file')
+  .option(
+    '--strict',
+    'Exit non-zero and refuse to register if any loader warning is present (issue #169)',
+  )
   .description('Register a workflow definition')
-  .action(async (inputPath: string) => {
+  .action(async (inputPath: string, opts: { strict?: boolean }) => {
     const filePath =
       inputPath.endsWith('.yaml') || inputPath.endsWith('.yml')
         ? inputPath
         : join(inputPath, 'workflow.yaml');
 
     try {
-      const definition = await loadWorkflowForRegistration(filePath);
+      const { definition, warnings } = await loadWorkflowForRegistration(filePath);
+
+      // Dormant issue #170 boundary-reject: inert today (DEFAULT_POLICY has no 'error' entries).
+      if (rejectOnErrorSeverity(warnings)) {
+        printLoaderWarnings(warnings);
+        console.error(
+          `Error: '${definition.id}' has a warning escalated to an error by policy — refusing to register.`,
+        );
+        process.exit(1);
+        return;
+      }
+
+      if (opts.strict && failsStrict(warnings)) {
+        printLoaderWarnings(warnings);
+        console.error(
+          `Error: '${definition.id}' v${definition.version} has ${warnings.length} warning(s); refusing to register due to --strict`,
+        );
+        process.exit(1);
+        return;
+      }
+
       const store = new JsonWorkflowStore();
       await store.register(definition);
+      printLoaderWarnings(warnings);
       const contextWarnings = lintWorkflowContext(definition);
       for (const warning of contextWarnings) {
         console.warn(`⚠  ${warning}`);

--- a/packages/cli/src/commands/validate-internal-error.test.ts
+++ b/packages/cli/src/commands/validate-internal-error.test.ts
@@ -8,13 +8,14 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-// Make loadWorkflowFromString throw a PLAIN Error (an "internal bug"); keep everything else
+// Make loadWorkflowFromStringWithDiagnostics throw a PLAIN Error (an "internal bug") — this is
+// the variant validate.ts's from-string branch now calls (issue #169); keep everything else
 // (WorkflowError, findTrustRoot, …) real.
 vi.mock('@sensigo/realm', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sensigo/realm')>();
   return {
     ...actual,
-    loadWorkflowFromString: () => {
+    loadWorkflowFromStringWithDiagnostics: () => {
       throw new Error('internal bug — not a WorkflowError');
     },
   };

--- a/packages/cli/src/commands/validate-strict.test.ts
+++ b/packages/cli/src/commands/validate-strict.test.ts
@@ -1,0 +1,213 @@
+// validate --strict + accumulator tests (issue #169). In-process via commander's parseAsync (same
+// pattern as validate-retry-timeout-advisory.test.ts) — no subprocess/dist rebuild needed.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { validateCommand } from './validate.js';
+import { clearProjectExtensionsCache } from '../extensions/load-project-extensions.js';
+
+describe('validate --strict (issue #169)', () => {
+  let dir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'realm-validate-strict-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('exits 0 and prints normally when --strict is set but there are no warnings', async () => {
+    const wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: clean-wf
+name: Clean WF
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+`,
+      'utf8',
+    );
+
+    await validateCommand.parseAsync([wfPath, '--strict'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('Valid: clean-wf v1 (1 steps)');
+    expect(printed).not.toContain('warning(s)');
+  });
+
+  it('exits 1 with a summary line naming the count when --strict is set and warnings are present', async () => {
+    const wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: typo-wf
+name: Typo WF
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+
+    await expect(
+      validateCommand.parseAsync([wfPath, '--strict'], { from: 'user' }),
+    ).rejects.toThrow('process.exit');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain(
+      'Valid: typo-wf v1 (1 steps) — 1 warning(s); failing due to --strict',
+    );
+    const warned = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain("unknown key 'dependson'");
+  });
+
+  it('without --strict, the same warning-bearing workflow exits 0 and still prints the warning', async () => {
+    const wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: typo-wf-lenient
+name: Typo WF Lenient
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+
+    await validateCommand.parseAsync([wfPath], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('Valid: typo-wf-lenient v1 (1 steps)');
+    expect(printed).not.toContain('warning(s)');
+    const warned = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain("unknown key 'dependson'");
+  });
+});
+
+describe('validate — double-count guard on the two-pass (extensions) branch (issue #169)', () => {
+  let proj: string;
+  let workflowDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clearProjectExtensionsCache();
+    proj = mkdtempSync(join(tmpdir(), 'realm-validate-double-count-'));
+    workflowDir = join(proj, 'workflows', 'wf');
+    mkdirSync(join(proj, 'dist'), { recursive: true });
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(join(proj, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+    writeFileSync(join(proj, 'dist', 'registry.js'), 'export default {};', 'utf8');
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(proj, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('one unknown key on a workflow that declares extensions (two loader passes) is counted/printed exactly once', async () => {
+    const wfPath = join(workflowDir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: two-pass-wf
+name: Two Pass WF
+version: 1
+extensions: ../../dist/registry.js
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+`,
+      'utf8',
+    );
+
+    await validateCommand.parseAsync([wfPath, '--strict'], { from: 'user' }).catch(() => {
+      // --strict exits 1 for this fixture; we only care about the count below.
+    });
+
+    const warned = warnSpy.mock.calls.map((c) => String(c[0]));
+    const unknownKeyWarnings = warned.filter((line) => line.includes("unknown key 'dependson'"));
+    expect(unknownKeyWarnings).toHaveLength(1);
+
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('1 warning(s); failing due to --strict');
+  });
+});
+
+describe('validate — accumulator honesty: retry advisory + sentinel + unknown key all counted (issue #169)', () => {
+  let dir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'realm-validate-accumulator-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('--strict counts a retry-without-timeout advisory AND an unknown key together (extension-free branch)', async () => {
+    const wfPath = join(dir, 'workflow.yaml');
+    writeFileSync(
+      wfPath,
+      `id: accumulator-wf
+name: Accumulator WF
+version: 1
+steps:
+  step-one:
+    description: a step
+    execution: auto
+    dependson: [nothing]
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`,
+      'utf8',
+    );
+
+    await expect(
+      validateCommand.parseAsync([wfPath, '--strict'], { from: 'user' }),
+    ).rejects.toThrow('process.exit');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('2 warning(s); failing due to --strict');
+    const warned = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain("unknown key 'dependson'");
+    expect(warned).toContain("declares 'retry' but no 'timeout_seconds'");
+  });
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -10,54 +10,99 @@ import { dirname, join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { load } from 'js-yaml';
 import {
-  loadWorkflowFromString,
-  loadWorkflowFromFile,
+  loadWorkflowFromStringWithDiagnostics,
+  loadWorkflowFromFileWithDiagnostics,
   findTrustRoot,
   WorkflowError,
   shouldEnforceTimeout,
   DEFAULT_EXECUTION_TIMEOUT_SECONDS,
+  resolveSeverity,
+  type LoaderWarning,
 } from '@sensigo/realm';
 import type { WorkflowDefinition } from '@sensigo/realm';
 import {
   loadProjectExtensions,
   checkForOrphanedManifests,
 } from '../extensions/load-project-extensions.js';
+import { printLoaderWarnings, rejectOnErrorSeverity, failsStrict } from '../lib/loader-warnings.js';
 
 /**
  * Advisory (issue A3, never rejects): an auto step declaring `retry:` but no `timeout_seconds`
  * has EVERY attempt bounded by the generous DEFAULT_EXECUTION_TIMEOUT_SECONDS default — a hung
- * attempt can take up to that long before the retry loop even considers the next one. Surfaces
- * one warning per such step so the author can opt into a tighter explicit timeout_seconds.
+ * attempt can take up to that long before the retry loop even considers the next one. Returns one
+ * RETRY_NO_TIMEOUT LoaderWarning per such step (issue #169: folded into the validate accumulator
+ * — printed via printLoaderWarnings alongside every other warning — instead of printed directly,
+ * so `--strict` and the dormant boundary-reject can see it too).
  */
-function warnRetryWithoutExplicitTimeout(definition: WorkflowDefinition): void {
+function findRetryWithoutExplicitTimeout(definition: WorkflowDefinition): LoaderWarning[] {
+  const warnings: LoaderWarning[] = [];
   for (const [stepName, step] of Object.entries(definition.steps)) {
     if (
       shouldEnforceTimeout(step) &&
       step.retry !== undefined &&
       step.timeout_seconds === undefined
     ) {
-      console.warn(
-        `⚠  Step '${stepName}': declares 'retry' but no 'timeout_seconds' — each attempt is ` +
+      warnings.push({
+        code: 'RETRY_NO_TIMEOUT',
+        severity: resolveSeverity('RETRY_NO_TIMEOUT'),
+        scope: 'step',
+        step: stepName,
+        message:
+          `⚠  Step '${stepName}': declares 'retry' but no 'timeout_seconds' — each attempt is ` +
           `bounded by the default execution timeout (${DEFAULT_EXECUTION_TIMEOUT_SECONDS}s). ` +
           `Consider an explicit 'timeout_seconds' if attempts should fail faster.`,
-      );
+      });
     }
   }
+  return warnings;
+}
+
+/** Wraps loadProjectExtensions' sentinel-credential warnings as LoaderWarning (issue #169). */
+function wrapSentinelWarnings(sentinelWarnings: string[] | undefined): LoaderWarning[] {
+  return (sentinelWarnings ?? []).map((message) => ({
+    code: 'EXTENSION_SENTINEL' as const,
+    severity: resolveSeverity('EXTENSION_SENTINEL'),
+    scope: 'workflow' as const,
+    message: `⚠  ${message}`,
+  }));
 }
 
 /**
- * The single success site BOTH validation branches (extension-free and file-based) share: the
- * advisory warning is structurally inseparable from the `Valid:` line it accompanies — a branch
- * cannot drop the advisory without also dropping the `Valid:` print that existing tests assert.
+ * The single success-path printer BOTH validation branches (extension-free and file-based)
+ * share: prints every accumulated warning, then the summary line. Under `--strict`, a non-empty
+ * accumulator turns the summary line into a failing one and returns true (the caller exits 1);
+ * otherwise the summary line — and, when present, the description line existing tests assert on
+ * — print exactly as before and this returns false.
  */
-function printValidationSuccess(definition: WorkflowDefinition): void {
-  warnRetryWithoutExplicitTimeout(definition);
-  console.log(
-    `Valid: ${definition.id} v${definition.version} (${Object.keys(definition.steps).length} steps)`,
-  );
+function printValidationOutcome(
+  definition: WorkflowDefinition,
+  warnings: LoaderWarning[],
+  strict: boolean,
+): boolean {
+  printLoaderWarnings(warnings);
+  const base = `Valid: ${definition.id} v${definition.version} (${Object.keys(definition.steps).length} steps)`;
+  if (strict && failsStrict(warnings)) {
+    console.log(`${base} — ${warnings.length} warning(s); failing due to --strict`);
+    return true;
+  }
+  console.log(base);
   if (definition.description !== undefined) {
     console.log(`  ${definition.description}`);
   }
+  return false;
+}
+
+/**
+ * The dormant issue #170 boundary-reject: inert today (DEFAULT_POLICY has no 'error' entries),
+ * but once #170 flips UNKNOWN_WORKFLOW_KEY/UNKNOWN_STEP_KEY, this refuses those workflows here.
+ */
+function rejectIfPolicyEscalates(warnings: LoaderWarning[]): boolean {
+  if (!rejectOnErrorSeverity(warnings)) return false;
+  printLoaderWarnings(warnings);
+  console.error(
+    `Invalid: ${warnings.length} warning(s) present, and at least one is escalated to an error by policy.`,
+  );
+  return true;
 }
 
 /** Pre-scan: does the YAML carry a top-level `extensions` key? (Parse errors → false; the
@@ -82,12 +127,17 @@ export const validateCommand = new Command('validate')
     '--extensions-module <path>',
     "Extensions module that REPLACES the workflow's declared 'extensions' modules (repair/override)",
   )
+  .option(
+    '--strict',
+    'Exit non-zero if any loader warning is present (unknown keys, retry-without-timeout, sentinel credentials — issue #169)',
+  )
   .description('Validate a workflow YAML file')
-  .action(async (inputPath: string, opts: { extensionsModule?: string }) => {
+  .action(async (inputPath: string, opts: { extensionsModule?: string; strict?: boolean }) => {
     const filePath =
       inputPath.endsWith('.yaml') || inputPath.endsWith('.yml')
         ? inputPath
         : join(inputPath, 'workflow.yaml');
+    const strict = opts.strict === true;
 
     let content: string;
     try {
@@ -108,10 +158,18 @@ export const validateCommand = new Command('validate')
       // WorkflowError, which the catch below renders as `Invalid:` + exit(1). resolve()
       // before dirname so a relative `workflow.yaml` doesn't collapse the walk to '.'.
       try {
-        const definition = loadWorkflowFromString(content);
+        const { definition, warnings: loaderWarnings } =
+          loadWorkflowFromStringWithDiagnostics(content);
         const workflowDir = dirname(resolve(filePath));
         checkForOrphanedManifests(workflowDir, findTrustRoot(workflowDir));
-        printValidationSuccess(definition);
+
+        const accumulated = [...loaderWarnings, ...findRetryWithoutExplicitTimeout(definition)];
+        if (rejectIfPolicyEscalates(accumulated)) {
+          process.exit(1);
+        }
+        if (printValidationOutcome(definition, accumulated, strict)) {
+          process.exit(1);
+        }
       } catch (err) {
         if (err instanceof WorkflowError) {
           console.error(`Invalid: ${err.message}`);
@@ -125,21 +183,36 @@ export const validateCommand = new Command('validate')
     // Extensions declared (or an override supplied): file-based two-pass validation.
     try {
       // Pass 1: structural validation + extension resolution metadata (source_dir/trust_root).
-      const definition = loadWorkflowFromFile(filePath);
+      // The universal, registry-independent structural load — its warnings are what we count.
+      const { definition, warnings: pass1Warnings } = loadWorkflowFromFileWithDiagnostics(filePath);
       const { registry, manifest, sentinelWarnings } = await loadProjectExtensions(definition, {
         ...(opts.extensionsModule !== undefined ? { overrideModule: opts.extensionsModule } : {}),
         secretMode: 'sentinel',
       });
-      for (const warning of sentinelWarnings ?? []) console.warn(`⚠  ${warning}`);
-      // Pass 2: step config validated against each resolved adapter's config_schema.
-      loadWorkflowFromFile(filePath, registry);
-      printValidationSuccess(definition);
+      // Pass 2: step config validated against each resolved adapter's config_schema. Same
+      // content as pass 1, registry only adds config_schema checks — its warnings are proven
+      // identical to pass 1's, so they are deliberately discarded here (not collected) to avoid
+      // double-counting the same unknown key twice.
+      loadWorkflowFromFileWithDiagnostics(filePath, registry);
+
+      const accumulated = [
+        ...pass1Warnings,
+        ...findRetryWithoutExplicitTimeout(definition),
+        ...wrapSentinelWarnings(sentinelWarnings),
+      ];
+      if (rejectIfPolicyEscalates(accumulated)) {
+        process.exit(1);
+      }
+      const strictFailed = printValidationOutcome(definition, accumulated, strict);
       if (manifest.modules.length > 0) {
         console.log(
           `Extensions: ${manifest.modules.map((m) => m.declared).join(', ')} ` +
             `(adapters: ${manifest.adapters.length}, handlers: ${manifest.handlers.length}, ` +
             `processors: ${manifest.processors.length})`,
         );
+      }
+      if (strictFailed) {
+        process.exit(1);
       }
     } catch (err) {
       console.error(`Invalid: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -2,9 +2,10 @@
 import { watch, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { Command } from 'commander';
-import { loadWorkflowFromFile, WorkflowError } from '@sensigo/realm';
+import { loadWorkflowFromFileWithDiagnostics, WorkflowError } from '@sensigo/realm';
 import type { WorkflowRegistrar } from '@sensigo/realm';
 import { loadWorkflowForRegistration } from './register.js';
+import { printLoaderWarnings, rejectOnErrorSeverity } from '../lib/loader-warnings.js';
 
 /**
  * Attempts to load and register a workflow YAML file.
@@ -13,14 +14,26 @@ import { loadWorkflowForRegistration } from './register.js';
  * workflow declares `extensions:`, the modules load + duck-validate and step config gets the
  * config_schema two-pass BEFORE persisting. NOTE: long-lived watch processes keep the FIRST
  * imported content of each module path (ESM cache) — restart watch to pick up module changes.
+ *
+ * Prints every accumulated loader warning via printLoaderWarnings (issue #169) and applies the
+ * dormant issue #170 boundary-reject (inert today) — but never `--strict` (watch is a dev loop;
+ * `--strict` is deliberately validate/register-only).
  * @param filePath Path to the workflow YAML file.
  * @param store    The registrar to register into.
  */
 async function registerFile(filePath: string, store: WorkflowRegistrar): Promise<void> {
   const timestamp = new Date().toISOString();
   try {
-    const definition = await loadWorkflowForRegistration(filePath);
+    const { definition, warnings } = await loadWorkflowForRegistration(filePath);
+    if (rejectOnErrorSeverity(warnings)) {
+      printLoaderWarnings(warnings);
+      console.error(
+        `[${timestamp}] Invalid: '${definition.id}' has a warning escalated to an error by policy — refusing to register.`,
+      );
+      return;
+    }
     await store.register(definition);
+    printLoaderWarnings(warnings);
     console.log(
       `[${timestamp}] Registered: ${definition.id} v${definition.version} (${Object.keys(definition.steps).length} steps)`,
     );
@@ -60,7 +73,10 @@ export async function watchWorkflow(
   if (resolvedProfilesDir === undefined) {
     const workflowDir = dirname(resolve(filePath));
     try {
-      const definition = loadWorkflowFromFile(filePath);
+      // WithDiagnostics + discard its warnings (issue #169): this load exists only to read
+      // profiles_dir, not to surface anything — registerFile (just above) already owns
+      // surfacing every warning for this same file, so printing here would double it.
+      const { definition } = loadWorkflowFromFileWithDiagnostics(filePath);
       resolvedProfilesDir =
         definition.profiles_dir !== undefined
           ? resolve(workflowDir, definition.profiles_dir)

--- a/packages/cli/src/extensions/load-project-manifest.test.ts
+++ b/packages/cli/src/extensions/load-project-manifest.test.ts
@@ -474,7 +474,7 @@ steps:
 
     // 1. Register with NO .env yet → degrade-with-WARN to sentinel (provisioning flow).
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const definition = await loadWorkflowForRegistration(workflowPath);
+    const { definition } = await loadWorkflowForRegistration(workflowPath);
     expect(definition.trust_root).toBe(root);
     expect(warn.mock.calls.flat().join(' ')).toContain('SENTINEL');
     warn.mockRestore();

--- a/packages/cli/src/lib/loader-warnings.ts
+++ b/packages/cli/src/lib/loader-warnings.ts
@@ -1,0 +1,47 @@
+// loader-warnings.ts — shared CLI surfacing for the structured loader-warning channel (issue
+// #169). Every CLI command that prints loader warnings funnels through printLoaderWarnings (the
+// only caller of renderLoaderWarning — no command hand-rolls a `⚠ ` string), and the dormant
+// #170 boundary-reject is factored into ONE shared helper so validate/register/watch can't drift.
+import {
+  renderLoaderWarning,
+  resolveSeverity,
+  DEFAULT_POLICY,
+  type LoaderWarning,
+  type WarningCode,
+} from '@sensigo/realm';
+
+/** Prints every warning via the single renderLoaderWarning format source. */
+export function printLoaderWarnings(warnings: LoaderWarning[]): void {
+  for (const w of warnings) {
+    console.warn(renderLoaderWarning(w));
+  }
+}
+
+/**
+ * The dormant issue #170 boundary-reject hook, factored ONCE so validate/register/watch can't
+ * drift from each other: resolves every warning against `policy` (default DEFAULT_POLICY — inert
+ * today, since every entry is 'warn') and returns true if ANY resolves to 'error'. Inert today;
+ * #170 flips DEFAULT_POLICY's UNKNOWN_WORKFLOW_KEY/UNKNOWN_STEP_KEY entries to make this live.
+ * Never called from the execution loader (run/agent/listen/create_workflow) — those stay lenient
+ * forever, grandfathering already-deployed workflows and keeping agents error-tolerant.
+ */
+export function rejectOnErrorSeverity(
+  warnings: LoaderWarning[],
+  policy: Record<WarningCode, 'warn' | 'error'> = DEFAULT_POLICY,
+): boolean {
+  return warnings.some((w) => resolveSeverity(w.code, policy) === 'error');
+}
+
+/**
+ * `--strict`: every accumulated warning resolved against an all-'error' policy — i.e. any
+ * warning at all fails the command. Derived from DEFAULT_POLICY's own key set so it can never
+ * drift from the real WarningCode union (no hand-maintained code list here).
+ */
+const ALL_ERROR_POLICY: Record<WarningCode, 'warn' | 'error'> = Object.fromEntries(
+  (Object.keys(DEFAULT_POLICY) as WarningCode[]).map((code) => [code, 'error']),
+) as Record<WarningCode, 'warn' | 'error'>;
+
+/** True if `--strict` should fail the command given these accumulated warnings. */
+export function failsStrict(warnings: LoaderWarning[]): boolean {
+  return rejectOnErrorSeverity(warnings, ALL_ERROR_POLICY);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -164,11 +164,22 @@ export { validateInputSchema } from './validation/input-schema.js';
 export {
   loadWorkflowFromFile,
   loadWorkflowFromString,
+  loadWorkflowFromFileWithDiagnostics,
+  loadWorkflowFromStringWithDiagnostics,
   findTrustRoot,
   CURRENT_WORKFLOW_SCHEMA_VERSION,
 } from './workflow/yaml-loader.js';
 export { JsonWorkflowStore } from './workflow/registrar.js';
 export type { WorkflowRegistrar } from './workflow/registrar.js';
+
+// Diagnostics — structured loader-warning channel (issue #169)
+export {
+  DEFAULT_POLICY,
+  resolveSeverity,
+  findUnknownKeys,
+  renderLoaderWarning,
+} from './workflow/diagnostics.js';
+export type { WarningCode, LoaderWarning } from './workflow/diagnostics.js';
 
 // Handler primitives
 export { resolveResource } from './handlers/primitives/resolve-resource.js';

--- a/packages/core/src/types/response-envelope.ts
+++ b/packages/core/src/types/response-envelope.ts
@@ -1,6 +1,7 @@
 // Types for the ResponseEnvelope returned by every step execution.
 import type { EvidenceSnapshot, RunPhase } from './run-record.js';
 import type { AgentAction, ErrorCode } from './workflow-error.js';
+import type { LoaderWarning } from '../workflow/diagnostics.js';
 
 export interface NextAction {
   instruction: {
@@ -62,6 +63,12 @@ export interface ResponseEnvelope {
   /** Audit trail of step executions in this response. For debugging and CLI inspection only. */
   evidence: EvidenceSnapshot[];
   warnings: string[];
+  /**
+   * Structured, code-tagged counterparts to `warnings` above (issue #169) — additive-optional,
+   * non-breaking. Only `create_workflow` populates this today; every other envelope producer
+   * omits it. Lets an agent self-correct on `code`/`key`/`did_you_mean` instead of parsing text.
+   */
+  diagnostics?: LoaderWarning[];
   errors: string[];
   /**
    * The canonical error code from the WorkflowError that produced this envelope.

--- a/packages/core/src/workflow/diagnostics.test.ts
+++ b/packages/core/src/workflow/diagnostics.test.ts
@@ -1,0 +1,179 @@
+// diagnostics.test.ts — golden-format + did_you_mean coverage for the structured loader-warning
+// channel (issue #169). This is the regression guard once the 4 loader console.warn sites moved
+// to renderLoaderWarning-based printing wrappers: any change to the rendered text must show up
+// here first.
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_POLICY,
+  resolveSeverity,
+  findUnknownKeys,
+  renderLoaderWarning,
+  type LoaderWarning,
+} from './diagnostics.js';
+
+describe('DEFAULT_POLICY / resolveSeverity', () => {
+  it('every DEFAULT_POLICY entry is "warn" today (no code is pre-flipped)', () => {
+    for (const severity of Object.values(DEFAULT_POLICY)) {
+      expect(severity).toBe('warn');
+    }
+  });
+
+  it('resolveSeverity looks up the default policy when none is given', () => {
+    expect(resolveSeverity('UNKNOWN_WORKFLOW_KEY')).toBe('warn');
+    expect(resolveSeverity('UNKNOWN_STEP_KEY')).toBe('warn');
+    expect(resolveSeverity('UNKNOWN_CREATE_WORKFLOW_KEY')).toBe('warn');
+  });
+
+  it('resolveSeverity honors an explicit policy override', () => {
+    const policy = { ...DEFAULT_POLICY, UNKNOWN_STEP_KEY: 'error' as const };
+    expect(resolveSeverity('UNKNOWN_STEP_KEY', policy)).toBe('error');
+    // Unaffected codes in the same override stay at their DEFAULT_POLICY value.
+    expect(resolveSeverity('UNKNOWN_WORKFLOW_KEY', policy)).toBe('warn');
+  });
+});
+
+describe('findUnknownKeys', () => {
+  const ALLOW_LIST = ['description', 'execution', 'depends_on', 'input_schema'] as const;
+
+  it('returns one LoaderWarning per own-key not in the allow-list', () => {
+    const warnings = findUnknownKeys(
+      { description: 'x', execution: 'auto', rogue_key: 1, another_rogue: 2 },
+      ALLOW_LIST,
+      { scope: 'step', code: 'UNKNOWN_STEP_KEY', step: 'my-step' },
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map((w) => w.key).sort()).toEqual(['another_rogue', 'rogue_key']);
+    for (const w of warnings) {
+      expect(w.code).toBe('UNKNOWN_STEP_KEY');
+      expect(w.severity).toBe('warn');
+      expect(w.scope).toBe('step');
+      expect(w.step).toBe('my-step');
+    }
+  });
+
+  it('returns an empty array when every key is in the allow-list', () => {
+    const warnings = findUnknownKeys({ description: 'x', execution: 'auto' }, ALLOW_LIST, {
+      scope: 'step',
+      code: 'UNKNOWN_STEP_KEY',
+      step: 'my-step',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it('did_you_mean: "dependson" (missing underscore) suggests "depends_on"', () => {
+    const warnings = findUnknownKeys({ dependson: ['a'] }, ALLOW_LIST, {
+      scope: 'step',
+      code: 'UNKNOWN_STEP_KEY',
+      step: 'my-step',
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.did_you_mean).toBe('depends_on');
+  });
+
+  it('did_you_mean: a far/unrelated key ("produces_state") suggests nothing', () => {
+    const warnings = findUnknownKeys({ produces_state: 'done' }, ALLOW_LIST, {
+      scope: 'step',
+      code: 'UNKNOWN_STEP_KEY',
+      step: 'my-step',
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.did_you_mean).toBeUndefined();
+  });
+
+  it('workflow-scope warnings carry id, not step', () => {
+    const warnings = findUnknownKeys({ rogue: 1 }, ['id', 'name'], {
+      scope: 'workflow',
+      code: 'UNKNOWN_WORKFLOW_KEY',
+      id: 'my-workflow',
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.id).toBe('my-workflow');
+    expect(warnings[0]!.step).toBeUndefined();
+  });
+});
+
+describe('renderLoaderWarning — golden format', () => {
+  it('UNKNOWN_WORKFLOW_KEY, no suggestion', () => {
+    const w: LoaderWarning = {
+      code: 'UNKNOWN_WORKFLOW_KEY',
+      severity: 'warn',
+      scope: 'workflow',
+      id: 'my-wf',
+      key: 'produces_state',
+      message:
+        "workflow 'my-wf': unknown key 'produces_state' — ignored (not a recognized workflow field).",
+    };
+    expect(renderLoaderWarning(w)).toBe(
+      "⚠ workflow 'my-wf': unknown key 'produces_state' — ignored (not a recognized workflow field).",
+    );
+  });
+
+  it('UNKNOWN_STEP_KEY, did_you_mean form', () => {
+    const warnings = findUnknownKeys({ dependson: ['a'] }, ['depends_on'], {
+      scope: 'step',
+      code: 'UNKNOWN_STEP_KEY',
+      step: 'my-step',
+    });
+    expect(renderLoaderWarning(warnings[0]!)).toBe(
+      "⚠ step 'my-step': unknown key 'dependson' — ignored (did you mean 'depends_on'?)",
+    );
+  });
+
+  it('UNKNOWN_CREATE_WORKFLOW_KEY renders the same templated shape as UNKNOWN_STEP_KEY', () => {
+    const warnings = findUnknownKeys({ rogue_field: 1 }, ['id', 'description'], {
+      scope: 'step',
+      code: 'UNKNOWN_CREATE_WORKFLOW_KEY',
+      step: 'step-a',
+    });
+    expect(renderLoaderWarning(warnings[0]!)).toBe(
+      "⚠ step 'step-a': unknown key 'rogue_field' — ignored (not a recognized step field).",
+    );
+  });
+
+  it('IDEMPOTENT_INERT_IN_FINALIZER and DUAL_SCHEMA_DECLARED render message verbatim — no ⚠ prefix added (byte-identical to the pre-#169 text)', () => {
+    const idempotentWarning: LoaderWarning = {
+      code: 'IDEMPOTENT_INERT_IN_FINALIZER',
+      severity: 'warn',
+      scope: 'step',
+      step: 'my-step',
+      message:
+        "Step 'my-step': 'idempotent: true' is inert in a finalizer-bearing workflow (its claim " +
+        "carries no deadline, so 'realm run reclaim --all' can never select it). Recover it with " +
+        "'realm run reclaim --step my-step --force'.",
+    };
+    expect(renderLoaderWarning(idempotentWarning)).toBe(idempotentWarning.message);
+    expect(renderLoaderWarning(idempotentWarning)).not.toMatch(/^⚠/);
+
+    const dualSchemaWarning: LoaderWarning = {
+      code: 'DUAL_SCHEMA_DECLARED',
+      severity: 'warn',
+      scope: 'step',
+      step: 'my-step',
+      message:
+        "Step 'my-step': declares both input_schema and output_schema; the agent's submitted " +
+        'output is validated against both — prefer one to avoid divergence.',
+    };
+    expect(renderLoaderWarning(dualSchemaWarning)).toBe(dualSchemaWarning.message);
+    expect(renderLoaderWarning(dualSchemaWarning)).not.toMatch(/^⚠/);
+  });
+
+  it('RETRY_NO_TIMEOUT and EXTENSION_SENTINEL render message verbatim — their own ⚠  (two-space) prefix is baked into message, not added here', () => {
+    const retryWarning: LoaderWarning = {
+      code: 'RETRY_NO_TIMEOUT',
+      severity: 'warn',
+      scope: 'step',
+      step: 'my-step',
+      message:
+        "⚠  Step 'my-step': declares 'retry' but no 'timeout_seconds' — each attempt is bounded.",
+    };
+    expect(renderLoaderWarning(retryWarning)).toBe(retryWarning.message);
+
+    const sentinelWarning: LoaderWarning = {
+      code: 'EXTENSION_SENTINEL',
+      severity: 'warn',
+      scope: 'workflow',
+      message: '⚠  Using sentinel credentials for adapter X.',
+    };
+    expect(renderLoaderWarning(sentinelWarning)).toBe(sentinelWarning.message);
+  });
+});

--- a/packages/core/src/workflow/diagnostics.ts
+++ b/packages/core/src/workflow/diagnostics.ts
@@ -1,0 +1,185 @@
+// diagnostics.ts — structured loader-warning channel (issue #169).
+//
+// Turns the loader's fire-and-forget console.warn calls into a structured, code-tagged type
+// (LoaderWarning) with a resolvable severity policy. This is what powers `validate`/`register
+// --strict`, feeds create_workflow's agent-facing `diagnostics` field, and pre-wires issue #170
+// (hard-reject at the next major version) as a dormant per-code policy flip — DEFAULT_POLICY is
+// the single datum #170 changes; nothing else in this module encodes the reject/warn decision.
+
+/**
+ * Every warning code the loader (or an MCP tool wrapping the same allow-list mechanism) can
+ * emit. Deliberately excludes ORPHANED_MANIFEST — that condition already throws a WorkflowError
+ * (`Invalid:` + exit 1) at the CLI layer; it is a hard error, never a warning.
+ */
+export type WarningCode =
+  | 'UNKNOWN_WORKFLOW_KEY'
+  | 'UNKNOWN_STEP_KEY'
+  | 'UNKNOWN_CREATE_WORKFLOW_KEY'
+  | 'IDEMPOTENT_INERT_IN_FINALIZER'
+  | 'DUAL_SCHEMA_DECLARED'
+  | 'RETRY_NO_TIMEOUT'
+  | 'EXTENSION_SENTINEL';
+
+/**
+ * A single structured diagnostic. `message` is the full human-readable text (matching, for the
+ * three unknown-key codes, exactly what `renderLoaderWarning` would independently reconstruct
+ * from the structured fields — kept in sync by construction, not by convention: see
+ * `findUnknownKeys` below). `scope`/`id`/`step`/`key`/`did_you_mean` are populated only by the
+ * unknown-key family; other codes carry just `code`/`severity`/`message`.
+ */
+export interface LoaderWarning {
+  code: WarningCode;
+  severity: 'warn' | 'error';
+  message: string;
+  scope: 'workflow' | 'step';
+  id?: string;
+  step?: string;
+  key?: string;
+  did_you_mean?: string;
+}
+
+/**
+ * The single datum issue #170 (hard-reject at the next major version) changes: flip
+ * UNKNOWN_WORKFLOW_KEY / UNKNOWN_STEP_KEY to 'error' here and the dormant boundary-reject at
+ * validate/register/watch (see yaml-loader.ts consumers) starts refusing those workflows.
+ * UNKNOWN_CREATE_WORKFLOW_KEY is deliberately never flipped — create_workflow stays lenient for
+ * agents forever (a distinct, permanent design decision, not an oversight).
+ */
+export const DEFAULT_POLICY: Record<WarningCode, 'warn' | 'error'> = {
+  UNKNOWN_WORKFLOW_KEY: 'warn',
+  UNKNOWN_STEP_KEY: 'warn',
+  UNKNOWN_CREATE_WORKFLOW_KEY: 'warn',
+  IDEMPOTENT_INERT_IN_FINALIZER: 'warn',
+  DUAL_SCHEMA_DECLARED: 'warn',
+  RETRY_NO_TIMEOUT: 'warn',
+  EXTENSION_SENTINEL: 'warn',
+};
+
+/**
+ * Pure lookup: resolves a warning code's severity against a policy table. `--strict` passes an
+ * all-'error' policy; issue #170 changes DEFAULT_POLICY itself; the dormant boundary-reject and
+ * tests inject a selective policy (e.g. only UNKNOWN_WORKFLOW_KEY/UNKNOWN_STEP_KEY → 'error').
+ */
+export function resolveSeverity(
+  code: WarningCode,
+  policy: Record<WarningCode, 'warn' | 'error'> = DEFAULT_POLICY,
+): 'warn' | 'error' {
+  return policy[code];
+}
+
+/**
+ * Levenshtein (edit) distance between two strings. Small, iterative, single-row DP — no
+ * dependency, kept internal to this module.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  let prevRow = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    const currRow = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      currRow.push(Math.min(currRow[j - 1]! + 1, prevRow[j]! + 1, prevRow[j - 1]! + cost));
+    }
+    prevRow = currRow;
+  }
+  return prevRow[b.length]!;
+}
+
+/**
+ * Suggests the closest allow-list entry to `key`, or undefined when nothing is close enough to
+ * be a plausible typo. Threshold: min(2, floor(key.length/3)+1) — tuned so a one-character-off
+ * typo like 'dependson' (missing the underscore in 'depends_on') hits, but an unrelated key from
+ * a different vocabulary entirely (e.g. the retired 'produces_state', 14 chars, edit-distance
+ * far from every current StepDefinition field) suggests nothing rather than a misleading guess.
+ * On a tie, the first allow-list entry (in its declared order) at the minimum distance wins —
+ * deterministic, not alphabetical.
+ */
+function closestKey(key: string, allowList: readonly string[]): string | undefined {
+  const threshold = Math.min(2, Math.floor(key.length / 3) + 1);
+  let best: string | undefined;
+  let bestDistance = Infinity;
+  for (const candidate of allowList) {
+    const distance = levenshteinDistance(key, candidate);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  return best !== undefined && bestDistance <= threshold ? best : undefined;
+}
+
+/** Builds the templated "unknown key" message text (everything after the `⚠ ` prefix). */
+function renderUnknownKeyMessage(
+  scope: 'workflow' | 'step',
+  target: string,
+  key: string,
+  didYouMean: string | undefined,
+): string {
+  // Punctuation deliberately differs by form, matching the design's own literal examples exactly:
+  // the no-suggestion form ends with a period (byte-identical to the pre-#169 text); the
+  // did_you_mean form's trailing '?)' is the sentence's natural end — no additional period.
+  if (didYouMean !== undefined) {
+    return `${target}: unknown key '${key}' — ignored (did you mean '${didYouMean}'?)`;
+  }
+  return `${target}: unknown key '${key}' — ignored (not a recognized ${scope} field).`;
+}
+
+/**
+ * Finds every own-key of `obj` not present in `allowList` and returns one LoaderWarning per
+ * offender. Pure — no printing, no throwing. Severity is resolved against DEFAULT_POLICY at
+ * construction time (a caller applying a different policy, e.g. `--strict`, re-resolves
+ * `code`/nothing-else via `resolveSeverity` rather than mutating this result).
+ */
+export function findUnknownKeys(
+  obj: Record<string, unknown>,
+  allowList: readonly string[],
+  ctx: { scope: 'workflow' | 'step'; code: WarningCode; id?: string; step?: string },
+): LoaderWarning[] {
+  const warnings: LoaderWarning[] = [];
+  const target =
+    ctx.scope === 'workflow' ? `workflow '${ctx.id ?? '<unknown>'}'` : `step '${ctx.step}'`;
+  for (const key of Object.keys(obj)) {
+    if (allowList.includes(key)) continue;
+    const did_you_mean = closestKey(key, allowList);
+    const warning: LoaderWarning = {
+      code: ctx.code,
+      severity: resolveSeverity(ctx.code),
+      message: renderUnknownKeyMessage(ctx.scope, target, key, did_you_mean),
+      scope: ctx.scope,
+      key,
+    };
+    if (ctx.id !== undefined) warning.id = ctx.id;
+    if (ctx.step !== undefined) warning.step = ctx.step;
+    if (did_you_mean !== undefined) warning.did_you_mean = did_you_mean;
+    warnings.push(warning);
+  }
+  return warnings;
+}
+
+const UNKNOWN_KEY_CODES = new Set<WarningCode>([
+  'UNKNOWN_WORKFLOW_KEY',
+  'UNKNOWN_STEP_KEY',
+  'UNKNOWN_CREATE_WORKFLOW_KEY',
+]);
+
+/**
+ * The SINGLE source of the `⚠ ` line format — every printer (the core plain wrappers in
+ * yaml-loader.ts, and the CLI's `printLoaderWarnings` helper) renders through this, never by
+ * hand-rolling a `⚠ ` string itself.
+ *
+ * The three unknown-key codes are templated fresh from the structured fields (so the
+ * `did_you_mean` suggestion is appended only when present) and always carry the `⚠ ` prefix —
+ * byte-identical to the pre-#169 console.warn text. Every other code (IDEMPOTENT_INERT_IN_FINALIZER,
+ * DUAL_SCHEMA_DECLARED, RETRY_NO_TIMEOUT, EXTENSION_SENTINEL) returns `message` verbatim: these
+ * are free-text warnings whose exact current prefix (or lack of one) is preserved byte-for-byte
+ * by whatever constructed them, not re-derived here.
+ */
+export function renderLoaderWarning(w: LoaderWarning): string {
+  if (UNKNOWN_KEY_CODES.has(w.code)) {
+    return `⚠ ${w.message}`;
+  }
+  return w.message;
+}

--- a/packages/core/src/workflow/yaml-loader.test.ts
+++ b/packages/core/src/workflow/yaml-loader.test.ts
@@ -2444,4 +2444,48 @@ steps:
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  it('a close-typo step key ("dependson") warns with a did_you_mean suggestion (issue #169)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const def = loadWorkflowFromString(`
+id: typo-step-key-wf
+name: Typo Step Key
+version: 1
+steps:
+  step-one:
+    description: First step
+    execution: agent
+  step-two:
+    description: Second step
+    execution: auto
+    dependson: [step-one]
+`);
+    expect(def.steps['step-two']?.description).toBe('Second step');
+    const out = warn.mock.calls.flat().join('\n');
+    expect(out).toContain(
+      "step 'step-two': unknown key 'dependson' — ignored (did you mean 'depends_on'?)",
+    );
+    warn.mockRestore();
+  });
+
+  it('a far/unrelated unknown step key ("produces_state") warns with NO did_you_mean suggestion (issue #169)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const def = loadWorkflowFromString(`
+id: far-key-wf
+name: Far Key
+version: 1
+steps:
+  step-one:
+    description: First step
+    execution: auto
+    produces_state: done
+`);
+    expect(def.steps['step-one']?.description).toBe('First step');
+    const out = warn.mock.calls.flat().join('\n');
+    expect(out).toContain(
+      "step 'step-one': unknown key 'produces_state' — ignored (not a recognized step field).",
+    );
+    expect(out).not.toContain('did you mean');
+    warn.mockRestore();
+  });
 });

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -11,6 +11,12 @@ import type {
 } from '../types/workflow-definition.js';
 import { KNOWN_STEP_KEYS, KNOWN_WORKFLOW_KEYS } from '../types/workflow-definition.js';
 import { WorkflowError } from '../types/workflow-error.js';
+import {
+  findUnknownKeys,
+  renderLoaderWarning,
+  resolveSeverity,
+  type LoaderWarning,
+} from './diagnostics.js';
 import { resolveTemplates } from './template-resolver.js';
 import type { ExtensionRegistry } from '../extensions/registry.js';
 import { normalizeTriggerFilter, validateTriggerStructure } from './trigger-schema.js';
@@ -198,13 +204,18 @@ export function findTrustRoot(dir: string): string {
 }
 
 /**
- * Loads a WorkflowDefinition from a YAML file on disk.
+ * Pure core of loadWorkflowFromFile (issue #169): parses + resolves everything a file-based load
+ * needs, but never prints and never chooses between the two public presentations — it always
+ * returns the definition alongside every collected LoaderWarning. `loadWorkflowFromFile` (prints
+ * via renderLoaderWarning, returns just the definition — byte-identical default behavior, the
+ * non-breaking invariant) and `loadWorkflowFromFileWithDiagnostics` (prints nothing, returns both)
+ * are both thin wrappers over this.
  * @throws WorkflowError on read failure or structural validation errors.
  */
-export function loadWorkflowFromFile(
+function loadWorkflowFromFileCore(
   filePath: string,
   registry?: ExtensionRegistry,
-): WorkflowDefinition {
+): { definition: WorkflowDefinition; warnings: LoaderWarning[] } {
   let content: string;
   try {
     content = readFileSync(filePath, 'utf8');
@@ -217,7 +228,9 @@ export function loadWorkflowFromFile(
       retryable: false,
     });
   }
-  const definition = parseWorkflowString(content, registry, { allowExtensions: true });
+  const { definition, warnings } = parseWorkflowString(content, registry, {
+    allowExtensions: true,
+  });
 
   // Resolve agent profiles — only possible when we have a file path.
   const workflowDir = dirname(resolve(filePath));
@@ -341,11 +354,42 @@ export function loadWorkflowFromFile(
 
   definition.origin = 'human';
 
+  return { definition, warnings };
+}
+
+/**
+ * Loads a WorkflowDefinition from a YAML file on disk. UNCHANGED signature/return type — the
+ * non-breaking invariant (issue #169): every existing execution caller keeps compiling and
+ * printing warnings for free. Structured warnings are reachable only via
+ * `loadWorkflowFromFileWithDiagnostics`.
+ * @throws WorkflowError on read failure or structural validation errors.
+ */
+export function loadWorkflowFromFile(
+  filePath: string,
+  registry?: ExtensionRegistry,
+): WorkflowDefinition {
+  const { definition, warnings } = loadWorkflowFromFileCore(filePath, registry);
+  for (const w of warnings) console.warn(renderLoaderWarning(w));
   return definition;
 }
 
 /**
- * Loads a WorkflowDefinition from a YAML string.
+ * Same as `loadWorkflowFromFile`, but prints nothing and returns every collected LoaderWarning
+ * alongside the definition (issue #169). Opt-in for callers that want to surface warnings
+ * themselves (validate/register/watch/`--strict`) instead of the default console.warn behavior.
+ */
+export function loadWorkflowFromFileWithDiagnostics(
+  filePath: string,
+  registry?: ExtensionRegistry,
+): { definition: WorkflowDefinition; warnings: LoaderWarning[] } {
+  return loadWorkflowFromFileCore(filePath, registry);
+}
+
+/**
+ * Loads a WorkflowDefinition from a YAML string. UNCHANGED signature/return type — the
+ * non-breaking invariant (issue #169): every existing execution caller keeps compiling and
+ * printing warnings for free. Structured warnings are reachable only via
+ * `loadWorkflowFromStringWithDiagnostics`.
  * Validates structure and DAG dependency references.
  * A declared `extensions` key is a hard load error — extensions require file-based loading
  * (no directory context exists to resolve relative extension module paths against).
@@ -355,6 +399,21 @@ export function loadWorkflowFromString(
   content: string,
   registry?: ExtensionRegistry,
 ): WorkflowDefinition {
+  const { definition, warnings } = parseWorkflowString(content, registry, {
+    allowExtensions: false,
+  });
+  for (const w of warnings) console.warn(renderLoaderWarning(w));
+  return definition;
+}
+
+/**
+ * Same as `loadWorkflowFromString`, but prints nothing and returns every collected LoaderWarning
+ * alongside the definition (issue #169).
+ */
+export function loadWorkflowFromStringWithDiagnostics(
+  content: string,
+  registry?: ExtensionRegistry,
+): { definition: WorkflowDefinition; warnings: LoaderWarning[] } {
   return parseWorkflowString(content, registry, { allowExtensions: false });
 }
 
@@ -428,13 +487,19 @@ function detectDependencyCycles(edges: Map<string, string[]>): string[][] {
  * Shared YAML → WorkflowDefinition parser. `allowExtensions` distinguishes file-based loading
  * (extensions permitted — a directory context exists) from string-based loading (hard error,
  * fired before any other processing).
+ *
+ * PURE (issue #169): never prints, never throws on a warning — every non-fatal condition is
+ * collected into the returned `warnings: LoaderWarning[]` instead of console.warn'd directly.
+ * Callers (loadWorkflowFromFile/loadWorkflowFromFileCore, loadWorkflowFromString) decide whether
+ * to print (the default, byte-identical wrappers) or surface the structured array
+ * (the `...WithDiagnostics` variants).
  * @throws WorkflowError on parse failure or structural validation errors.
  */
 function parseWorkflowString(
   content: string,
   registry: ExtensionRegistry | undefined,
   opts: { allowExtensions: boolean },
-): WorkflowDefinition {
+): { definition: WorkflowDefinition; warnings: LoaderWarning[] } {
   // Step 1: Parse YAML
   let raw: unknown;
   try {
@@ -452,6 +517,7 @@ function parseWorkflowString(
   }
 
   const errors: string[] = [];
+  const warnings: LoaderWarning[] = [];
 
   // Step 2: Top-level validation
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
@@ -474,13 +540,13 @@ function parseWorkflowString(
   // (hard-reject) and #169 (structured warnings channel) are deliberately out of scope here.
   {
     const workflowId = typeof doc['id'] === 'string' ? doc['id'] : '<unknown>';
-    for (const key of Object.keys(doc)) {
-      if (!(KNOWN_WORKFLOW_KEYS as readonly string[]).includes(key)) {
-        console.warn(
-          `⚠ workflow '${workflowId}': unknown key '${key}' — ignored (not a recognized workflow field).`,
-        );
-      }
-    }
+    warnings.push(
+      ...findUnknownKeys(doc, KNOWN_WORKFLOW_KEYS, {
+        scope: 'workflow',
+        code: 'UNKNOWN_WORKFLOW_KEY',
+        id: workflowId,
+      }),
+    );
   }
 
   // Project extensions: hard error for string-based loading (fires before any other
@@ -555,14 +621,14 @@ function parseWorkflowString(
 
     // WARN (do not reject) on an unknown step key — runs after template resolution above, so a
     // template-expanded step's keys are checked too. Same non-breaking posture as the
-    // workflow-level check (issue #144); #170/#169 remain deliberately out of scope.
-    for (const key of Object.keys(step)) {
-      if (!(KNOWN_STEP_KEYS as readonly string[]).includes(key)) {
-        console.warn(
-          `⚠ step '${stepName}': unknown key '${key}' — ignored (not a recognized step field).`,
-        );
-      }
-    }
+    // workflow-level check (issue #144).
+    warnings.push(
+      ...findUnknownKeys(step, KNOWN_STEP_KEYS, {
+        scope: 'step',
+        code: 'UNKNOWN_STEP_KEY',
+        step: stepName,
+      }),
+    );
 
     if (stepName === 'run' || stepName === 'context') {
       errors.push(`Step name '${stepName}' is reserved and cannot be used as a step identifier`);
@@ -698,11 +764,16 @@ function parseWorkflowString(
     // `deadline: null` (issue #101), so the flag is inert — `realm run reclaim --all` can never
     // select it. The author should know it stays per-step-manual-reclaim-only.
     if (step['idempotent'] === true && step['execution'] === 'auto' && hasFinalizerStep) {
-      console.warn(
-        `Step '${stepName}': 'idempotent: true' is inert in a finalizer-bearing workflow (its claim ` +
+      warnings.push({
+        code: 'IDEMPOTENT_INERT_IN_FINALIZER',
+        severity: resolveSeverity('IDEMPOTENT_INERT_IN_FINALIZER'),
+        scope: 'step',
+        step: stepName,
+        message:
+          `Step '${stepName}': 'idempotent: true' is inert in a finalizer-bearing workflow (its claim ` +
           `carries no deadline, so 'realm run reclaim --all' can never select it). Recover it with ` +
           `'realm run reclaim --step ${stepName} --force'.`,
-      );
+      });
     }
 
     // output_schema is only valid on execution: agent steps.
@@ -719,10 +790,15 @@ function parseWorkflowString(
       step['input_schema'] !== undefined &&
       step['output_schema'] !== undefined
     ) {
-      console.warn(
-        `Step '${stepName}': declares both input_schema and output_schema; the agent's submitted ` +
+      warnings.push({
+        code: 'DUAL_SCHEMA_DECLARED',
+        severity: resolveSeverity('DUAL_SCHEMA_DECLARED'),
+        scope: 'step',
+        step: stepName,
+        message:
+          `Step '${stepName}': declares both input_schema and output_schema; the agent's submitted ` +
           `output is validated against both — prefer one to avoid divergence.`,
-      );
+      });
     }
 
     // trace_schema is only valid on execution: agent steps.
@@ -1205,7 +1281,7 @@ function parseWorkflowString(
   // Step 4: Stamp schema version and return typed result
   const definition = doc as unknown as WorkflowDefinition;
   definition.schema_version = CURRENT_WORKFLOW_SCHEMA_VERSION;
-  return definition;
+  return { definition, warnings };
 }
 
 /** Returns true if any step in the raw steps map declares use_template. */

--- a/packages/mcp-server/src/tools/create-workflow-diagnostics.test.ts
+++ b/packages/mcp-server/src/tools/create-workflow-diagnostics.test.ts
@@ -1,0 +1,104 @@
+// create_workflow structured diagnostics tests (issue #169): an unknown step key surfaces as
+// BOTH a rendered string in envelope.warnings (unchanged field, non-breaking) AND a structured
+// LoaderWarning in the new envelope.diagnostics field (the agent-native value — a framework can
+// self-correct on code/key/did_you_mean instead of parsing text). The workflow is still created
+// either way; create_workflow never rejects on an unknown step key.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore, JsonWorkflowStore, DEFAULT_POLICY } from '@sensigo/realm';
+import { handleCreateWorkflow, type CreateWorkflowArgs } from './create-workflow.js';
+
+describe('create_workflow — structured diagnostics (issue #169)', () => {
+  let runDir: string;
+  let workflowDir: string;
+  let stores: { runStore: JsonFileStore; workflowStore: JsonWorkflowStore };
+
+  beforeEach(async () => {
+    runDir = await mkdtemp(join(tmpdir(), 'realm-cw-diag-run-'));
+    workflowDir = await mkdtemp(join(tmpdir(), 'realm-cw-diag-wf-'));
+    stores = {
+      runStore: new JsonFileStore(runDir),
+      workflowStore: new JsonWorkflowStore(workflowDir),
+    };
+  });
+
+  it('an unknown step key is created anyway, and appears in both warnings and diagnostics', async () => {
+    const args = {
+      steps: [
+        {
+          id: 'step-a',
+          description: 'Do something',
+          dependson: ['nowhere'], // typo for depends_on — not a declared CreateWorkflowStep field
+        },
+      ],
+    } as unknown as CreateWorkflowArgs;
+
+    const result = await handleCreateWorkflow(args, stores);
+
+    expect(result.status).toBe('ok');
+    // The workflow was still created — an unknown step key never blocks create_workflow.
+    const def = await stores.workflowStore.get(result.data['workflow_id'] as string);
+    expect(Object.keys(def.steps)).toHaveLength(1);
+
+    // envelope.warnings (unchanged string[] field) carries the rendered text.
+    expect(result.warnings.some((w) => w.includes("unknown key 'dependson'"))).toBe(true);
+    expect(result.warnings.some((w) => w.includes("did you mean 'depends_on'?"))).toBe(true);
+
+    // envelope.diagnostics (new, additive-optional) carries the structured LoaderWarning.
+    expect(result.diagnostics).toBeDefined();
+    const diag = result.diagnostics!.find((d) => d.key === 'dependson');
+    expect(diag).toBeDefined();
+    expect(diag!.code).toBe('UNKNOWN_CREATE_WORKFLOW_KEY');
+    expect(diag!.did_you_mean).toBe('depends_on');
+    expect(diag!.step).toBe('step-a');
+  });
+
+  it('a step with only declared fields produces no diagnostics', async () => {
+    const result = await handleCreateWorkflow(
+      { steps: [{ id: 'step-a', description: 'Do something' }] },
+      stores,
+    );
+    expect(result.status).toBe('ok');
+    expect(result.diagnostics ?? []).toEqual([]);
+  });
+
+  it('a far/unrelated unknown key ("produces_state") gets no did_you_mean suggestion', async () => {
+    const args = {
+      steps: [
+        {
+          id: 'step-a',
+          description: 'Do something',
+          produces_state: 'done',
+        },
+      ],
+    } as unknown as CreateWorkflowArgs;
+
+    const result = await handleCreateWorkflow(args, stores);
+    expect(result.status).toBe('ok');
+    const diag = result.diagnostics!.find((d) => d.key === 'produces_state');
+    expect(diag).toBeDefined();
+    expect(diag!.did_you_mean).toBeUndefined();
+  });
+
+  it('UNKNOWN_CREATE_WORKFLOW_KEY still warns (never refuses) even when UNKNOWN_STEP_KEY is flipped to error (issue #170 leniency proof)', async () => {
+    const original = DEFAULT_POLICY.UNKNOWN_STEP_KEY;
+    DEFAULT_POLICY.UNKNOWN_STEP_KEY = 'error';
+    try {
+      const args = {
+        steps: [{ id: 'step-a', description: 'Do something', dependson: ['x'] }],
+      } as unknown as CreateWorkflowArgs;
+
+      const result = await handleCreateWorkflow(args, stores);
+
+      // create_workflow is UNCHANGED by the loader's UNKNOWN_STEP_KEY flip — it uses a distinct
+      // code (UNKNOWN_CREATE_WORKFLOW_KEY) that #170 never touches, so the workflow is still
+      // created and the response is still 'ok', not a refusal.
+      expect(result.status).toBe('ok');
+      expect(result.diagnostics!.some((d) => d.code === 'UNKNOWN_CREATE_WORKFLOW_KEY')).toBe(true);
+    } finally {
+      DEFAULT_POLICY.UNKNOWN_STEP_KEY = original;
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/create-workflow.ts
+++ b/packages/mcp-server/src/tools/create-workflow.ts
@@ -7,13 +7,40 @@ import {
   JsonFileStore,
   WorkflowError,
   resolvePreExecutionAgentAction,
+  findUnknownKeys,
+  renderLoaderWarning,
   type WorkflowDefinition,
   type ResponseEnvelope,
   type JsonSchema,
+  type LoaderWarning,
   CURRENT_WORKFLOW_SCHEMA_VERSION,
 } from '@sensigo/realm';
 import { handleStartRun, type HandleRunStores } from './start-run.js';
 import { sseJsonStringify } from '../sse-json.js';
+
+/**
+ * The step-shape allow-list (issue #169): `Object.keys(stepSchema.shape)` is the single source
+ * of truth for detecting unknown step keys in create_workflow submissions — no hand-maintained
+ * list, no drift from the real accepted fields. Module-scoped (hoisted from its previous home
+ * function-local to `registerCreateWorkflow`) so `handleCreateWorkflow` can reach it.
+ * `.describe()` is the "soft-teach" half of the fix (prevention complementing detection): it
+ * enumerates the valid field set directly in the tool's parameter schema, so an agent learns the
+ * shape upfront instead of only discovering a typo after submitting it.
+ */
+const stepSchema = z
+  .object({
+    id: z.string(),
+    description: z.string(),
+    depends_on: z.array(z.string()).optional(),
+    input_schema: z.record(z.unknown()).optional(),
+    timeout_seconds: z.number().optional(),
+  })
+  .passthrough()
+  .describe(
+    'A single workflow step. Valid fields: id, description, depends_on, input_schema, ' +
+      'timeout_seconds. Any other field is dropped and returned as a warning — do not invent ' +
+      'step fields.',
+  );
 
 export interface CreateWorkflowStep {
   id: string;
@@ -247,6 +274,19 @@ export async function handleCreateWorkflow(
 
   await workflowStore.register(definition);
 
+  // Issue #169: each raw submitted step's extra keys survive stepSchema's .passthrough() — find
+  // them against the SAME allow-list the schema itself declares (Object.keys(stepSchema.shape),
+  // the single source of truth, no hand-maintained list). Distinct code (UNKNOWN_CREATE_WORKFLOW_KEY)
+  // from the loader's UNKNOWN_STEP_KEY — #170 never flips it, so create_workflow stays lenient for
+  // agents forever. The workflow is still created either way; this only ever warns, never rejects.
+  const stepDiagnostics: LoaderWarning[] = args.steps.flatMap((step) =>
+    findUnknownKeys(step as unknown as Record<string, unknown>, Object.keys(stepSchema.shape), {
+      scope: 'step',
+      code: 'UNKNOWN_CREATE_WORKFLOW_KEY',
+      step: step.id,
+    }),
+  );
+
   const result = await handleStartRun(
     { workflow_id: workflowId, params: {} },
     {
@@ -255,21 +295,17 @@ export async function handleCreateWorkflow(
     },
   );
 
-  return { ...result, command: 'create_workflow', data: { workflow_id: workflowId } };
+  return {
+    ...result,
+    command: 'create_workflow',
+    data: { workflow_id: workflowId },
+    warnings: [...result.warnings, ...stepDiagnostics.map(renderLoaderWarning)],
+    diagnostics: [...(result.diagnostics ?? []), ...stepDiagnostics],
+  };
 }
 
 /** Registers the create_workflow MCP tool on the server. */
 export function registerCreateWorkflow(server: McpServer, opts?: HandleRunStores): void {
-  const stepSchema = z
-    .object({
-      id: z.string(),
-      description: z.string(),
-      depends_on: z.array(z.string()).optional(),
-      input_schema: z.record(z.unknown()).optional(),
-      timeout_seconds: z.number().optional(),
-    })
-    .passthrough();
-
   server.tool(
     'create_workflow',
     'Create a dynamic Realm workflow at runtime and immediately start a run. Use this when you have a multi-step task and want to track your own execution plan. Returns next_action pointing at your first step — proceed with execute_step as normal.',


### PR DESCRIPTION
## Context

#144 (v0.22.0) made the loader **warn** on unknown workflow/step keys, but those warnings were fire-and-forget `console.warn`: CI couldn't fail on them, the `create_workflow` **agent** couldn't see them (stderr never reaches a tool response), and a future hard-reject (#170) had no clean mechanism.

realm is **agent-native** — its diagnostics are consumed by LLM agents, not just humans. So this ships structured, code-tagged diagnostics (the pattern rustc/LSP use for machine consumers, and that Instructor/Pydantic-AI rely on for LLM self-correction), not just a lint flag.

Designed through a full Peer + Reviewer debate. The Reviewer caught a **blocking** flaw in the first design (changing the loader's return type is a semver-major break to the public `@sensigo/realm` API); the converged design is **non-breaking**.

## Motivation

Make loader warnings actionable — for CI, for humans, and above all for authoring agents — and reduce #170 to a one-line policy flip.

## Changes

**Core — the channel (`workflow/diagnostics.ts`, new)**
- `LoaderWarning { code, severity, message, scope, key?, did_you_mean? }`, a code→severity **policy table** (`DEFAULT_POLICY`, all `warn` today), `resolveSeverity`, pure `findUnknownKeys`, and a single `renderLoaderWarning` (one format source).
- **"Did you mean…" suggestions** (Levenshtein): a mistyped `dependson` now prints `⚠ step 'x': unknown key 'dependson' — ignored (did you mean 'depends_on'?)`.

**Core — non-breaking factoring (the hard invariant)**
- `parseWorkflowString` is now **pure** (collects warnings as data, no I/O, no throw).
- `loadWorkflowFromFile` / `loadWorkflowFromString` keep their **exact signatures and default `console.warn` behavior** — every existing caller and external consumer (`@sensigo/realm-testing`) compiles untouched.
- New additive exports: `loadWorkflowFrom{File,String}WithDiagnostics` → `{ definition, warnings }`, printing nothing.

**CLI**
- **`realm workflow validate --strict`** and **`realm workflow register --strict`** — exit non-zero on any warning; `register --strict` refuses to persist (never calls `store.register`). Default behavior unchanged.
- A per-command accumulator honors "fail on anything you print" (loader warnings + retry advisory + sentinel warnings).
- A **dormant boundary-reject** at validate/register/watch — inert today, so **#170 becomes a one-line policy flip**. Execution (`run`/`agent`/`listen`) stays lenient: deployed workflows keep running.

**MCP — agent-facing**
- `create_workflow` surfaces unknown step keys via an allow-list **derived from the zod `.shape`** (single source of truth, no drift), using a distinct `UNKNOWN_CREATE_WORKFLOW_KEY` code so agents stay lenient forever (#170 never flips it). The workflow is still created — keys are dropped-and-warned, never rejected.
- Envelope gains an additive **`diagnostics?: LoaderWarning[]`** alongside the unchanged `warnings: string[]`, so an agent can branch on `code`/`key`/`did_you_mean` instead of parsing text.

**Docs:** CHANGELOG `[Unreleased]`; `--strict` in `cli-commands.md`; the unknown-key/did-you-mean surface in `yaml-schema.md`; the `diagnostics` field + `create_workflow` metadata table (incl. the previously-undocumented `description`, disambiguated from `task_description`) in `mcp-protocol.md`.

## Verification

- `lint` · `build` · `check:versions` (0.22.0, no bump) · `audit` (0) — green.
- `TURBO_FORCE=true npm run test` — **8/8 tasks**: core 67/1658, cli 62/665, mcp 19/159, testing 4/77. Zero failures.
- **Non-breaking invariant verified:** public loader signatures unchanged; `core/index.ts` exports purely additive; the ~10 execution callers and `@sensigo/realm-testing` are absent from the diff and compile untouched.
- **#170-flip probe (re-run independently):** flipping `DEFAULT_POLICY.UNKNOWN_STEP_KEY→'error'` makes `validate` refuse **without** `--strict` (exit 1) while `create_workflow` stays `status: ok` with a `warn` diagnostic — proving the dormant hook is live *and* correctly scoped. Restored byte-identical.
- **Built-CLI:** typo → did-you-mean warning, exit 0; `--strict` → exit 1; `register --strict` → refuses to register, exit 1; clean → exit 0.

## Rollback

Revert the three commits (`8ffedf6`, `803bfa8`, `34933d9`). Purely additive — no schema/data migration, no signature change; reverting restores prior behavior exactly.

## Related

- Closes #169. Follows #144 (the warn).
- Follow-ups filed: **#170** (hard-reject at 1.0.0 — now a one-line policy flip), **#175** (per-code `--allow`/`--max-warnings`), **#176** (create_workflow posture revisit), **#177** (dedup-store flake), **#178** (empty `task_description` wipes `quick_start`).
