### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.26.0] — 2026-07-16
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.25.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.26.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,7 +93,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.25.0';
+export const VERSION = '0.26.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.25.0';
+export const VERSION = '0.26.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -105,7 +105,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.25.0',
+    version: '0.26.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -51,4 +51,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.25.0';
+export const VERSION = '0.26.0';


### PR DESCRIPTION
## Context

Release **v0.26.0** (minor). The store-honesty hardening arc since v0.25.0 — the #185 trace sub-arc tidy plus the #188 pluggable-store contract — cut per `.github/instructions/pre-publication.instructions.md` Part B.

## Motivation

`[Unreleased]` holds a coherent, complete set (#187 + #198 + #188 PR-1/PR-2 + its docs), all merged, all milestone work done. The `### Added` (#188 field-fidelity capability) justifies a minor over a patch.

## Changes

Mechanical release commit only:
- `docs: update changelog for v0.26.0` — renames `## [Unreleased]` → `## [0.26.0] — 2026-07-16`.
- `chore: release v0.26.0` — bumps all four `package.json` + the five source `VERSION`/`.version()` constants to `0.26.0`; tag `v0.26.0` on the release commit.

**Release contents (already on `main`):**
- **Added** — the `RunStore` field-fidelity contract + framework-agnostic conformance TCK (`@sensigo/realm-testing`), forcing any store to prove its declared fidelity is honest (#188 PR-2); documented in `docs/reference/testing.md`.
- **Changed** — `append_trace` now rejects terminal runs (#187); the MCP `runStore` option accepts any `RunStore` implementation with co-located artifact-store injection (#188 PR-1, the cloud-injection unblock).
- **Fixed** — `realm run reclaim` now clears the reclaimed step's stale trace buffer (#198).

## Verification

```bash
npm run check:versions          # all five strings = 0.26.0
git rev-parse v0.26.0           # == this PR's release commit (3f562f4)

# After merge + tag push (Part B step 5-7):
#   git switch main && git pull && git push --tags   → triggers publish.yml (OIDC)
npm view @sensigo/realm@0.26.0 version               # 0.26.0
npm install @sensigo/realm@0.26.0                     # ESM import { VERSION } === '0.26.0'
npx @sensigo/realm-cli@0.26.0 --version               # 0.26.0
```

Merge with a **merge commit** (not squash/rebase) — the tag is on the branch's release commit; a rewrite would dangle it and break `publish.yml`.

## Rollback

If a broken artifact surfaces post-publish, cut a patch (v0.26.1) via the same Part B sequence — npm publishes are immutable. Pre-merge, branch + tag can be deleted. No consumer migration required (all changes are additive/backwards-compatible; the local `JsonFileStore` path is byte-identical).

## Related

Ships #187, #198, #188 (PR-1 + PR-2 + docs). #188 conditional PR-3 (#204) stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
