### PR TITLE
feat(core): RunStore field-fidelity contract + forcing conformance TCK (#188 PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **The `RunStore` contract now declares field fidelity (issue #188).** A store declares (via optional `persistedRunRecordFields`, fail-closed default) which load-bearing `RunRecord` fields it round-trips; the engine surfaces an honest diagnostic — instead of silently misreading a dropped field as legitimate absence — when a store doesn't persist a field it depends on (`capability_blocks` → capability-block state unavailable; `workflow_context_snapshots` → snapshot history not durable; `extension_identity` → drift detection unavailable). A framework-agnostic conformance TCK (`@sensigo/realm-testing`) forces any store to prove its declared fidelity is honest (a store that claims to persist a field but drops it fails conformance) and asserts `claimStep`'s single-owner guarantee. `JsonFileStore` declares the full set → zero behavior change locally. Prerequisite-hardening for pluggable/cloud run stores; the `claimStep` doc now states the cross-host single-owner obligation. (Partitioned artifact-reachability enforcement in purge/gc/export is tracked separately as #188 PR-3.)
+
 ### Changed
 
 - **`append_trace` now rejects a terminal run (issue #187).** A late `append_trace` to a `completed`/`failed`/`abandoned`/`aborted` run returns a typed error (`report_to_user`) instead of writing unreadable WAL residue — closing the one orphan source correct purge ordering cannot reach (a WAL born after purge's snapshot).

--- a/packages/cli/src/commands/capability-warn-enumeration.test.ts
+++ b/packages/cli/src/commands/capability-warn-enumeration.test.ts
@@ -52,6 +52,9 @@ const N_A: Record<string, string> = {
     'the child drives via recoverable-settle + the A5 surfaces, so warning at spawn would duplicate it',
   'test-runner.ts':
     'test harness — emitting warnings here would change test output; not a production run-creating path',
+  'run-store-fidelity-contract.ts':
+    'the issue #188 RunStore fidelity/claimStep TCK — creates throwaway runs purely to exercise ' +
+    'conformance cases against a store under test; not a production run-creating path',
 };
 
 describe('#134 pre-flight capability warning — create-site enumeration (Part B3)', () => {

--- a/packages/cli/src/store-contracts/run-store-fidelity.contract.test.ts
+++ b/packages/cli/src/store-contracts/run-store-fidelity.contract.test.ts
@@ -1,0 +1,57 @@
+// RunStore field-fidelity + claimStep single-owner TCK conformance for JsonFileStore (issue #188,
+// PR-2).
+//
+// Lives in @sensigo/realm-cli, NOT in @sensigo/realm's own packages/core test suite, for the SAME
+// reason json-file-store.contract.test.ts (issue #183) does: @sensigo/realm-testing depends on
+// @sensigo/realm, so a devDependency the other way round (packages/core → @sensigo/realm-testing)
+// would be a genuine circular PACKAGE dependency. @sensigo/realm-cli already depends on both (no
+// new dependency needed).
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '@sensigo/realm';
+import type { WorkflowDefinition } from '@sensigo/realm';
+import { runStoreFidelityContract, type RunStoreFidelityLaw } from '@sensigo/realm-testing';
+
+const LAWS: RunStoreFidelityLaw[] = ['FIDELITY_HONESTY', 'CLAIM_SINGLE_OWNER'];
+
+const agentWf: WorkflowDefinition = {
+  id: 'run-store-fidelity-tck-wf',
+  name: 'RunStore Fidelity TCK WF',
+  version: 1,
+  steps: {
+    work: { description: 'Agent step, immediately eligible', execution: 'agent', depends_on: [] },
+  },
+};
+
+describe('JsonFileStore — RunStore fidelity TCK conformance (issue #188)', () => {
+  it('declares the full LoadBearingRunRecordField set (byte-identical local behavior depends on this)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'json-file-store-fidelity-tck-'));
+    try {
+      const store = new JsonFileStore(dir);
+      expect(store.persistedRunRecordFields?.has('capability_blocks')).toBe(true);
+      expect(store.persistedRunRecordFields?.has('workflow_context_snapshots')).toBe(true);
+      expect(store.persistedRunRecordFields?.has('extension_identity')).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  for (const law of LAWS) {
+    it(`conforms to ${law}`, async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'json-file-store-fidelity-tck-'));
+      try {
+        const store = new JsonFileStore(dir);
+        const cases = runStoreFidelityContract({ store, definition: agentWf, stepName: 'work' });
+        const matching = cases.filter((c) => c.law === law);
+        expect(matching.length).toBeGreaterThan(0);
+        for (const c of matching) {
+          await c.run();
+        }
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/packages/core/src/engine/execution-loop-fidelity-gate.test.ts
+++ b/packages/core/src/engine/execution-loop-fidelity-gate.test.ts
@@ -1,0 +1,234 @@
+// execution-loop's workflow_context_snapshots / extension_identity field-fidelity gates (issue
+// #188, PR-2). Also proves the #119 WARN-never-gate flow is unaffected.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeStep } from './execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type {
+  RunStore,
+  CreateRunOptions,
+  LoadBearingRunRecordField,
+} from '../store/store-interface.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { ExtensionIdentityEntry } from '../types/extension-identity.js';
+
+/**
+ * Delegates every RunStore method to a real, functional JsonFileStore, but reports a SMALLER
+ * (understated) `persistedRunRecordFields` declaration than the truth. This isolates "does the
+ * gate fire based on the declaration" from "does the store actually drop the field on write" —
+ * the latter is the TCK's FIDELITY_HONESTY job (run-store-fidelity-contract.ts), not this test's.
+ */
+class DeclaredFieldsOverrideStore implements RunStore {
+  readonly persistsClaims: boolean;
+  readonly persistedRunRecordFields: ReadonlySet<LoadBearingRunRecordField>;
+
+  constructor(
+    private readonly inner: JsonFileStore,
+    declaredFields: ReadonlySet<LoadBearingRunRecordField>,
+  ) {
+    this.persistsClaims = inner.persistsClaims;
+    this.persistedRunRecordFields = declaredFields;
+  }
+
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    return this.inner.create(options);
+  }
+  get(runId: string): Promise<RunRecord> {
+    return this.inner.get(runId);
+  }
+  update(record: RunRecord): Promise<RunRecord> {
+    return this.inner.update(record);
+  }
+  list(workflowId?: string): Promise<RunRecord[]> {
+    return this.inner.list(workflowId);
+  }
+  claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord> {
+    return this.inner.claimStep(runId, stepName, definition);
+  }
+}
+
+const sampleIdentity: ExtensionIdentityEntry = {
+  captured_at: '2026-01-01T00:00:00.000Z',
+  modules: [],
+  tree: {
+    roots: [],
+    rules: 'test-rules',
+    file_count: 0,
+    total_bytes: 0,
+    tree_hash: 'deadbeef',
+    truncated: false,
+  },
+  coverage: 'dir_tree_v1',
+};
+
+describe('execution-loop — workflow_context_snapshots field-fidelity gate (issue #188)', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'exec-fidelity-ctx-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const wfWithContext: WorkflowDefinition = {
+    id: 'ctx-wf',
+    name: 'Ctx WF',
+    version: 1,
+    workflow_context: { doc: { source: { path: '/nonexistent/tck-context-file.md' } } },
+    steps: { work: { description: 'w', execution: 'auto', depends_on: [] } },
+  };
+
+  it('fires an honest warning when the store does NOT declare workflow_context_snapshots', async () => {
+    const inner = new JsonFileStore(dir);
+    const store = new DeclaredFieldsOverrideStore(
+      inner,
+      new Set(['capability_blocks', 'extension_identity']),
+    );
+    const { run } = await inner.create({ workflowId: 'ctx-wf', workflowVersion: 1, params: {} });
+
+    const envelope = await executeStep(store, wfWithContext, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => ({}),
+    });
+
+    expect(envelope.warnings.some((w) => w.includes('workflow_context_snapshots'))).toBe(true);
+    expect(envelope.status).toBe('ok'); // advisory only — NEVER blocks
+  });
+
+  it('stays silent when the store DOES declare workflow_context_snapshots (byte-identical local case)', async () => {
+    const inner = new JsonFileStore(dir);
+    const { run } = await inner.create({ workflowId: 'ctx-wf', workflowVersion: 1, params: {} });
+
+    const envelope = await executeStep(inner, wfWithContext, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => ({}),
+    });
+
+    expect(envelope.warnings).toEqual([]);
+    expect(envelope.status).toBe('ok');
+  });
+});
+
+describe('execution-loop — extension_identity field-fidelity gate (issue #188)', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'exec-fidelity-ext-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const plainWf: WorkflowDefinition = {
+    id: 'ext-wf',
+    name: 'Ext WF',
+    version: 1,
+    steps: { work: { description: 'w', execution: 'auto', depends_on: [] } },
+  };
+
+  it('fires an honest warning when the store does NOT declare extension_identity (and a registry identity is present)', async () => {
+    const inner = new JsonFileStore(dir);
+    const store = new DeclaredFieldsOverrideStore(
+      inner,
+      new Set(['capability_blocks', 'workflow_context_snapshots']),
+    );
+    const { run } = await inner.create({ workflowId: 'ext-wf', workflowVersion: 1, params: {} });
+    const registry = new ExtensionRegistry();
+    registry.setIdentity(sampleIdentity);
+
+    const envelope = await executeStep(store, plainWf, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => ({}),
+      registry,
+    });
+
+    expect(envelope.warnings.some((w) => w.includes('extension_identity'))).toBe(true);
+    expect(envelope.status).toBe('ok');
+  });
+
+  it('stays silent when the store DOES declare extension_identity (byte-identical local case)', async () => {
+    const inner = new JsonFileStore(dir);
+    const { run } = await inner.create({ workflowId: 'ext-wf', workflowVersion: 1, params: {} });
+    const registry = new ExtensionRegistry();
+    registry.setIdentity(sampleIdentity);
+
+    const envelope = await executeStep(inner, plainWf, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => ({}),
+      registry,
+    });
+
+    expect(envelope.warnings).toEqual([]);
+    expect(envelope.status).toBe('ok');
+  });
+
+  it('no registry identity at all → no gate, byte-identical to pre-#188 (extension-free runs untouched)', async () => {
+    const inner = new JsonFileStore(dir);
+    const store = new DeclaredFieldsOverrideStore(inner, new Set()); // declares NOTHING
+    const { run } = await inner.create({ workflowId: 'ext-wf', workflowVersion: 1, params: {} });
+
+    const envelope = await executeStep(store, plainWf, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => ({}),
+      // no registry passed at all
+    });
+
+    expect(envelope.warnings).toEqual([]);
+  });
+});
+
+describe('execution-loop — #119 WARN-never-gate is preserved (issue #188)', () => {
+  it('a genuine drift warning AND a fidelity-gap warning co-occur, and execution still completes normally', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'exec-fidelity-119-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const store = new DeclaredFieldsOverrideStore(inner, new Set()); // declares nothing
+      const wf: WorkflowDefinition = {
+        id: 'drift-wf',
+        name: 'Drift WF',
+        version: 1,
+        steps: { work: { description: 'w', execution: 'auto', depends_on: [] } },
+      };
+      const { run } = await inner.create({
+        workflowId: 'drift-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const registry1 = new ExtensionRegistry();
+      registry1.setIdentity(sampleIdentity);
+      const first = await executeStep(store, wf, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({}),
+        registry: registry1,
+      });
+      // First call: fidelity gate fires (store declares nothing); no drift yet (no prior history
+      // to differ from) since the store doesn't retain extension_identity across calls anyway.
+      expect(first.status).toBe('ok');
+      expect(first.warnings.some((w) => w.includes('extension_identity'))).toBe(true);
+
+      // #119's own existing drift-warning behavior (a DIFFERENT registry identity than history)
+      // is exercised elsewhere (extension-identity-append.test.ts) against a store that DOES
+      // persist the field — reconfirm here that execution completing normally (never blocked) is
+      // unaffected by the fidelity gate stacking alongside it.
+      expect(first.run_phase).toBe('completed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -23,6 +23,7 @@ import type {
   LiteralNode,
 } from '../types/workflow-definition.js';
 import type { RunStore } from '../store/store-interface.js';
+import { persistsField } from '../store/store-fidelity.js';
 import type { TraceBufferStore, BufferedEntry } from '../store/trace-buffer-store.js';
 import { captureEvidence } from '../evidence/snapshot.js';
 import {
@@ -1077,6 +1078,17 @@ export async function executeStep(
       ...pendingRun,
       workflow_context_snapshots: contextSnapshots,
     });
+    // issue #188 field-fidelity gate: advisory only, never blocks — the re-snapshot above
+    // already self-healed CURRENT context regardless of what the store persists. This warns
+    // that the HISTORY of snapshots won't survive on a store that doesn't declare the field
+    // (every future execution will re-enter this branch and re-snapshot from scratch).
+    if (!persistsField(store, 'workflow_context_snapshots')) {
+      traceWarnings.push(
+        "this run store does not persist 'workflow_context_snapshots' — snapshot history is " +
+          'not durable on this store (re-snapshotting recovers current context each time, but ' +
+          'prior snapshots are lost)',
+      );
+    }
   }
 
   // Extension-code drift evidence (issue #119): lazy append-on-change, mirroring the
@@ -1088,6 +1100,19 @@ export async function executeStep(
   // identity (extension-free runs) → byte-identical behavior, field never written.
   const registryIdentity = options.registry?.identity;
   if (registryIdentity !== undefined) {
+    // issue #188 field-fidelity gate: a SEPARATE, unconditional advisory (independent of
+    // whether THIS call's append-on-change detects an actual diff below) — if the store can't
+    // persist extension_identity at all, the baseline resets every execution, so drift can
+    // NEVER accumulate or be detected on this store, not just "not detected this time". Preserves
+    // the #119 WARN-never-gate flow exactly: this only ever pushes a warning, never blocks or
+    // alters the append-on-change logic that follows.
+    if (!persistsField(store, 'extension_identity')) {
+      traceWarnings.push(
+        "this run store does not persist 'extension_identity' — drift detection is unavailable " +
+          '(the baseline resets every execution, so drift can never accumulate or be detected ' +
+          'on this store)',
+      );
+    }
     const identityHistory = pendingRun.extension_identity ?? [];
     const lastIdentity = identityHistory[identityHistory.length - 1];
     if (lastIdentity === undefined || extensionIdentityDiffers(lastIdentity, registryIdentity)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from './types/workflow-error.js';
 export { resolvePreExecutionAgentAction } from './engine/error-resolution.js';
 export * from './types/workflow-definition.js';
 export * from './store/store-interface.js';
+export { persistsField } from './store/store-fidelity.js';
 export { JsonFileStore } from './store/json-file-store.js';
 export type { ReconcileSummary } from './store/json-file-store.js';
 export type { PerRunArtifactStore } from './store/per-run-artifact-store.js';

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -10,7 +10,7 @@ import lockfile from 'proper-lockfile';
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import { WorkflowError } from '../types/workflow-error.js';
-import type { RunStore, CreateRunOptions } from './store-interface.js';
+import type { RunStore, CreateRunOptions, LoadBearingRunRecordField } from './store-interface.js';
 import type { PerRunArtifactStore } from './per-run-artifact-store.js';
 import { findEligibleSteps, deriveRunPhase } from '../engine/eligibility.js';
 import { computeClaimDeadline } from '../engine/claim-liveness.js';
@@ -105,6 +105,17 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
 
   /** This store round-trips the per-claim `claims` liveness clock (issue #101). */
   readonly persistsClaims = true;
+
+  /**
+   * Round-trips every `RunRecord` field it's given (issue #188) — `create`/`update` serialize the
+   * whole record to JSON and `get` parses it back verbatim, so nothing is dropped field-by-field.
+   * Declaring the full set keeps every field-fidelity gate dormant on the local default.
+   */
+  readonly persistedRunRecordFields: ReadonlySet<LoadBearingRunRecordField> = new Set([
+    'capability_blocks',
+    'workflow_context_snapshots',
+    'extension_identity',
+  ]);
 
   constructor(runsDir?: string) {
     this.runsDir = runsDir ?? DEFAULT_RUNS_DIR;

--- a/packages/core/src/store/store-fidelity.ts
+++ b/packages/core/src/store/store-fidelity.ts
@@ -1,0 +1,19 @@
+// Pure helper for the RunStore field-fidelity capability (issue #188). Every runtime honesty gate
+// (execution-loop.ts, get-run-state.ts) and the forcing conformance TCK (@sensigo/realm-testing)
+// checks fidelity through this ONE function, so there is a single place that encodes the
+// fail-closed default — never a scattered `store.persistedRunRecordFields?.has(x) ?? false` at
+// each call site, which would risk one site quietly drifting to a different (unsafe) default.
+import type { LoadBearingRunRecordField, RunStore } from './store-interface.js';
+
+/**
+ * Whether `store` guarantees to round-trip `field` (issue #188). Fail-closed: a store that
+ * doesn't declare `persistedRunRecordFields` at all, or declares a set that doesn't include
+ * `field`, is treated as NOT persisting it — the engine must never assume an absent declaration
+ * means "safe to trust the field's absence on read."
+ */
+export function persistsField(
+  store: Pick<RunStore, 'persistedRunRecordFields'>,
+  field: LoadBearingRunRecordField,
+): boolean {
+  return store.persistedRunRecordFields?.has(field) ?? false;
+}

--- a/packages/core/src/store/store-interface.ts
+++ b/packages/core/src/store/store-interface.ts
@@ -2,6 +2,27 @@
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 
+/**
+ * The load-bearing `RunRecord` fields whose ABSENCE the engine interprets (control flow / the
+ * drift-detection pillar) — a store that drops one silently corrupts behavior, so it must
+ * DECLARE which it round-trips (issue #188). This is a CLOSED set — only fields with a real,
+ * verified read-site consumer (see `RunStore.persistedRunRecordFields`'s own doc for the
+ * consumer list), not an open-ended "everything RunRecord might ever carry":
+ *  - `capability_blocks` — read by `findCapabilityBlockedSteps` (capability.ts), which returns
+ *    `[]` on `undefined`; a store that drops it makes a genuinely-blocked step silently look
+ *    unblocked to `get_run_state` / `list` / `run-agent`.
+ *  - `workflow_context_snapshots` — read by the execution loop's `=== undefined` branch, which
+ *    re-snapshots when absent; a store that drops it loses snapshot HISTORY (current context
+ *    self-heals via re-snapshot, but prior snapshots are gone).
+ *  - `extension_identity` — read by the execution loop's drift-evidence append (issue #119) and
+ *    `realm inspect --check-drift`; a store that drops it resets the drift baseline every
+ *    execution, so drift can never accumulate or be detected.
+ */
+export type LoadBearingRunRecordField =
+  | 'capability_blocks'
+  | 'workflow_context_snapshots'
+  | 'extension_identity';
+
 export interface CreateRunOptions {
   workflowId: string;
   workflowVersion: number;
@@ -39,6 +60,24 @@ export interface RunStore {
   persistsClaims: boolean;
 
   /**
+   * Which {@link LoadBearingRunRecordField}s this store guarantees to round-trip through
+   * `create`/`update`/`get` (issue #188). OPTIONAL and FAIL-CLOSED: `undefined` (or a field
+   * absent from the declared set) means the engine must NOT assume the field's absence on a
+   * read is authoritative — it surfaces the gap honestly instead (see the runtime gates in
+   * `execution-loop.ts` and `get-run-state.ts`). A store that persists every `RunRecord` field
+   * it's given (the common case — `JsonFileStore` and the `@sensigo/realm-testing` in-memory
+   * store both do, by generic serialize/deserialize or by never dropping anything on write)
+   * declares the FULL set, which makes every gate dormant: zero behavior change.
+   *
+   * This is intentionally the inverse of a REQUIRED capability: the default (absent) is the
+   * CONSERVATIVE reading (assume nothing is persisted, warn accordingly), so adding this field
+   * cannot retroactively break an external implementer that predates it (cf. issue #169's
+   * "never make a capability required" precedent) — it only makes such a store's pre-existing
+   * silent field-drop finally visible.
+   */
+  readonly persistedRunRecordFields?: ReadonlySet<LoadBearingRunRecordField>;
+
+  /**
    * Create a new run record, or — when an `idempotencyKey` is supplied and a run with the
    * same `(workflowId, idempotencyKey)` already exists — return that existing run instead.
    *
@@ -74,6 +113,15 @@ export interface RunStore {
    *    throws STATE_STEP_NOT_ELIGIBLE.
    * 4. Adds step to in_progress_steps, increments version, writes.
    * Returns the updated record.
+   *
+   * **Cross-cutting single-owner obligation (issue #188):** MUST be atomic and single-owner
+   * across ALL processes/hosts sharing this store: two concurrent `claimStep` calls for the
+   * same `(runId, step)` MUST NOT both succeed. A store that cannot guarantee this (e.g.
+   * without a row-lock/CAS) breaks both the resurrect-race protection (#184) and the
+   * trace-buffer epoch minting (#185). This obligation is stated here for any external store
+   * implementer; a store's own conformance suite must verify it holds across its actual
+   * concurrency model (the in-repo TCK's `claimStep` test only verifies the same-host case —
+   * see its own doc for why cross-host cannot be verified generically).
    */
   claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord>;
 }

--- a/packages/mcp-server/src/tools/get-run-state-fidelity-gate.test.ts
+++ b/packages/mcp-server/src/tools/get-run-state-fidelity-gate.test.ts
@@ -1,0 +1,111 @@
+// get_run_state's capability_blocks field-fidelity gate (issue #188, PR-2).
+//
+// A minimal hand-rolled RunStore double — handleGetRunState only ever calls `.get()`, so the
+// double only needs to implement that faithfully; every other method throws if reached (proving
+// it never is).
+import { describe, it, expect } from 'vitest';
+import { JsonFileStore } from '@sensigo/realm';
+import type { RunRecord, RunStore, LoadBearingRunRecordField } from '@sensigo/realm';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { handleGetRunState } from './get-run-state.js';
+
+function makeRun(over: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: 'r1',
+    workflow_id: 'wf',
+    workflow_version: 1,
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: [],
+    skipped_steps: [],
+    run_phase: 'running',
+    version: 1,
+    params: {},
+    evidence: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    terminal_state: false,
+    ...over,
+  };
+}
+
+/** A minimal RunStore double whose ONLY faithfully-implemented method is `get` (the only one
+ *  handleGetRunState calls) — every other method throws if reached, proving it never is. */
+function makeGetOnlyStore(
+  run: RunRecord,
+  persistedFields: LoadBearingRunRecordField[] | undefined,
+): RunStore {
+  return {
+    persistsClaims: true,
+    ...(persistedFields !== undefined
+      ? { persistedRunRecordFields: new Set(persistedFields) }
+      : {}),
+    async get() {
+      return run;
+    },
+    async create() {
+      throw new Error('not exercised by get_run_state');
+    },
+    async update() {
+      throw new Error('not exercised by get_run_state');
+    },
+    async list() {
+      throw new Error('not exercised by get_run_state');
+    },
+    async claimStep() {
+      throw new Error('not exercised by get_run_state');
+    },
+  };
+}
+
+describe('get_run_state — capability_blocks field-fidelity gate (issue #188)', () => {
+  it('fires an honest warning when the store does NOT declare it persists capability_blocks', async () => {
+    const store = makeGetOnlyStore(makeRun(), []); // declares an EMPTY set — persists nothing
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: store });
+    expect(summary.warnings).toBeDefined();
+    expect(summary.warnings!.some((w) => w.includes('capability_blocks'))).toBe(true);
+  });
+
+  it('fires the same warning when the store declares NO persistedRunRecordFields at all (fail-closed default)', async () => {
+    const store = makeGetOnlyStore(makeRun(), undefined);
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: store });
+    expect(summary.warnings).toBeDefined();
+    expect(summary.warnings!.some((w) => w.includes('capability_blocks'))).toBe(true);
+  });
+
+  it('stays silent when the store DOES declare it persists capability_blocks', async () => {
+    const store = makeGetOnlyStore(makeRun(), ['capability_blocks']);
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: store });
+    expect(summary.warnings).toBeUndefined();
+  });
+
+  it('a real JsonFileStore (declares the full set) never surfaces the gate — local behavior unaffected', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'get-run-state-fidelity-'));
+    const runStore = new JsonFileStore(dir);
+    const { run } = await runStore.create({ workflowId: 'wf', workflowVersion: 1, params: {} });
+    const summary = await handleGetRunState({ run_id: run.id }, { runStore });
+    expect(summary.warnings).toBeUndefined();
+  });
+
+  it('the gate is advisory only — capability_blocks/next_actions_status logic is unaffected by fidelity', async () => {
+    const blockedRun = makeRun({
+      capability_blocks: {
+        blocked: {
+          requirement: { kind: 'handler', name: 'missing_handler' },
+          code: 'ENGINE_HANDLER_NOT_REGISTERED',
+          at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    });
+    const store = makeGetOnlyStore(blockedRun, []); // declares nothing — gate SHOULD fire
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: store });
+    // The gate fires...
+    expect(summary.warnings?.some((w) => w.includes('capability_blocks'))).toBe(true);
+    // ...but the actual capability_blocks advisory + status are computed exactly as before,
+    // from whatever the store DID return (the gate only adds honesty, never changes the read).
+    expect(summary.next_actions_status).toBe('blocked_on_capability');
+    expect(summary.capability_blocks).toHaveLength(1);
+  });
+});

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -10,6 +10,7 @@ import {
   findEligibleSteps,
   classifyInProgressClaims,
   findCapabilityBlockedSteps,
+  persistsField,
   type RunPhase,
   type NextAction,
   type ClaimState,
@@ -111,6 +112,14 @@ export interface RunStateSummary {
    * here (a legacy run, or a skip family not yet carrying a detail).
    */
   skip_details?: Record<string, SkipDetail>;
+  /**
+   * Honest store-fidelity diagnostics (issue #188) — present only when non-empty. Advisory only,
+   * never a throw: surfaces when the configured run store does NOT declare it persists a
+   * load-bearing `RunRecord` field this response depends on, so a consumer knows a field reading
+   * as absent/empty may be a store limitation rather than genuine absence (e.g. `capability_blocks`
+   * reading `[]` could mean "no blocks" OR "this store doesn't persist blocks at all").
+   */
+  warnings?: string[];
 }
 
 /**
@@ -128,6 +137,20 @@ export async function handleGetRunState(
   // computed once and used both to refine the status (below) and as the advisory array (in the return).
   // Terminal guard mirrors stuck_claims: a sealed run surfaces nothing to do.
   const capabilityBlocks = run.terminal_state ? [] : findCapabilityBlockedSteps(run);
+
+  // issue #188 field-fidelity gate: capability_blocks read above is only trustworthy if the
+  // configured store actually persists it — a store that silently drops it makes a genuinely
+  // blocked step look identical to "no blocks" ([] either way). Advisory only: this NEVER changes
+  // capabilityBlocks/nextActionsStatus above, it only tells the consumer the read may be a store
+  // limitation rather than a real absence.
+  const fidelityWarnings: string[] = [];
+  if (!persistsField(runStore, 'capability_blocks')) {
+    fidelityWarnings.push(
+      "this run store does not persist 'capability_blocks' — capability-block state is " +
+        'unavailable and not authoritative (an empty result may mean "no blocks" or "this ' +
+        'store cannot report blocks at all").',
+    );
+  }
 
   // Compute next_actions + diagnostic status (read-only). Precedence:
   // terminal → skipped_terminal; gate open → awaiting_human; no/unresolved workflow →
@@ -223,6 +246,7 @@ export async function handleGetRunState(
     ...(run.skip_details !== undefined && Object.keys(run.skip_details).length > 0
       ? { skip_details: run.skip_details }
       : {}),
+    ...(fidelityWarnings.length > 0 ? { warnings: fidelityWarnings } : {}),
   };
 }
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -8,6 +8,12 @@ export type {
   ArtifactStoreContractCase,
   PerRunArtifactStoreContractAdapter,
 } from './store/per-run-artifact-store-contract.js';
+export { runStoreFidelityContract } from './store/run-store-fidelity-contract.js';
+export type {
+  RunStoreFidelityLaw,
+  RunStoreFidelityContractCase,
+  RunStoreFidelityContractAdapter,
+} from './store/run-store-fidelity-contract.js';
 
 // Fixtures
 export {

--- a/packages/testing/src/store/in-memory-store.test.ts
+++ b/packages/testing/src/store/in-memory-store.test.ts
@@ -2,7 +2,18 @@
 // reclaim/detection are testable on the testing default store.
 import { describe, it, expect } from 'vitest';
 import { InMemoryStore } from './in-memory-store.js';
-import type { WorkflowDefinition } from '@sensigo/realm';
+import {
+  runStoreFidelityContract,
+  type RunStoreFidelityLaw,
+} from './run-store-fidelity-contract.js';
+import { WorkflowError } from '@sensigo/realm';
+import type {
+  WorkflowDefinition,
+  RunStore,
+  RunRecord,
+  CreateRunOptions,
+  LoadBearingRunRecordField,
+} from '@sensigo/realm';
 
 const autoFree: WorkflowDefinition = {
   id: 'p',
@@ -36,5 +47,120 @@ describe('InMemoryStore — claims parity (#101)', () => {
     const { run } = await store.create({ workflowId: 'a', workflowVersion: 1, params: {} });
     const claimed = await store.claimStep(run.id, 'work', agentWf);
     expect(claimed.claims?.['work']).toEqual({ deadline: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RunStore field-fidelity + claimStep single-owner TCK conformance (issue #188, PR-2).
+// ---------------------------------------------------------------------------
+
+const ALL_FIELDS: LoadBearingRunRecordField[] = [
+  'capability_blocks',
+  'workflow_context_snapshots',
+  'extension_identity',
+];
+
+describe('InMemoryStore — RunStore fidelity TCK conformance (issue #188)', () => {
+  it('declares the full LoadBearingRunRecordField set (parity with JsonFileStore)', () => {
+    const store = new InMemoryStore();
+    for (const field of ALL_FIELDS) {
+      expect(store.persistedRunRecordFields?.has(field)).toBe(true);
+    }
+  });
+
+  const laws: RunStoreFidelityLaw[] = ['FIDELITY_HONESTY', 'CLAIM_SINGLE_OWNER'];
+  for (const law of laws) {
+    it(`conforms to ${law}`, async () => {
+      const store = new InMemoryStore();
+      const cases = runStoreFidelityContract({ store, definition: agentWf, stepName: 'work' });
+      const matching = cases.filter((c) => c.law === law);
+      expect(matching.length).toBeGreaterThan(0);
+      for (const c of matching) {
+        await c.run();
+      }
+    });
+  }
+});
+
+/**
+ * A deliberately DISHONEST RunStore (issue #188): declares it persists `extension_identity` in
+ * `persistedRunRecordFields`, but silently drops the field on every `update` — proves the TCK's
+ * FIDELITY_HONESTY law actually catches a lying store, rather than passing vacuously. Mirrors
+ * InMemoryStore's own logic for everything else (a faithful store in every OTHER respect), so the
+ * ONLY thing under test is the one deliberate lie.
+ */
+class FieldDroppingFakeStore implements RunStore {
+  private readonly runs = new Map<string, RunRecord>();
+  readonly persistsClaims = true;
+  readonly persistedRunRecordFields: ReadonlySet<LoadBearingRunRecordField> = new Set([
+    'extension_identity',
+  ]);
+
+  async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    const now = new Date().toISOString();
+    const record: RunRecord = {
+      id: crypto.randomUUID(),
+      workflow_id: options.workflowId,
+      workflow_version: options.workflowVersion,
+      completed_steps: [],
+      in_progress_steps: [],
+      failed_steps: [],
+      skipped_steps: [],
+      run_phase: 'running',
+      version: 0,
+      params: options.params,
+      evidence: [],
+      created_at: now,
+      updated_at: now,
+      terminal_state: false,
+    };
+    this.runs.set(record.id, record);
+    return { run: record, created: true };
+  }
+
+  async get(runId: string): Promise<RunRecord> {
+    const record = this.runs.get(runId);
+    if (record === undefined) {
+      throw new WorkflowError(`Run '${runId}' not found`, {
+        code: 'STATE_RUN_NOT_FOUND',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
+    return record;
+  }
+
+  async update(record: RunRecord): Promise<RunRecord> {
+    // THE LIE: extension_identity is stripped here despite being declared persisted above.
+    const { extension_identity: _dropped, ...rest } = record;
+    const updated: RunRecord = {
+      ...rest,
+      version: record.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+    this.runs.set(updated.id, updated);
+    return updated;
+  }
+
+  async claimStep(): Promise<RunRecord> {
+    throw new Error('not exercised by the fidelity-honesty law');
+  }
+
+  async list(workflowId?: string): Promise<RunRecord[]> {
+    const all = [...this.runs.values()];
+    return workflowId !== undefined ? all.filter((r) => r.workflow_id === workflowId) : all;
+  }
+}
+
+describe('FieldDroppingFakeStore — the TCK catches a dishonest store (issue #188)', () => {
+  it('FIDELITY_HONESTY fails a store that declares extension_identity but drops it on write', async () => {
+    const store = new FieldDroppingFakeStore();
+    const cases = runStoreFidelityContract({ store, definition: agentWf, stepName: 'work' });
+    const target = cases.find(
+      (c) => c.law === 'FIDELITY_HONESTY' && c.name.includes('extension_identity'),
+    );
+    expect(target, 'expected a FIDELITY_HONESTY case for extension_identity').toBeDefined();
+    await expect(target!.run()).rejects.toThrow(/DISHONEST/);
   });
 });

--- a/packages/testing/src/store/in-memory-store.ts
+++ b/packages/testing/src/store/in-memory-store.ts
@@ -9,6 +9,7 @@ import {
   type RunRecord,
   type CreateRunOptions,
   type WorkflowDefinition,
+  type LoadBearingRunRecordField,
 } from '@sensigo/realm';
 
 /** In-memory implementation of RunStore. Uses a Map keyed by run ID. No I/O, no locking. */
@@ -19,6 +20,14 @@ export class InMemoryStore implements RunStore {
 
   /** Parity with JsonFileStore: round-trips the per-claim `claims` liveness clock (issue #101). */
   readonly persistsClaims = true;
+
+  /** Parity with JsonFileStore (issue #188): every `create`/`update` stores the whole `RunRecord`
+   *  object as-is (no field-by-field mapping), so nothing is ever dropped — declares the full set. */
+  readonly persistedRunRecordFields: ReadonlySet<LoadBearingRunRecordField> = new Set([
+    'capability_blocks',
+    'workflow_context_snapshots',
+    'extension_identity',
+  ]);
 
   async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
     // Idempotency: a key match applies the re-encounter policy, like JsonFileStore.
@@ -111,7 +120,24 @@ export class InMemoryStore implements RunStore {
     stepName: string,
     definition: WorkflowDefinition,
   ): Promise<RunRecord> {
-    const run = await this.get(runId);
+    // issue #188: read the record SYNCHRONOUSLY (a direct Map.get, not `await this.get(...)`) so
+    // the read → eligibility-check → write below is one indivisible synchronous stretch. This is
+    // what makes claimStep single-owner for concurrent same-process calls (the cross-cutting
+    // obligation on RunStore.claimStep; the TCK's concurrent-claimStep case exercises exactly
+    // this against this store). `await this.get(runId)` would NOT be safe here even though the
+    // lookup itself has no I/O: unwrapping an already-resolved promise still costs one microtask
+    // tick, during which a second `Promise.all`'d claimStep call's own (equally synchronous) read
+    // can run BEFORE either call has written — verified empirically: two concurrent claimStep
+    // calls for the same (runId, step) both resolved successfully before this fix.
+    const run = this.runs.get(runId);
+    if (run === undefined) {
+      throw new WorkflowError(`Run '${runId}' not found`, {
+        code: 'STATE_RUN_NOT_FOUND',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      });
+    }
     const alreadyDone = [
       ...run.completed_steps,
       ...run.in_progress_steps,

--- a/packages/testing/src/store/run-store-fidelity-contract.ts
+++ b/packages/testing/src/store/run-store-fidelity-contract.ts
@@ -1,0 +1,188 @@
+// run-store-fidelity-contract.ts — framework-agnostic Test Compatibility Kit (TCK) for RunStore
+// field-fidelity honesty + claimStep single-owner conformance (issue #188, PR-2).
+//
+// Pure case descriptors, NOT describe/it/expect — mirrors per-run-artifact-store-contract.ts's
+// own precedent (issue #183) and its rationale: importing vitest here would make it a runtime
+// dependency of this published package (this module ships in @sensigo/realm-testing's dist).
+// Each calling test file supplies an adapter and wires the returned descriptors into ITS OWN test
+// framework.
+//
+// This is "the forcing part" (issue #188): FIDELITY_HONESTY does not just check that a store
+// SAYS it persists a field — it writes a real sample value through create/update and reads it
+// back, so a store that DECLARES `persistedRunRecordFields` dishonestly (claims a field, drops it
+// on write) fails conformance here, before it ever ships. A store that declares NOTHING passes
+// this law vacuously (zero cases generated) — see `runStoreFidelityContract`'s own doc.
+import {
+  WorkflowError,
+  type RunStore,
+  type LoadBearingRunRecordField,
+  type WorkflowDefinition,
+  type CapabilityBlock,
+  type WorkflowContextSnapshot,
+  type ExtensionIdentityEntry,
+} from '@sensigo/realm';
+
+/** One of the two laws every `RunStore` implementation should be run against (issue #188). */
+export type RunStoreFidelityLaw = 'FIDELITY_HONESTY' | 'CLAIM_SINGLE_OWNER';
+
+/**
+ * A single, framework-agnostic contract case. `run()` throws (rejects) on failure — any test
+ * framework's `await run()` (rejecting fails the test) or `expect(run()).resolves...` /
+ * `expect(run()).rejects...` maps directly onto this.
+ */
+export interface RunStoreFidelityContractCase {
+  law: RunStoreFidelityLaw;
+  name: string;
+  run: () => Promise<void>;
+}
+
+/** Adapter a calling test file supplies to parameterize the contract against one concrete store. */
+export interface RunStoreFidelityContractAdapter {
+  /** The store under test. */
+  store: RunStore;
+  /**
+   * A workflow definition carrying exactly one step, named `stepName`, that is immediately
+   * eligible on a freshly-created run (no unmet `depends_on`) — used by CLAIM_SINGLE_OWNER to
+   * race two concurrent `claimStep` calls against a fresh run of this definition.
+   */
+  definition: WorkflowDefinition;
+  stepName: string;
+}
+
+/**
+ * One realistic, minimal-but-valid sample value per {@link LoadBearingRunRecordField} — used by
+ * FIDELITY_HONESTY to actually exercise a round-trip. Deliberately real shapes (not `{}` or
+ * `null`), since a store that only round-trips empty/degenerate values would not actually prove
+ * fidelity for the shapes the engine truly writes.
+ */
+const SAMPLE_VALUES: {
+  capability_blocks: Record<string, CapabilityBlock>;
+  workflow_context_snapshots: Record<string, WorkflowContextSnapshot>;
+  extension_identity: ExtensionIdentityEntry[];
+} = {
+  capability_blocks: {
+    'tck-step': {
+      requirement: { kind: 'handler', name: 'tck-handler' },
+      code: 'ENGINE_HANDLER_NOT_REGISTERED',
+      at: '2026-01-01T00:00:00.000Z',
+    },
+  },
+  workflow_context_snapshots: {
+    'tck-key': {
+      source_path: '/tck/sample.md',
+      content: 'hello',
+      content_hash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      loaded_at: '2026-01-01T00:00:00.000Z',
+    },
+  },
+  extension_identity: [
+    {
+      captured_at: '2026-01-01T00:00:00.000Z',
+      modules: [],
+      tree: {
+        roots: [],
+        rules: 'tck-rules',
+        file_count: 0,
+        total_bytes: 0,
+        tree_hash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        truncated: false,
+      },
+      coverage: 'dir_tree_v1',
+    },
+  ],
+};
+
+/**
+ * Builds the contract cases for `adapter`.
+ *
+ * **FIDELITY_HONESTY** — one case PER FIELD in `adapter.store.persistedRunRecordFields` (zero
+ * cases if the store declares nothing — a store with no declaration passes this law vacuously,
+ * by construction, and gets the conservative runtime gates instead; that combination is
+ * correct-by-design, not a TCK gap). Each case: `create` a fresh run, `update` it to carry a
+ * realistic sample value for that field, `get` it back, and byte-compare (via JSON, since every
+ * `LoadBearingRunRecordField` is plain-JSON-serializable data) what was written against what was
+ * read. A mismatch means the store's declaration is DISHONEST.
+ *
+ * **CLAIM_SINGLE_OWNER** — races two concurrent `claimStep(runId, sameStep)` calls against a
+ * fresh run; asserts exactly one resolves and the other rejects with
+ * `STATE_STEP_ALREADY_CLAIMED`. **Cross-host caveat: this only exercises and asserts the
+ * SAME-PROCESS (same-host) guarantee** — for an in-memory store this is same-process by
+ * construction; for a lock-based store like `JsonFileStore` it exercises same-host
+ * multi-process safety via the real OS-level lock the two concurrent calls contend on, but this
+ * TCK run happens within ONE test process, so it does not and cannot exercise true cross-host
+ * concurrency. The CROSS-HOST single-owner obligation (stated on `RunStore.claimStep`'s own
+ * JSDoc) can only be verified by a store's OWN conformance suite against its real concurrent
+ * backend (e.g. a Postgres store's suite exercising genuine multi-connection contention) — do
+ * NOT read a green result here as proof of cross-host safety.
+ */
+export function runStoreFidelityContract(
+  adapter: RunStoreFidelityContractAdapter,
+): RunStoreFidelityContractCase[] {
+  const cases: RunStoreFidelityContractCase[] = [];
+
+  const declaredFields =
+    adapter.store.persistedRunRecordFields ?? new Set<LoadBearingRunRecordField>();
+  for (const field of declaredFields) {
+    cases.push({
+      law: 'FIDELITY_HONESTY',
+      name: `a store declaring '${field}' actually round-trips it (create → update → get)`,
+      run: async () => {
+        const { run } = await adapter.store.create({
+          workflowId: `tck-fidelity-${field}`,
+          workflowVersion: 1,
+          params: {},
+        });
+        const sampleValue = SAMPLE_VALUES[field];
+        await adapter.store.update({ ...run, [field]: sampleValue });
+        const reread = await adapter.store.get(run.id);
+        const actual = (reread as unknown as Record<string, unknown>)[field];
+        const wroteJson = JSON.stringify(sampleValue);
+        const readJson = JSON.stringify(actual);
+        if (readJson !== wroteJson) {
+          throw new Error(
+            `store declares persistedRunRecordFields includes '${field}' but a round-trip did ` +
+              `NOT preserve it — the declared fidelity is DISHONEST (issue #188). wrote: ` +
+              `${wroteJson}, read back: ${readJson}`,
+          );
+        }
+      },
+    });
+  }
+
+  cases.push({
+    law: 'CLAIM_SINGLE_OWNER',
+    name: 'two concurrent claimStep calls for the same (runId, step) — exactly one succeeds',
+    run: async () => {
+      const { run } = await adapter.store.create({
+        workflowId: `tck-claim-${Math.random().toString(36).slice(2)}`,
+        workflowVersion: 1,
+        params: {},
+      });
+      const results = await Promise.allSettled([
+        adapter.store.claimStep(run.id, adapter.stepName, adapter.definition),
+        adapter.store.claimStep(run.id, adapter.stepName, adapter.definition),
+      ]);
+      const fulfilled = results.filter((r) => r.status === 'fulfilled');
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (fulfilled.length !== 1) {
+        throw new Error(
+          `expected exactly ONE of two concurrent claimStep calls for the same (runId, step) to ` +
+            `succeed, got ${fulfilled.length} — the single-owner guarantee is violated (breaks ` +
+            'the resurrect-race protection, issue #184, and the trace-buffer epoch minting, issue #185).',
+        );
+      }
+      for (const r of rejected) {
+        const err: unknown = r.reason;
+        if (!(err instanceof WorkflowError) || err.code !== 'STATE_STEP_ALREADY_CLAIMED') {
+          const described = err instanceof WorkflowError ? err.code : String(err);
+          throw new Error(
+            `expected the losing claimStep call to reject with a WorkflowError carrying code ` +
+              `STATE_STEP_ALREADY_CLAIMED, got: ${described}`,
+          );
+        }
+      }
+    },
+  });
+
+  return cases;
+}


### PR DESCRIPTION
## Context

**PR-2 of #188** — the store field-fidelity contract, enforced by a forcing conformance TCK. Closes #188's field-fidelity half. Builds on PR-1's injection seam (merged `2cf68b9`). Decided through a 2-round Peer exploration + a Design Reviewer pass (prior-art: DNS authoritative-answer, Chandra–Toueg failure-detector impossibility, JDBC/Django/CSI capability declaration).

## Motivation

The Design Reviewer disproved an earlier "these fields are informational" scope assumption: `capability_blocks`, `workflow_context_snapshots`, and `extension_identity` are read and drive control flow / the drift-detection pillar. A columnar/cloud store silently dropping them is active corruption on the exact deployment #188 targets — e.g. a dropped `extension_identity` resets the drift baseline every execution, so a swapped adapter passes undetected. The engine must be *forced* to know when a store can't back a guarantee, and never silently misread a dropped field as legitimate absence.

## Changes

- **The capability** — `RunStore.persistedRunRecordFields?: ReadonlySet<LoadBearingRunRecordField>` (a closed set of the three fields with verified read-site consumers), **optional + fail-closed default**: absent ⇒ the engine surfaces the gap honestly. `JsonFileStore` + the testing `InMemoryStore` declare the full set → gates dormant → zero local regression. (Optional-default = non-breaking *and* safe, the inverse of a required flag — cf. #169.)
- **The forcing conformance TCK** (`@sensigo/realm-testing`, framework-agnostic, the #183 precedent) — the centerpiece: a store's *declared* fidelity must be *honest* (a round-trip must actually preserve each declared field), so a store that claims to persist `extension_identity` but drops it **fails conformance before it ships**; plus a concurrent-`claimStep` single-owner law (with an explicit "same-host only; cross-host is the store's own suite's job" caveat).
- **Three runtime honesty gates** at the verified non-dormant sites (`get_run_state`/`capability_blocks`, `execute_step`/`workflow_context_snapshots` + `extension_identity`) — each **loud-surfaces** a fidelity gap as an advisory warning/diagnostic; **#119's WARN-never-gate posture is preserved** (execution is never blocked — verified additive-only + a co-occurrence test).
- **`claimStep` single-owner JSDoc clause** — states the cross-host obligation (a forking claim breaks #184 *and* #185).
- **Bonus:** the TCK exposed and fixed a real pre-existing concurrency bug in the testing `InMemoryStore.claimStep` (an `await this.get()` microtask yield let two concurrent claims both succeed).

Partitioned purge/gc/export reachability enforcement is deferred to **PR-3** (single-domain-blessed makes it non-urgent + dormant until CLI-injection).

## Verification

```bash
npm run lint && npm run build && npm run check:versions   # clean; versions unchanged
npm audit --omit=dev --audit-level=high                   # 0 vulnerabilities
TURBO_FORCE=true npm run test                             # core 1710, mcp 191, testing 81, cli 707
```

Independently reproduced (reviewer, on the branch):
- **Mutation-probe (a):** `persistsField` forced `true` → all 6 gate-fires tests redden; restore → green.
- **Mutation-probe (b):** remove the fake store's field-drop → the "TCK catches a dishonest store" test reddens ("resolved instead of rejecting") — proving the TCK detects a *real* drop, not a vacuous pass; restore → green.
- **#119:** `execution-loop.ts` diff is purely additive (zero deletions); the co-occurrence test confirms a fidelity warning + a completed step coexist.
- **`claimStep` fix:** verified no `await` between the sync read and the write.

## Rollback

Revert this PR. `persistedRunRecordFields` is additive/optional; `JsonFileStore` behavior is byte-identical; the gates are advisory (never block). No store/schema/on-disk change. Rides `[Unreleased]`.

## Related

PR-2 of #188 (closes the field-fidelity half). PR-3 (partitioned reachability enforcement + CLI-injection) deferred. The `claimStep` cross-host clause is cross-cutting with #184/#185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
