### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.24.0] — 2026-07-15
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.23.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.24.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,7 +92,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.23.0';
+export const VERSION = '0.24.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.23.0';
+export const VERSION = '0.24.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.23.0',
+    version: '0.24.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -45,4 +45,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.23.0';
+export const VERSION = '0.24.0';


### PR DESCRIPTION
## Context

Release **v0.24.0** (minor). This ships the complete **false-attestation program** — four merged, previously-unreleased PRs that stop realm's store layer from making false statements about the world (conflating *absence*, *unreachability*, and *corruption*). Cut per `.github/instructions/pre-publication.instructions.md` Part B.

## Motivation

`[Unreleased]` had accumulated the full program (#183 → #184 → #186 → #163) and every milestone PR is merged. Per Part B, a release is cut once `[Unreleased]` holds at least one `Added`/`Changed`/`Security` entry (#163 is `Added`) and all milestone PRs are merged — both hold.

## Changes

Mechanical release commit only — no source logic changes beyond the version bump:
- `docs: update changelog for v0.24.0` — renames `## [Unreleased]` → `## [0.24.0] — 2026-07-15`.
- `chore: release v0.24.0` — bumps `version` in all four `package.json` + the five source `VERSION`/`.version()` constants to `0.24.0` (via `scripts/release.mjs`). Tag `v0.24.0` created on the release commit.

**Release contents (already on `main`):**
- **Fixed #183** — store layer no longer conflates absence/unreachability/corruption (ENOENT→success · other errno→typed throw · parse→recover+warn).
- **Fixed #184** — `realm run purge` honest + can't destroy a resumed run (run-file lock + terminal re-verify under lock; `blocked` bucket; key-lock TOCTOU; honest `bytes freed`).
- **Fixed #186** — `realm run export` self-describes incompleteness (`realm_export_version: 2`, `complete`, `artifact_errors`), never withholds recoverable evidence.
- **Added #163** — `realm run gc` reaps run-less orphaned WAL/sidecar artifacts (fail-closed, age-floored, dry-run default) + honest non-zero exit when a sweep can't complete.

## Verification

```bash
# On this branch:
npm run check:versions          # all five strings = 0.24.0
git rev-parse v0.24.0           # == this PR's release commit (02f2e46)

# After merge + tag push (Part B step 5-7):
#   git switch main && git pull && git push --tags   → triggers publish.yml (OIDC)
# Then by-value:
npm view @sensigo/realm@0.24.0 version              # 0.24.0
npm install @sensigo/realm@0.24.0                    # ESM import { VERSION } === '0.24.0'
npx @sensigo/realm-cli@0.24.0 --version              # 0.24.0
```

Merge with a **merge commit** (not squash/rebase) — the tag is on the branch's release commit; a rewrite would dangle it and break `publish.yml`.

## Rollback

If a broken artifact surfaces post-publish, cut a patch release (v0.24.1) via the same Part B sequence — npm publishes are immutable. Pre-merge, the branch + tag can simply be deleted. No consumer migration required (all four items are backwards-compatible; no public-API break).

## Related

Closes the program: #183, #184, #186, #163. Deferred follow-ups: #164 (`.lock` reaping), #185 (epoch-tagged buffer, v0.25.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
