### PR TITLE
fix(mcp): empty quick_start no longer wipes the generated protocol default (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project are documented here.
 
 - The YAML loader's internal parser is now pure — warnings are collected as data and handed to the caller, which decides whether to print them (the default, byte-identical behavior) or surface them structurally instead. No observable behavior change for existing callers.
 
+### Fixed
+
+- **An empty or whitespace-only `protocol.quick_start` no longer wipes the agent protocol's generated quick-start default (issue #178).** Whether authored directly in workflow YAML (`protocol: { quick_start: "" }`) or submitted via `create_workflow`'s `metadata.task_description: ""`, a blank value is now treated as absent instead of silently blanking the imperative "how to begin" instruction the driving agent reads from `get_workflow_protocol`. A genuinely non-empty value (including one with incidental surrounding whitespace around real content) is still used verbatim, unchanged.
+
 ---
 
 ## [0.22.0] — 2026-07-13

--- a/packages/mcp-server/src/protocol/generator.test.ts
+++ b/packages/mcp-server/src/protocol/generator.test.ts
@@ -47,6 +47,61 @@ describe('generateProtocol', () => {
     expect(protocol.quick_start).toBe('Custom start');
   });
 
+  // issue #178: an empty/whitespace-only authored quick_start must not blank the generated
+  // default — `??` treats '' as "present," this must not.
+  describe('quick_start — empty/whitespace-only falls back to the generated default (issue #178)', () => {
+    const GENERATED_DEFAULT =
+      "Call start_run with workflow_id 'test-wf'. The engine handles all steps automatically. " +
+      'Follow the next_action in each response until the workflow completes.';
+
+    it('protocol.quick_start: "" falls back to the generated default', () => {
+      const definition: WorkflowDefinition = {
+        id: 'test-wf',
+        name: 'Test',
+        version: 1,
+        protocol: { quick_start: '' },
+        steps: {},
+      };
+      const protocol = generateProtocol(definition);
+      expect(protocol.quick_start).toBe(GENERATED_DEFAULT);
+    });
+
+    it('protocol.quick_start: "   " (whitespace-only) falls back to the generated default', () => {
+      const definition: WorkflowDefinition = {
+        id: 'test-wf',
+        name: 'Test',
+        version: 1,
+        protocol: { quick_start: '   ' },
+        steps: {},
+      };
+      const protocol = generateProtocol(definition);
+      expect(protocol.quick_start).toBe(GENERATED_DEFAULT);
+    });
+
+    it('absent protocol.quick_start still falls back to the generated default (unchanged, regression guard)', () => {
+      const definition: WorkflowDefinition = {
+        id: 'test-wf',
+        name: 'Test',
+        version: 1,
+        steps: {},
+      };
+      const protocol = generateProtocol(definition);
+      expect(protocol.quick_start).toBe(GENERATED_DEFAULT);
+    });
+
+    it('a real quick_start with surrounding whitespace but real content is used VERBATIM — not swallowed', () => {
+      const definition: WorkflowDefinition = {
+        id: 'test-wf',
+        name: 'Test',
+        version: 1,
+        protocol: { quick_start: '  Custom start with padding  ' },
+        steps: {},
+      };
+      const protocol = generateProtocol(definition);
+      expect(protocol.quick_start).toBe('  Custom start with padding  ');
+    });
+  });
+
   it('uses protocol.rules override when present', () => {
     const definition: WorkflowDefinition = {
       id: 'test-wf',

--- a/packages/mcp-server/src/protocol/generator.ts
+++ b/packages/mcp-server/src/protocol/generator.ts
@@ -144,9 +144,15 @@ export function generateProtocol(definition: WorkflowDefinition): WorkflowProtoc
 
   const rules = definition.protocol?.rules ?? DEFAULT_RULES;
 
+  // issue #178: `??` only falls back on null/undefined — an empty or whitespace-only authored
+  // quick_start is a "present" value that would otherwise win and blank out the generated
+  // default. Treat it as absent instead; a genuinely non-empty value (including one with
+  // incidental surrounding whitespace around real content) is still used verbatim.
+  const authoredQuickStart = definition.protocol?.quick_start;
   const quick_start =
-    definition.protocol?.quick_start ??
-    `Call start_run with workflow_id '${definition.id}'. ${agentStepCount > 0 ? `The engine will run auto steps automatically and return control at the first step requiring agent action.` : `The engine handles all steps automatically.`} Follow the next_action in each response until the workflow completes.`;
+    authoredQuickStart !== undefined && authoredQuickStart.trim() !== ''
+      ? authoredQuickStart
+      : `Call start_run with workflow_id '${definition.id}'. ${agentStepCount > 0 ? `The engine will run auto steps automatically and return control at the first step requiring agent action.` : `The engine handles all steps automatically.`} Follow the next_action in each response until the workflow completes.`;
 
   const protocol: WorkflowProtocol = {
     workflow_id: definition.id,

--- a/packages/mcp-server/src/tools/create-workflow.test.ts
+++ b/packages/mcp-server/src/tools/create-workflow.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { JsonFileStore, JsonWorkflowStore } from '@sensigo/realm';
 import { handleCreateWorkflow, type CreateWorkflowArgs } from './create-workflow.js';
 import { handleExecuteStep } from './execute-step.js';
+import { generateProtocol } from '../protocol/generator.js';
 
 describe('handleCreateWorkflow', () => {
   let runDir: string;
@@ -278,6 +279,54 @@ describe('handleCreateWorkflow', () => {
     const def = await stores.workflowStore.get(result.data['workflow_id'] as string);
     expect(def.description).toBe('Declarative purpose.');
     expect(def.protocol?.quick_start).toBe('Imperative how-to-begin.');
+  });
+
+  // issue #178: mirrors metadata.description's empty/whitespace-only guard — a blank
+  // task_description must not create a protocol: { quick_start: '' } that would blank the
+  // generated default.
+  it('metadata.task_description: "" does not set protocol.quick_start — the generated protocol shows the default', async () => {
+    const result = await handleCreateWorkflow(
+      {
+        steps: [{ id: 'step-a', description: 'Do something' }],
+        metadata: { task_description: '' },
+      },
+      stores,
+    );
+    expect(result.status).toBe('ok');
+    const def = await stores.workflowStore.get(result.data['workflow_id'] as string);
+    expect(def.protocol?.quick_start).toBeUndefined();
+    const protocol = generateProtocol(def);
+    expect(protocol.quick_start.length).toBeGreaterThan(0);
+    expect(protocol.quick_start).toContain('Call start_run');
+  });
+
+  it('metadata.task_description: "   " (whitespace-only) does not set protocol.quick_start — the generated protocol shows the default', async () => {
+    const result = await handleCreateWorkflow(
+      {
+        steps: [{ id: 'step-a', description: 'Do something' }],
+        metadata: { task_description: '   ' },
+      },
+      stores,
+    );
+    expect(result.status).toBe('ok');
+    const def = await stores.workflowStore.get(result.data['workflow_id'] as string);
+    expect(def.protocol?.quick_start).toBeUndefined();
+    const protocol = generateProtocol(def);
+    expect(protocol.quick_start.length).toBeGreaterThan(0);
+    expect(protocol.quick_start).toContain('Call start_run');
+  });
+
+  it('a real metadata.task_description still maps to protocol.quick_start exactly as before (regression guard)', async () => {
+    const result = await handleCreateWorkflow(
+      {
+        steps: [{ id: 'step-a', description: 'Do something' }],
+        metadata: { task_description: 'A real task description.' },
+      },
+      stores,
+    );
+    expect(result.status).toBe('ok');
+    const def = await stores.workflowStore.get(result.data['workflow_id'] as string);
+    expect(def.protocol?.quick_start).toBe('A real task description.');
   });
 });
 

--- a/packages/mcp-server/src/tools/create-workflow.ts
+++ b/packages/mcp-server/src/tools/create-workflow.ts
@@ -232,7 +232,10 @@ function buildWorkflowDefinition(workflowId: string, args: CreateWorkflowArgs): 
     steps: stepsRecord,
   };
 
-  if (metadata?.task_description !== undefined) {
+  // issue #178: mirrors metadata.description's guard below — an empty/whitespace-only
+  // task_description is treated as not-provided, so we never create a pointless
+  // protocol: { quick_start: '' } object (which would otherwise blank the generated default).
+  if (metadata?.task_description !== undefined && metadata.task_description.trim() !== '') {
     definition.protocol = { quick_start: metadata.task_description };
   }
 


### PR DESCRIPTION
## Context

`get_workflow_protocol`'s `quick_start` is the **imperative "how to begin"** instruction the driving agent reads. It has a sensible generated default — but the default was reachable only when the field was *absent*.

## Root Cause

`packages/mcp-server/src/protocol/generator.ts`:

```ts
const quick_start = definition.protocol?.quick_start ?? `Call start_run with workflow_id '…'. …`;
```

`??` falls back only on `null`/`undefined`. An **empty or whitespace-only string is a "present" value and wins**, so a blank `quick_start` silently replaced the default — leaving the agent with *no* start guidance, strictly worse than omitting the field.

**Two entry paths reached it, not one** (broader than the issue first described):

| input | before | after |
|---|---|---|
| human-authored YAML `protocol: { quick_start: "" }` (or `"   "`) | `""` ❌ | generated default ✅ |
| `create_workflow` with `metadata.task_description: ""` (no trim guard) | `""` ❌ | generated default ✅ |
| omitted | default ✅ | default ✅ |
| a real value (incl. one with padding) | verbatim ✅ | verbatim ✅ (untrimmed) |

## Changes

- **`generator.ts` (the fix).** Treat an empty/whitespace-only authored `quick_start` as **absent** and fall back to the generated default. This is the single consumption chokepoint, so it closes **both** entry paths. The default's text is **byte-identical**; a genuinely non-empty value — including one with incidental surrounding whitespace around real content — is still returned **verbatim, untrimmed**.
- **`create-workflow.ts` (defence-in-depth + consistency).** `metadata.task_description` now gets the same `.trim() !== ''` guard that `metadata.description` received in #144, so we never construct a pointless `protocol: { quick_start: '' }` at all. The two `metadata` fields stay symmetric and independent (the #144 declarative-vs-imperative role split is untouched).

**Deliberate non-change:** the identical `??` on `rules` (`definition.protocol?.rules ?? DEFAULT_RULES`) is **left alone**. An empty `rules: []` is *expressible author intent* ("I want no rules"); an empty-string `quick_start` never is — you would simply omit the key. The two are not analogous despite sharing the `??` shape.

## Verification

- `lint` · `build` · `check:versions` (0.22.0, no bump) · `audit` (0) — green.
- `TURBO_FORCE=true npm run test` — **8/8 tasks**, zero failures. Only `@sensigo/realm-mcp` moved (166, +7: 4 generator + 3 create_workflow) — confirming the change stayed inside the scoped package.
- **Mutation-probe:** reverting the guard to the plain `??` reddens exactly the empty-string and whitespace-only tests; restored byte-identical. The fix is genuinely test-guarded.
- **Behavioral proof** against the built module: `""` / `"   "` / absent all yield the generated default; a real value is verbatim; `"  Padded start  "` is preserved untrimmed.

## Rollback

`git revert` the single commit (`b479746`). Purely a fallback-condition change — no type, schema, or data migration; reverting restores prior behavior exactly.

## Related

Closes #178. Surfaced while documenting `create_workflow`'s metadata table during #169 (PR #179). Follows #144, which added `metadata.description` and its trim guard — the asymmetry this fixes.
