### PR TITLE
fix(core): honest seal-at-claim for the agent trace buffer (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **The agent trace buffer is no longer ownerless (issue #185).** A claiming execution's canonical trace now (1) always preserves the execution's own conclusion instead of letting older buffered lines truncate it out, (2) captures every buffered line present at settlement (closing a race that silently dropped a concurrently-appended line), and (3) carries an honest `trace_summary` caveat when it adopted buffered lines that may originate from a prior or concurrent writer — the engine no longer folds unattributable observations into a step's evidence while asserting single authorship. Faithful per-writer separation via an optional client-supplied nonce is tracked as a follow-up.
+
+---
+
 ## [0.24.0] — 2026-07-15
 
 ### Added

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -2877,6 +2877,350 @@ describe('WAL trace buffer integration (B-lite)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Trace provenance — honest seal-at-claim (issue #185)
+// ---------------------------------------------------------------------------
+
+describe('trace provenance — honest seal-at-claim (issue #185)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  const agentDef: WorkflowDefinition = {
+    id: 'wal-test-wf',
+    name: 'WAL Test Workflow',
+    version: 1,
+    steps: {
+      'step-agent': {
+        description: 'Agent step',
+        execution: 'agent',
+        depends_on: [],
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-185-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  describe('Finding 1 — budget-priority preserves the conclusion', () => {
+    it('a WAL with more entries than the truncation budget still yields a canonical trace containing the execute_step conclusion, dropping the OLDEST buffer lines as overflow', async () => {
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      // 105 buffer lines, appended in one batch (oldest → newest is array order) — 5 more than
+      // the 100-entry budget once the conclusion is added (106 total candidates).
+      const bufferBatch = Array.from({ length: 105 }, (_, i) => ({ event: `buffered_${i}` }));
+      await bufferStore.append(run.id, 'step-agent', bufferBatch);
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        traceBufferStore: bufferStore,
+        trace: [{ event: 'the_conclusion' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      const trace = snap?.trace ?? [];
+
+      // The conclusion survived.
+      expect(trace.some((e) => e.event === 'the_conclusion')).toBe(true);
+
+      // Truncation occurred and is reported honestly.
+      expect(snap?.trace_summary?.truncated).toBe(true);
+      expect(snap?.trace_summary?.truncation_reason).toBe('count_limit');
+      expect(snap?.trace_summary?.submitted_entries).toBe(106); // 105 buffer + 1 conclusion
+      expect(snap?.trace_summary?.discarded_overflow_entries).toBe(6); // 106 - 100 budget
+      expect(snap?.trace_summary?.stored_entries).toBe(101); // 100 real + 1 sentinel
+
+      // The 6 OLDEST buffer lines (buffered_0..buffered_5) were dropped, never the conclusion.
+      const survivingEvents = new Set(trace.map((e) => e.event));
+      for (let i = 0; i < 6; i++) {
+        expect(survivingEvents.has(`buffered_${i}`)).toBe(false);
+      }
+      for (let i = 6; i < 105; i++) {
+        expect(survivingEvents.has(`buffered_${i}`)).toBe(true);
+      }
+
+      // The conclusion is chronologically last among real (non-sentinel) entries — highest seq.
+      const nonSentinel = trace.filter((e) => e.event !== 'trace.truncated');
+      expect(nonSentinel[nonSentinel.length - 1]?.event).toBe('the_conclusion');
+      const conclusionEntry = trace.find((e) => e.event === 'the_conclusion');
+      const oldestSurvivingBuffer = trace.find((e) => e.event === 'buffered_6');
+      expect(oldestSurvivingBuffer!.seq).toBeLessThan(conclusionEntry!.seq);
+
+      // The sentinel is present and last.
+      expect(trace[trace.length - 1]?.event).toBe('trace.truncated');
+    });
+
+    it('the conclusion still survives when the WAL alone (no execute_step.trace overlap needed) pushes the merge past the byte budget', async () => {
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      // Fewer than 100 entries, but each large enough that the total blows the 50KB budget
+      // before the count limit would ever trigger (verified: 95 * ~555 bytes ≈ 52.7KB > 50KB,
+      // while 95 < the 100-entry count limit).
+      const bigValue = 'x'.repeat(500); // MAX_STRING_VALUE (500) — stays uncapped by normalizeData
+      const bufferBatch = Array.from({ length: 95 }, (_, i) => ({
+        event: `buffered_${i}`,
+        data: { payload: bigValue },
+      }));
+      await bufferStore.append(run.id, 'step-agent', bufferBatch);
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        traceBufferStore: bufferStore,
+        trace: [{ event: 'the_conclusion' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      const trace = snap?.trace ?? [];
+
+      expect(trace.some((e) => e.event === 'the_conclusion')).toBe(true);
+      expect(snap?.trace_summary?.truncated).toBe(true);
+      expect(snap?.trace_summary?.truncation_reason).toBe('byte_limit');
+      // Whatever was dropped is from the front (oldest) of the buffer — buffered_0 specifically.
+      const survivingEvents = new Set(trace.map((e) => e.event));
+      expect(survivingEvents.has('buffered_0')).toBe(false);
+    });
+  });
+
+  describe('Finding 2 — the post-claim re-read closes the silent-loss window', () => {
+    it('a line appended in the window between the pre-claim read and the claim is captured, not silently lost before WAL delete()', async () => {
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      // Simulates a concurrent append_trace landing AFTER the pre-claim WAL read (already
+      // executed by the time executeStep reaches claimStep) but before/at the claim itself.
+      const originalClaimStep = store.claimStep.bind(store);
+      const claimSpy = vi
+        .spyOn(store, 'claimStep')
+        .mockImplementationOnce(async (runId, stepId, def) => {
+          await bufferStore.append(runId, stepId, [{ event: 'race_window_line' }]);
+          return originalClaimStep(runId, stepId, def);
+        });
+
+      try {
+        const envelope = await executeStep(store, agentDef, {
+          runId: run.id,
+          command: 'step-agent',
+          input: {},
+          dispatcher: async () => ({}),
+          traceBufferStore: bufferStore,
+          // No options.trace, no pre-seeded buffer — the pre-claim read sees NOTHING at all.
+        });
+
+        expect(envelope.status).toBe('ok');
+        const snap = envelope.evidence[0];
+        expect(snap?.trace?.some((e) => e.event === 'race_window_line')).toBe(true);
+
+        // The WAL is gone after settlement — the line was captured before delete(), not lost.
+        const remaining = await bufferStore.read(run.id, 'step-agent');
+        expect(remaining).toHaveLength(0);
+      } finally {
+        claimSpy.mockRestore();
+      }
+    });
+
+    it('enforce-mode schema validation still runs pre-claim (against a possibly-incomplete set) — its verdict is carried onto the final captured summary', async () => {
+      const schemaEnforceDef: WorkflowDefinition = {
+        id: 'wal-schema-185-wf',
+        name: 'WAL Schema 185 Workflow',
+        version: 1,
+        steps: {
+          'step-agent': {
+            description: 'Agent step with trace schema',
+            execution: 'agent',
+            depends_on: [],
+            // Validates against the NORMALIZED entry shape (seq/event), which every canonical
+            // trace entry always has — unlike a schema requiring a custom field nested under
+            // `data`, this one can actually pass.
+            trace_schema: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['seq', 'event'],
+                properties: { seq: { type: 'number' }, event: { type: 'string' } },
+              },
+            },
+            trace_validation_mode: 'enforce',
+          },
+        },
+      };
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, schemaEnforceDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        traceBufferStore: bufferStore,
+        trace: [{ event: 'ok_entry' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace_summary?.schema_applied).toBe(true);
+      expect(snap?.trace_summary?.validation_mode).toBe('enforce');
+      expect(snap?.trace_summary?.validation_errors).toBe(0);
+    });
+  });
+
+  describe('Fix 3 — the honest trace_summary caveat', () => {
+    it('adopting any buffer/WAL line carries buffered_lines_adopted with the exact count', async () => {
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      await bufferStore.append(run.id, 'step-agent', [
+        { event: 'buffered_a' },
+        { event: 'buffered_b' },
+      ]);
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        traceBufferStore: bufferStore,
+        trace: [{ event: 'the_conclusion' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace_summary?.buffered_lines_adopted).toBe(2);
+    });
+
+    it('an execute_step.trace-only execution (no buffer contribution) carries NO caveat', async () => {
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        traceBufferStore: bufferStore,
+        trace: [{ event: 'the_conclusion' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace_summary?.buffered_lines_adopted).toBeUndefined();
+    });
+
+    it('no traceBufferStore configured at all → no caveat (pre-#185 shape, still exact)', async () => {
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        trace: [{ event: 'the_conclusion' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace_summary?.buffered_lines_adopted).toBeUndefined();
+    });
+  });
+
+  describe('Regression guard — off the overflow/race/foreign-line paths, output is unchanged', () => {
+    it('a normal WAL contribution (buffer well under budget) + a conclusion produces the same merged trace shape as before #185', async () => {
+      const bufferStore = new InMemoryTraceBufferStore();
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      await bufferStore.append(run.id, 'step-agent', [{ event: 'wal_first' }]);
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        traceBufferStore: bufferStore,
+        trace: [{ event: 'final_last' }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace).toHaveLength(2);
+      const walEntry = snap?.trace?.find((e) => e.event === 'wal_first');
+      const finalEntry = snap?.trace?.find((e) => e.event === 'final_last');
+      expect(walEntry?.seq).toBeLessThan(finalEntry!.seq);
+      expect(snap?.trace_summary?.truncated).toBe(false);
+      expect(snap?.trace_summary?.buffered_lines_adopted).toBe(1);
+    });
+
+    it('an execute_step.trace-only step (no traceBufferStore) is byte-identical to before #185', async () => {
+      const { run } = await store.create({
+        workflowId: 'wal-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => ({}),
+        trace: [{ event: 'direct_trace', data: { k: 'v' } }],
+      });
+
+      expect(envelope.status).toBe('ok');
+      const snap = envelope.evidence[0];
+      expect(snap?.trace).toEqual([{ seq: 1, event: 'direct_trace', data: { k: 'v' } }]);
+      expect(snap?.trace_summary).toEqual({
+        submitted_entries: 1,
+        stored_entries: 1,
+        discarded_entries: 0,
+        discarded_reserved_event_entries: 0,
+        discarded_overflow_entries: 0,
+        truncated: false,
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Step 5 dispatch-failure envelope — agent_action, next_actions, run_version
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -8,6 +8,7 @@ import type {
   EvidenceSnapshot,
   WorkflowContextSnapshot,
   AgentTraceEntry,
+  TraceNormalizationSummary,
 } from '../types/run-record.js';
 import type { ToolCallRecord } from '../types/mcp-types.js';
 import { extensionIdentityDiffers } from '../types/extension-identity.js';
@@ -587,6 +588,101 @@ function mergeWarnings(traceWarnings: string[], cleanupWarning?: string): string
   return cleanupWarning !== undefined ? [...traceWarnings, cleanupWarning] : [...traceWarnings];
 }
 
+/**
+ * Issue #185 Fix 1 (budget-priority): builds the merged, canonicalized trace for an agent step,
+ * giving `traceInput` (the `execute_step` conclusion — unambiguously THIS execution's own)
+ * priority into the truncation budget over `bufferEntries` (buffer/WAL lines, which may
+ * originate from a prior or concurrent writer — see Fix 3 / `buffered_lines_adopted`).
+ *
+ * Previously the merge sorted `options.trace` last (chronologically) and handed the WHOLE set to
+ * `normalizeTrace`, which keeps the FIRST N entries and drops the rest once truncated. When a
+ * prior/concurrent attempt left more than the budget's worth of buffer lines, the winner's own
+ * conclusion was the first thing dropped — canonical trace became majority-foreign plus a
+ * truncation sentinel, with the real conclusion gone. This function establishes the invariant
+ * that `traceInput`, when present, always survives, while keeping truncation accounting honest
+ * (the OLDEST buffer lines are the ones actually reported as overflow).
+ *
+ * `normalizeTrace`'s global keep-first truncation semantics are UNCHANGED — every single-input
+ * trace still depends on them, and this function calls it unmodified. Instead, THIS function
+ * decides the ORDER entries reach `normalizeTrace`:
+ *   1. A throwaway DRY pass processes candidates in PRIORITY order (the conclusion first, then
+ *      buffer lines newest→oldest, using each entry's chronological RANK — not a timestamp
+ *      comparison, so same-batch buffer entries sharing one `_internalTs` still resolve
+ *      unambiguously) purely to learn how many entries the budget admits (`acceptedCount`).
+ *   2. The REAL call then processes: the first `acceptedCount` priority-order candidates,
+ *      re-sorted into TRUE CHRONOLOGICAL order (so `seq` still functions as a chronological
+ *      proxy) — followed by the remaining priority-order tail, UNCHANGED. Because a fixed
+ *      accepted set's total byte/count cost is order-invariant (see below), this reordered
+ *      prefix is guaranteed to be accepted in full, and the tail then reproduces the EXACT SAME
+ *      trip point (same running total, same next candidate) the dry pass already found — so the
+ *      real call organically, honestly re-derives its own accurate sentinel/summary. No manual
+ *      patching of `normalizeTrace`'s output is needed anywhere in this function.
+ *
+ * Why the reordered prefix can never re-trigger truncation before the tail: `normalizeTrace`
+ * assigns `seq` sequentially as entries are accepted, so processing a FIXED accepted set in a
+ * different order only relabels which member gets which number 1..N — the total serialized byte
+ * cost of that field is therefore order-invariant, as is every other (content-derived) field. A
+ * first-trigger scan's running total is a partial sum of non-negative terms, so it never exceeds
+ * the set's own final total — and the dry pass already proved that final total fits. This also
+ * means a reserved-prefix (`trace.*`) buffer entry landing inside the reordered prefix costs
+ * nothing (skipped for free, as always) and is self-correcting: the real call simply accepts one
+ * further tail entry to compensate, still preferring the next-newest buffer line — the "prefer
+ * newest" invariant holds exactly, not just approximately.
+ *
+ * Pass-through (byte-identical to pre-#185 behavior) when `bufferEntries` is empty — the
+ * regression guard this preserves.
+ */
+function buildPriorityMergedTrace(
+  bufferEntries: BufferedEntry[],
+  traceInput: AgentTraceEntry[] | undefined,
+): NormalizeTraceResult {
+  if (bufferEntries.length === 0) {
+    return normalizeTrace(traceInput ?? []);
+  }
+
+  // Chronological rank: buffer entries keep their stored (append) order — read() returns them
+  // oldest-first, across however many separate append() batches contributed. options.trace
+  // entries (the execute_step conclusion) always rank after every buffer entry, mirroring the
+  // pre-#185 merge's "conclusion sorts last" intent — a plain integer rank sidesteps same-batch
+  // buffer entries sharing one `_internalTs` (a real, common case: one append() call stamps its
+  // whole batch with a single timestamp), which a timestamp-only sort cannot resolve stably.
+  type Ranked = AgentTraceEntry & { _rank: number };
+  const rankedBuffer: Ranked[] = bufferEntries.map((entry, i) => {
+    const { _internalTs: _drop, ...rest } = entry;
+    return { ...rest, _rank: i };
+  });
+  const rankedTrace: Ranked[] = (traceInput ?? []).map((entry, i) => ({
+    ...entry,
+    _rank: bufferEntries.length + i,
+  }));
+
+  // Priority order: the conclusion first (always favored), then buffer lines newest→oldest.
+  const priorityOrder: Ranked[] = [...rankedTrace, ...[...rankedBuffer].reverse()];
+
+  const dryRun = normalizeTrace(priorityOrder.map(({ _rank: _drop, ...rest }) => rest));
+  if (!dryRun.summary.truncated) {
+    // Nothing exceeds the budget — chronological merge + a single normalize, byte-identical to
+    // the pre-#185 merge shape (no selection needed).
+    const chronological = [...priorityOrder]
+      .sort((a, b) => a._rank - b._rank)
+      .map(({ _rank: _drop, ...rest }) => rest);
+    return normalizeTrace(chronological);
+  }
+
+  // stored_entries counts the dry pass's own sentinel too — subtract it to get the count of
+  // genuinely-submitted candidates the budget actually admits, in priority order.
+  const acceptedCount = dryRun.summary.stored_entries - 1;
+  const survivorsChronological = priorityOrder
+    .slice(0, acceptedCount)
+    .sort((a, b) => a._rank - b._rank);
+  const tail = priorityOrder.slice(acceptedCount); // unchanged priority-order tail — see doc above
+  const reordered: AgentTraceEntry[] = [...survivorsChronological, ...tail].map(
+    ({ _rank: _drop, ...rest }) => rest,
+  );
+
+  return normalizeTrace(reordered);
+}
+
 /** Builds a minimal error ResponseEnvelope from primitive fields. */
 function errorEnvelope(
   command: string,
@@ -800,14 +896,29 @@ export async function executeStep(
     }
   }
 
-  // Step 2d: Merge WAL buffer + execute_step trace, normalize, validate (agent steps only, pre-claim).
-  // walEntries is declared at this scope so it is in scope at the captureEvidence call site below.
+  // Step 2d: PRE-claim WAL read — issue #185 Fix 2: this read serves the enforce-gate ONLY.
+  // Schema validation stays pre-claim so an invalid trace still doesn't consume a claim. The
+  // trace actually CAPTURED into evidence is built from a fresh POST-claim re-read further below
+  // (once the claim below freezes appends) — see that block's comment for why: a concurrent
+  // append_trace landing in the narrow window between this read and the claim would otherwise
+  // never be adopted, then be silently destroyed when the WAL is deleted at settlement (issue
+  // #185 Finding 2). A rare line landing in exactly that window bypasses THIS enforce check —
+  // documented, accepted (see the post-claim block).
+  //
+  // walEntries is declared at this outer scope because it is REASSIGNED to the post-claim read
+  // below and referenced at the captureEvidence call site further down this function.
   const traceWarnings: string[] = [];
   let preNormalizedTrace: NormalizeTraceResult | undefined;
   let walEntries: BufferedEntry[] = [];
+  let preClaimSchemaResult:
+    | {
+        schema_applied: NonNullable<TraceNormalizationSummary['schema_applied']>;
+        validation_mode: NonNullable<TraceNormalizationSummary['validation_mode']>;
+        validation_errors: NonNullable<TraceNormalizationSummary['validation_errors']>;
+      }
+    | undefined;
 
   if (stepDef?.execution === 'agent') {
-    // Read WAL buffer if a buffer store is configured.
     walEntries =
       options.traceBufferStore !== undefined
         ? await options.traceBufferStore.read(options.runId, options.command)
@@ -817,21 +928,10 @@ export async function executeStep(
       walEntries.length > 0 || (options.trace !== undefined && options.trace.length > 0);
 
     if (hasAnyTrace) {
-      // Build merge set: WAL entries carry their _internalTs; execute_step entries
-      // receive Date.now() so they sort after all WAL batches (step conclusion ordering).
-      const finalTs = Date.now();
-      const mergeSet: Array<AgentTraceEntry & { _internalTs: number }> = [
-        ...walEntries, // already have _internalTs from buffer store
-        ...(options.trace ?? []).map((e) => ({ ...e, _internalTs: finalTs })),
-      ];
-
-      // Sort by _internalTs to produce chronological order, then strip the field before
-      // passing to normalizeTrace (which operates on plain AgentTraceEntry[]).
-      mergeSet.sort((a, b) => a._internalTs - b._internalTs);
-      const sortedEntries: AgentTraceEntry[] = mergeSet.map(({ _internalTs: _, ...rest }) => rest);
-
-      // Normalize the merged set once. This is the single canonicalization pass.
-      preNormalizedTrace = normalizeTrace(sortedEntries);
+      // issue #185 Fix 1: budget-priority merge (see buildPriorityMergedTrace's own doc) — this
+      // pre-claim pass exists only to feed validateTraceSchema below; its RESULT is discarded
+      // (not stored into the outer preNormalizedTrace) once the enforce-gate decision is made.
+      const preClaimNormalized = buildPriorityMergedTrace(walEntries, options.trace);
 
       // Validate trace schema if configured (unchanged call site).
       if (stepDef.trace_schema !== undefined) {
@@ -839,28 +939,32 @@ export async function executeStep(
         if (mode === 'enforce') {
           try {
             validateTraceSchema(
-              preNormalizedTrace.entries,
+              preClaimNormalized.entries,
               stepDef.trace_schema,
               options.command,
               'enforce',
             );
-            preNormalizedTrace.summary.schema_applied = true;
-            preNormalizedTrace.summary.validation_mode = 'enforce';
-            preNormalizedTrace.summary.validation_errors = 0;
+            preClaimSchemaResult = {
+              schema_applied: true,
+              validation_mode: 'enforce',
+              validation_errors: 0,
+            };
           } catch (err) {
             // On enforce rejection: do NOT delete the WAL — agent retries with WAL preserved.
             return makeErrorEnvelope(options, run, err as WorkflowError, definition);
           }
         } else {
           const result = validateTraceSchema(
-            preNormalizedTrace.entries,
+            preClaimNormalized.entries,
             stepDef.trace_schema,
             options.command,
             'warn',
           );
-          preNormalizedTrace.summary.schema_applied = true;
-          preNormalizedTrace.summary.validation_mode = 'warn';
-          preNormalizedTrace.summary.validation_errors = result.errorCount;
+          preClaimSchemaResult = {
+            schema_applied: true,
+            validation_mode: 'warn',
+            validation_errors: result.errorCount,
+          };
           if (result.errorCount > 0) {
             traceWarnings.push(result.warning);
           }
@@ -916,6 +1020,50 @@ export async function executeStep(
       definition,
       traceWarnings.length > 0 ? traceWarnings : undefined,
     );
+  }
+
+  // issue #185 Fix 2: POST-claim WAL re-read. Appends are frozen once a step is in_progress
+  // (claimed above) — so THIS read is complete, unlike the pre-claim read further up, which only
+  // served the enforce-gate. Re-running unconditionally (whether or not the pre-claim read found
+  // anything) is required: Finding 2's race is exactly a concurrent append_trace landing AFTER
+  // the pre-claim read but before/at the claim, meaning the pre-claim read alone could show
+  // nothing while a line already exists by the time we reach here. This re-read — and the
+  // re-normalized result built from it — is what is actually captured into evidence below; the
+  // pre-claim result above is discarded once the enforce-gate decision was made.
+  //
+  // walEntries is REASSIGNED here (declared pre-claim above) — from this point on it denotes the
+  // complete, post-claim set, which is also what the captureEvidence call site further below
+  // keys its `stepDef?.execution === 'agent' && walEntries.length > 0` check on.
+  if (stepDef?.execution === 'agent') {
+    walEntries =
+      options.traceBufferStore !== undefined
+        ? await options.traceBufferStore.read(options.runId, options.command)
+        : [];
+
+    if (walEntries.length > 0 || (options.trace !== undefined && options.trace.length > 0)) {
+      // issue #185 Fix 1: same budget-priority merge as the pre-claim pass, now over the
+      // complete post-claim set — this is the value captured into evidence.
+      preNormalizedTrace = buildPriorityMergedTrace(walEntries, options.trace);
+
+      // Carry over the enforce-gate's schema-validation result (computed pre-claim against a
+      // possibly-incomplete set) rather than re-validating here — Fix 2 deliberately keeps
+      // validation pre-claim (see that block's comment); this just republishes its verdict onto
+      // the summary that is actually captured.
+      if (preClaimSchemaResult !== undefined) {
+        preNormalizedTrace.summary.schema_applied = preClaimSchemaResult.schema_applied;
+        preNormalizedTrace.summary.validation_mode = preClaimSchemaResult.validation_mode;
+        preNormalizedTrace.summary.validation_errors = preClaimSchemaResult.validation_errors;
+      }
+
+      // issue #185 Fix 3: the honest label. Any buffer/WAL line adopted here is NOT attributable
+      // to this execution — the agent trace buffer has no single owner, so an adopted line may
+      // originate from a prior attempt (e.g. a crashed run this one resumed) or a concurrent one
+      // racing on the same (run, step). Present only when buffer lines were actually adopted;
+      // an options.trace-only execution carries no caveat.
+      if (walEntries.length > 0) {
+        preNormalizedTrace.summary.buffered_lines_adopted = walEntries.length;
+      }
+    }
   }
 
   // Load workflow context once at run start — skip if already populated.

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -39,6 +39,19 @@ export interface TraceNormalizationSummary {
   validation_mode?: 'warn' | 'enforce';
   /** Number of Ajv validation errors found. Zero means schema-conformant. Present when schema_applied is true. */
   validation_errors?: number;
+  /**
+   * Issue #185 (honest seal): the count of buffer/WAL lines adopted into this canonical trace.
+   * Present ONLY when > 0 — i.e., only when this execution's canonical trace includes lines it
+   * cannot itself attribute: the agent trace buffer is not owned by any one writer, so an
+   * adopted line may have been appended by a PRIOR execution attempt (e.g. a crashed run this
+   * one resumed) or by a CONCURRENT one racing on the same (run, step). The engine records this
+   * as an honest fact rather than silently asserting single authorship over content it cannot
+   * verify the provenance of. Absent (never `0` or `false`) when canonical trace was built
+   * entirely from this execution's own `execute_step` submission — no caveat is warranted there.
+   * Faithful per-writer separation (a client-supplied nonce distinguishing writers) is tracked as
+   * a follow-up; this field is deliberately just an honest count, not an attribution mechanism.
+   */
+  buffered_lines_adopted?: number;
 }
 
 /** Diagnostic metadata captured during step execution. Written once; read by inspect. */


### PR DESCRIPTION
## Context

The next engine minor (v0.25.0) after the false-attestation program. Closes the **seal-only v1** of #185 — the honest-provenance floor for the agent trace buffer. Chosen through a fresh 2-round Peer exploration + external prior-art survey (Kafka producer-epoch, Kleppmann fencing tokens, HDFS generation stamp), which **rejected** the previously-banked "epoch-tagged buffer" design: it was a *fencing* answer to a *provenance* problem, its correctness depended on the *untrusted* MCP client echoing a token, and it degraded the common single-streamer case. Internal + non-protocol-additive.

## Root Cause

The agent trace buffer WAL (`trace-buffer-<runId>-<stepId>.jsonl`) is **ownerless** — keyed by `(runId, stepId)`, not by who wrote it. `execute_step` merged whatever it found in the buffer into the claiming execution's canonical evidence. Beyond mis-attribution, the exploration verified two concrete, active harms:

1. **Finding 1 (corruption):** the merge sorted `options.trace` (the execution's own conclusion) last and `normalizeTrace` keeps the *first* N entries; when a prior/concurrent attempt left more buffer lines than the budget, the winner's own conclusion was the *first thing dropped* — canonical trace became majority-foreign + a truncation sentinel. Worst in the dominant sequential-abandon case (a re-drive adopting a crashed prior attempt's older lines).
2. **Finding 2 (silent loss):** the adoption read was pre-claim; a concurrent `append_trace` landing after that read but before the claim froze the step was never adopted, then silently destroyed when the WAL was unlinked at settlement.

## Changes

Three internal changes in `packages/core/src/engine/execution-loop.ts` (+ one additive type field):

- **Fix 1 — budget-priority (`buildPriorityMergedTrace`):** the execution's own `options.trace` always survives truncation; the *oldest buffer lines* are dropped first. Achieved with a throwaway dry-pass + a real-pass over reordered candidates — `normalizeTrace`'s global keep-first semantics are **unchanged** (every single-input trace still depends on them), and the truncation summary stays honest because the real pass re-derives it.
- **Fix 2 — post-claim re-read:** a fresh WAL read *after* the claim (appends are frozen once `in_progress`) is what gets captured; the pre-claim read serves the enforce-gate only. Closes the silent-loss window.
- **Fix 3 — honest label:** `TraceNormalizationSummary.buffered_lines_adopted` (additive, optional) records when canonical trace adopted buffered lines that may originate from a prior/concurrent writer — the engine no longer asserts single authorship over content it cannot attribute. Engine metadata; bypasses `trace_schema`/`normalizeTrace`/`FINAL_LIMIT`.

**Out of scope (filed):** faithful per-writer separation via a client-minted nonce (#197); clear stale WAL on claim-overwrite (#198); the new field's Postgres round-trip (#188).

## Verification

```bash
npm run lint && npm run build && npm run check:versions   # clean; versions match (no bump)
npm audit --omit=dev --audit-level=high                   # 0 vulnerabilities
TURBO_FORCE=true npm run test                             # core 1701/1701 (+9 new), all packages green
```

Independently reproduced (by the reviewer, on the branch):
- **Mutation-probe Fix 1:** revert `buildPriorityMergedTrace` to chronological order → both Finding-1 tests redden (conclusion dropped); restore → green.
- **Mutation-probe Fix 2:** skip the post-claim re-read → the race test reddens (line silently lost) while the enforce-verdict test correctly stays green; restore → green.
- **Regression guard:** a single-agent step / `options.trace`-only execution produces byte-identical canonical trace to pre-#185 (`toEqual`), confirming the empty-buffer fast path is a true pass-through.

## Rollback

Revert this PR. No schema, store-interface, protocol, or on-disk WAL-format change — `buffered_lines_adopted` is an additive optional field; `normalizeTrace`, all stores, `claimStep`, `append_trace`, and `execute_step` inputs are byte-unchanged. No release has shipped this (rides `[Unreleased]` → v0.25.0).

## Related

Closes the seal-only v1 of #185. Follow-ups: #197 (faithful nonce), #198 (stale-WAL clear), #188 (Postgres round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
