### PR TITLE
test(cli): de-flake dedup-store TTL tests with deterministic fake timers (#177)

### DIFF
--- a/packages/cli/src/lib/dedup-store.test.ts
+++ b/packages/cli/src/lib/dedup-store.test.ts
@@ -1,12 +1,10 @@
 // Tests for dedup stores. The shared suite runs against both implementations.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FileDedupStore, InMemoryDedupStore } from './dedup-store.js';
 import type { DedupStore } from './dedup-store.js';
-
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 const cases: Array<[string, () => DedupStore]> = [
   ['FileDedupStore', () => new FileDedupStore(mkdtempSync(join(tmpdir(), 'dedup-')), 'wf')],
@@ -14,6 +12,11 @@ const cases: Array<[string, () => DedupStore]> = [
 ];
 
 describe.each(cases)('%s', (_name, factory) => {
+  // Belt-and-suspenders alongside the per-test try/finally below (issue #177):
+  // guarantees fake timers can't leak into sibling tests/files even if a test throws
+  // before reaching its own `finally`.
+  afterEach(() => vi.useRealTimers());
+
   it('check returns false for unseen key', () => {
     const store = factory();
     expect(store.check('unseen', 60_000)).toBe(false);
@@ -26,10 +29,28 @@ describe.each(cases)('%s', (_name, factory) => {
   });
 
   it('record + check after TTL expires → false', async () => {
-    const store = factory();
-    store.record('k', 100);
-    await sleep(150);
-    expect(store.check('k', 100)).toBe(false);
+    // issue #177: was a real `sleep(150)` racing a real 100ms TTL — flaky under CPU
+    // contention. Fake timers instead, with a causal before/after assertion so the
+    // clock — not a race — is what proves expiry.
+    //
+    // FileDedupStore's expiry mixes a mockable Date.now() with a REAL file mtime, so:
+    //  (a) fake timers must be installed BEFORE record() so the fake clock and the
+    //      file's real mtime start aligned;
+    //  (b) the advance must be generous (≫ the 100ms TTL, so any install/mtime skew
+    //      is dwarfed) yet stay under 1 hour (FileDedupStore.check only scans
+    //      floor(ttlMs/3_600_000)+2 hour-buckets from Date.now() — advancing by hours
+    //      would move the record out of the scanned range and `check` would return
+    //      false because the record was NOT FOUND, not because it expired).
+    vi.useFakeTimers();
+    try {
+      const store = factory();
+      store.record('k', 100);
+      expect(store.check('k', 100)).toBe(true); // live BEFORE the TTL — the causal half
+      await vi.advanceTimersByTimeAsync(60_000); // ≫ TTL, ≪ 1 hour
+      expect(store.check('k', 100)).toBe(false); // expired AFTER — driven by the clock, not a race
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('double record for the same key → no throw', () => {
@@ -61,11 +82,24 @@ describe('FileDedupStore cleanup', () => {
 });
 
 describe('InMemoryDedupStore cleanup', () => {
+  // Belt-and-suspenders alongside the try/finally below (issue #177) — guarantees fake
+  // timers can't leak into sibling tests/files even if the test throws early.
+  afterEach(() => vi.useRealTimers());
+
   it('evicts expired entries', async () => {
-    const store = new InMemoryDedupStore();
-    store.record('k', 100);
-    await sleep(150);
-    store.cleanup(0);
-    expect(store.check('k')).toBe(false);
+    // issue #177: was a real sleep(150) racing a real 100ms TTL. InMemoryDedupStore's
+    // expiry is pure Date.now() (no filesystem mtime involved), so this one is a
+    // straightforward fake-timers conversion — no bucket/mtime trap to worry about.
+    vi.useFakeTimers();
+    try {
+      const store = new InMemoryDedupStore();
+      store.record('k', 100);
+      expect(store.check('k')).toBe(true); // live BEFORE the TTL — the causal half
+      await vi.advanceTimersByTimeAsync(60_000); // ≫ TTL
+      store.cleanup(0);
+      expect(store.check('k')).toBe(false); // expired AFTER — driven by the clock, not a race
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Context

`dedup-store.test.ts`'s TTL tests were **flaky under full-suite CPU contention** (surfaced during #169; filed as #177). They passed 11/11 in isolation but failed once in a full run (`expected true to be false`).

## Root Cause

The tests drove **real wall-clock TTLs** — `store.record('k', 100)` then `await sleep(150)` — racing a real 100 ms expiry. Under parallel load that race can invert. Same class as the `slack-gate-notifier` bounded-drain flake fixed in #172 / PR #173.

## Changes

Test-only — one file (`packages/cli/src/lib/dedup-store.test.ts`); the source is untouched.

- Both time-dependent tests converted to **deterministic fake timers** with a **causal** assertion — *live before the TTL* → advance the clock → *expired after* — so the clock, not a race, is what proves expiry. The `sleep` helper is gone.
- `afterEach(() => vi.useRealTimers())` added to both affected `describe` blocks (plus per-test `try/finally`) so fake timers cannot leak into siblings.

**The subtlety that made this non-trivial:** the two stores expire *differently*.

| store | expiry mechanism | consequence |
|---|---|---|
| `InMemoryDedupStore` | pure `Date.now()` | trivially mockable |
| `FileDedupStore` | `Date.now() − stat.mtime` — the record is an empty file whose **real filesystem mtime** is the only data | mixes a **mocked** clock with a **real** mtime |

So a naive `vi.useFakeTimers()` would compare a fake `now` to a real mtime and break `FileDedupStore`. It works only because vitest **anchors the fake clock to real system time at install**, which requires two rules, both applied:
1. install fake timers **before** `record()` (so the fake clock and the file's real mtime start aligned — measured skew: **−2 ms**);
2. advance by a margin **≫ the TTL but ≪ 1 hour** — `FileDedupStore.check` only scans `floor(ttl/3_600_000)+2` **hour-buckets**, so advancing by hours would move the record out of the scanned range and `check` would return `false` because the record was **not found**, passing the test for the *wrong reason*. `60_000 ms` keeps it findable so expiry is genuinely decided by the mtime comparison.

## Verification

- **Isolation:** 11/11 across 5 runs (report) / 3 runs (independent). Runtime dropped from ~478 ms of real sleeps to ~20 ms.
- **Full suite:** `TURBO_FORCE=true npm run test` → 8/8, zero failures; `realm-cli` count unchanged (62 files / 665 tests — a pure rewrite). Siblings after `dedup-store` all pass → no fake-timer leak.
- **Mutation-probes (independent, source-level) — proving the tests aren't vacuous:**
  - Disabling `FileDedupStore`'s `now − mtime < ttl` comparison **reddens** its TTL test — which can only happen if the record is genuinely **found** after the advance. This settles the missed-bucket concern definitively.
  - Disabling **both** of `InMemoryDedupStore`'s expiry paths (`evictExpired()` *and* the `Date.now() < expiry` comparison) reddens both its TTL and cleanup tests.
  - Source restored byte-identical after each; 11/11 green.
- `lint` · `build` · `check:versions` · `audit` — green.

## Rollback

`git revert` the single commit (`cd0b2e3`). Test-only; no runtime, schema, or version impact.

## Related

Closes #177. Surfaced during #169 (PR #179). Same wall-clock-flake pattern as #172 / PR #173, using the same fake-timer approach.
