### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.25.0] — 2026-07-15
+
+### Added
+
+- **`EvidenceSnapshot.trace_summary.buffered_lines_adopted` (issue #185).** An optional count, present only when > 0, recording how many buffer/WAL lines a claiming execution adopted into its canonical trace — an honest signal that the trace may include observations from a prior or concurrent writer (the agent trace buffer has no single owner). Faithful per-writer separation via an optional client-supplied nonce is tracked as a follow-up (#197).
 
 ### Fixed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.24.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.25.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,7 +92,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.24.0';
+export const VERSION = '0.25.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.24.0';
+export const VERSION = '0.25.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -68,7 +68,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.24.0',
+    version: '0.25.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -45,4 +45,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.24.0';
+export const VERSION = '0.25.0';


### PR DESCRIPTION
## Context

Release **v0.25.0** (minor). The next engine minor after the false-attestation program (v0.24.0), shipping the seal-only v1 of #185 — the honest-provenance floor for the agent trace buffer. Cut per `.github/instructions/pre-publication.instructions.md` Part B.

## Motivation

`[Unreleased]` carries #185 (merged in PR #199) with both a `### Added` entry (the new `EvidenceSnapshot.trace_summary.buffered_lines_adopted` field — new consumer-visible API, which justifies a minor over a patch) and a `### Fixed` entry (the behavioral correctness fixes). All milestone work is merged.

## Changes

Mechanical release commit only — no source logic changes beyond the version bump:
- `docs: update changelog for v0.25.0` — renames `## [Unreleased]` → `## [0.25.0] — 2026-07-15`; adds the `### Added` note for the new `trace_summary` field.
- `chore: release v0.25.0` — bumps `version` in all four `package.json` + the five source `VERSION`/`.version()` constants to `0.25.0` (via `scripts/release.mjs`). Tag `v0.25.0` created on the release commit.

**Release contents (already on `main`, #185 seal-only v1):**
- **Fixed** — the agent trace buffer is no longer ownerless: canonical trace always preserves the execution's own conclusion (was truncated out by older buffered lines), captures every buffered line present at settlement (closing a silent-loss race), and carries an honest caveat when it adopted buffered lines that may originate from a prior/concurrent writer.
- **Added** — `EvidenceSnapshot.trace_summary.buffered_lines_adopted` (the honest count).

## Verification

```bash
npm run check:versions          # all five strings = 0.25.0
git rev-parse v0.25.0           # == this PR's release commit (51253f2)

# After merge + tag push (Part B step 5-7):
#   git switch main && git pull && git push --tags   → triggers publish.yml (OIDC)
npm view @sensigo/realm@0.25.0 version               # 0.25.0
npm install @sensigo/realm@0.25.0                     # ESM import { VERSION } === '0.25.0'
npx @sensigo/realm-cli@0.25.0 --version               # 0.25.0
```

Merge with a **merge commit** (not squash/rebase) — the tag is on the branch's release commit; a rewrite would dangle it and break `publish.yml`.

## Rollback

If a broken artifact surfaces post-publish, cut a patch release (v0.25.1) via the same Part B sequence — npm publishes are immutable. Pre-merge, the branch + tag can be deleted. No consumer migration required (the `buffered_lines_adopted` field is additive/optional; no public-API break).

## Related

Ships #185 (seal-only v1). Follow-ups: #197 (faithful nonce), #198 (stale-WAL clear), #188 (Postgres round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
