### PR TITLE
fix(core): fs absence/unreachability contract — stop the store layer lying about I/O failure (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **The store layer no longer conflates absence, unreachability, and corruption (issue #183).** `deleteAllForRun` (on `JsonFileStore`, `FailedAttemptStore`, and `JsonTraceBufferStore`), the run/pointer/WAL reads, and the WAL directory listing now treat only `ENOENT` as "not there" — idempotent, never an error. Any OTHER I/O errno (permissions, a read-only filesystem, a torn mount, disk failure) now THROWS a typed `ENGINE_ARTIFACT_DELETE_FAILED` error naming the failing artifact, instead of being silently swallowed and reported as success. This closes the `realm run purge` false-attestation bug: previously, if an artifact genuinely could not be deleted, `purge` would still report it as `purged` — the safety story `purge --force` (an irreversible, operator-invoked deletion) depends on now actually holds. Parse/JSON corruption (a torn WAL line, a garbage idempotency-key pointer) is unaffected by this change in one direction and improved in another: it still recovers (per-line skip, or self-healing to "absent") rather than throwing — but recovery is no longer silent, emitting a structured warning so an operator or log consumer can see it happened. A crash mid-write to a trace-buffer WAL file no longer discards the entire buffer — only the one torn line is skipped, and every entry recorded before the crash is preserved.
+
+---
+
 ## [0.23.0] — 2026-07-14
 
 ### Added

--- a/packages/cli/src/commands/store-fs-guard.test.ts
+++ b/packages/cli/src/commands/store-fs-guard.test.ts
@@ -1,0 +1,188 @@
+// Source-text guards for the fs absence/unreachability contract (issue #183).
+//
+// Two independent anti-recurrence checks, both source-text (not type-reflection) — same
+// discipline as purge-guard.test.ts's #107 declarer-enumeration guard:
+//
+//  1. No raw `unlink(` call may appear in store code outside the fs-io.ts primitive itself and
+//     the one documented atomic-write.ts exemption. A future edit that reaches for
+//     `unlink(...).catch(() => {})` instead of `deleteIfExists` silently reintroduces exactly the
+//     bug #183 fixes — this test fails loudly on that drift instead.
+//  2. Every store class WIRED into purge.ts's PerRunArtifactStore orchestrator (see
+//     purge-guard.test.ts's WIRED_ORDER) must have a TCK-invoking contract test somewhere in the
+//     repo — a store that adds `deleteAllForRun` and is wired into purge.ts but never actually
+//     run through `perRunArtifactStoreContract` would silently ship unverified against the L1-L4
+//     laws.
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// packages/cli/src/commands → packages/
+const PACKAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+/** Every non-test, non-declaration .ts file directly under (and recursively within) `root`. */
+function walkTsSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts') && !entry.endsWith('.d.ts')) {
+        out.push(full);
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** Every `.test.ts` file recursively within `root`. */
+function walkTestFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith('.test.ts')) out.push(full);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+// -----------------------------------------------------------------------------------------------
+// Guard 1: no raw `unlink(` in store code, outside the allow-list
+// -----------------------------------------------------------------------------------------------
+
+/** Files exempt from the raw-unlink ban, with why (issue #183). */
+const ALLOW_LISTED_FILES: Record<string, string> = {
+  'core/src/store/fs-io.ts':
+    'the primitive itself — deleteIfExists wraps the one legitimate raw unlink call.',
+  'core/src/store/atomic-write.ts':
+    "best-effort cleanup of the WRITER'S OWN temp file on a failed atomic write — converting " +
+    'it would let a failed temp-cleanup mask the real write error (see its own inline comment).',
+};
+
+/** Store-code scan roots (relative to PACKAGES_DIR): every file under core's store/ directory,
+ *  plus json-trace-buffer-store.ts specifically (it lives in mcp-server/src/, not under a
+ *  store/ subdirectory, but owns on-disk WAL artifacts exactly like the other two stores). */
+function storeCodeFiles(): string[] {
+  const coreStoreFiles = walkTsSourceFiles(join(PACKAGES_DIR, 'core', 'src', 'store'));
+  const traceBufferStoreFile = join(
+    PACKAGES_DIR,
+    'mcp-server',
+    'src',
+    'json-trace-buffer-store.ts',
+  );
+  return [...coreStoreFiles, traceBufferStoreFile];
+}
+
+function relativeToPackages(file: string): string {
+  return file.slice(PACKAGES_DIR.length + 1);
+}
+
+/** A conservative per-line match: `unlink` (word-boundary) followed by `(`, ignoring pure comment
+ *  lines (`//` or `*` after trimming — covers both line comments and JSDoc continuation lines).
+ *  Deliberately does NOT try to strip trailing inline comments — a false positive there would
+ *  just mean examining one extra line by hand, which is cheap; a false NEGATIVE (missing a real
+ *  call) is what this guard exists to prevent. */
+const RAW_UNLINK_CALL = /\bunlink\s*\(/;
+
+function findRawUnlinkCalls(file: string): number[] {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  const hits: number[] = [];
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+    if (RAW_UNLINK_CALL.test(trimmed)) hits.push(i + 1);
+  });
+  return hits;
+}
+
+describe('store-fs-guard — no raw unlink outside fs-io.ts / the atomic-write.ts exemption (issue #183)', () => {
+  it('at least one store-code file is scanned (the scan is wired correctly)', () => {
+    expect(storeCodeFiles().length).toBeGreaterThan(0);
+  });
+
+  it('every ALLOW_LISTED_FILES entry still exists (no stale exemption)', () => {
+    for (const rel of Object.keys(ALLOW_LISTED_FILES)) {
+      const full = join(PACKAGES_DIR, rel);
+      expect(statSync(full).isFile(), `allow-listed file no longer exists: ${rel}`).toBe(true);
+    }
+  });
+
+  it('no raw unlink( call appears in store code outside the allow-list', () => {
+    const violations: string[] = [];
+    for (const file of storeCodeFiles()) {
+      const rel = relativeToPackages(file);
+      if (rel in ALLOW_LISTED_FILES) continue;
+      const hits = findRawUnlinkCalls(file);
+      for (const line of hits) violations.push(`${rel}:${line}`);
+    }
+    expect(
+      violations,
+      `Raw unlink() call(s) found outside the fs-io.ts/atomic-write.ts allow-list: ` +
+        `${violations.join(', ')}. Use deleteIfExists from './fs-io.js' instead (issue #183) — ` +
+        `or, if this really is a new legitimate exemption, add it to ALLOW_LISTED_FILES with a reason.`,
+    ).toEqual([]);
+  });
+
+  it('the allow-listed files THEMSELVES still contain their expected raw unlink (sanity — proves the matcher is not just vacuously passing)', () => {
+    for (const rel of Object.keys(ALLOW_LISTED_FILES)) {
+      const full = join(PACKAGES_DIR, rel);
+      const hits = findRawUnlinkCalls(full);
+      expect(
+        hits.length,
+        `expected at least one raw unlink( in allow-listed ${rel}`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------------------------
+// Guard 2: every WIRED PerRunArtifactStore has a TCK-invoking contract test
+// -----------------------------------------------------------------------------------------------
+
+// Mirrors purge-guard.test.ts's WIRED_ORDER exactly (kept as an independent literal here rather
+// than imported — these are two intentionally separate guard files, per issue #183's own
+// instruction to add this as a new file; duplicating three class-name literals is cheaper than
+// coupling the two guards' internals together).
+const WIRED_STORES = ['JsonTraceBufferStore', 'FailedAttemptStore', 'JsonFileStore'];
+
+/** Every `.test.ts` file anywhere in the repo that calls `perRunArtifactStoreContract(`,
+ *  cross-referenced against which WIRED store class name(s) it also imports/references — a
+ *  same-file co-occurrence proxy for "this store was actually run through the TCK" (source-text,
+ *  not type-reflection, matching this repo's established anti-recurrence convention). */
+function tckCoveredStores(): Set<string> {
+  const covered = new Set<string>();
+  const packages = ['core', 'cli', 'mcp-server', 'testing'];
+  for (const pkg of packages) {
+    const root = join(PACKAGES_DIR, pkg, 'src');
+    for (const file of walkTestFiles(root)) {
+      const src = readFileSync(file, 'utf8');
+      if (!src.includes('perRunArtifactStoreContract(')) continue;
+      for (const storeName of WIRED_STORES) {
+        if (src.includes(storeName)) covered.add(storeName);
+      }
+    }
+  }
+  return covered;
+}
+
+describe('store-fs-guard — every WIRED PerRunArtifactStore has a TCK-invoking contract test (issue #183)', () => {
+  it('at least one contract test file invokes perRunArtifactStoreContract (the scan is wired correctly)', () => {
+    expect(tckCoveredStores().size).toBeGreaterThan(0);
+  });
+
+  it('EVERY store in WIRED_STORES is covered by a TCK-invoking test file', () => {
+    const covered = tckCoveredStores();
+    const uncovered = WIRED_STORES.filter((name) => !covered.has(name));
+    expect(
+      uncovered,
+      `${uncovered.join(', ')} ${uncovered.length === 1 ? 'is' : 'are'} WIRED into purge.ts's ` +
+        `orchestrator but no test file both imports it and calls perRunArtifactStoreContract(...) ` +
+        `— add a *.contract.test.ts wiring it into the TCK (see json-file-store.contract.test.ts ` +
+        `under packages/cli/src/store-contracts/ for the pattern).`,
+    ).toEqual([]);
+  });
+});

--- a/packages/cli/src/store-contracts/failed-attempt-store.contract.test.ts
+++ b/packages/cli/src/store-contracts/failed-attempt-store.contract.test.ts
@@ -1,0 +1,63 @@
+// PerRunArtifactStore TCK conformance for FailedAttemptStore (issue #183).
+//
+// See json-file-store.contract.test.ts (this directory) for why this lives in @sensigo/realm-cli
+// rather than @sensigo/realm's own test suite: @sensigo/realm-testing depends on @sensigo/realm,
+// so the reverse devDependency would be a genuine circular package dependency.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { FailedAttemptStore } from '@sensigo/realm';
+import {
+  perRunArtifactStoreContract,
+  type PerRunArtifactStoreContractAdapter,
+} from '@sensigo/realm-testing';
+
+const LAWS = [
+  'L1_ABSENCE_RESOLVES',
+  'L2_IDEMPOTENT',
+  'L3_FAILURE_REJECTS',
+  'L4_TYPED_REJECTION',
+] as const;
+
+/** Fresh adapter per law — see json-file-store.contract.test.ts for why. injectFailure replaces
+ *  the `.attempts.jsonl` sidecar with a DIRECTORY (works on every platform and any uid). */
+async function makeAdapter(): Promise<{
+  adapter: PerRunArtifactStoreContractAdapter;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'failed-attempt-store-tck-'));
+  const store = new FailedAttemptStore(dir);
+  const runId = randomUUID();
+  await store.append(runId, JSON.stringify({ ts: Date.now(), seed: 'tck' }));
+
+  const adapter: PerRunArtifactStoreContractAdapter = {
+    store,
+    runIdWithArtifact: runId,
+    runIdAbsent: randomUUID(),
+    injectFailure: async (id: string) => {
+      const path = join(dir, `${id}.attempts.jsonl`);
+      await rm(path, { recursive: true, force: true });
+      await mkdir(path);
+    },
+  };
+
+  return { adapter, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe('FailedAttemptStore — PerRunArtifactStore TCK conformance (issue #183)', () => {
+  for (const law of LAWS) {
+    it(law, async () => {
+      const { adapter, cleanup } = await makeAdapter();
+      try {
+        const cases = perRunArtifactStoreContract(adapter);
+        const target = cases.find((c) => c.law === law);
+        expect(target, `no case registered for law ${law}`).toBeDefined();
+        await target!.run();
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+});

--- a/packages/cli/src/store-contracts/json-file-store.contract.test.ts
+++ b/packages/cli/src/store-contracts/json-file-store.contract.test.ts
@@ -1,0 +1,74 @@
+// PerRunArtifactStore TCK conformance for JsonFileStore (issue #183).
+//
+// Lives in @sensigo/realm-cli, NOT in @sensigo/realm's own packages/core test suite, because
+// @sensigo/realm-testing depends on @sensigo/realm — a devDependency the other way round would be
+// a genuine circular PACKAGE dependency (verified empirically: adding
+// `"@sensigo/realm-testing": "*"` to packages/core/package.json's devDependencies makes
+// `turbo run build` fail with "Cyclic dependency detected: @sensigo/realm#build,
+// @sensigo/realm-testing#build"). @sensigo/realm-cli already depends on BOTH @sensigo/realm and
+// @sensigo/realm-testing (no new dependency needed) — and it's also where "does purge's safety
+// story hold" is most at home, since purge.ts is the operator-facing caller whose correctness
+// this whole contract exists for. store-fs-guard.test.ts's WIRED⇒TCK check looks for this file
+// by content (imports JsonFileStore + calls perRunArtifactStoreContract), not by path.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { JsonFileStore } from '@sensigo/realm';
+import {
+  perRunArtifactStoreContract,
+  type PerRunArtifactStoreContractAdapter,
+} from '@sensigo/realm-testing';
+
+const LAWS = [
+  'L1_ABSENCE_RESOLVES',
+  'L2_IDEMPOTENT',
+  'L3_FAILURE_REJECTS',
+  'L4_TYPED_REJECTION',
+] as const;
+
+/**
+ * Fresh adapter per law: deleteAllForRun is destructive (L2 deletes the seeded artifact) and
+ * injectFailure mutates on-disk state — reusing one adapter/store instance across multiple laws
+ * in sequence would leak state between them (see per-run-artifact-store-contract.ts's own usage
+ * note). injectFailure replaces the run's JSON file with a DIRECTORY — works on every platform
+ * and any uid (unlike chmod, which the TCK's own doc explicitly disqualifies).
+ */
+async function makeAdapter(): Promise<{
+  adapter: PerRunArtifactStoreContractAdapter;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'json-file-store-tck-'));
+  const store = new JsonFileStore(dir);
+  const { run } = await store.create({ workflowId: 'wf-tck', workflowVersion: 1, params: {} });
+
+  const adapter: PerRunArtifactStoreContractAdapter = {
+    store,
+    runIdWithArtifact: run.id,
+    runIdAbsent: randomUUID(),
+    injectFailure: async (runId: string) => {
+      const path = join(dir, `${runId}.json`);
+      await rm(path, { recursive: true, force: true });
+      await mkdir(path);
+    },
+  };
+
+  return { adapter, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe('JsonFileStore — PerRunArtifactStore TCK conformance (issue #183)', () => {
+  for (const law of LAWS) {
+    it(law, async () => {
+      const { adapter, cleanup } = await makeAdapter();
+      try {
+        const cases = perRunArtifactStoreContract(adapter);
+        const target = cases.find((c) => c.law === law);
+        expect(target, `no case registered for law ${law}`).toBeDefined();
+        await target!.run();
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+});

--- a/packages/cli/src/store-contracts/json-trace-buffer-store.contract.test.ts
+++ b/packages/cli/src/store-contracts/json-trace-buffer-store.contract.test.ts
@@ -1,0 +1,78 @@
+// PerRunArtifactStore TCK conformance for JsonTraceBufferStore (issue #183).
+//
+// See json-file-store.contract.test.ts (this directory) for why this lives in @sensigo/realm-cli
+// rather than alongside JsonTraceBufferStore's own test suite in @sensigo/realm-mcp: keeping all
+// three fs stores' TCK conformance tests co-located (this directory already depends on both
+// @sensigo/realm and @sensigo/realm-mcp, exactly as purge.ts — the operator-facing orchestrator
+// this contract protects — does) is simpler than splitting them across packages for no benefit
+// (@sensigo/realm-mcp itself has no circular-dependency blocker the way @sensigo/realm does, but
+// there's no reason to split the TCK wiring across two packages when one already has everything).
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, mkdir, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { JsonTraceBufferStore } from '@sensigo/realm-mcp';
+import {
+  perRunArtifactStoreContract,
+  type PerRunArtifactStoreContractAdapter,
+} from '@sensigo/realm-testing';
+
+const LAWS = [
+  'L1_ABSENCE_RESOLVES',
+  'L2_IDEMPOTENT',
+  'L3_FAILURE_REJECTS',
+  'L4_TYPED_REJECTION',
+] as const;
+
+/**
+ * Fresh adapter per law — see json-file-store.contract.test.ts for why. injectFailure replaces
+ * the seeded WAL file with a DIRECTORY. The exact filename is looked up via `readdir` + the
+ * known `trace-buffer-<runId>-*.jsonl` glob (mirroring deleteAllForRun's own matcher) rather than
+ * recomputing JsonTraceBufferStore's private base64url stepId encoding — this stays robust to an
+ * internal encoding change.
+ */
+async function makeAdapter(): Promise<{
+  adapter: PerRunArtifactStoreContractAdapter;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'json-trace-buffer-store-tck-'));
+  const store = new JsonTraceBufferStore(dir);
+  const runId = randomUUID();
+  await store.append(runId, 'tck-step', [{ event: 'tck-seed' }]);
+
+  const adapter: PerRunArtifactStoreContractAdapter = {
+    store,
+    runIdWithArtifact: runId,
+    runIdAbsent: randomUUID(),
+    injectFailure: async (id: string) => {
+      const prefix = `trace-buffer-${id}-`;
+      const entries = await readdir(dir);
+      const match = entries.find((f) => f.startsWith(prefix) && f.endsWith('.jsonl'));
+      if (match === undefined) {
+        throw new Error(`no seeded WAL file found for run '${id}' — adapter setup bug`);
+      }
+      const path = join(dir, match);
+      await rm(path, { recursive: true, force: true });
+      await mkdir(path);
+    },
+  };
+
+  return { adapter, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe('JsonTraceBufferStore — PerRunArtifactStore TCK conformance (issue #183)', () => {
+  for (const law of LAWS) {
+    it(law, async () => {
+      const { adapter, cleanup } = await makeAdapter();
+      try {
+        const cases = perRunArtifactStoreContract(adapter);
+        const target = cases.find((c) => c.law === law);
+        expect(target, `no case registered for law ${law}`).toBeDefined();
+        await target!.run();
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -2361,8 +2361,18 @@ export async function executeChain(
   let entryRun: RunRecord | undefined;
   try {
     entryRun = await store.get(options.runId);
-  } catch {
-    entryRun = undefined; // run not readable → fall through to the normal path
+  } catch (err) {
+    // issue #183: the store layer no longer conflates absence with unreachability — store.get()
+    // now throws a typed I/O error (rather than mapping it to STATE_RUN_NOT_FOUND) when the run
+    // record exists but can't actually be read. Swallow ONLY the expected "doesn't exist" case
+    // and fall through to the normal path (which re-attempts the read and surfaces its own
+    // properly-typed ENGINE_STORE_FAILED); re-throw everything else immediately rather than
+    // silently treating a real I/O failure as "the run doesn't exist."
+    if (err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND') {
+      entryRun = undefined;
+    } else {
+      throw err;
+    }
   }
   if (entryRun !== undefined && isTerminalPhase(entryRun.run_phase)) {
     return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,16 @@ export { JsonFileStore } from './store/json-file-store.js';
 export type { ReconcileSummary } from './store/json-file-store.js';
 export type { PerRunArtifactStore } from './store/per-run-artifact-store.js';
 export { atomicWriteFile } from './store/atomic-write.js';
+export {
+  deleteIfExists,
+  readIfExists,
+  statIfExists,
+  FsIoError,
+  isRetryableArtifactErrno,
+  artifactDeleteFailedError,
+  toArtifactDeleteFailedError,
+} from './store/fs-io.js';
+export type { ArtifactDeleteFailure } from './store/fs-io.js';
 export { hashParams, canonicalJson } from './store/params-hash.js';
 export { decideIdempotencyPolicy } from './store/idempotency-policy.js';
 export type { IdempotencyDecision } from './store/idempotency-policy.js';

--- a/packages/core/src/store/failed-attempt-store.ts
+++ b/packages/core/src/store/failed-attempt-store.ts
@@ -11,11 +11,11 @@
 //     the keys/ subdir).
 //   - The path is derived ONLY from the server-generated UUIDv4 runId (`[0-9a-f-]`), never from
 //     caller-supplied input — a path-safety invariant.
-import { existsSync } from 'node:fs';
-import { appendFile, readFile, stat, unlink } from 'node:fs/promises';
+import { appendFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { FailedAttemptRecord } from '../observability/failed-attempt-record.js';
 import type { PerRunArtifactStore } from './per-run-artifact-store.js';
+import { readIfExists, deleteIfExists, toArtifactDeleteFailedError } from './fs-io.js';
 
 /**
  * Append-and-stop byte ceiling per sidecar (~80+ full ≤3072B records — ample forensics). Approximate
@@ -77,7 +77,12 @@ export class FailedAttemptStore implements PerRunArtifactStore {
    */
   async read(runId: string): Promise<FailedAttemptReadResult> {
     const path = this.sidecarPath(runId);
-    if (!existsSync(path)) return { records: [], capped: false };
+    // issue #183: readIfExists distinguishes absence (undefined → empty result, the pre-existing
+    // behavior) from a genuine I/O failure (now propagates, rather than being silently swallowed
+    // into the same empty result an absent file produces — that conflation is exactly what let a
+    // real read failure masquerade as "no failed attempts recorded").
+    const content = await readIfExists(path);
+    if (content === undefined) return { records: [], capped: false };
 
     let capped = false;
     try {
@@ -85,13 +90,6 @@ export class FailedAttemptStore implements PerRunArtifactStore {
       capped = info.size >= FAILED_ATTEMPT_SIDECAR_MAX_BYTES;
     } catch {
       // ignore — capped stays false
-    }
-
-    let content: string;
-    try {
-      content = await readFile(path, 'utf8');
-    } catch {
-      return { records: [], capped };
     }
 
     const records: FailedAttemptRecord[] = [];
@@ -114,6 +112,11 @@ export class FailedAttemptStore implements PerRunArtifactStore {
    * double-invocation already removed it) is a no-op, never an error.
    */
   async deleteAllForRun(runId: string, _dirEntries?: readonly string[]): Promise<void> {
-    await unlink(this.sidecarPath(runId)).catch(() => {});
+    const path = this.sidecarPath(runId);
+    try {
+      await deleteIfExists(path);
+    } catch (err) {
+      throw toArtifactDeleteFailedError(runId, 'FailedAttemptStore', [], path, err);
+    }
   }
 }

--- a/packages/core/src/store/fs-io.test.ts
+++ b/packages/core/src/store/fs-io.test.ts
@@ -1,0 +1,258 @@
+// Tests for the fs-io.ts absence/unreachability primitive (issue #183).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  deleteIfExists,
+  readIfExists,
+  statIfExists,
+  withWin32Retry,
+  FsIoError,
+  isRetryableArtifactErrno,
+  artifactDeleteFailedError,
+  toArtifactDeleteFailedError,
+} from './fs-io.js';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'fs-io-test-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('deleteIfExists', () => {
+  it('ENOENT → resolves false (already gone, success, idempotent)', async () => {
+    await expect(deleteIfExists(join(dir, 'never-existed'))).resolves.toBe(false);
+  });
+
+  it('deletes an existing file and resolves true', async () => {
+    const path = join(dir, 'present.txt');
+    await writeFile(path, 'hello');
+    await expect(deleteIfExists(path)).resolves.toBe(true);
+    await expect(deleteIfExists(path)).resolves.toBe(false); // second call: already gone
+  });
+
+  it('a non-ENOENT errno (unlinking a directory) throws a typed FsIoError, never silently succeeds', async () => {
+    const dirPath = join(dir, 'a-directory');
+    await mkdir(dirPath);
+    await expect(deleteIfExists(dirPath)).rejects.toThrow(FsIoError);
+    try {
+      await deleteIfExists(dirPath);
+      expect.unreachable('expected deleteIfExists to throw for a directory target');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FsIoError);
+      const fsErr = err as FsIoError;
+      expect(fsErr.path).toBe(dirPath);
+      // EISDIR on Linux; some platforms may report EPERM for unlink-on-directory — either way it
+      // must NOT be ENOENT (which would mean deleteIfExists incorrectly treated it as absent).
+      expect(fsErr.code).not.toBe('ENOENT');
+    }
+  });
+});
+
+describe('readIfExists', () => {
+  it('ENOENT → resolves undefined (absent)', async () => {
+    await expect(readIfExists(join(dir, 'never-existed'))).resolves.toBeUndefined();
+  });
+
+  it('returns raw file contents verbatim — no parsing', async () => {
+    const path = join(dir, 'present.txt');
+    await writeFile(path, '{"not":"parsed here"}');
+    await expect(readIfExists(path)).resolves.toBe('{"not":"parsed here"}');
+  });
+
+  it('a non-ENOENT errno (reading a directory) throws a typed FsIoError', async () => {
+    const dirPath = join(dir, 'a-directory');
+    await mkdir(dirPath);
+    await expect(readIfExists(dirPath)).rejects.toThrow(FsIoError);
+    try {
+      await readIfExists(dirPath);
+      expect.unreachable('expected readIfExists to throw for a directory target');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FsIoError);
+      expect((err as FsIoError).code).not.toBe('ENOENT');
+    }
+  });
+});
+
+describe('statIfExists', () => {
+  it('ENOENT → resolves undefined (absent)', async () => {
+    await expect(statIfExists(join(dir, 'never-existed'))).resolves.toBeUndefined();
+  });
+
+  it('returns Stats for an existing path', async () => {
+    const path = join(dir, 'present.txt');
+    await writeFile(path, 'hello');
+    const info = await statIfExists(path);
+    expect(info).toBeDefined();
+    expect(info!.isFile()).toBe(true);
+  });
+
+  it('a non-ENOENT errno throws a typed FsIoError', async () => {
+    // A path whose PARENT component is a file, not a directory (ENOTDIR) — corruption, not
+    // absence, per the module doc: "ENOTDIR is corruption, not absence — it must be loud."
+    const filePath = join(dir, 'a-file');
+    await writeFile(filePath, 'hello');
+    const bogusChildPath = join(filePath, 'child');
+    await expect(statIfExists(bogusChildPath)).rejects.toThrow(FsIoError);
+    try {
+      await statIfExists(bogusChildPath);
+      expect.unreachable('expected statIfExists to throw for a path through a non-directory');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FsIoError);
+      const fsErr = err as FsIoError;
+      expect(fsErr.code).toBe('ENOTDIR');
+      expect(fsErr.code).not.toBe('ENOENT');
+    }
+  });
+});
+
+describe('isRetryableArtifactErrno', () => {
+  it('EACCES/EISDIR/EPERM/EROFS are NOT retryable (permanent — same permission/mount state)', () => {
+    expect(isRetryableArtifactErrno('EACCES')).toBe(false);
+    expect(isRetryableArtifactErrno('EISDIR')).toBe(false);
+    expect(isRetryableArtifactErrno('EPERM')).toBe(false);
+    expect(isRetryableArtifactErrno('EROFS')).toBe(false);
+  });
+
+  it('EBUSY/EIO ARE retryable (transient — a lock elsewhere, a flaky disk read)', () => {
+    expect(isRetryableArtifactErrno('EBUSY')).toBe(true);
+    expect(isRetryableArtifactErrno('EIO')).toBe(true);
+  });
+
+  it('an unrecognized errno defaults to NOT retryable (conservative)', () => {
+    expect(isRetryableArtifactErrno('ESOMETHING_UNKNOWN')).toBe(false);
+  });
+});
+
+describe('artifactDeleteFailedError / toArtifactDeleteFailedError', () => {
+  it('builds a WorkflowError with code, category, and details.failures', () => {
+    const err = artifactDeleteFailedError(
+      'run-1',
+      'SomeStore',
+      ['a.json'],
+      [{ artifact: 'b.json', code: 'EACCES', message: 'permission denied' }],
+    );
+    expect(err.code).toBe('ENGINE_ARTIFACT_DELETE_FAILED');
+    expect(err.category).toBe('ENGINE');
+    expect(err.details['runId']).toBe('run-1');
+    expect(err.details['store']).toBe('SomeStore');
+    expect(err.details['deleted']).toEqual(['a.json']);
+    expect(err.details['failures']).toEqual([
+      { artifact: 'b.json', code: 'EACCES', message: 'permission denied' },
+    ]);
+  });
+
+  it('retryable is true iff ANY failure is retryable', () => {
+    const permanentOnly = artifactDeleteFailedError(
+      'run-1',
+      'S',
+      [],
+      [{ artifact: 'x', code: 'EACCES', message: 'm' }],
+    );
+    expect(permanentOnly.retryable).toBe(false);
+
+    const withTransient = artifactDeleteFailedError(
+      'run-1',
+      'S',
+      [],
+      [
+        { artifact: 'x', code: 'EACCES', message: 'm' },
+        { artifact: 'y', code: 'EBUSY', message: 'm2' },
+      ],
+    );
+    expect(withTransient.retryable).toBe(true);
+  });
+
+  it('toArtifactDeleteFailedError extracts code/message from an FsIoError', () => {
+    const fsErr = new FsIoError(
+      'unlink',
+      '/some/path',
+      Object.assign(new Error('boom'), { code: 'EIO' }),
+    );
+    const wrapped = toArtifactDeleteFailedError('run-1', 'SomeStore', [], '/some/path', fsErr);
+    expect(wrapped.code).toBe('ENGINE_ARTIFACT_DELETE_FAILED');
+    expect(wrapped.retryable).toBe(true); // EIO is retryable
+    expect(wrapped.details['failures']).toEqual([
+      { artifact: '/some/path', code: 'EIO', message: fsErr.message },
+    ]);
+  });
+
+  it('toArtifactDeleteFailedError falls back to UNKNOWN for a non-errno, non-FsIoError value', () => {
+    const wrapped = toArtifactDeleteFailedError(
+      'run-1',
+      'SomeStore',
+      [],
+      '/some/path',
+      'not an error',
+    );
+    const failures = wrapped.details['failures'] as Array<{ code: string }>;
+    expect(failures[0]!.code).toBe('UNKNOWN');
+  });
+});
+
+describe('win32 bounded retry policy (withWin32Retry, gated on process.platform)', () => {
+  // Mocking the real `unlink`/`readFile`/`stat` bindings from 'node:fs/promises' under
+  // Vitest+ESM throws "Cannot spy on export ... Module namespace is not configurable in ESM" —
+  // so the retry POLICY (decoupled from any specific fs call — see withWin32Retry's own doc
+  // comment) is tested directly here with an injected fake `op`, rather than through
+  // deleteIfExists/readIfExists/statIfExists + a mocked fs module.
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('on win32, a transient EBUSY-shaped op is retried and can eventually succeed', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls++;
+      if (calls < 3) throw Object.assign(new Error('busy'), { code: 'EBUSY' });
+      return 'ok';
+    };
+
+    await expect(withWin32Retry(op)).resolves.toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  it('on win32, a non-retryable errno (EACCES) is NOT retried — throws immediately', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    let calls = 0;
+    const op = async (): Promise<never> => {
+      calls++;
+      throw Object.assign(new Error('denied'), { code: 'EACCES' });
+    };
+
+    await expect(withWin32Retry(op)).rejects.toMatchObject({ code: 'EACCES' });
+    expect(calls).toBe(1); // no retry attempted for a permanent errno
+  });
+
+  it('on win32, exhausting all retries still throws the last error', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    let calls = 0;
+    const op = async (): Promise<never> => {
+      calls++;
+      throw Object.assign(new Error('always busy'), { code: 'EBUSY' });
+    };
+
+    await expect(withWin32Retry(op)).rejects.toMatchObject({ code: 'EBUSY' });
+    expect(calls).toBe(4); // 1 initial attempt + WIN32_RETRY_COUNT (3) retries
+  });
+
+  it('on POSIX (non-win32), a transient EBUSY-shaped op is NOT retried — throws immediately', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    let calls = 0;
+    const op = async (): Promise<never> => {
+      calls++;
+      throw Object.assign(new Error('busy'), { code: 'EBUSY' });
+    };
+
+    await expect(withWin32Retry(op)).rejects.toMatchObject({ code: 'EBUSY' });
+    expect(calls).toBe(1); // POSIX: no retry/delay, even for a transient-shaped errno
+  });
+});

--- a/packages/core/src/store/fs-io.ts
+++ b/packages/core/src/store/fs-io.ts
@@ -1,0 +1,179 @@
+// fs-io.ts — the ENOENT-discriminating filesystem primitive (issue #183).
+//
+// Every store I/O site must distinguish three outcomes, never conflate them:
+//   1. ENOENT → absence → success (idempotent: a delete of a missing file succeeds; a read of a
+//      missing file returns "absent").
+//   2. Any OTHER errno (EACCES/EPERM/EIO/EROFS/EBUSY/EISDIR/ENOTDIR/…) → THROW a typed error.
+//      ENOTDIR is corruption, not absence — it must be loud.
+//   3. Parse/JSON corruption → RECOVER (per-line skip / self-heal) + a loud structured warning.
+//      Never silence, never throw. This is the CALLER's job — these primitives return raw
+//      bytes/booleans/stats only, never parse.
+//
+// A `process.platform === 'win32'`-gated bounded retry absorbs transient EBUSY/EPERM/ENOTEMPTY —
+// the same shape Node's own `fs.rm` uses (`maxRetries`/`retryDelay`) — because Windows
+// file-locking (an antivirus scan, an open handle from another process) can make a delete/read
+// transiently fail where POSIX would succeed immediately. No retry/delay on POSIX: a genuine
+// EACCES there is not transient, and retrying would only slow down a real permission failure.
+import { unlink, readFile, stat } from 'node:fs/promises';
+import type { Stats } from 'node:fs';
+import { WorkflowError } from '../types/workflow-error.js';
+
+const WIN32_RETRY_COUNT = 3;
+const WIN32_RETRY_DELAY_MS = 50;
+const WIN32_RETRYABLE_CODES = new Set(['EBUSY', 'EPERM', 'ENOTEMPTY']);
+
+/** Errno classified as transient (worth retrying) for the ENGINE_ARTIFACT_DELETE_FAILED
+ *  aggregate's `retryable` field — a lock held elsewhere, a flaky disk read. */
+const RETRYABLE_ARTIFACT_ERRNO = new Set(['EBUSY', 'EIO']);
+/** Errno classified as permanent (retrying will not help — same permission/mount state). Listed
+ *  explicitly (rather than "everything else") so the default for an unrecognized/unknown errno
+ *  stays the conservative `false` — never advertise a retry that might not help. */
+const NON_RETRYABLE_ARTIFACT_ERRNO = new Set(['EACCES', 'EISDIR', 'EPERM', 'EROFS']);
+
+function errnoCode(err: unknown): string | undefined {
+  return (err as NodeJS.ErrnoException | undefined)?.code;
+}
+
+/**
+ * Thrown by the fs-io primitives for any non-ENOENT errno. Callers map this to a typed,
+ * domain-specific `WorkflowError` (e.g. `ENGINE_ARTIFACT_DELETE_FAILED` via
+ * {@link toArtifactDeleteFailedError} below) at the aggregate layer — this class exists only to
+ * carry the raw path + errno + cause across that boundary without losing information.
+ */
+export class FsIoError extends Error {
+  readonly path: string;
+  readonly code: string;
+
+  constructor(op: string, path: string, cause: unknown) {
+    const code = errnoCode(cause) ?? 'UNKNOWN';
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    super(`${op} failed for '${path}' (${code}): ${causeMessage}`);
+    this.name = 'FsIoError';
+    this.path = path;
+    this.code = code;
+    if (cause instanceof Error) this.cause = cause;
+  }
+}
+
+/**
+ * Exported ONLY so the retry policy itself can be unit-tested directly with an injected fake
+ * `op` (mocking `node:fs/promises`'s real `unlink`/`readFile`/`stat` under Vitest+ESM is brittle —
+ * "Cannot spy on export ... Module namespace is not configurable in ESM" — so the policy is
+ * decoupled from any specific fs call and tested in isolation instead). Not part of the module's
+ * intended per-call public surface (`deleteIfExists`/`readIfExists`/`statIfExists` are).
+ */
+export async function withWin32Retry<T>(op: () => Promise<T>): Promise<T> {
+  if (process.platform !== 'win32') return op();
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= WIN32_RETRY_COUNT; attempt++) {
+    try {
+      return await op();
+    } catch (err) {
+      lastErr = err;
+      const code = errnoCode(err);
+      if (code === undefined || !WIN32_RETRYABLE_CODES.has(code)) throw err;
+      if (attempt < WIN32_RETRY_COUNT) {
+        await new Promise((resolve) => setTimeout(resolve, WIN32_RETRY_DELAY_MS));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Deletes `path`. ENOENT → `false` (already gone — success, idempotent). Any other errno → throws
+ * {@link FsIoError}. Returns `true` if this call actually deleted the file.
+ */
+export async function deleteIfExists(path: string): Promise<boolean> {
+  try {
+    await withWin32Retry(() => unlink(path));
+    return true;
+  } catch (err) {
+    if (errnoCode(err) === 'ENOENT') return false;
+    throw new FsIoError('unlink', path, err);
+  }
+}
+
+/**
+ * Reads `path` as utf8. ENOENT → `undefined` (absent). Any other errno → throws {@link FsIoError}.
+ * Parsing is the CALLER's job — this returns raw bytes only.
+ */
+export async function readIfExists(path: string): Promise<string | undefined> {
+  try {
+    return await withWin32Retry(() => readFile(path, 'utf8'));
+  } catch (err) {
+    if (errnoCode(err) === 'ENOENT') return undefined;
+    throw new FsIoError('readFile', path, err);
+  }
+}
+
+/**
+ * Stats `path`. ENOENT → `undefined` (absent). Any other errno → throws {@link FsIoError}.
+ */
+export async function statIfExists(path: string): Promise<Stats | undefined> {
+  try {
+    return await withWin32Retry(() => stat(path));
+  } catch (err) {
+    if (errnoCode(err) === 'ENOENT') return undefined;
+    throw new FsIoError('stat', path, err);
+  }
+}
+
+/**
+ * Retryable classification for the `ENGINE_ARTIFACT_DELETE_FAILED` aggregate error (issue #183):
+ * `EACCES`/`EISDIR`/`EPERM`/`EROFS` are permanent (retrying won't help — same permission/mount
+ * state); `EBUSY`/`EIO` are transient (a lock held elsewhere, a flaky disk read) — worth
+ * retrying. Any other or unknown errno defaults to `false` — conservative, since advertising a
+ * retry that might not help is worse than not advertising one that would have.
+ */
+export function isRetryableArtifactErrno(code: string): boolean {
+  return RETRYABLE_ARTIFACT_ERRNO.has(code) && !NON_RETRYABLE_ARTIFACT_ERRNO.has(code);
+}
+
+/** One artifact this store failed to delete, at the aggregate layer. */
+export interface ArtifactDeleteFailure {
+  artifact: string;
+  code: string;
+  message: string;
+}
+
+/**
+ * Builds the aggregate `ENGINE_ARTIFACT_DELETE_FAILED` `WorkflowError` every
+ * `PerRunArtifactStore.deleteAllForRun` implementation throws on a genuine (non-ENOENT) failure —
+ * the single typed shape `purge` (and any other caller) can rely on regardless of which store, or
+ * which internal read/delete step, actually failed. `retryable` is true iff ANY listed failure is
+ * itself retryable (a partial success followed by one transient failure is worth retrying as a
+ * whole).
+ */
+export function artifactDeleteFailedError(
+  runId: string,
+  store: string,
+  deleted: string[],
+  failures: ArtifactDeleteFailure[],
+): WorkflowError {
+  const summary = failures.map((f) => `${f.artifact} (${f.code})`).join(', ');
+  return new WorkflowError(`${store} failed to delete artifact(s) for run '${runId}': ${summary}`, {
+    code: 'ENGINE_ARTIFACT_DELETE_FAILED',
+    category: 'ENGINE',
+    agentAction: 'report_to_user',
+    retryable: failures.some((f) => isRetryableArtifactErrno(f.code)),
+    details: { runId, store, deleted, failures },
+  });
+}
+
+/**
+ * Convenience for the common single-failure case: extracts the errno (from an {@link FsIoError}
+ * or a raw `NodeJS.ErrnoException`) and message from `err`, then wraps it via
+ * {@link artifactDeleteFailedError}.
+ */
+export function toArtifactDeleteFailedError(
+  runId: string,
+  store: string,
+  deleted: string[],
+  artifact: string,
+  err: unknown,
+): WorkflowError {
+  const code = err instanceof FsIoError ? err.code : (errnoCode(err) ?? 'UNKNOWN');
+  const message = err instanceof Error ? err.message : String(err);
+  return artifactDeleteFailedError(runId, store, deleted, [{ artifact, code, message }]);
+}

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -1,6 +1,6 @@
 // Local file-backed run store. Stores each run as a JSON file in ~/.realm/runs/.
 // Uses proper-lockfile to prevent concurrent writes.
-import { mkdir, readFile, readdir, unlink } from 'node:fs/promises';
+import { mkdir, readFile, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
@@ -17,6 +17,7 @@ import { computeClaimDeadline } from '../engine/claim-liveness.js';
 import { hashParams } from './params-hash.js';
 import { decideIdempotencyPolicy } from './idempotency-policy.js';
 import { atomicWriteFile } from './atomic-write.js';
+import { readIfExists, deleteIfExists, toArtifactDeleteFailedError } from './fs-io.js';
 
 const DEFAULT_RUNS_DIR = join(homedir(), '.realm', 'runs');
 
@@ -125,12 +126,24 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     await mkdir(this.keysDir(), { recursive: true });
   }
 
-  /** Read a pointer file; returns undefined if absent or unparseable (self-heals via reclaim/fallback). */
+  /**
+   * Read a pointer file. Absence (ENOENT) → undefined. A genuine I/O failure (permissions, a
+   * torn mount, …) THROWS — issue #183: previously any error here, I/O or parse alike, silently
+   * self-healed to "absent," which let a real read failure masquerade as a missing pointer. Parse
+   * corruption (a torn/garbage pointer file) still self-heals to undefined — `create()` and
+   * `reconcileKeys()` both depend on that recovery — but is no longer SILENT: a loud, structured
+   * warning is emitted so an operator/log consumer can see the corruption happened.
+   */
   private async readPointer(keyPath: string): Promise<KeyPointer | undefined> {
-    if (!existsSync(keyPath)) return undefined;
+    const raw = await readIfExists(keyPath);
+    if (raw === undefined) return undefined;
     try {
-      return JSON.parse(await readFile(keyPath, 'utf8')) as KeyPointer;
-    } catch {
+      return JSON.parse(raw) as KeyPointer;
+    } catch (err) {
+      console.warn(
+        `⚠ realm: corrupt idempotency-key pointer at '${keyPath}' — treating as absent and ` +
+          `self-healing (${err instanceof Error ? err.message : String(err)}).`,
+      );
       return undefined;
     }
   }
@@ -272,20 +285,14 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
 
   async get(runId: string): Promise<RunRecord> {
     const path = this.filePath(runId);
-    if (!existsSync(path)) {
-      throw this.runNotFoundError(runId);
-    }
-    // issue #107: closes the TOCTOU window between the existsSync check above and this read — a
-    // concurrent purge (or any other deletion) can remove the file in between. ENOENT here maps to
-    // the SAME STATE_RUN_NOT_FOUND the pre-check promises; anything else rethrows (#132's torn-read
-    // loudness is preserved — this only silences the one specific, expected race).
-    let raw: string;
-    try {
-      raw = await readFile(path, 'utf8');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') throw this.runNotFoundError(runId);
-      throw err;
-    }
+    // issue #183: readIfExists collapses the old existsSync-then-readFile TOCTOU pair into one
+    // ENOENT-discriminating read — ENOENT (whether the file was never there, or a concurrent
+    // purge removed it between calls) maps to the SAME STATE_RUN_NOT_FOUND; any OTHER errno
+    // PROPAGATES rather than being mapped to STATE_RUN_NOT_FOUND — mapping a real I/O failure to
+    // "not found" is exactly the already_purged false-attestation bug #183 exists to close.
+    // #132's torn-read loudness is preserved throughout.
+    const raw = await readIfExists(path);
+    if (raw === undefined) throw this.runNotFoundError(runId);
     const parsed = JSON.parse(raw) as Record<string, unknown>;
 
     // Legacy format detection: runs written before Phase 35 have `state` but no `completed_steps`.
@@ -639,8 +646,14 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
       record = await this.get(runId);
     } catch (err) {
       if (err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND') return; // already gone
-      throw err;
+      // issue #183: any OTHER failure here means deleteAllForRun cannot even determine what to
+      // delete (or confirm the run file itself is reachable) — wrap it into the SAME aggregate
+      // shape the unlink failures below use, so a caller (e.g. purge) always observes ONE
+      // consistent, typed failure contract regardless of which internal step actually failed.
+      throw toArtifactDeleteFailedError(runId, 'JsonFileStore', [], this.filePath(runId), err);
     }
+
+    const deleted: string[] = [];
 
     // Conditional pointer delete: only when this run actually owns an idempotency key. A
     // `rerun`/supersede may have repointed the key to a NEWER run since this run was minted —
@@ -649,15 +662,34 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     // self-heals a dangling pointer regardless, so skipping a repointed one here is always safe.
     if (record.idempotency_key !== undefined) {
       const keyPath = this.keyPath(record.workflow_id, record.idempotency_key);
-      const pointer = await this.readPointer(keyPath);
+      let pointer: KeyPointer | undefined;
+      try {
+        pointer = await this.readPointer(keyPath);
+      } catch (err) {
+        throw toArtifactDeleteFailedError(runId, 'JsonFileStore', deleted, keyPath, err);
+      }
       if (pointer !== undefined && pointer.run_id === runId) {
-        await unlink(keyPath).catch(() => {});
+        try {
+          const didDelete = await deleteIfExists(keyPath);
+          if (didDelete) deleted.push(keyPath);
+        } catch (err) {
+          // Sequential stop-on-first-hard-error: a pointer we cannot delete means we STOP here —
+          // do NOT proceed to the run-file delete below. Leaving the run file in place on a
+          // partial failure is the safe outcome (issue #107's crash-anchor invariant): the run is
+          // re-enumerated and the whole purge retried on the next pass.
+          throw toArtifactDeleteFailedError(runId, 'JsonFileStore', deleted, keyPath, err);
+        }
       }
     }
 
     // The run file LAST — it is the crash re-enumeration anchor: a crash mid-purge leaves this
     // file in place, so the run is found again on the next purge/list pass and retried
     // idempotently (the pointer, if any, is already gone by then).
-    await unlink(this.filePath(runId)).catch(() => {});
+    try {
+      const didDelete = await deleteIfExists(this.filePath(runId));
+      if (didDelete) deleted.push(this.filePath(runId));
+    } catch (err) {
+      throw toArtifactDeleteFailedError(runId, 'JsonFileStore', deleted, this.filePath(runId), err);
+    }
   }
 }

--- a/packages/core/src/store/per-run-artifact-store.ts
+++ b/packages/core/src/store/per-run-artifact-store.ts
@@ -18,6 +18,12 @@ export interface PerRunArtifactStore {
    * call, or a call after a concurrent purge already removed the artifact, is a no-op, never an
    * error).
    *
+   * Corollary contract (issue #183): **a store MUST NOT report success for artifacts it cannot
+   * see. Absence (ENOENT) is success; unreachability (any other errno) MUST throw.** A store that
+   * silently swallows a real I/O error (permissions, a torn mount, disk failure) and resolves
+   * anyway is lying to every caller — most consequentially `realm run purge`, whose entire
+   * safety story rests on `purged` meaning the artifact is actually gone.
+   *
    * @param dirEntries Optional pre-scanned `readdir(runsDir)` listing, supplied by a BATCH purge so
    *   glob-based stores avoid one `readdir` per run (O(N×dir) → O(dir)). This is a filesystem-only
    *   optimization — non-fs stores (e.g. Postgres) and exact-path stores ignore it. When omitted, a

--- a/packages/core/src/types/workflow-error.ts
+++ b/packages/core/src/types/workflow-error.ts
@@ -57,6 +57,10 @@ export type ErrorCode =
   // ENGINE
   | 'ENGINE_INTERNAL'
   | 'ENGINE_STORE_FAILED'
+  // a PerRunArtifactStore.deleteAllForRun implementation could not delete (or could not even
+  // confirm the presence/absence of) an artifact it owns for a run — a genuine non-ENOENT I/O
+  // failure, never used for a plain "already gone" (issue #183)
+  | 'ENGINE_ARTIFACT_DELETE_FAILED'
   | 'ENGINE_ADAPTER_FAILED'
   | 'ENGINE_ADAPTER_NOT_REGISTERED'
   | 'ENGINE_PROCESSOR_FAILED'

--- a/packages/mcp-server/src/json-trace-buffer-store.test.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.test.ts
@@ -33,6 +33,23 @@ describe('JsonTraceBufferStore', () => {
     expect(entries[0]?.event).toBe('evt');
   });
 
+  it('read() is torn-line-safe: a corrupt/partial line is skipped, sibling good lines in the SAME file survive (issue #183)', async () => {
+    // Exercises readWal directly (via the public read()/append() surface) — distinct from the
+    // readAllForRun torn-line test below, which exercises a DIFFERENT method that already had its
+    // own per-line discipline before #183. readWal's old behavior was whole-buffer discard on ANY
+    // parse error (`catch { return { count: 0, bytes: 0, lines: [] }; }`) — this proves that's
+    // fixed: a crash mid-appendFile no longer nukes every entry recorded before it.
+    await store.append('run-1', 'step-a', [{ event: 'a1' }]);
+    await store.append('run-1', 'step-a', [{ event: 'a2' }]);
+    const path = join(dir, walFileName('run-1', 'step-a'));
+    await appendFile(path, '{ this is not valid json\n', 'utf8');
+
+    const entries = await store.read('run-1', 'step-a');
+
+    expect(entries).toHaveLength(2); // only the two well-formed lines — not zero
+    expect(entries.map((e) => e.event).sort()).toEqual(['a1', 'a2']);
+  });
+
   describe('deleteAllForRun (issue #107)', () => {
     it('deletes every WAL file for the run across multiple steps', async () => {
       await store.append('run-1', 'step-a', [{ event: 'a' }]);

--- a/packages/mcp-server/src/json-trace-buffer-store.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.ts
@@ -1,6 +1,6 @@
 // json-trace-buffer-store.ts — File-based TraceBufferStore using JSONL WAL files.
 import { existsSync } from 'node:fs';
-import { readFile, appendFile, unlink, readdir } from 'node:fs/promises';
+import { appendFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import lockfile from 'proper-lockfile';
 import {
@@ -13,6 +13,9 @@ import {
   BUFFER_LIMIT_BYTES,
   FINAL_LIMIT_ENTRIES,
   FINAL_LIMIT_BYTES,
+  readIfExists,
+  deleteIfExists,
+  toArtifactDeleteFailedError,
 } from '@sensigo/realm';
 import type { AgentTraceEntry } from '@sensigo/realm';
 import { WorkflowError } from '@sensigo/realm';
@@ -42,22 +45,30 @@ export class JsonTraceBufferStore implements TraceBufferStore, PerRunArtifactSto
   private async readWal(
     walPath: string,
   ): Promise<{ count: number; bytes: number; lines: WalLine[] }> {
-    if (!existsSync(walPath)) {
+    // issue #183: readIfExists distinguishes absence (undefined → empty, the pre-existing
+    // behavior) from a genuine I/O failure (now propagates). The old whole-buffer catch treated
+    // BOTH a real I/O failure AND a single torn/partial line (e.g. a crash mid-appendFile — the
+    // abandoned-agent scenario) as "corrupted WAL, discard everything" — losing every earlier,
+    // perfectly good line to one partial write. Per-line parsing below (mirroring
+    // readAllForRun's discipline) skips only the bad line and keeps the rest.
+    const content = await readIfExists(walPath);
+    if (content === undefined) {
       return { count: 0, bytes: 0, lines: [] };
     }
-    try {
-      const content = await readFile(walPath, 'utf8');
-      const lines: WalLine[] = content
-        .split('\n')
-        .filter((l) => l.trim().length > 0)
-        .map((l) => JSON.parse(l) as WalLine);
-      const count = lines.reduce((acc, l) => acc + l.entries.length, 0);
-      const bytes = Buffer.byteLength(content);
-      return { count, bytes, lines };
-    } catch {
-      // Treat corrupted WAL as empty.
-      return { count: 0, bytes: 0, lines: [] };
+
+    const lines: WalLine[] = [];
+    for (const raw of content.split('\n')) {
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) continue;
+      try {
+        lines.push(JSON.parse(trimmed) as WalLine);
+      } catch {
+        console.warn(`⚠ realm: skipping unparseable trace-buffer WAL line in '${walPath}'`);
+      }
     }
+    const count = lines.reduce((acc, l) => acc + l.entries.length, 0);
+    const bytes = Buffer.byteLength(content);
+    return { count, bytes, lines };
   }
 
   async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
@@ -146,8 +157,15 @@ export class JsonTraceBufferStore implements TraceBufferStore, PerRunArtifactSto
   }
 
   async delete(runId: string, stepId: string): Promise<void> {
+    // issue #183: this single-step cleanup is best-effort BY CONVENTION at every call site (all
+    // four callers — execution-loop.ts ×3, reclaim-step.ts ×1 — already wrap this call in their
+    // own try/catch that converts a failure into a warning, never treating success as load-bearing
+    // the way deleteAllForRun/purge do). Converting the raw unlink to deleteIfExists here doesn't
+    // change that contract (delete() can still fail — callers already expect and handle it); it
+    // just stops a real I/O error from being invisibly swallowed with NO signal at all, which the
+    // source-text guard (store-fs-guard.test.ts) also requires (no raw unlink in this file).
     const walPath = this.walPath(runId, stepId);
-    await unlink(walPath).catch(() => {});
+    await deleteIfExists(walPath);
   }
 
   /**
@@ -166,15 +184,31 @@ export class JsonTraceBufferStore implements TraceBufferStore, PerRunArtifactSto
     } else {
       try {
         files = await readdir(this.runsDir);
-      } catch {
-        return;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          files = []; // runsDir itself absent → nothing to delete, success
+        } else {
+          throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', [], this.runsDir, err);
+        }
       }
     }
-    await Promise.all(
-      files
-        .filter((f) => f.startsWith(prefix) && f.endsWith('.jsonl'))
-        .map((f) => unlink(join(this.runsDir, f)).catch(() => {})),
-    );
+
+    // SORTED candidates — deterministic residue (which artifact fails first is reproducible
+    // across retries/tests, not dependent on readdir's unspecified ordering).
+    const matching = [...files].filter((f) => f.startsWith(prefix) && f.endsWith('.jsonl')).sort();
+
+    const deleted: string[] = [];
+    for (const file of matching) {
+      const path = join(this.runsDir, file);
+      try {
+        const didDelete = await deleteIfExists(path);
+        if (didDelete) deleted.push(file);
+      } catch (err) {
+        // Sequential stop-on-first-hard-error: don't attempt the remaining candidates once one
+        // has genuinely failed — report exactly what succeeded before the failure.
+        throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', deleted, file, err);
+      }
+    }
   }
 
   /**
@@ -198,8 +232,11 @@ export class JsonTraceBufferStore implements TraceBufferStore, PerRunArtifactSto
     let files: string[];
     try {
       files = await readdir(this.runsDir);
-    } catch {
-      return {};
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {}; // runsDir itself absent → no WAL for anyone, not just this run
+      }
+      throw err;
     }
 
     const result: Record<string, unknown[]> = {};
@@ -214,11 +251,12 @@ export class JsonTraceBufferStore implements TraceBufferStore, PerRunArtifactSto
         continue; // malformed filename — skip this one file, not the whole export
       }
 
-      let content: string;
-      try {
-        content = await readFile(join(this.runsDir, file), 'utf8');
-      } catch {
-        continue; // vanished or unreadable between readdir and this read — skip, not a throw
+      // issue #183: readIfExists discriminates ENOENT (vanished between readdir and this read — a
+      // benign race, skip) from a genuine I/O failure (now throws, rather than being silently
+      // treated the same as the benign-vanished case).
+      const content = await readIfExists(join(this.runsDir, file));
+      if (content === undefined) {
+        continue;
       }
 
       const lines: unknown[] = [];

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -2,6 +2,12 @@
 
 // Store
 export { InMemoryStore } from './store/in-memory-store.js';
+export { perRunArtifactStoreContract } from './store/per-run-artifact-store-contract.js';
+export type {
+  ArtifactStoreLaw,
+  ArtifactStoreContractCase,
+  PerRunArtifactStoreContractAdapter,
+} from './store/per-run-artifact-store-contract.js';
 
 // Fixtures
 export {

--- a/packages/testing/src/store/per-run-artifact-store-contract.ts
+++ b/packages/testing/src/store/per-run-artifact-store-contract.ts
@@ -1,0 +1,137 @@
+// per-run-artifact-store-contract.ts — framework-agnostic Test Compatibility Kit (TCK) for
+// PerRunArtifactStore implementations (issue #183).
+//
+// Pure case descriptors, NOT describe/it/expect: importing vitest here would make it a runtime
+// dependency of this published package (this module ships in @sensigo/realm-testing's dist,
+// alongside runFixtureTests and the other framework-agnostic helpers in this package). Each
+// calling test file (one per concrete store) supplies an adapter and wires the returned
+// descriptors into ITS OWN test framework.
+//
+// Fault injection is an OPAQUE, adapter-supplied `injectFailure` callback — never a prescribed
+// mechanism. In particular, do NOT use `chmod 0o500` as an injector: it is a no-op on Windows and
+// silently ineffective when the test process runs as root (common in CI containers) — either way
+// L3 would pass VACUOUSLY (the "failure" never actually happens, so `deleteAllForRun` resolves
+// exactly as it should for a genuine success, and the law reports green for the wrong reason). A
+// robust injector replaces the target with a directory (works on every platform, any uid — you
+// cannot `unlink`/`readFile` a directory as if it were a file, regardless of permissions) or, for
+// a store with no filesystem at all (e.g. a future Postgres-backed store), mocks the underlying
+// I/O call to reject.
+//
+// Usage (see json-file-store.test.ts / failed-attempt-store.test.ts / json-trace-buffer-store.test.ts
+// for the real wiring): construct a FRESH adapter per law you exercise — `deleteAllForRun` is
+// destructive (L2 deletes the seeded artifact) and `injectFailure` mutates on-disk state, so
+// reusing one adapter/store instance across multiple laws in sequence is not safe.
+//
+//   const cases = perRunArtifactStoreContract(makeAdapter());
+//   for (const c of cases) {
+//     it(`${c.law}: ${c.name}`, async () => {
+//       const freshCases = perRunArtifactStoreContract(makeAdapter()); // fresh per law
+//       await freshCases.find((x) => x.law === c.law)!.run();
+//     });
+//   }
+import { WorkflowError, type PerRunArtifactStore } from '@sensigo/realm';
+
+/** One of the four laws every `PerRunArtifactStore` implementation must satisfy (issue #183). */
+export type ArtifactStoreLaw =
+  | 'L1_ABSENCE_RESOLVES'
+  | 'L2_IDEMPOTENT'
+  | 'L3_FAILURE_REJECTS'
+  | 'L4_TYPED_REJECTION';
+
+/**
+ * A single, framework-agnostic contract case. `run()` throws (rejects) on failure — any test
+ * framework's `await run()` (rejecting fails the test) or `expect(run()).resolves...` /
+ * `expect(run()).rejects...` maps directly onto this.
+ */
+export interface ArtifactStoreContractCase {
+  law: ArtifactStoreLaw;
+  name: string;
+  run: () => Promise<void>;
+}
+
+/** Adapter a calling test file supplies to parameterize the contract against one concrete store. */
+export interface PerRunArtifactStoreContractAdapter {
+  /** The store under test. */
+  store: PerRunArtifactStore;
+  /**
+   * A runId guaranteed to have at least one real, present artifact this store owns, seeded
+   * BEFORE the case runs. L2 (idempotent) and L3/L4 (failure) all act on this runId.
+   */
+  runIdWithArtifact: string;
+  /** A runId guaranteed to own NO artifact at all (never seeded). Used by L1. */
+  runIdAbsent: string;
+  /**
+   * Makes the artifact(s) for `runIdWithArtifact` genuinely unreachable (a non-ENOENT failure) —
+   * e.g. replace the target file with a directory, or mock the underlying I/O call to reject.
+   * Called immediately before L3/L4 exercise the store. The calling test file is responsible for
+   * ensuring this actually produces a hard failure on its platform — see the module doc above for
+   * why `chmod 0o500` is disqualified.
+   */
+  injectFailure: (runId: string) => void | Promise<void>;
+}
+
+export function perRunArtifactStoreContract(
+  adapter: PerRunArtifactStoreContractAdapter,
+): ArtifactStoreContractCase[] {
+  return [
+    {
+      law: 'L1_ABSENCE_RESOLVES',
+      name: 'deleteAllForRun resolves (never rejects) for a run that owns no artifact',
+      run: async () => {
+        await adapter.store.deleteAllForRun(adapter.runIdAbsent);
+      },
+    },
+    {
+      law: 'L2_IDEMPOTENT',
+      name: 'deleteAllForRun is idempotent — a second call after a successful delete still resolves',
+      run: async () => {
+        await adapter.store.deleteAllForRun(adapter.runIdWithArtifact);
+        await adapter.store.deleteAllForRun(adapter.runIdWithArtifact); // already gone — still resolves
+      },
+    },
+    {
+      law: 'L3_FAILURE_REJECTS',
+      name: 'deleteAllForRun rejects when the artifact exists but is genuinely unreachable (non-ENOENT)',
+      run: async () => {
+        await adapter.injectFailure(adapter.runIdWithArtifact);
+        let threw = false;
+        try {
+          await adapter.store.deleteAllForRun(adapter.runIdWithArtifact);
+        } catch {
+          threw = true;
+        }
+        if (!threw) {
+          throw new Error(
+            'deleteAllForRun resolved despite an injected non-ENOENT failure — the store ' +
+              'reported success for an artifact it could not actually delete (issue #183).',
+          );
+        }
+      },
+    },
+    {
+      law: 'L4_TYPED_REJECTION',
+      name: 'the L3 rejection is a WorkflowError carrying a code and details.failures',
+      run: async () => {
+        await adapter.injectFailure(adapter.runIdWithArtifact);
+        let caught: unknown;
+        try {
+          await adapter.store.deleteAllForRun(adapter.runIdWithArtifact);
+          throw new Error('expected deleteAllForRun to reject, but it resolved');
+        } catch (err) {
+          caught = err;
+        }
+        if (!(caught instanceof WorkflowError)) {
+          const kind = caught instanceof Error ? caught.constructor.name : typeof caught;
+          throw new Error(`expected a WorkflowError rejection, got: ${kind}`);
+        }
+        if (typeof caught.code !== 'string' || caught.code.length === 0) {
+          throw new Error('WorkflowError.code is missing or empty');
+        }
+        const failures = (caught.details as { failures?: unknown } | undefined)?.failures;
+        if (!Array.isArray(failures) || failures.length === 0) {
+          throw new Error('WorkflowError.details.failures is missing, empty, or not an array');
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Context

Realm's store layer conflated **absence**, **unreachability**, and **corruption** — it swallowed or fabricated on I/O failure. The result was a **false-attestation class** across three artifact-lifecycle primitives (surfaced in a multi-round design debate): `realm run purge` could report `purged`/`already_purged` + exit 0 **while the data was still on disk**; `readWal` discarded an entire buffer on one torn line; `readPointer` treated an unreadable pointer as absent (→ a duplicate run for a used idempotency key). This PR is the **foundation** of a 6-issue program (#183 first; #184/#186/#163 follow in v0.24.0; #185 on its own engine minor).

## Root Cause

`deleteAllForRun` blanket-swallowed unlink errors (`.catch(() => {})`); `existsSync`/`readdir` returned `false`/`[]` for **any** error (unreachability read as absence); `readWal`/`readPointer` caught I/O **and** parse together. Prior art: PostgreSQL's 2018 fsync-gate (*never proceed, never report success*), K8s foreground deletion (ordering without blocking degrades to the orphaning mode), CWE-390.

## Changes

**The three-way rule:** `ENOENT` → absence → **success** · any other I/O errno → **throw a typed `ENGINE_ARTIFACT_DELETE_FAILED`** · parse/corruption → **recover (per-line skip / self-heal) + a loud warning, never silence, never throw**.

- **`store/fs-io.ts` (new):** `deleteIfExists` / `readIfExists` / `statIfExists` — ENOENT-discriminating, errno taxonomy, **win32-gated** bounded retry (Node `fs.rm` precedent), per-errno `retryable`. `ENGINE_ARTIFACT_DELETE_FAILED` added to `ErrorCode`.
- **Converted every fabrication site:** all three `deleteAllForRun` (sequential stop-on-first-hard-error, **sorted** candidates, aggregate throw carrying the failing paths); both `readdir` fabrications; the three `existsSync` probes; `readWal` (per-line torn-safe, was whole-buffer discard); `readPointer` (I/O-throw, parse-self-heal+warn); `readAllForRun`; `FailedAttemptStore.read`; `JsonTraceBufferStore.delete`; and `executeChain`'s terminal guard (re-throws non-`STATE_RUN_NOT_FOUND`).
- **`get()` propagates non-ENOENT** instead of masking it as `STATE_RUN_NOT_FOUND` — the root of the `already_purged` lie.
- **Exempt (unchanged, allow-listed):** `atomic-write.ts` temp cleanup, `FailedAttemptStore.append`'s ceiling stat, and **`gc.ts`'s fail-closed `readdir`** (correct there, catastrophic in purge — same code, opposite blast radius).
- **Enforcement (3 layers):** a source-text guard forbidding raw `node:fs` `unlink` in store code (+ allow-list); WIRED⇒TCK-registered; and a **framework-agnostic TCK** in `@sensigo/realm-testing` (pure case descriptors, no `vitest` dep; opaque `injectFailure`; directory-in-place injector, *not* `chmod` which passes vacuously under root). Four laws — absence→resolves · idempotent · **failure→rejects** · rejection legible.

**Non-breaking:** no store-interface signature changed; `purge.ts` needed zero changes (its #107 bucketing already absorbs the throw).

## Verification

- `lint` · `build` · `check:versions` (0.23.0, no bump) · `audit` (0) — green.
- `TURBO_FORCE=true npm run test` — **8/8 tasks, zero failures** (core 68/1678, mcp 19/167, testing 4/77, cli 66/683; +`fs-io.test.ts`, +3 `.contract.test.ts`, +`store-fs-guard.test.ts`).
- **TCK non-vacuity (verified independently):** reverting `get()`'s honest-throw reddens the TCK's **L3 + L4** on `JsonFileStore` — the contract catches the exact bug it exists to catch.
- **Mutation-probes:** revert `get()`→`STATE_RUN_NOT_FOUND` reddens the TCK; revert `readWal`→whole-buffer-discard reddens the torn-line test; a raw `unlink` in store code reddens the source-text guard.
- **Behavioral (reproduced independently):** `realm run purge <id> --force` with an unreadable WAL (a directory in its place) → bucketed `failed`, names the path + `EISDIR`, **exit 1**, and the **run file survives** (crash-anchor intact). A clean purge exits 0.

## Rollback

Revert the single commit (`a936468`). No schema/data migration, no signature change; reverting restores the prior (silently-lying) behaviour.

## Related

Closes #183. Foundation for #184 (+#164), #186, #163; and #185. Follows the false-attestation debate.
