### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.23.0] — 2026-07-14
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.22.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.23.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,7 +81,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.22.0';
+export const VERSION = '0.23.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.22.0';
+export const VERSION = '0.23.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.22.0',
+    version: '0.23.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -39,4 +39,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.22.0';
+export const VERSION = '0.23.0';


### PR DESCRIPTION
## Context

Release **v0.23.0** (minor). Ships the work already merged to `main` and sitting in `[Unreleased]`. No new code — this PR only finalizes the CHANGELOG heading and bumps the four `package.json` versions + five `VERSION` constants via `scripts/release.mjs`.

## Motivation

Publish the structured loader-warning channel (#169) and the `quick_start` fix (#178), accumulated since v0.22.0.

## Changes

Contents of this release (all landed via #179 / #180 / #181):

**Added**
- **Structured loader-warning channel (#169)** — loader warnings are now typed, code-tagged data (`LoaderWarning { code, severity, message, scope, key?, did_you_mean? }`) resolved through a code→severity policy, instead of fire-and-forget `console.warn`.
- **New additive public exports from `@sensigo/realm`** — `loadWorkflowFrom{File,String}WithDiagnostics` plus the diagnostics module (`DEFAULT_POLICY`, `resolveSeverity`, `findUnknownKeys`, `renderLoaderWarning`, `WarningCode`/`LoaderWarning`). **Non-breaking:** `loadWorkflowFromFile`/`loadWorkflowFromString` keep their exact signatures and default `console.warn` behavior — existing callers need no change.
- **`realm workflow validate --strict` and `realm workflow register --strict`** — exit non-zero on any warning; `register --strict` refuses to persist. Opt-in CI enforcement; default behavior unchanged.
- **"Did you mean…" suggestions** on unknown keys (a mistyped `dependson` now suggests `depends_on`).
- **Agent-facing structured diagnostics** — `create_workflow` returns an additive `diagnostics?: LoaderWarning[]` on the envelope (alongside the unchanged `warnings: string[]`), so an authoring agent can self-correct on `code`/`key`/`did_you_mean`.

**Changed**
- The loader's internal parser is now pure (warnings collected as data; the public wrappers print). No observable behavior change.

**Fixed**
- **An empty or whitespace-only `protocol.quick_start` no longer wipes the agent protocol's generated default (#178)** — whether authored in YAML or submitted as `create_workflow`'s `metadata.task_description`.

Also merged this cycle (test-only, no CHANGELOG): #177 — de-flaked the `dedup-store` TTL tests.

## Verification

- `npm run lint` · `npm run build` · `npm audit --omit=dev --audit-level=high` (0) — green.
- `TURBO_FORCE=true npm run test` — 8/8 tasks, zero failures. Suite is flake-free (both known flakes, #172 and #177, are de-flaked).
- `scripts/release.mjs` bumped all 4 `package.json` + 5 `VERSION` constants to 0.23.0 and tagged `v0.23.0` on `d63ee0c` (build sanity-check passed inside the script).
- Zero open PRs and **zero known defects** at cut time.

## Rollback

Standard release rollback (pre-publication Part B step 8): if the publish workflow half-completes, re-push the tag; if a broken artifact ships, cut a patch release. No runtime/schema/data migration in this release.

## Related

Releases #169 (PR #179), #178 (PR #180), #177 (PR #181). Merge with a **merge commit** (not squash/rebase) so the `v0.23.0` tag stays reachable from `main`.
