### PR TITLE
refactor(mcp): widen runStore to the RunStore interface + co-located artifact-store injection (#188 PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here.
 ### Changed
 
 - **`append_trace` now rejects a terminal run (issue #187).** A late `append_trace` to a `completed`/`failed`/`abandoned`/`aborted` run returns a typed error (`report_to_user`) instead of writing unreadable WAL residue — closing the one orphan source correct purge ordering cannot reach (a WAL born after purge's snapshot).
+- **The MCP server's `runStore` option now accepts any `RunStore` implementation (issue #188, PR-1 — internal/API-surface, non-breaking).** Was concrete `JsonFileStore`-only, which meant a Postgres/cloud-backed run store could neither satisfy the option type nor be injected at all. Artifact stores (the trace buffer, the failed-attempt sidecar) can now also be injected as objects, for backends that don't co-locate artifacts on the filesystem — with an explicit co-location contract (documented on `RealmMcpServerOptions`): inject BOTH artifact stores together (co-located with the run store's own domain), or use a `JsonFileStore` run store and let both be derived exactly as before. The local default is unchanged and byte-identical; a run store without a derivable path and no injected artifact stores now fails loudly at construction instead of silently losing every trace. Prerequisite for pluggable/cloud run stores — does not itself add any capability flags or gates (that is PR-2).
 
 ### Fixed
 

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -1,0 +1,361 @@
+// Tests for createRealmMcpServer's construction seam (issue #188, PR-1): the RunStore injection
+// widen + the co-located artifact-store injection contract.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  InMemoryTraceBufferStore,
+  WorkflowError,
+  findEligibleSteps,
+  deriveRunPhase,
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+} from '@sensigo/realm';
+import type { RunStore, RunRecord, CreateRunOptions, WorkflowDefinition } from '@sensigo/realm';
+import { createRealmMcpServer } from './server.js';
+import { JsonTraceBufferStore } from './json-trace-buffer-store.js';
+import type { FailedAttemptStoreLike } from './tools/start-run.js';
+
+/**
+ * Minimal hand-rolled `RunStore` — deliberately does NOT expose `runsDirPath` (no filesystem
+ * backing at all), mirroring the shape a Postgres/object-storage-backed run store would have.
+ * Used to exercise the "run store without runsDirPath" branches of the co-location seam.
+ */
+class MinimalRunStore implements RunStore {
+  private readonly runs = new Map<string, RunRecord>();
+  readonly persistsClaims = true;
+
+  async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    const now = new Date().toISOString();
+    const record: RunRecord = {
+      id: randomUUID(),
+      workflow_id: options.workflowId,
+      workflow_version: options.workflowVersion,
+      completed_steps: [],
+      in_progress_steps: [],
+      failed_steps: [],
+      skipped_steps: [],
+      run_phase: 'running',
+      version: 0,
+      params: options.params,
+      evidence: [],
+      created_at: now,
+      updated_at: now,
+      terminal_state: false,
+    };
+    this.runs.set(record.id, record);
+    return { run: record, created: true };
+  }
+
+  async get(runId: string): Promise<RunRecord> {
+    const record = this.runs.get(runId);
+    if (record === undefined) {
+      throw new WorkflowError(`Run '${runId}' not found`, {
+        code: 'STATE_RUN_NOT_FOUND',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    return record;
+  }
+
+  async update(record: RunRecord): Promise<RunRecord> {
+    const existing = this.runs.get(record.id);
+    if (existing === undefined) {
+      throw new WorkflowError(`Run '${record.id}' not found`, {
+        code: 'STATE_RUN_NOT_FOUND',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    if (existing.version !== record.version) {
+      throw new WorkflowError('Version conflict — run was modified by another process', {
+        code: 'STATE_SNAPSHOT_MISMATCH',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: true,
+      });
+    }
+    const updated: RunRecord = {
+      ...record,
+      run_phase: deriveRunPhase(record),
+      version: record.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+    this.runs.set(updated.id, updated);
+    return updated;
+  }
+
+  async claimStep(
+    runId: string,
+    stepName: string,
+    definition: WorkflowDefinition,
+  ): Promise<RunRecord> {
+    const run = await this.get(runId);
+    const alreadyDone = [
+      ...run.completed_steps,
+      ...run.in_progress_steps,
+      ...run.failed_steps,
+      ...run.skipped_steps,
+    ];
+    if (alreadyDone.includes(stepName)) {
+      throw new WorkflowError(`Step '${stepName}' is already claimed or done`, {
+        code: 'STATE_STEP_ALREADY_CLAIMED',
+        category: 'STATE',
+        agentAction: 'resolve_precondition',
+        retryable: false,
+      });
+    }
+    if (!findEligibleSteps(definition, run).includes(stepName)) {
+      throw new WorkflowError(`Step '${stepName}' is not eligible`, {
+        code: 'STATE_STEP_NOT_ELIGIBLE',
+        category: 'STATE',
+        agentAction: 'resolve_precondition',
+        retryable: false,
+      });
+    }
+    const updated: RunRecord = {
+      ...run,
+      in_progress_steps: [...run.in_progress_steps, stepName],
+      version: run.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+    this.runs.set(updated.id, updated);
+    return updated;
+  }
+
+  async list(workflowId?: string): Promise<RunRecord[]> {
+    const all = [...this.runs.values()];
+    return workflowId !== undefined ? all.filter((r) => r.workflow_id === workflowId) : all;
+  }
+}
+
+/** A minimal FailedAttemptStoreLike double that records every append() call for assertion. */
+function makeFailedAttemptStoreDouble(): FailedAttemptStoreLike & {
+  appended: Array<{ runId: string; line: string }>;
+} {
+  const appended: Array<{ runId: string; line: string }> = [];
+  return {
+    appended,
+    async append(runId: string, line: string): Promise<void> {
+      appended.push({ runId, line });
+    },
+    async read() {
+      return { records: [], capped: false };
+    },
+    async deleteAllForRun(): Promise<void> {},
+    async listOrphans() {
+      return [];
+    },
+  };
+}
+
+const agentWorkflowDef = (id: string): WorkflowDefinition => ({
+  id,
+  name: 'Seam Test WF',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    'step-agent': { description: 'Agent step', execution: 'agent', depends_on: [] },
+  },
+});
+
+/** Connects a fresh in-memory MCP client to `server` and returns a typed callTool helper. */
+async function connectClient(
+  server: McpServer,
+): Promise<(name: string, args: Record<string, unknown>) => Promise<Record<string, unknown>>> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'seam-test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return async (name: string, args: Record<string, unknown>) => {
+    const raw = await client.callTool({ name, arguments: args });
+    const content = (raw as { content: Array<{ type: string; text: string }> }).content;
+    return JSON.parse(content[0]!.text) as Record<string, unknown>;
+  };
+}
+
+describe('createRealmMcpServer — RunStore injection seam (issue #188, PR-1)', () => {
+  describe('local default — byte-identical to pre-#188 behavior', () => {
+    it('a JsonFileStore run store (no artifact stores injected) derives co-located artifact stores from runsDirPath — append_trace → execute_step round-trips a WAL', async () => {
+      const runDir = await mkdtemp(join(tmpdir(), 'realm-seam-runs-'));
+      const workflowDir = await mkdtemp(join(tmpdir(), 'realm-seam-wf-'));
+      try {
+        const workflowStore = new JsonWorkflowStore(workflowDir);
+        const def = agentWorkflowDef('seam-local-wf');
+        await workflowStore.register(def);
+
+        const server = createRealmMcpServer({
+          runStore: new JsonFileStore(runDir),
+          workflowStore,
+        });
+        const callTool = await connectClient(server);
+
+        const startEnvelope = await callTool('start_run', { workflow_id: def.id });
+        const runId = startEnvelope['run_id'] as string;
+
+        await callTool('append_trace', {
+          run_id: runId,
+          step_id: 'step-agent',
+          entries: [{ event: 'wal_entry' }],
+        });
+
+        const execEnvelope = await callTool('execute_step', {
+          run_id: runId,
+          command: 'step-agent',
+          params: {},
+        });
+
+        // execute_step's own MCP response deliberately strips evidence/data (agents are
+        // directed to get_run_state instead) — so the round-trip proof is that the WAL was
+        // actually ADOPTED and cleared, not merely ignored. A fresh JsonTraceBufferStore
+        // pointed at the SAME runDir (as the co-located derivation would have used internally)
+        // reads empty ONLY if the derivation genuinely pointed there and execute_step consumed it.
+        expect(execEnvelope['status']).toBe('ok');
+        const verifyTraceBufferStore = new JsonTraceBufferStore(runDir);
+        const remaining = await verifyTraceBufferStore.read(runId, 'step-agent');
+        expect(remaining).toHaveLength(0);
+      } finally {
+        await rm(runDir, { recursive: true, force: true });
+        await rm(workflowDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('injected artifact stores are used', () => {
+    it('an injected traceBufferStore is the one execute_step actually reads from (not a derived default)', async () => {
+      const workflowDir = await mkdtemp(join(tmpdir(), 'realm-seam-inject-wf-'));
+      try {
+        const workflowStore = new JsonWorkflowStore(workflowDir);
+        const def = agentWorkflowDef('seam-inject-wf');
+        await workflowStore.register(def);
+
+        const injectedTraceBufferStore = new InMemoryTraceBufferStore();
+        const injectedFailedAttemptStore = makeFailedAttemptStoreDouble();
+
+        const server = createRealmMcpServer({
+          runStore: new MinimalRunStore(), // no runsDirPath — injection is the ONLY path here
+          workflowStore,
+          traceBufferStore: injectedTraceBufferStore,
+          failedAttemptStore: injectedFailedAttemptStore,
+        });
+        const callTool = await connectClient(server);
+
+        const startEnvelope = await callTool('start_run', { workflow_id: def.id });
+        const runId = startEnvelope['run_id'] as string;
+
+        await callTool('append_trace', {
+          run_id: runId,
+          step_id: 'step-agent',
+          entries: [{ event: 'injected_wal_entry' }],
+        });
+        // Prove it landed in the INJECTED instance specifically, before execute_step consumes it.
+        const preFinalize = await injectedTraceBufferStore.read(runId, 'step-agent');
+        expect(preFinalize.some((e) => e.event === 'injected_wal_entry')).toBe(true);
+
+        const execEnvelope = await callTool('execute_step', {
+          run_id: runId,
+          command: 'step-agent',
+          params: {},
+        });
+
+        // execute_step's own MCP response deliberately strips evidence/data — the round-trip
+        // proof is that the INJECTED store (the only trace-buffer store that exists in this
+        // test — MinimalRunStore has no runsDirPath, so nothing could have been derived) was
+        // actually adopted-from and cleared by a successful execute_step.
+        expect(execEnvelope['status']).toBe('ok');
+        const remaining = await injectedTraceBufferStore.read(runId, 'step-agent');
+        expect(remaining).toHaveLength(0);
+      } finally {
+        await rm(workflowDir, { recursive: true, force: true });
+      }
+    });
+
+    it('an injected failedAttemptStore receives a record on a validation-rejected execute_step', async () => {
+      const workflowDir = await mkdtemp(join(tmpdir(), 'realm-seam-inject-fa-wf-'));
+      try {
+        const workflowStore = new JsonWorkflowStore(workflowDir);
+        const def: WorkflowDefinition = {
+          id: 'seam-inject-fa-wf',
+          name: 'Seam Inject FA WF',
+          version: 1,
+          schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+          steps: {
+            'step-agent': {
+              description: 'Agent step with a required input field',
+              execution: 'agent',
+              depends_on: [],
+              input_schema: { type: 'object', required: ['must_have'] },
+            },
+          },
+        };
+        await workflowStore.register(def);
+
+        const injectedFailedAttemptStore = makeFailedAttemptStoreDouble();
+
+        const server = createRealmMcpServer({
+          runStore: new MinimalRunStore(),
+          workflowStore,
+          traceBufferStore: new InMemoryTraceBufferStore(),
+          failedAttemptStore: injectedFailedAttemptStore,
+        });
+        const callTool = await connectClient(server);
+
+        const startEnvelope = await callTool('start_run', { workflow_id: def.id });
+        const runId = startEnvelope['run_id'] as string;
+
+        // Missing the required 'must_have' field → VALIDATION_INPUT_SCHEMA rejection, which is
+        // exactly the path that fans out to the failed-attempt sidecar.
+        const execEnvelope = await callTool('execute_step', {
+          run_id: runId,
+          command: 'step-agent',
+          params: {},
+        });
+        expect(execEnvelope['status']).toBe('error');
+        expect(execEnvelope['error_code']).toBe('VALIDATION_INPUT_SCHEMA');
+
+        expect(injectedFailedAttemptStore.appended.length).toBe(1);
+        expect(injectedFailedAttemptStore.appended[0]?.runId).toBe(runId);
+      } finally {
+        await rm(workflowDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('co-location fail-loud', () => {
+    it('a run store without runsDirPath and NO injected artifact stores throws a typed misconfiguration error — never a silent empty-trace store', () => {
+      expect(() => createRealmMcpServer({ runStore: new MinimalRunStore() })).toThrow(
+        /runsDirPath/,
+      );
+    });
+
+    it('the thrown error is a typed WorkflowError (ENGINE_INTERNAL, stop, not retryable)', () => {
+      try {
+        createRealmMcpServer({ runStore: new MinimalRunStore() });
+        expect.unreachable('createRealmMcpServer should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(WorkflowError);
+        expect((err as WorkflowError).code).toBe('ENGINE_INTERNAL');
+        expect((err as WorkflowError).agentAction).toBe('stop');
+        expect((err as WorkflowError).retryable).toBe(false);
+      }
+    });
+
+    it('injecting only ONE of the two artifact stores (with a runsDirPath-less run store) still throws — partial injection is not enough', () => {
+      expect(() =>
+        createRealmMcpServer({
+          runStore: new MinimalRunStore(),
+          traceBufferStore: new InMemoryTraceBufferStore(),
+          // failedAttemptStore NOT injected.
+        }),
+      ).toThrow(/runsDirPath/);
+    });
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -9,13 +9,17 @@ import {
   JsonWorkflowStore,
   JsonFileStore,
   FailedAttemptStore,
+  WorkflowError,
   createDefaultRegistry,
+  type RunStore,
+  type TraceBufferStore,
 } from '@sensigo/realm';
 import type { WorkflowDefinition } from '@sensigo/realm';
 import { JsonTraceBufferStore } from './json-trace-buffer-store.js';
 import { registerListWorkflows } from './tools/list-workflows.js';
 import { registerGetWorkflowProtocol } from './tools/get-workflow-protocol.js';
 import { registerStartRun } from './tools/start-run.js';
+import type { FailedAttemptStoreLike } from './tools/start-run.js';
 import { registerExecuteStep } from './tools/execute-step.js';
 import { registerSubmitHumanResponse } from './tools/submit-human-response.js';
 import { registerGetRunState } from './tools/get-run-state.js';
@@ -37,8 +41,41 @@ export interface RealmMcpServerOptions {
   /** Pre-populated workflow store. When provided, tools use this instead of creating
    *  a new JsonWorkflowStore() pointing at ~/.realm/workflows/. */
   workflowStore?: JsonWorkflowStore;
-  /** Run store. When provided, tools use this instead of creating a new JsonFileStore(). */
-  runStore?: JsonFileStore;
+  /**
+   * Run store. Any `RunStore` implementation (issue #188, PR-1 — was `JsonFileStore`-only).
+   * When omitted, defaults to a new `JsonFileStore()` pointing at `~/.realm/runs/`.
+   *
+   * **Co-location contract with `traceBufferStore` / `failedAttemptStore` below:** the run store
+   * and the trace-buffer / failed-attempt artifact stores MUST share ONE reachability domain.
+   * `append_trace` writes a WAL that `execute_step` reads back at finalization, and the
+   * failed-attempt sidecar is looked up the same way — if the run store and the artifact stores
+   * point at DIFFERENT backing domains (e.g. a cloud run store paired with a locally-derived
+   * trace buffer, or vice versa), traces and sidecar entries are silently lost: nothing will ever
+   * look in the same place twice. Two supported configurations:
+   *  - **Local default (unchanged, byte-identical to pre-#188 behavior):** no `traceBufferStore`/
+   *    `failedAttemptStore` injected, and the run store exposes `runsDirPath` (the `JsonFileStore`
+   *    case) → both artifact stores are derived from that path, exactly as before this PR.
+   *  - **Injected / single-domain-blessed (the cloud case):** inject BOTH `traceBufferStore` AND
+   *    `failedAttemptStore` as objects already co-located with the run store's own domain (e.g.
+   *    both backed by the same Postgres database or object-storage bucket the run store uses) —
+   *    the INJECTOR guarantees co-location; `createRealmMcpServer` does not and cannot verify it.
+   *
+   * A run store that does NOT expose `runsDirPath` (cannot derive a local path) AND has NOT had
+   * BOTH artifact stores injected is a misconfiguration: `createRealmMcpServer` throws rather than
+   * silently falling back to an empty or wrong-domain artifact store.
+   */
+  runStore?: RunStore;
+  /**
+   * Trace-buffer WAL store for incremental agent-trace ingestion (B-lite). Object injection, not
+   * a path string — a Postgres/object-storage-backed run store has no filesystem directory to
+   * derive one from. See the co-location contract on `runStore` above.
+   */
+  traceBufferStore?: TraceBufferStore;
+  /**
+   * Durable per-run failed-attempt sidecar store (observability P3). Object injection — see the
+   * co-location contract on `runStore` above.
+   */
+  failedAttemptStore?: FailedAttemptStoreLike;
 }
 
 /**
@@ -90,10 +127,42 @@ export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer
 
   // Shared trace buffer store: one instance used by both append_trace and execute_step so
   // WAL entries written by append_trace are visible when execute_step finalizes the step.
-  const effectiveRunStore = options?.runStore ?? new JsonFileStore();
-  const traceBufferStore = new JsonTraceBufferStore(effectiveRunStore.runsDirPath);
-  // Durable failed-attempt sidecar store, co-located with run files (observability P3).
-  const failedAttemptStore = new FailedAttemptStore(effectiveRunStore.runsDirPath);
+  const effectiveRunStore: RunStore = options?.runStore ?? new JsonFileStore();
+
+  // issue #188, PR-1: the co-location seam. See the doc comment on `runStore` above for the full
+  // contract. Three cases, checked in order:
+  let traceBufferStore: TraceBufferStore;
+  let failedAttemptStore: FailedAttemptStoreLike;
+  if (options?.traceBufferStore !== undefined && options?.failedAttemptStore !== undefined) {
+    // Both injected — the injector guarantees co-location (see the contract doc above); use them
+    // as-is, no derivation.
+    traceBufferStore = options.traceBufferStore;
+    failedAttemptStore = options.failedAttemptStore;
+  } else if ('runsDirPath' in effectiveRunStore) {
+    // The local JsonFileStore case — derive whichever artifact store was NOT already injected
+    // from the run store's own directory. When neither was injected (the ordinary local-default
+    // path), this is byte-identical to pre-#188 behavior. A store the caller DID inject here
+    // (a partial injection) is still respected, never silently overridden.
+    const runsDirPath = (effectiveRunStore as JsonFileStore).runsDirPath;
+    traceBufferStore = options?.traceBufferStore ?? new JsonTraceBufferStore(runsDirPath);
+    failedAttemptStore = options?.failedAttemptStore ?? new FailedAttemptStore(runsDirPath);
+  } else {
+    // The run store cannot supply an artifact directory (e.g. a Postgres-backed RunStore) AND no
+    // artifact stores were injected — a misconfiguration. Fail loud rather than silently deriving
+    // an empty or wrong-domain store that would lose every trace/sidecar entry at finalization.
+    throw new WorkflowError(
+      "createRealmMcpServer: the run store does not expose 'runsDirPath' (it is not a local " +
+        'JsonFileStore) and no traceBufferStore/failedAttemptStore were injected. Artifact ' +
+        'stores cannot be derived — inject BOTH traceBufferStore and failedAttemptStore ' +
+        "co-located with the run store's own domain, or use a JsonFileStore run store.",
+      {
+        code: 'ENGINE_INTERNAL',
+        category: 'ENGINE',
+        agentAction: 'stop',
+        retryable: false,
+      },
+    );
+  }
 
   registerListWorkflows(server, effectiveOptions);
   registerGetWorkflowProtocol(server, effectiveOptions);

--- a/packages/mcp-server/src/tools/abandon-run.ts
+++ b/packages/mcp-server/src/tools/abandon-run.ts
@@ -7,11 +7,13 @@ import {
   abandonRun,
   resolvePreExecutionAgentAction,
   type RunPhase,
+  type RunStore,
 } from '@sensigo/realm';
 import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleAbandonRunStores {
-  runStore?: JsonFileStore;
+  /** Any `RunStore` implementation (issue #188, PR-1 — was `JsonFileStore`-only). */
+  runStore?: RunStore;
 }
 
 export interface AbandonRunSummary {

--- a/packages/mcp-server/src/tools/append-trace.ts
+++ b/packages/mcp-server/src/tools/append-trace.ts
@@ -11,12 +11,14 @@ import {
   type TraceBufferStore,
   type AgentTraceEntry,
   type ResponseEnvelope,
+  type RunStore,
 } from '@sensigo/realm';
 import { traceEntrySchema } from './execute-step.js';
 import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleAppendTraceStores {
-  runStore?: JsonFileStore;
+  /** Any `RunStore` implementation (issue #188, PR-1 — was `JsonFileStore`-only). */
+  runStore?: RunStore;
   workflowStore?: JsonWorkflowStore;
   traceBufferStore?: TraceBufferStore;
 }
@@ -145,14 +147,7 @@ export async function handleAppendTrace(
 }
 
 /** Registers the append_trace MCP tool on the server. */
-export function registerAppendTrace(
-  server: McpServer,
-  opts?: {
-    runStore?: JsonFileStore;
-    workflowStore?: JsonWorkflowStore;
-    traceBufferStore?: TraceBufferStore;
-  },
-): void {
+export function registerAppendTrace(server: McpServer, opts?: HandleAppendTraceStores): void {
   server.tool(
     'append_trace',
     [

--- a/packages/mcp-server/src/tools/create-workflow.ts
+++ b/packages/mcp-server/src/tools/create-workflow.ts
@@ -4,7 +4,6 @@ import { createHash } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   JsonWorkflowStore,
-  JsonFileStore,
   WorkflowError,
   resolvePreExecutionAgentAction,
   findUnknownKeys,
@@ -13,6 +12,7 @@ import {
   type ResponseEnvelope,
   type JsonSchema,
   type LoaderWarning,
+  type RunStore,
   CURRENT_WORKFLOW_SCHEMA_VERSION,
 } from '@sensigo/realm';
 import { handleStartRun, type HandleRunStores } from './start-run.js';
@@ -260,7 +260,7 @@ function buildWorkflowDefinition(workflowId: string, args: CreateWorkflowArgs): 
  */
 export async function handleCreateWorkflow(
   args: CreateWorkflowArgs,
-  stores?: { workflowStore?: JsonWorkflowStore; runStore?: JsonFileStore },
+  stores?: { workflowStore?: JsonWorkflowStore; runStore?: RunStore },
 ): Promise<ResponseEnvelope> {
   const errors = validateArgs(args);
   if (errors.length > 0) {

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -12,9 +12,8 @@ import {
   type StepDispatcher,
   type ResponseEnvelope,
   type AgentTraceEntry,
-  type FailedAttemptStore,
 } from '@sensigo/realm';
-import type { HandleRunStores } from './start-run.js';
+import type { HandleRunStores, FailedAttemptStoreLike } from './start-run.js';
 import { sseJsonStringify } from '../sse-json.js';
 
 /**
@@ -44,7 +43,7 @@ async function emitFailedAttemptTelemetry(
   },
   workflowId: string,
   result: ResponseEnvelope,
-  failedAttemptStore?: FailedAttemptStore,
+  failedAttemptStore?: FailedAttemptStoreLike,
 ): Promise<void> {
   // Build the shared metadata-only record once (bail both sinks if it can't be built).
   let record: ReturnType<typeof buildFailedAttemptRecord>;

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -14,11 +14,13 @@ import {
   type NextAction,
   type ClaimState,
   type SkipDetail,
+  type RunStore,
 } from '@sensigo/realm';
 import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleRunStateStores {
-  runStore?: JsonFileStore;
+  /** Any `RunStore` implementation (issue #188, PR-1 — was `JsonFileStore`-only). */
+  runStore?: RunStore;
   /**
    * Optional workflow store used to compute `next_actions`. When absent (or the workflow is not
    * registered), `next_actions_status` is `'workflow_unresolved'`. Intentionally NOT defaulted to a

--- a/packages/mcp-server/src/tools/start-run.ts
+++ b/packages/mcp-server/src/tools/start-run.ts
@@ -15,6 +15,7 @@ import {
   createDefaultRegistry,
   type StepDispatcher,
   type ResponseEnvelope,
+  type RunStore,
   type TraceBufferStore,
   type FailedAttemptStore,
   ExtensionRegistry,
@@ -26,8 +27,21 @@ function logDedup(fields: Record<string, unknown>): void {
   console.error(JSON.stringify({ event: 'idempotency_dedup', ...fields }));
 }
 
+/**
+ * Structural (not nominal) shape of `FailedAttemptStore`'s public surface, derived via `Pick` so a
+ * duck-typed cloud-backed object can satisfy it too — the concrete `FailedAttemptStore` class has
+ * a private `runsDir` field, so a plain object literal implementing these methods could never be
+ * assignable to the class type itself (issue #188, PR-1: the co-location injection seam). Used
+ * anywhere a `FailedAttemptStore`-like store is threaded through as an injectable option.
+ */
+export type FailedAttemptStoreLike = Pick<
+  FailedAttemptStore,
+  'append' | 'read' | 'deleteAllForRun' | 'listOrphans'
+>;
+
 export interface HandleRunStores {
-  runStore?: JsonFileStore;
+  /** Run store. Any `RunStore` implementation (issue #188, PR-1 — was `JsonFileStore`-only). */
+  runStore?: RunStore;
   workflowStore?: JsonWorkflowStore;
   /** Extension registry for resolving service adapters and step handlers. */
   registry?: ExtensionRegistry;
@@ -42,7 +56,7 @@ export interface HandleRunStores {
   /** Trace buffer store for incremental WAL-based trace ingestion (B-lite). */
   traceBufferStore?: TraceBufferStore;
   /** Durable per-run sidecar for failed agent-attempt telemetry (observability P3). */
-  failedAttemptStore?: FailedAttemptStore;
+  failedAttemptStore?: FailedAttemptStoreLike;
 }
 
 // Fallback dispatcher for agent steps and auto steps without a registry entry.


### PR DESCRIPTION
## Context

**PR-1 of #188** — the injection seam. A prerequisite that unblocks injecting a non-`JsonFileStore` `RunStore` (the long-standing 0.8.0 cloud-injection blocker). Decided through a 2-round Peer exploration + a Design Reviewer pass (prior-art-grounded: DNS authoritative-answer, Chandra–Toueg failure-detector impossibility, JDBC/Django/CSI capability declaration). This PR does **not** close #188 — the capability contract + field-fidelity gate are PR-2. `[refactor]`, internal/API-surface, non-breaking.

## Motivation

The MCP server was hard-typed to `JsonFileStore` and derived its artifact stores by reading `effectiveRunStore.runsDirPath` (a `JsonFileStore`-only property). So a Postgres/cloud `RunStore` could neither satisfy the option type nor supply that path — realm-cloud literally could not inject one. The single-domain-blessed cloud vision (AI reads run logs centrally; artifacts co-located with the run record) needs this seam.

## Changes

- **Mechanical type-widen** `runStore?: JsonFileStore` → `RunStore` across the ~9 mcp-server tool option-interfaces. Verified behavior-neutral: every widened tool calls only `RunStore`-interface methods (`get`/`create`/`update`/`claimStep`/`list`), never a `JsonFileStore`-only method.
- **The co-location seam in `server.ts`** — artifact stores (`traceBufferStore`, `failedAttemptStore`) can now be object-injected. Three branches: both injected → use (injector guarantees co-location); else run store exposes `runsDirPath` → derive (the local `JsonFileStore` case, **byte-identical** to before); else → **fail loud** with a typed `WorkflowError` rather than silently deriving a wrong-domain/empty store that would lose every trace at finalization.
- **An explicit co-location contract** documented on `RealmMcpServerOptions`: the run store and injected artifact stores MUST share one reachability domain (the engine cannot verify this — it's the injector's responsibility).
- **`FailedAttemptStoreLike`** — a `Pick` structural type so a duck-typed cloud object can be injected (the concrete class has a private field blocking nominal assignment). Type-only; no core change.

No capability flags, no purge/gc/export/reclaim changes, no `claimStep` change, no field-fidelity gate — all PR-2.

## Verification

```bash
npm run lint && npm run build && npm run check:versions   # clean; versions unchanged
npm audit --omit=dev --audit-level=high                   # 0 vulnerabilities
TURBO_FORCE=true npm run test                             # core 1704, mcp 186 (+6), testing 77, cli 704
```

Independently reproduced (reviewer, on the branch):
- **Local byte-identical:** a `JsonFileStore` run store with no injection derives + clears the WAL at its own dir through a real MCP client/server round-trip.
- **Injected stores used:** an injected trace buffer / failed-attempt double receives the entries directly.
- **Mutation-probe:** replacing the fail-loud `throw` with a silent fallback reddens all 3 fail-loud tests (the misconfiguration would silently lose traces); restore → 6/6 green.

## Rollback

Revert this PR. Non-breaking, additive API surface (widened option type + two optional injected fields); the local default is byte-identical, no store/schema/on-disk change. No release has shipped this (rides `[Unreleased]`).

## Related

PR-1 of #188. PR-2 (capability contract + field-fidelity gate + minimal partitioned declare-or-refuse) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
