### PR TITLE
chore: tidy-close the #185 trace thread — append_trace terminal guard (#187) + reclaim clears stale WAL (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **`append_trace` now rejects a terminal run (issue #187).** A late `append_trace` to a `completed`/`failed`/`abandoned`/`aborted` run returns a typed error (`report_to_user`) instead of writing unreadable WAL residue — closing the one orphan source correct purge ordering cannot reach (a WAL born after purge's snapshot).
+
+### Fixed
+
+- **`realm run reclaim` now clears the reclaimed step's stale trace buffer (issue #198).** The `clearStaleWal` hook was inert (the CLI never passed a trace-buffer store); wiring it means a re-driven step starts from a clean buffer instead of inheriting a dead attempt's lines, and a failed clear now warns loudly instead of being silently swallowed (the #183 contract). Reduces how often #185's "may include a prior/concurrent writer" caveat fires.
+
+---
+
 ## [0.25.0] — 2026-07-15
 
 ### Added

--- a/packages/cli/src/commands/reclaim.ts
+++ b/packages/cli/src/commands/reclaim.ts
@@ -69,7 +69,14 @@ export const reclaimCommand = new Command('reclaim')
     ) => {
       const { JsonFileStore, JsonWorkflowStore, reclaimStep, classifyInProgressClaims } =
         await import('@sensigo/realm');
+      const { JsonTraceBufferStore } = await import('@sensigo/realm-mcp');
       const store = new JsonFileStore();
+      // issue #198: wire the trace buffer so a reclaim clears the reclaimed step's stale WAL —
+      // without this, reclaimStep's own clearStaleWal hook is inert (traceBufferStore stays
+      // undefined) and the next attempt adopts the dead attempt's buffered lines, which is the
+      // mechanical reason a sequential-abandon-then-retry is #185's dominant "adopted a
+      // prior/concurrent writer's lines" population.
+      const traceBufferStore = new JsonTraceBufferStore(store.runsDirPath);
 
       // Loud-fail on a store that cannot persist the claim clock (liveness recovery unavailable).
       if (!store.persistsClaims) {
@@ -157,7 +164,7 @@ export const reclaimCommand = new Command('reclaim')
         let reclaimed = 0;
         for (const { runId: rid, claim } of selected) {
           try {
-            const result = await reclaimStep(store, rid, claim.step);
+            const result = await reclaimStep(store, rid, claim.step, { traceBufferStore });
             if (result.outcome === 'reclaimed') reclaimed += 1;
             console.log(`  ✓ ${rid} / ${claim.step}: ${result.outcome} (was ${result.priorState})`);
           } catch (err) {
@@ -212,7 +219,7 @@ export const reclaimCommand = new Command('reclaim')
             `⚠ Reclaiming '${opts.step}' on run '${runId}' — this re-drives the step; ` +
               `its side effects may repeat.`,
           );
-          const result = await reclaimStep(store, runId, opts.step);
+          const result = await reclaimStep(store, runId, opts.step, { traceBufferStore });
           if (result.outcome === 'reclaimed') {
             console.log(
               `Reclaimed '${opts.step}' (was ${result.priorState}). It is eligible again — the next ` +

--- a/packages/core/src/engine/reclaim-step.test.ts
+++ b/packages/core/src/engine/reclaim-step.test.ts
@@ -8,11 +8,13 @@ import { findEligibleSteps } from './eligibility.js';
 import { classifyInProgressClaims } from './claim-liveness.js';
 import { executeStep } from './execution-loop.js';
 import { JsonFileStore } from '../store/json-file-store.js';
+import { InMemoryTraceBufferStore } from '../store/trace-buffer-store.js';
 import { ExtensionRegistry } from '../extensions/registry.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import type { RunStore } from '../store/store-interface.js';
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { TraceBufferStore } from '../store/trace-buffer-store.js';
 import type { StepHandler } from '../extensions/step-handler.js';
 
 const autoWf: WorkflowDefinition = {
@@ -332,5 +334,123 @@ describe('reclaimStep — finalizer-wedge recovery (headline)', () => {
     expect(final.terminal_state).toBe(true);
     expect(cleanupRan).toHaveBeenCalledTimes(1);
     expect(final.completed_steps).toContain('cleanup'); // the finalizer ran on recovery
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clearing the stale trace buffer on reclaim (issue #198).
+// ---------------------------------------------------------------------------
+
+const agentReclaimWf: WorkflowDefinition = {
+  id: 'reclaim-agent-wf',
+  name: 'Reclaim Agent WF',
+  version: 1,
+  steps: {
+    'step-agent': { description: 'agent step', execution: 'agent', depends_on: [] },
+  },
+};
+
+describe('reclaimStep — clearing the stale trace buffer (issue #198)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-reclaim-wal-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("clears the reclaimed step's WAL — a subsequent claim + executeStep adopts NO stale lines (no buffered_lines_adopted caveat)", async () => {
+    const { run } = await store.create({
+      workflowId: 'reclaim-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const claimed = await store.claimStep(run.id, 'step-agent', agentReclaimWf);
+    await store.update({ ...claimed, claims: { 'step-agent': { deadline: pastIso() } } });
+
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'dead_attempt_line' }]);
+    expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(1);
+
+    const result = await reclaimStep(store, run.id, 'step-agent', { traceBufferStore });
+    expect(result.outcome).toBe('reclaimed');
+
+    // The WAL is gone — cleared by the reclaim itself, not left for the next attempt to inherit.
+    expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
+
+    // A subsequent claim + executeStep starts from a clean buffer: no stale lines adopted, so
+    // Fix 3's (#185) caveat never fires — this execution's trace is entirely its own.
+    const envelope = await executeStep(store, agentReclaimWf, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      trace: [{ event: 'fresh_conclusion' }],
+    });
+    expect(envelope.status).toBe('ok');
+    const snap = envelope.evidence[0];
+    expect(snap?.trace).toEqual([{ seq: 1, event: 'fresh_conclusion' }]);
+    expect(snap?.trace_summary?.buffered_lines_adopted).toBeUndefined();
+  });
+
+  it('clearStaleWal warns loudly (never rethrows) on a real I/O failure — the reclaim itself still succeeds', async () => {
+    const { run } = await store.create({
+      workflowId: 'reclaim-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const claimed = await store.claimStep(run.id, 'work', autoWf);
+    await store.update({ ...claimed, claims: { work: { deadline: pastIso() } } });
+
+    const failingTraceBufferStore: TraceBufferStore = {
+      append: async () => {
+        throw new Error('should not be called');
+      },
+      read: async () => [],
+      delete: async () => {
+        throw new Error('simulated disk failure');
+      },
+      deleteAllForRun: async () => {},
+      readAllForRun: async () => ({}),
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await reclaimStep(store, run.id, 'work', {
+        traceBufferStore: failingTraceBufferStore,
+      });
+      // Not blocked — the reclaim itself succeeded despite the WAL clear failing.
+      expect(result.outcome).toBe('reclaimed');
+      const after = await store.get(run.id);
+      expect(after.in_progress_steps).not.toContain('work');
+
+      // But it was NOT silently swallowed (issue #183 contract) — a warning was emitted naming
+      // the run, the step, and the underlying error.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [message] = warnSpy.mock.calls[0]!;
+      expect(String(message)).toContain(run.id);
+      expect(String(message)).toContain('work');
+      expect(String(message)).toContain('simulated disk failure');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('reclaimStep without a traceBufferStore is unchanged — the undefined early-return still holds (no regression for any caller that omits it)', async () => {
+    const { run } = await store.create({
+      workflowId: 'reclaim-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const claimed = await store.claimStep(run.id, 'work', autoWf);
+    await store.update({ ...claimed, claims: { work: { deadline: pastIso() } } });
+
+    // No options at all — mirrors every pre-#198 caller.
+    const result = await reclaimStep(store, run.id, 'work');
+    expect(result.outcome).toBe('reclaimed');
   });
 });

--- a/packages/core/src/engine/reclaim-step.ts
+++ b/packages/core/src/engine/reclaim-step.ts
@@ -69,6 +69,23 @@ function applyReclaim(run: RunRecord, stepName: string, now: Date): RunRecord {
   };
 }
 
+/**
+ * Clears the reclaimed step's stale trace buffer (issue #198). This is correct, not merely
+ * tidy: reclaim IS the recovery boundary for a dead claim — the buffer being cleared here was
+ * never adopted into any settled evidence (the claim wedged before `execute_step` ever reached
+ * its post-claim adoption read — see #185's execution-loop.ts), so nothing is being discarded
+ * that any consumer has seen or could ever see. #185 already discards a losing attempt's WAL
+ * lines at the WINNER's settlement time (whoever claims the step next adopts them, then they're
+ * unlinked); #198 simply does the same discard EARLIER — at the moment the dead attempt is
+ * declared dead, rather than leaving it on disk for the next attempt to silently adopt and then
+ * have to caveat as "may include a prior writer" (`buffered_lines_adopted`). No SETTLED evidence
+ * is ever touched by this function — only pre-claim, never-adopted buffer content.
+ *
+ * Best-effort and non-blocking by design: a failed clear must never fail the reclaim itself (the
+ * claim recovery is the important, safety-gated act; WAL hygiene is secondary) — but per the
+ * #183 contract (a real I/O failure must be loud, never silently swallowed), a genuine delete
+ * failure now warns instead of vanishing into an empty catch.
+ */
 async function clearStaleWal(
   traceBufferStore: TraceBufferStore | undefined,
   runId: string,
@@ -77,8 +94,12 @@ async function clearStaleWal(
   if (traceBufferStore === undefined) return;
   try {
     await traceBufferStore.delete(runId, stepName);
-  } catch {
-    // Best-effort WAL hygiene — a failed delete never blocks the reclaim.
+  } catch (err) {
+    console.warn(
+      `⚠ realm: failed to clear stale trace buffer for run '${runId}' step '${stepName}' during ` +
+        `reclaim (${err instanceof Error ? err.message : String(err)}) — the reclaim itself ` +
+        `still succeeded; the next attempt may adopt this buffer's lines.`,
+    );
   }
 }
 

--- a/packages/mcp-server/src/tools/append-trace.test.ts
+++ b/packages/mcp-server/src/tools/append-trace.test.ts
@@ -9,7 +9,7 @@ import {
   InMemoryTraceBufferStore,
   BUFFER_LIMIT_COUNT,
 } from '@sensigo/realm';
-import type { WorkflowDefinition } from '@sensigo/realm';
+import type { WorkflowDefinition, RunRecord } from '@sensigo/realm';
 import { CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
 import { handleAppendTrace, registerAppendTrace } from './append-trace.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -231,6 +231,92 @@ describe('handleAppendTrace', () => {
     expect(result.status).toBe('ok');
     if (result.status === 'ok') {
       // Only 'valid_event' survives normalization.
+      expect(result.buffer_count).toBe(1);
+    }
+  });
+});
+
+describe('append_trace terminal-run guard (issue #187)', () => {
+  let runDir: string;
+  let workflowDir: string;
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+  let traceBufferStore: InMemoryTraceBufferStore;
+
+  beforeEach(async () => {
+    runDir = await mkdtemp(join(tmpdir(), 'realm-append-trace-terminal-runs-'));
+    workflowDir = await mkdtemp(join(tmpdir(), 'realm-append-trace-terminal-wf-'));
+    runStore = new JsonFileStore(runDir);
+    workflowStore = new JsonWorkflowStore(workflowDir);
+    traceBufferStore = new InMemoryTraceBufferStore();
+
+    const def = makeWorkflowDef();
+    await writeFile(join(workflowDir, `${def.id}.json`), JSON.stringify(def, null, 2), 'utf8');
+  });
+
+  /** Drives a fresh run to exactly the requested terminal `run_phase` via deriveRunPhase's own
+   *  rules (see engine/eligibility.ts) — abandoned_at / aborted_at / terminal_reason /
+   *  failed_steps are the ONLY inputs that decide it. */
+  async function makeTerminalRun(
+    phase: 'completed' | 'failed' | 'abandoned' | 'aborted',
+  ): Promise<RunRecord> {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const patch: Partial<RunRecord> =
+      phase === 'completed'
+        ? { terminal_state: true, terminal_reason: 'Workflow completed.' }
+        : phase === 'failed'
+          ? {
+              terminal_state: true,
+              terminal_reason: `Step 'step-agent' failed: boom`,
+              failed_steps: ['step-agent'],
+            }
+          : phase === 'aborted'
+            ? { terminal_state: true, aborted_at: { step_id: 'step-agent' } }
+            : { terminal_state: true, abandoned_at: new Date().toISOString() };
+    const updated = await runStore.update({ ...run, ...patch });
+    expect(updated.run_phase).toBe(phase); // sanity: confirms the fixture actually reaches the phase under test
+    return updated;
+  }
+
+  it.each(['completed', 'failed', 'abandoned', 'aborted'] as const)(
+    'append_trace to a %s run is rejected (typed error, report_to_user) and writes NO WAL',
+    async (phase) => {
+      const run = await makeTerminalRun(phase);
+
+      await expect(
+        handleAppendTrace(
+          { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'late_entry' }] },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({
+        code: 'STATE_STEP_NOT_ELIGIBLE',
+        agentAction: 'report_to_user',
+        retryable: false,
+        details: { step_state: 'run_terminal', run_phase: phase },
+      });
+
+      // No WAL was written — the buffer is empty (append() was never reached).
+      const remaining = await traceBufferStore.read(run.id, 'step-agent');
+      expect(remaining).toHaveLength(0);
+    },
+  );
+
+  it('append_trace to a non-terminal run with an eligible step is unaffected — still succeeds, byte-identical to before', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const result = await handleAppendTrace(
+      { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'ok_entry' }] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
       expect(result.buffer_count).toBe(1);
     }
   });

--- a/packages/mcp-server/src/tools/append-trace.ts
+++ b/packages/mcp-server/src/tools/append-trace.ts
@@ -6,6 +6,7 @@ import {
   JsonFileStore,
   WorkflowError,
   buildPreExecutionErrorEnvelope,
+  isTerminalPhase,
   type AppendResult,
   type TraceBufferStore,
   type AgentTraceEntry,
@@ -44,6 +45,31 @@ export async function handleAppendTrace(
 
   // 1. Load the run. Throws STATE_RUN_NOT_FOUND if missing.
   const run = await runStore.get(args.run_id);
+
+  // 1b. issue #187: reject a terminal run BEFORE any step guard or WAL write. A WAL appended to
+  // a completed/failed/abandoned/aborted run is always unreadable residue — the step it names
+  // will never finalize again, so nothing will ever adopt or delete it. This is the one orphan
+  // source correct purge ordering structurally can't reach (a WAL born after purge's snapshot
+  // but before the run-file unlink) — refusing it here means it is never created in the first
+  // place. A terminal run is permanent, so this is agentAction: 'report_to_user' (NOT
+  // provide_input/retryable — retrying can't un-terminate a run).
+  if (isTerminalPhase(run.run_phase)) {
+    throw new WorkflowError(
+      `Run '${args.run_id}' is terminal (phase: '${run.run_phase}') — trace entries can no longer be adopted by any step.`,
+      {
+        code: 'STATE_STEP_NOT_ELIGIBLE',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+        details: {
+          step_id: args.step_id,
+          step_state: 'run_terminal',
+          run_phase: run.run_phase,
+          run_version: run.version,
+        },
+      },
+    );
+  }
 
   // 2. Load the workflow definition.
   const definition = await workflowStore.get(run.workflow_id);


### PR DESCRIPTION
## Context

Tidy-closes the #185 trace-buffer sub-arc with two small, independent engine-hygiene fixes. `[chore]`, internal + one agent-visible guard. Closes #187 and #198.

## Motivation

Two loose ends surfaced during the #185 Peer exploration:

- **#187** — `append_trace` guards the *step* (`completed_steps`/`failed_steps`/`in_progress_steps`) but never the *run's* terminal phase. A WAL appended to a terminal run is always unreadable residue (its step will never finalize again), and it is the one orphan source correct purge ordering structurally cannot reach — a WAL born after purge's snapshot but before the run-file unlink.
- **#198** — the WAL-clearing hook already exists (`reclaimStep` calls `clearStaleWal`), but it was **inert**: `reclaim.ts` never passed a trace-buffer store, so a reclaimed step left its stale WAL on disk and the next attempt adopted the dead attempt's lines — the mechanical reason sequential-abandon-then-retry is #185's dominant "adopted a prior/concurrent writer's lines" population. Its catch also silently swallowed a real I/O failure.

## Changes

- **#187 (`append-trace.ts`):** a run-terminal guard via `isTerminalPhase(run.run_phase)`, inserted before any step guard or WAL write — returns a typed `STATE_STEP_NOT_ELIGIBLE` error, `agentAction: 'report_to_user'`, `retryable: false` (a terminal run is permanent). No WAL is written on this path.
- **#198 (`reclaim.ts` + `reclaim-step.ts`):** wire `JsonTraceBufferStore(store.runsDirPath)` into both `reclaimStep` call sites (mirroring `gc.ts`'s dynamic import) so a reclaim clears the reclaimed step's stale WAL; and make `clearStaleWal` **warn** on a delete failure instead of silently swallowing it (the #183 contract) — still non-blocking, the reclaim never fails on a WAL-clear error.

No `execution-loop.ts` / #185 merge-adoption logic, WAL-format, `claimStep`, or #197 nonce scope touched.

## Verification

```bash
npm run lint && npm run build && npm run check:versions   # clean; versions match (no bump)
npm audit --omit=dev --audit-level=high                   # 0 vulnerabilities
TURBO_FORCE=true npm run test                             # core 1704, mcp 180, testing 77, cli 704 — all green
```

Independently reproduced (by the reviewer, on the branch):
- **#187 mutation-probe:** disable the terminal guard → the 4 terminal-phase tests redden, non-terminal stays green; restore → green.
- **#198 file-backed proof:** `reclaimStep(store, id, step, { traceBufferStore })` deletes the real WAL file; the same call *without* `{ traceBufferStore }` (pre-fix state) leaves it on disk — proving the wiring is what does the work.

## Rollback

Revert this PR. No schema/store-interface/WAL-format change; `#187`'s guard and `#198`'s wiring are additive. `#187` is an agent-visible behavior change (a late `append_trace` to a terminal run now errors) — the only consumer-facing effect. No release has shipped this (rides `[Unreleased]`).

## Related

Closes #187, #198. Completes the #185 trace sub-arc; the deferred client-nonce (#197) remains the only piece left by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
