### PR TITLE
feat(store): fenced trio for TraceBufferStore — interface, implementations, forcing TCK (#207 PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ All notable changes to this project are documented here.
   `deleteAllForRun()` to serialize on the same per-(runId, stepId) critical sections. Both in-repo
   stores (`JsonTraceBufferStore`, `InMemoryTraceBufferStore`) now declare the trio — dormant until
   a consumer adopts it (this PR touches no call site; see #207 PR-2 for that). A new exported core
-  helper, `isStepSettledOrInFlight`, replaces four inlined four-array membership checks with one
-  chokepoint (and fixes a latent `skipped_steps` omission at one of them). A new framework-agnostic
+  helper, `isStepSettledOrInFlight`, centralizes four inlined four-array membership checks into one
+  chokepoint (all four already covered `skipped_steps` correctly — no behavior change at these
+  sites; the separate, latent `skipped_steps` omission in `append_trace`'s own eligibility check is
+  closed in PR-2, when that tool adopts the helper). A new framework-agnostic
   conformance TCK (`@sensigo/realm-testing`'s `fencedTraceBufferContract`) forces any fenced-trio
   store to prove `STRUCTURAL`/`FENCE_REFUSES`/`CS_OCCUPANCY`/`PER_KEY_INDEPENDENCE`/
   `NO_SILENT_LOSS` — a store enforcing the fence via a transaction-scoped SQL predicate instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`TraceBufferStore`'s fenced trio (issue #207, PR-1 of 2).** Three new OPTIONAL methods —
+  `appendFenced`, `deleteFenced`, `deleteAllForRunFenced` — let a store fence a write or delete
+  against a caller-supplied guard that re-verifies its premise inside the same critical section the
+  destructive effect uses, closing the race where an unconditional `delete()` could destroy trace
+  data a concurrent `append()` just committed. Declaring any one of the three requires declaring
+  all three; declaring the trio also commits the store's legacy `read()`/`delete()`/
+  `deleteAllForRun()` to serialize on the same per-(runId, stepId) critical sections. Both in-repo
+  stores (`JsonTraceBufferStore`, `InMemoryTraceBufferStore`) now declare the trio — dormant until
+  a consumer adopts it (this PR touches no call site; see #207 PR-2 for that). A new exported core
+  helper, `isStepSettledOrInFlight`, replaces four inlined four-array membership checks with one
+  chokepoint (and fixes a latent `skipped_steps` omission at one of them). A new framework-agnostic
+  conformance TCK (`@sensigo/realm-testing`'s `fencedTraceBufferContract`) forces any fenced-trio
+  store to prove `STRUCTURAL`/`FENCE_REFUSES`/`CS_OCCUPANCY`/`PER_KEY_INDEPENDENCE`/
+  `NO_SILENT_LOSS` — a store enforcing the fence via a transaction-scoped SQL predicate instead of
+  an in-process critical section produces an explicit, visible documented-skip for the three
+  latch-based laws rather than a silent omission (that store's own in-transaction suite must verify
+  race closure — mirroring `CLAIM_SINGLE_OWNER`'s own cross-host caveat, issue #188). Semver:
+  minor-additive.
+
+---
+
 ## [0.26.0] — 2026-07-16
 
 ### Added

--- a/packages/cli/src/commands/store-fs-guard.test.ts
+++ b/packages/cli/src/commands/store-fs-guard.test.ts
@@ -203,3 +203,62 @@ describe('store-fs-guard — every WIRED PerRunArtifactStore has a TCK-invoking 
     ).toEqual([]);
   });
 });
+
+// -----------------------------------------------------------------------------------------------
+// Guard 3: every store declaring the fenced trio has a fenced-TCK-invoking contract test
+// (issue #207 — same Guard-2 co-occurrence pattern, a new independent literal for the same
+// duplication-over-coupling reason as WIRED_STORES above)
+// -----------------------------------------------------------------------------------------------
+
+const WIRED_FENCED_STORES = ['JsonTraceBufferStore', 'InMemoryTraceBufferStore'];
+
+/** This guard's OWN file — excluded from its own scan below (issue #207). Without this, the
+ *  guard would trivially "cover" every store forever: this file's own doc comments and the
+ *  `WIRED_FENCED_STORES` array literal itself contain both the store class name strings AND the
+ *  literal substring `fencedTraceBufferContract(` (inside the string-literal argument to
+ *  `.includes(...)` a few lines below), so scanning this file would always find a false
+ *  co-occurrence regardless of whether any REAL wiring test exists. Confirmed this same
+ *  self-referential gap already existed, unnoticed, in Guard 2's `tckCoveredStores` above (it
+ *  scans its own file too, for the same reason) — not fixed there (out of this task's scope,
+ *  pre-existing and unrelated to issue #207), but not repeated here. */
+const THIS_GUARD_FILE = fileURLToPath(import.meta.url);
+
+/** Every `.test.ts` file anywhere in the repo (other than this guard's own file) that calls
+ *  `fencedTraceBufferContract(`, cross-referenced against which WIRED_FENCED_STORES class
+ *  name(s) it also imports/references — the same same-file co-occurrence proxy
+ *  `tckCoveredStores` uses above, for the fenced TCK. */
+function fencedTckCoveredStores(): Set<string> {
+  const covered = new Set<string>();
+  const packages = ['core', 'cli', 'mcp-server', 'testing'];
+  for (const pkg of packages) {
+    const root = join(PACKAGES_DIR, pkg, 'src');
+    for (const file of walkTestFiles(root)) {
+      if (file === THIS_GUARD_FILE) continue;
+      const src = readFileSync(file, 'utf8');
+      if (!src.includes('fencedTraceBufferContract(')) continue;
+      for (const storeName of WIRED_FENCED_STORES) {
+        if (src.includes(storeName)) covered.add(storeName);
+      }
+    }
+  }
+  return covered;
+}
+
+describe('store-fs-guard — every fenced-trio-declaring store has a fenced-TCK-invoking contract test (issue #207)', () => {
+  it('at least one contract test file invokes fencedTraceBufferContract (the scan is wired correctly)', () => {
+    expect(fencedTckCoveredStores().size).toBeGreaterThan(0);
+  });
+
+  it('EVERY store in WIRED_FENCED_STORES is covered by a fenced-TCK-invoking test file', () => {
+    const covered = fencedTckCoveredStores();
+    const uncovered = WIRED_FENCED_STORES.filter((name) => !covered.has(name));
+    expect(
+      uncovered,
+      `${uncovered.join(', ')} ${uncovered.length === 1 ? 'declares' : 'declare'} the fenced trio ` +
+        `but no test file both imports it and calls fencedTraceBufferContract(...) — add a ` +
+        `*-fenced.contract.test.ts wiring it into the TCK (see ` +
+        `json-trace-buffer-store-fenced.contract.test.ts under packages/cli/src/store-contracts/ ` +
+        `for the pattern).`,
+    ).toEqual([]);
+  });
+});

--- a/packages/cli/src/store-contracts/in-memory-trace-buffer-store-fenced.contract.test.ts
+++ b/packages/cli/src/store-contracts/in-memory-trace-buffer-store-fenced.contract.test.ts
@@ -1,0 +1,57 @@
+// Fenced-trio TCK conformance for InMemoryTraceBufferStore (issue #207).
+//
+// See json-trace-buffer-store-fenced.contract.test.ts (this directory) and
+// json-file-store.contract.test.ts for why these TCK-wiring tests live in @sensigo/realm-cli
+// rather than alongside each store's own package: @sensigo/realm-testing depends on
+// @sensigo/realm, so a devDependency the other way round (packages/core → @sensigo/realm-testing)
+// would be a genuine circular PACKAGE dependency (the #183 precedent). @sensigo/realm-cli already
+// depends on both.
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { InMemoryTraceBufferStore } from '@sensigo/realm';
+import { fencedTraceBufferContract, type FencedTraceBufferLaw } from '@sensigo/realm-testing';
+
+const LAWS: FencedTraceBufferLaw[] = [
+  'STRUCTURAL',
+  'FENCE_REFUSES',
+  'CS_OCCUPANCY',
+  'PER_KEY_INDEPENDENCE',
+  'NO_SILENT_LOSS',
+];
+
+function makeKey(): { runId: string; stepId: string } {
+  return { runId: randomUUID(), stepId: 'fenced-tck-step' };
+}
+
+describe('InMemoryTraceBufferStore — fenced-trio TCK conformance (issue #207)', () => {
+  for (const law of LAWS) {
+    it(law, async () => {
+      // A fresh store per law — the in-memory store's per-key chain map has no cross-test state
+      // to worry about, but a fresh instance keeps each law's cases fully isolated regardless.
+      const store = new InMemoryTraceBufferStore();
+      const cases = fencedTraceBufferContract({
+        store,
+        makeKey,
+        fenceForm: 'guard-in-cs',
+      });
+      const matching = cases.filter((c) => c.law === law);
+      expect(matching.length, `no cases registered for law ${law}`).toBeGreaterThan(0);
+      for (const c of matching) {
+        await c.run();
+      }
+    });
+  }
+
+  // PER_KEY_INDEPENDENCE's own doc states a global-lock store hangs into the framework timeout —
+  // give it a short, explicit timeout so a regression here fails fast rather than waiting out the
+  // suite's default timeout (mutation-probe g in this task's report relies on this).
+  it('PER_KEY_INDEPENDENCE (short-timeout variant, for the mutation-probe)', async () => {
+    const store = new InMemoryTraceBufferStore();
+    const cases = fencedTraceBufferContract({ store, makeKey, fenceForm: 'guard-in-cs' });
+    const target = cases.find(
+      (c) => c.law === 'PER_KEY_INDEPENDENCE' && c.name.includes('disjoint-run'),
+    );
+    expect(target).toBeDefined();
+    await target!.run();
+  }, 2000);
+});

--- a/packages/cli/src/store-contracts/json-trace-buffer-store-fenced.contract.test.ts
+++ b/packages/cli/src/store-contracts/json-trace-buffer-store-fenced.contract.test.ts
@@ -1,0 +1,89 @@
+// Fenced-trio TCK conformance for JsonTraceBufferStore (issue #207).
+//
+// See json-trace-buffer-store.contract.test.ts (this directory, the #183 PerRunArtifactStore TCK
+// for the same store) for why this lives in @sensigo/realm-cli rather than alongside
+// JsonTraceBufferStore's own test suite in @sensigo/realm-mcp: keeping all fs-store TCK
+// conformance tests co-located (this directory already depends on both @sensigo/realm and
+// @sensigo/realm-mcp) is simpler than splitting across packages for no benefit.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { JsonTraceBufferStore } from '@sensigo/realm-mcp';
+import { fencedTraceBufferContract, type FencedTraceBufferLaw } from '@sensigo/realm-testing';
+
+const LAWS: FencedTraceBufferLaw[] = [
+  'STRUCTURAL',
+  'FENCE_REFUSES',
+  'CS_OCCUPANCY',
+  'PER_KEY_INDEPENDENCE',
+  'NO_SILENT_LOSS',
+];
+
+/**
+ * A deliberately generous lock profile for this TCK's own store instance (issue #207) — the
+ * default profile (~4s worst-case budget) is already ample for this suite's sub-second latch
+ * durations, but the TCK's own latch-based laws briefly hold the CS open across several `await`s
+ * (drain round-trips, `setImmediate`), so an inflated retry budget removes any risk of a
+ * concurrent caller's lock acquisition giving up (ELOCKED) before the law's own observation
+ * window completes on a loaded CI runner. Passed via the constructor-injectable lock-profile
+ * parameter (issue #207); this is the "injectable generous lock profile" the adapter's own doc
+ * requires for `guard-in-cs` stores.
+ */
+const GENEROUS_LOCK_PROFILE = {
+  retries: { retries: 20, minTimeout: 20, maxTimeout: 200 },
+  stale: 5000,
+  realpath: false,
+};
+
+async function makeAdapter(): Promise<{
+  adapter: Parameters<typeof fencedTraceBufferContract>[0];
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'json-trace-buffer-store-fenced-tck-'));
+  const store = new JsonTraceBufferStore(dir, GENEROUS_LOCK_PROFILE);
+  return {
+    adapter: {
+      store,
+      makeKey: () => ({ runId: randomUUID(), stepId: 'fenced-tck-step' }),
+      fenceForm: 'guard-in-cs',
+      lockProfile: GENEROUS_LOCK_PROFILE,
+    },
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe('JsonTraceBufferStore — fenced-trio TCK conformance (issue #207)', () => {
+  for (const law of LAWS) {
+    it(law, async () => {
+      // Fresh adapter (fresh tmpdir) per law — CS_OCCUPANCY/NO_SILENT_LOSS mutate on-disk state
+      // and a stale WAL file from an earlier law must never leak into a later one.
+      const { adapter, cleanup } = await makeAdapter();
+      try {
+        const cases = fencedTraceBufferContract(adapter);
+        const matching = cases.filter((c) => c.law === law);
+        expect(matching.length, `no cases registered for law ${law}`).toBeGreaterThan(0);
+        for (const c of matching) {
+          await c.run();
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  it('PER_KEY_INDEPENDENCE (short-timeout variant, for the mutation-probe)', async () => {
+    const { adapter, cleanup } = await makeAdapter();
+    try {
+      const cases = fencedTraceBufferContract(adapter);
+      const target = cases.find(
+        (c) => c.law === 'PER_KEY_INDEPENDENCE' && c.name.includes('disjoint-run'),
+      );
+      expect(target).toBeDefined();
+      await target!.run();
+    } finally {
+      await cleanup();
+    }
+  }, 3000);
+});

--- a/packages/core/src/engine/eligibility.ts
+++ b/packages/core/src/engine/eligibility.ts
@@ -298,6 +298,27 @@ export function buildEvidenceByStep(run: RunRecord): Record<string, Record<strin
 }
 
 /**
+ * True iff `stepId` is a member of `completed_steps ∪ failed_steps ∪ skipped_steps ∪
+ * in_progress_steps` on `run` — the shared "already settled or currently claimed" membership
+ * test, factored out (issue #207) from four inline four-array checks that had drifted apart in
+ * shape at their call sites. `append_trace.ts` has its own, separate `skipped_steps` omission
+ * (D3 §2) — NOT fixed by this PR (append_trace.ts is untouched here; adopting this helper there
+ * is PR-2's job). This chokepoint is what makes that fix, once made, a one-line call instead of a
+ * fifth hand-copied four-array check. Pure and synchronous by design — every call site that
+ * depends on running with no `await` between a check and a mutation (e.g. `InMemoryStore
+ * .claimStep`'s issue #188 no-await-between-check-and-mutate fix) can call this helper without
+ * reintroducing a microtask-yield point.
+ */
+export function isStepSettledOrInFlight(run: RunRecord, stepId: string): boolean {
+  return (
+    run.completed_steps.includes(stepId) ||
+    run.failed_steps.includes(stepId) ||
+    run.skipped_steps.includes(stepId) ||
+    run.in_progress_steps.includes(stepId)
+  );
+}
+
+/**
  * Returns the names of all steps currently eligible for execution.
  * Gate serialization: if any gate is open, no steps are eligible.
  * A step is eligible if:
@@ -322,12 +343,7 @@ export function findEligibleSteps(definition: WorkflowDefinition, run: RunRecord
     if (step.execution === 'guard' || step.execution === 'finalizer') continue;
 
     // Already done or in-flight.
-    if (
-      run.completed_steps.includes(stepName) ||
-      run.in_progress_steps.includes(stepName) ||
-      run.failed_steps.includes(stepName) ||
-      run.skipped_steps.includes(stepName)
-    ) {
+    if (isStepSettledOrInFlight(run, stepName)) {
       continue;
     }
 
@@ -363,12 +379,7 @@ export function findEligibleGuardSteps(definition: WorkflowDefinition, run: RunR
     if (step.execution !== 'guard') continue;
 
     // Already settled.
-    if (
-      run.completed_steps.includes(stepName) ||
-      run.in_progress_steps.includes(stepName) ||
-      run.failed_steps.includes(stepName) ||
-      run.skipped_steps.includes(stepName)
-    ) {
+    if (isStepSettledOrInFlight(run, stepName)) {
       continue;
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export {
   deriveRunPhase,
   buildEvidenceByStep,
   propagateSkips,
+  isStepSettledOrInFlight,
 } from './engine/eligibility.js';
 export {
   TERMINAL_PHASES,

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -12,7 +12,11 @@ import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import type { RunStore, CreateRunOptions, LoadBearingRunRecordField } from './store-interface.js';
 import type { PerRunArtifactStore } from './per-run-artifact-store.js';
-import { findEligibleSteps, deriveRunPhase } from '../engine/eligibility.js';
+import {
+  findEligibleSteps,
+  deriveRunPhase,
+  isStepSettledOrInFlight,
+} from '../engine/eligibility.js';
 import { computeClaimDeadline } from '../engine/claim-liveness.js';
 import { TERMINAL_PHASES } from '../engine/lifecycle.js';
 import { hashParams } from './params-hash.js';
@@ -423,12 +427,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
       const run = JSON.parse(raw) as RunRecord;
 
       // Guard: step must not already be claimed.
-      if (
-        run.in_progress_steps.includes(stepName) ||
-        run.completed_steps.includes(stepName) ||
-        run.failed_steps.includes(stepName) ||
-        run.skipped_steps.includes(stepName)
-      ) {
+      if (isStepSettledOrInFlight(run, stepName)) {
         throw new WorkflowError(
           `Step '${stepName}' is already claimed or completed on run '${runId}'.`,
           {

--- a/packages/core/src/store/trace-buffer-store.ts
+++ b/packages/core/src/store/trace-buffer-store.ts
@@ -47,6 +47,89 @@ export interface TraceBufferStore {
    * Never mutates; never throws on a missing run (an absent run/store location is just `{}`).
    */
   readAllForRun(runId: string): Promise<Record<string, unknown[]>>;
+
+  /**
+   * **The fenced trio (issue #207).** `appendFenced`, `deleteFenced`, and `deleteAllForRunFenced`
+   * are an ALL-OR-NOTHING optional capability: declaring ANY of the three requires declaring ALL
+   * THREE (the TCK's STRUCTURAL law enforces this deterministically). Declaring the trio is also
+   * a commitment that `read()`, `delete()`, and `deleteAllForRun()` serialize on the SAME
+   * per-(runId, stepId) critical sections the fenced methods use — a store that declares the trio
+   * but lets a legacy `read()`/`delete()`/`deleteAllForRun()` call bypass those critical sections
+   * has not actually implemented the capability.
+   *
+   * Guard contract, shared by all three methods:
+   * - `guard` is invoked at least once per call. Implementations MAY retry internally — every TCK
+   *   assertion about guard invocation is count-TOLERANT ("at least one"), never an exact count.
+   * - ALL guard invocations complete BEFORE the method's destructive/mutating effect (the write
+   *   for `appendFenced`; the delete for `deleteFenced`/`deleteAllForRunFenced`).
+   * - `guard` performs exactly one lock-free `runStore.get` read (the #132 atomic-rename-safe
+   *   read) — never more than one, and never a locked read.
+   * - `guard` never acquires a lock of its own. Global lock-ordering rule: a WAL critical-section
+   *   holder must never acquire the run-file lock, and a run-file-lock holder must never acquire a
+   *   WAL lock — callers that touch both (e.g. purge) always delete artifacts strictly BEFORE
+   *   their run-locked anchor delete, never the other way around.
+   * - A guard rejection propagates to the caller UNWRAPPED — the method performs no write/delete,
+   *   and the store's own error-wrapping (e.g. `toArtifactDeleteFailedError`) never touches it.
+   *
+   * Two-obligation form for a transaction-scoped store that enforces the race via a native SQL
+   * predicate instead of an in-process critical section (`fenceForm: 'native-predicate'` in the
+   * TCK): (1) `guard` is still invoked at least once per call, but MAY run outside the store's
+   * atomic section — it must never `await` foreign code while holding a transaction/row lock, and
+   * must never open a second pooled connection while the first is held. (2) The actual racing
+   * predicate must be enforced by a CONFLICT-INDUCING read in the SAME transaction as the
+   * buffer write (e.g. `SELECT ... FOR SHARE` at minimum — a plain same-transaction `WHERE` under
+   * READ COMMITTED is insufficient; it is vulnerable to statement-snapshot staleness). **A
+   * native-predicate store's race closure is NOT verified by a green TCK run** — the latch-based
+   * laws (`CS_OCCUPANCY`, `PER_KEY_INDEPENDENCE`, `NO_SILENT_LOSS`) produce an explicit, visible
+   * documented skip for such a store, never a silent pass; that store's OWN in-transaction fencing
+   * suite is what must verify race closure (the same posture `RunStore.claimStep`'s cross-host
+   * obligation already states for `CLAIM_SINGLE_OWNER`, issue #188).
+   *
+   * Legacy `append`/`delete`/`deleteAllForRun` remain on the interface, byte-frozen, for any store
+   * that does not declare the fenced trio.
+   */
+  appendFenced?(
+    runId: string,
+    stepId: string,
+    entries: AgentTraceEntry[],
+    guard: () => Promise<void>,
+  ): Promise<AppendResult>;
+
+  /**
+   * See `appendFenced`'s doc (above) for the shared guard contract and the all-or-nothing
+   * declaration rule. Runs `guard` inside the SAME per-(runId, stepId) critical section
+   * `appendFenced` uses, immediately before deleting the buffer. Returns the number of entries
+   * actually deleted — `0` means the buffer was already absent (absence is success; the guard
+   * still runs first, and still gates the no-op). This same-critical-section count is what lets a
+   * caller (e.g. reclaim) report how many entries a destructive drain actually destroyed without a
+   * separate, lock-re-entrant `read()` call — a store's own critical section must never be
+   * re-entered from within itself.
+   */
+  deleteFenced?(runId: string, stepId: string, guard: () => Promise<void>): Promise<number>;
+
+  /**
+   * See `appendFenced`'s doc (above) for the shared guard contract and the all-or-nothing
+   * declaration rule. Deletes every buffer for `runId` across all steps. `guard` is RE-INVOKED
+   * inside EACH per-file (per-(runId, stepId)) critical section, immediately before that file's
+   * delete — a refusal on any one file aborts the whole sweep with that file's error
+   * (stop-on-first-error, matching the legacy `deleteAllForRun`'s own semantics). When zero files
+   * match `runId` at all, `guard` is still invoked at least once, before the (empty) scan —
+   * refusal on an empty sweep is never a required behavior, only that the guard is consulted (the
+   * TCK asserts invocation count, not a refusal outcome, for this case). A guard rejection (e.g. a
+   * typed `STATE_RUN_BUSY`) propagates to the caller UNWRAPPED, past the store's own
+   * `toArtifactDeleteFailedError` wrapping — which still wraps genuine unlink/I-O failures,
+   * preserving the #183 absence/unreachable/corrupt trichotomy: a guard refusal is neither
+   * "absent" nor a genuine I/O failure, it is a third, distinct outcome that must reach the caller
+   * exactly as the guard threw it.
+   *
+   * @param dirEntries Optional pre-scanned directory listing (see the legacy method's own doc) —
+   *   ignored by non-fs implementations.
+   */
+  deleteAllForRunFenced?(
+    runId: string,
+    guard: () => Promise<void>,
+    dirEntries?: readonly string[],
+  ): Promise<void>;
 }
 
 /** An AgentTraceEntry extended with engine-assigned ordering timestamp (milliseconds). */
@@ -105,16 +188,54 @@ export function normalizeEntryForBuffer(entry: AgentTraceEntry): AgentTraceEntry
 /**
  * In-memory TraceBufferStore for use in tests and non-persistent environments.
  * Entries are lost on process restart (no file I/O).
+ *
+ * Declares the fenced trio (issue #207): `append`, `read`, `delete`, and `deleteAllForRun` all
+ * serialize on the SAME per-(runId, stepId) critical section `appendFenced`/`deleteFenced` use,
+ * via a per-key async mutex (a promise-chain map) — every one of the six operations for a given
+ * key runs strictly after the previous operation on THAT SAME key has settled (success or
+ * failure). Liveness posture: a hung guard hangs only that key's chain — a different key's chain
+ * is untouched and proceeds normally (this per-key granularity is load-bearing; see the TCK's
+ * PER_KEY_INDEPENDENCE law). The chain map's entry for a key is deleted once its own tail
+ * settles and no newer call has chained after it, so an idle key holds no Map entry (no leak).
  */
 export class InMemoryTraceBufferStore implements TraceBufferStore {
   private buffers = new Map<string, BufferedEntry[]>();
+  private chains = new Map<string, Promise<void>>();
 
   private key(runId: string, stepId: string): string {
     return `${runId}:${stepId}`;
   }
 
-  async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
-    const k = this.key(runId, stepId);
+  /**
+   * Runs `fn` strictly after the current tail of the per-key chain for `k` has settled (whether
+   * that prior link resolved or rejected), and installs `fn`'s own settlement as the new tail.
+   * Returns/throws `fn`'s real result — chain-tracking never swallows or reshapes it. Removes the
+   * map entry for `k` once this call's tail settles, but only if no NEWER call has since replaced
+   * it (an identity check against the exact promise reference this call stored).
+   */
+  private async withKeyLock<T>(k: string, fn: () => Promise<T>): Promise<T> {
+    const prior = this.chains.get(k) ?? Promise.resolve();
+    // Neutralize prior's rejection for CHAINING purposes only — a failed operation on this key
+    // must not permanently wedge every future operation on the same key.
+    const settledPrior = prior.then(
+      () => undefined,
+      () => undefined,
+    );
+    const result = settledPrior.then(fn);
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.chains.set(k, tail);
+    void tail.then(() => {
+      if (this.chains.get(k) === tail) {
+        this.chains.delete(k);
+      }
+    });
+    return result;
+  }
+
+  private appendUnlocked(k: string, entries: AgentTraceEntry[]): AppendResult {
     const existing = this.buffers.get(k) ?? [];
 
     if (entries.length === 0) {
@@ -160,24 +281,88 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
     };
   }
 
+  async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
+    const k = this.key(runId, stepId);
+    return this.withKeyLock(k, async () => this.appendUnlocked(k, entries));
+  }
+
+  /** guard runs INSIDE the per-key critical section, immediately before the write — see the
+   *  interface doc for the full guard contract. */
+  async appendFenced(
+    runId: string,
+    stepId: string,
+    entries: AgentTraceEntry[],
+    guard: () => Promise<void>,
+  ): Promise<AppendResult> {
+    const k = this.key(runId, stepId);
+    return this.withKeyLock(k, async () => {
+      await guard();
+      return this.appendUnlocked(k, entries);
+    });
+  }
+
   async read(runId: string, stepId: string): Promise<BufferedEntry[]> {
-    return this.buffers.get(this.key(runId, stepId)) ?? [];
+    const k = this.key(runId, stepId);
+    return this.withKeyLock(k, async () => this.buffers.get(k) ?? []);
   }
 
   async delete(runId: string, stepId: string): Promise<void> {
-    this.buffers.delete(this.key(runId, stepId));
+    const k = this.key(runId, stepId);
+    await this.withKeyLock(k, async () => {
+      this.buffers.delete(k);
+    });
+  }
+
+  /** guard runs INSIDE the same per-key critical section `appendFenced` uses, immediately before
+   *  the delete — see the interface doc for the full guard contract. Returns the number of
+   *  entries actually deleted (0 = buffer already absent; the guard still ran first). */
+  async deleteFenced(runId: string, stepId: string, guard: () => Promise<void>): Promise<number> {
+    const k = this.key(runId, stepId);
+    return this.withKeyLock(k, async () => {
+      await guard();
+      const existing = this.buffers.get(k);
+      this.buffers.delete(k);
+      return existing?.length ?? 0;
+    });
   }
 
   async deleteAllForRun(runId: string, _dirEntries?: readonly string[]): Promise<void> {
-    for (const key of [...this.buffers.keys()]) {
-      if (key.startsWith(`${runId}:`)) {
-        this.buffers.delete(key);
-      }
+    const prefix = `${runId}:`;
+    const keys = [...this.buffers.keys()].filter((k) => k.startsWith(prefix));
+    for (const k of keys) {
+      await this.withKeyLock(k, async () => {
+        this.buffers.delete(k);
+      });
+    }
+  }
+
+  /** guard is RE-INVOKED inside EACH per-(runId, stepId) critical section, immediately before
+   *  that key's delete — see the interface doc for the full guard contract, including the
+   *  zero-match-sweep invocation requirement (handled below: the guard still runs at least once
+   *  even when this run has no buffers at all). */
+  async deleteAllForRunFenced(
+    runId: string,
+    guard: () => Promise<void>,
+    _dirEntries?: readonly string[],
+  ): Promise<void> {
+    const prefix = `${runId}:`;
+    const keys = [...this.buffers.keys()].filter((k) => k.startsWith(prefix));
+    if (keys.length === 0) {
+      await guard();
+      return;
+    }
+    for (const k of keys) {
+      await this.withKeyLock(k, async () => {
+        await guard();
+        this.buffers.delete(k);
+      });
     }
   }
 
   /** Returns each in-memory buffer for the run, keyed by stepId, as its stored `BufferedEntry[]`
-   *  (already-flattened individual entries — this store's own natural shape; see `append`). */
+   *  (already-flattened individual entries — this store's own natural shape; see `append`).
+   *  Lock-free point-in-time diagnostic, matching #159's shipped `export`/`readAllForRun` posture
+   *  — deliberately NOT serialized through the per-key mutex (see D3 residual 9). */
   async readAllForRun(runId: string): Promise<Record<string, unknown[]>> {
     const result: Record<string, unknown[]> = {};
     const prefix = `${runId}:`;

--- a/packages/core/src/store/trace-buffer-store.ts
+++ b/packages/core/src/store/trace-buffer-store.ts
@@ -113,9 +113,12 @@ export interface TraceBufferStore {
    * inside EACH per-file (per-(runId, stepId)) critical section, immediately before that file's
    * delete — a refusal on any one file aborts the whole sweep with that file's error
    * (stop-on-first-error, matching the legacy `deleteAllForRun`'s own semantics). When zero files
-   * match `runId` at all, `guard` is still invoked at least once, before the (empty) scan —
-   * refusal on an empty sweep is never a required behavior, only that the guard is consulted (the
-   * TCK asserts invocation count, not a refusal outcome, for this case). A guard rejection (e.g. a
+   * match `runId` at all, `guard` is still consulted at least once — the scan (resolving which
+   * files match) necessarily runs first, then the guard is invoked at least once even for that
+   * empty result. If it throws, the sweep rejects with that error exactly as it would for a
+   * non-empty sweep — propagation is UNIFORM across the zero-match and non-empty cases (the TCK
+   * asserts rejection here, not merely invocation count: a refusing guard makes even a zero-match
+   * sweep reject). A guard rejection (e.g. a
    * typed `STATE_RUN_BUSY`) propagates to the caller UNWRAPPED, past the store's own
    * `toArtifactDeleteFailedError` wrapping — which still wraps genuine unlink/I-O failures,
    * preserving the #183 absence/unreachable/corrupt trichotomy: a guard refusal is neither
@@ -191,9 +194,9 @@ export function normalizeEntryForBuffer(entry: AgentTraceEntry): AgentTraceEntry
  *
  * Declares the fenced trio (issue #207): `append`, `read`, `delete`, and `deleteAllForRun` all
  * serialize on the SAME per-(runId, stepId) critical section `appendFenced`/`deleteFenced` use,
- * via a per-key async mutex (a promise-chain map) — every one of the six operations for a given
- * key runs strictly after the previous operation on THAT SAME key has settled (success or
- * failure). Liveness posture: a hung guard hangs only that key's chain — a different key's chain
+ * via a per-key async mutex (a promise-chain map) — every one of the seven operations (the four
+ * legacy methods plus the three fenced ones) for a given key runs strictly after the previous
+ * operation on THAT SAME key has settled (success or failure). Liveness posture: a hung guard hangs only that key's chain — a different key's chain
  * is untouched and proceeds normally (this per-key granularity is load-bearing; see the TCK's
  * PER_KEY_INDEPENDENCE law). The chain map's entry for a key is deleted once its own tail
  * settles and no newer call has chained after it, so an idle key holds no Map entry (no leak).

--- a/packages/mcp-server/src/json-trace-buffer-store-lock-guard.test.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store-lock-guard.test.ts
@@ -1,0 +1,77 @@
+// Source-text guard (issue #207, store-fs-guard.test.ts-style — see packages/cli/src/commands/
+// store-fs-guard.test.ts for the established convention this mirrors): exactly ONE
+// `lockfile.lock(` call site may exist in json-trace-buffer-store.ts — the `lockWal` private
+// helper. This is the cheapest forcing mechanism for two guarantees that matter across every
+// critical-section acquisition in this file: (1) the shared base lock options (`stale`/
+// `realpath`, and the per-path `retries` override) are pinned in exactly one place, so a future
+// edit can't accidentally acquire a lock with a different, un-reviewed options shape; (2) every
+// acquisition passes an explicit `onCompromised` handler (a loud `console.warn`), never
+// `proper-lockfile`'s own default handler, which THROWS inside a timer callback and crashes the
+// process — a second, bare `lockfile.lock(` call site would bypass both guarantees silently.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FILE_PATH = join(dirname(fileURLToPath(import.meta.url)), 'json-trace-buffer-store.ts');
+
+/** Every non-comment line containing a `lockfile.lock(` call. Deliberately conservative — see
+ *  store-fs-guard.test.ts's own RAW_UNLINK_CALL doc for why a false positive (one extra line to
+ *  check by hand) is preferable to a false negative here. */
+const LOCKFILE_LOCK_CALL = /\blockfile\.lock\s*\(/;
+
+function findLockCalls(source: string): number[] {
+  const lines = source.split('\n');
+  const hits: number[] = [];
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+    if (LOCKFILE_LOCK_CALL.test(trimmed)) hits.push(i + 1);
+  });
+  return hits;
+}
+
+describe('json-trace-buffer-store — exactly one lockfile.lock( call site (issue #207)', () => {
+  it('the file exists and is scanned (the guard is wired correctly)', () => {
+    const source = readFileSync(FILE_PATH, 'utf8');
+    expect(source.length).toBeGreaterThan(0);
+  });
+
+  it('exactly one lockfile.lock( call site exists — the lockWal helper', () => {
+    const source = readFileSync(FILE_PATH, 'utf8');
+    const hits = findLockCalls(source);
+    expect(
+      hits,
+      `expected exactly one lockfile.lock( call site (inside the lockWal helper), found ` +
+        `${hits.length} at line(s): ${hits.join(', ')}. Every critical-section acquisition ` +
+        '(append/appendFenced/read/delete/deleteFenced/deleteAllForRun/deleteAllForRunFenced) ' +
+        'must go through the single lockWal chokepoint — route any new acquisition through it ' +
+        'instead of calling lockfile.lock( directly.',
+    ).toHaveLength(1);
+  });
+
+  it('the one call site is inside the lockWal helper specifically (not some other method)', () => {
+    const source = readFileSync(FILE_PATH, 'utf8');
+    const lines = source.split('\n');
+    const [hitLine] = findLockCalls(source);
+    expect(hitLine, 'no lockfile.lock( call site found at all').toBeDefined();
+    // Walk backwards from the call site to the nearest preceding method signature and confirm
+    // it's `lockWal`.
+    let ownerMethod: string | undefined;
+    for (let i = hitLine! - 1; i >= 0; i--) {
+      const match = /private\s+async\s+(\w+)\s*\(/.exec(lines[i]!);
+      if (match) {
+        ownerMethod = match[1];
+        break;
+      }
+    }
+    expect(ownerMethod).toBe('lockWal');
+  });
+
+  it('lockWal always passes an explicit onCompromised handler (sanity — proves the matcher call site really is the guarded helper)', () => {
+    const source = readFileSync(FILE_PATH, 'utf8');
+    const helperMatch = /private async lockWal\([\s\S]*?\n {2}\}\n/.exec(source);
+    expect(helperMatch, 'could not locate the lockWal helper body').not.toBeNull();
+    expect(helperMatch![0]).toMatch(/onCompromised\s*:/);
+  });
+});

--- a/packages/mcp-server/src/json-trace-buffer-store.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.ts
@@ -1,7 +1,7 @@
 // json-trace-buffer-store.ts — File-based TraceBufferStore using JSONL WAL files.
 import { existsSync } from 'node:fs';
 import { appendFile, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import lockfile from 'proper-lockfile';
 import {
   type TraceBufferStore,
@@ -65,6 +65,19 @@ const DEFAULT_LOCK_PROFILE: TraceBufferLockProfile = {
 /** `append`/`appendFenced` keep the pre-existing, more patient retry count (today's shipped
  *  behavior, unchanged) — appends are the highest-frequency, most latency-sensitive operation. */
 const APPEND_RETRIES = 10;
+
+/** Best-effort extraction of the runId from a WAL path's basename, for the `onCompromised` warn
+ *  message only (issue #207 correction) — mirrors `listOrphans`'s fixed-length-36 slice (never
+ *  string-splits on '-', which the base64url-encoded stepId segment can legitimately contain).
+ *  Returns `undefined` if the basename doesn't match the expected shape; never throws — this is
+ *  purely a best-effort logging aid, not a parser any control-flow depends on. */
+function runIdFromWalPath(walPath: string): string | undefined {
+  const base = basename(walPath);
+  if (!base.startsWith(WAL_PREFIX) || !base.endsWith(WAL_SUFFIX)) return undefined;
+  const afterPrefix = base.slice(WAL_PREFIX.length, -WAL_SUFFIX.length);
+  if (afterPrefix.length <= RUN_ID_LENGTH || afterPrefix[RUN_ID_LENGTH] !== '-') return undefined;
+  return afterPrefix.slice(0, RUN_ID_LENGTH);
+}
 
 /** True iff `err` is `proper-lockfile`'s own lock-contention error (retry budget exhausted). */
 function isLockContentionError(err: unknown): boolean {
@@ -144,10 +157,19 @@ export class JsonTraceBufferStore
       stale: this.lockProfile.stale,
       realpath: this.lockProfile.realpath,
       onCompromised: (err) => {
+        // issue #207 correction: decode the runId (fixed-length slice, mirrors listOrphans) so
+        // the warn carries genuine run/step context rather than only the raw path — the stepId
+        // segment stays base64url-encoded in that path (not decoded here; this is a best-effort
+        // logging aid, not a place to risk throwing on a malformed name).
+        const runId = runIdFromWalPath(walPath);
+        const context =
+          runId !== undefined
+            ? ` (runId=${runId}; stepId is base64url-encoded within the path)`
+            : '';
         console.warn(
-          `[JsonTraceBufferStore] lock compromised for '${walPath}': ${err.message} — a stale ` +
-            'lock was stolen; this is the accepted cost of tokenless mutual exclusion (issue ' +
-            '#207 residual 1), never a silent crash',
+          `[JsonTraceBufferStore] lock compromised for '${walPath}'${context}: ${err.message} — ` +
+            'a stale lock was stolen; this is the accepted cost of tokenless mutual exclusion ' +
+            '(issue #207 residual 1), never a silent crash',
         );
       },
     });
@@ -412,12 +434,19 @@ export class JsonTraceBufferStore
    * `guard` is RE-INVOKED inside EACH per-file critical section, immediately before that file's
    * delete (issue #207) — a refusal on any one file aborts the whole sweep with that file's error
    * (stop-on-first-error, matching the legacy method's own semantics). When zero files match
-   * `runId` at all, `guard` is still invoked once, before the (empty) scan. A guard rejection, and
-   * a per-file lock-contention failure (classified `STATE_RUN_BUSY`, mirroring `deleteAllForRun`'s
-   * own classification above), both propagate UNWRAPPED — never touched by
-   * `toArtifactDeleteFailedError`, which still wraps genuine unlink/I-O failures (the #183
-   * absence/unreachable/corrupt trichotomy, extended with this third, distinct guard-refusal
-   * outcome).
+   * `runId` at all, `guard` is still consulted at least once (issue #207 correction: the scan
+   * — resolving which files match — necessarily runs FIRST, since there is nothing to invoke a
+   * per-file guard against otherwise; the guard is then invoked once for the empty case). If it
+   * throws, the sweep rejects with that error exactly as it would for a non-empty sweep —
+   * propagation is UNIFORM across the zero-match and non-empty cases (the TCK asserts rejection
+   * here, not merely invocation count: a refusing guard makes even a zero-match sweep reject). A
+   * guard rejection, and a per-file lock-contention failure (classified `STATE_RUN_BUSY`,
+   * mirroring `deleteAllForRun`'s own classification above), both propagate UNWRAPPED — never
+   * touched by `toArtifactDeleteFailedError`, which still wraps genuine unlink/I-O failures (the
+   * #183 absence/unreachable/corrupt trichotomy, extended with this third, distinct guard-refusal
+   * outcome). The guard call itself sits OUTSIDE the try/catch scope that performs this wrapping
+   * (see the loop body below) — so a guard that happens to throw an `FsIoError` (e.g. its own
+   * lock-free `runStore.get` hitting EACCES) is never mistaken for `deleteIfExists`'s own failure.
    */
   async deleteAllForRunFenced(
     runId: string,
@@ -442,17 +471,23 @@ export class JsonTraceBufferStore
         throw err;
       }
       try {
+        // issue #207 correction: `guard()` sits OUTSIDE the FsIoError-wrap scope below — a guard
+        // rejection of ANY type, including one that happens to itself be an FsIoError (a
+        // realistic case: the guard's lock-free `runStore.get` hitting EACCES), must propagate
+        // exactly as thrown. The earlier shape wrapped BOTH the guard call and `deleteIfExists`
+        // in one try/catch keyed only on `err instanceof FsIoError` — which mistook a
+        // guard-thrown FsIoError for deleteIfExists's own failure and wrapped it too.
         await guard();
-        const didDelete = await deleteIfExists(path);
-        if (didDelete) deleted.push(file);
-      } catch (err) {
-        // Only deleteIfExists's own failure mode (FsIoError) gets wrapped — a guard rejection
-        // (whatever type the caller's guard throws; typically a typed WorkflowError like
-        // STATE_RUN_BUSY, but never assumed) propagates exactly as thrown.
-        if (err instanceof FsIoError) {
-          throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', deleted, file, err);
+        try {
+          const didDelete = await deleteIfExists(path);
+          if (didDelete) deleted.push(file);
+        } catch (err) {
+          // Only deleteIfExists's own failure mode (FsIoError) gets wrapped here.
+          if (err instanceof FsIoError) {
+            throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', deleted, file, err);
+          }
+          throw err;
         }
-        throw err;
       } finally {
         await release();
       }

--- a/packages/mcp-server/src/json-trace-buffer-store.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.ts
@@ -19,6 +19,7 @@ import {
   deleteIfExists,
   statIfExists,
   toArtifactDeleteFailedError,
+  FsIoError,
 } from '@sensigo/realm';
 import type { AgentTraceEntry } from '@sensigo/realm';
 import { WorkflowError } from '@sensigo/realm';
@@ -38,22 +39,118 @@ const WAL_PREFIX = 'trace-buffer-';
 const WAL_SUFFIX = '.jsonl';
 const RUN_ID_LENGTH = 36;
 
+/** A `proper-lockfile` retry policy: either a bare retry count (its own simple default backoff)
+ *  or an explicit `retry`-module-compatible options object. */
+type LockRetries = number | { retries: number; minTimeout?: number; maxTimeout?: number };
+
+/** Lock-acquisition profile shared by every `lockWal` call in this file (issue #207).
+ *  Constructor-injectable so a conformance suite can inflate the retry budget (e.g. to make a
+ *  deliberately slow/latched guard's lock contention observable instead of exhausting the retry
+ *  budget too quickly and masking the scenario under test). */
+export interface TraceBufferLockProfile {
+  retries: LockRetries;
+  stale: number;
+  realpath: boolean;
+}
+
+/** Default profile: ~4s worst-case budget (6 retries, 50ms→1000ms exponential backoff) —
+ *  outlasts any legitimate millisecond-scale critical section by orders of magnitude, but never
+ *  hangs an engine path for minutes on genuine contention. */
+const DEFAULT_LOCK_PROFILE: TraceBufferLockProfile = {
+  retries: { retries: 6, minTimeout: 50, maxTimeout: 1000 },
+  stale: 5000,
+  realpath: false,
+};
+
+/** `append`/`appendFenced` keep the pre-existing, more patient retry count (today's shipped
+ *  behavior, unchanged) — appends are the highest-frequency, most latency-sensitive operation. */
+const APPEND_RETRIES = 10;
+
+/** True iff `err` is `proper-lockfile`'s own lock-contention error (retry budget exhausted). */
+function isLockContentionError(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | undefined)?.code === 'ELOCKED';
+}
+
+/** Classifies a lock-acquisition failure as `STATE_RUN_BUSY` (issue #207) — the same code/
+ *  category/agentAction/retryable convention `JsonFileStore`'s own `runBusyError` uses for the
+ *  analogous run-file-lock-contention case. Retryable: a live holder self-heals (the lock is
+ *  released), and a genuinely stale lock is eventually stolen by the next contender. */
+function lockBusyError(walPath: string): WorkflowError {
+  return new WorkflowError(
+    `Could not acquire the trace-buffer lock for '${walPath}' — contention exceeded the retry budget`,
+    {
+      code: 'STATE_RUN_BUSY',
+      category: 'STATE',
+      agentAction: 'report_to_user',
+      retryable: true,
+      details: { walPath },
+    },
+  );
+}
+
 /**
  * File-based TraceBufferStore that persists WAL entries to JSONL files on disk.
  * WAL file path: <runsDir>/trace-buffer-<runId>-<base64url(stepId)>.jsonl
+ *
+ * Crash model: like `JsonFileStore`, this store never calls `fsync` — process-crash consistency
+ * comes from `appendFile`'s per-line granularity plus `readWal`'s per-line, torn-line-tolerant
+ * parsing (a crash mid-write can leave one unparseable trailing line, which is skipped; every
+ * earlier, already-written line survives intact). Durability across a true power loss (not just a
+ * process crash) is outside this store's contract, unchanged from its pre-#207 posture.
+ *
+ * Declares the fenced trio (issue #207): `read`, `delete`, and `deleteAllForRun` now serialize on
+ * the SAME per-(runId, stepId) critical section (a `proper-lockfile` lock on the WAL path)
+ * `appendFenced`/`deleteFenced`/`deleteAllForRunFenced` use — see `lockWal` and the interface's
+ * own doc for the full contract.
  */
 export class JsonTraceBufferStore
   implements TraceBufferStore, PerRunArtifactStore, OrphanSweepableStore
 {
   private readonly runsDir: string;
+  private readonly lockProfile: TraceBufferLockProfile;
 
-  constructor(runsDir: string) {
+  constructor(runsDir: string, lockProfile?: Partial<TraceBufferLockProfile>) {
     this.runsDir = runsDir;
+    this.lockProfile = { ...DEFAULT_LOCK_PROFILE, ...lockProfile };
   }
 
   private walPath(runId: string, stepId: string): string {
     const safeStepId = Buffer.from(stepId).toString('base64url');
     return join(this.runsDir, `trace-buffer-${runId}-${safeStepId}.jsonl`);
+  }
+
+  /**
+   * The SOLE `lockfile.lock(` call site in this file (issue #207) — every critical-section
+   * acquisition (`append`, `appendFenced`, `read`, `delete`, `deleteFenced`, `deleteAllForRun`,
+   * `deleteAllForRunFenced`) goes through this one chokepoint. Pins the shared base options
+   * (`stale`/`realpath`) and always installs an explicit `onCompromised` handler — a loud
+   * `console.warn` naming the WAL path — never `proper-lockfile`'s own default handler, which
+   * THROWS from inside a timer callback and crashes the process. `retriesOverride` lets
+   * `append`/`appendFenced` keep their own, more patient retry count; every other caller uses
+   * this store's configured `lockProfile.retries` (constructor-injectable — e.g. a conformance
+   * suite inflating it to make contention observable rather than exhausted-too-fast).
+   *
+   * Verified (issue #207): `lockfile.lock(path, { realpath: false })` acquires cleanly against a
+   * path that does not yet exist — no pre-lock placeholder file is needed for that. `append()`'s
+   * own placeholder-creation below predates this and stays byte-identical for that method, but no
+   * fenced method replicates it.
+   */
+  private async lockWal(
+    walPath: string,
+    retriesOverride?: LockRetries,
+  ): Promise<() => Promise<void>> {
+    return lockfile.lock(walPath, {
+      retries: retriesOverride ?? this.lockProfile.retries,
+      stale: this.lockProfile.stale,
+      realpath: this.lockProfile.realpath,
+      onCompromised: (err) => {
+        console.warn(
+          `[JsonTraceBufferStore] lock compromised for '${walPath}': ${err.message} — a stale ` +
+            'lock was stolen; this is the accepted cost of tokenless mutual exclusion (issue ' +
+            '#207 residual 1), never a silent crash',
+        );
+      },
+    });
   }
 
   private async readWal(
@@ -85,6 +182,59 @@ export class JsonTraceBufferStore
     return { count, bytes, lines };
   }
 
+  /**
+   * The actual write logic, shared by `append` and `appendFenced` (issue #207) so BUFFER_FULL /
+   * normalization / `AppendResult` shape live in exactly one place. Assumes the caller already
+   * holds the per-path critical section.
+   */
+  private async appendWithinCS(walPath: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
+    const { count: existingCount, bytes: existingBytes } = await this.readWal(walPath);
+
+    const normalized = entries
+      .map((e) => normalizeEntryForBuffer(e))
+      .filter((e): e is AgentTraceEntry => e !== null);
+
+    if (normalized.length === 0) {
+      return {
+        buffer_count: existingCount,
+        buffer_bytes: existingBytes,
+        limit_count: BUFFER_LIMIT_COUNT,
+        limit_bytes: BUFFER_LIMIT_BYTES,
+        final_limit_entries: FINAL_LIMIT_ENTRIES,
+        final_limit_bytes: FINAL_LIMIT_BYTES,
+      };
+    }
+
+    const newLine = JSON.stringify({ ts: Date.now(), entries: normalized });
+    const newBytes = Buffer.byteLength(newLine + '\n');
+
+    if (
+      existingCount + normalized.length > BUFFER_LIMIT_COUNT ||
+      existingBytes + newBytes > BUFFER_LIMIT_BYTES
+    ) {
+      throw new WorkflowError('Trace buffer full for step', {
+        code: 'BUFFER_FULL',
+        category: 'ENGINE',
+        agentAction: 'provide_input',
+        retryable: false,
+        details: { buffer_count: existingCount, buffer_bytes: existingBytes },
+      });
+    }
+
+    await appendFile(walPath, newLine + '\n', 'utf8');
+
+    const updatedCount = existingCount + normalized.length;
+    const updatedBytes = existingBytes + newBytes;
+    return {
+      buffer_count: updatedCount,
+      buffer_bytes: updatedBytes,
+      limit_count: BUFFER_LIMIT_COUNT,
+      limit_bytes: BUFFER_LIMIT_BYTES,
+      final_limit_entries: FINAL_LIMIT_ENTRIES,
+      final_limit_bytes: FINAL_LIMIT_BYTES,
+    };
+  }
+
   async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
     const walPath = this.walPath(runId, stepId);
 
@@ -108,53 +258,8 @@ export class JsonTraceBufferStore
 
     let release: (() => Promise<void>) | undefined;
     try {
-      release = await lockfile.lock(walPath, { retries: 10, stale: 5000, realpath: false });
-
-      const { count: existingCount, bytes: existingBytes } = await this.readWal(walPath);
-
-      const normalized = entries
-        .map((e) => normalizeEntryForBuffer(e))
-        .filter((e): e is AgentTraceEntry => e !== null);
-
-      if (normalized.length === 0) {
-        return {
-          buffer_count: existingCount,
-          buffer_bytes: existingBytes,
-          limit_count: BUFFER_LIMIT_COUNT,
-          limit_bytes: BUFFER_LIMIT_BYTES,
-          final_limit_entries: FINAL_LIMIT_ENTRIES,
-          final_limit_bytes: FINAL_LIMIT_BYTES,
-        };
-      }
-
-      const newLine = JSON.stringify({ ts: Date.now(), entries: normalized });
-      const newBytes = Buffer.byteLength(newLine + '\n');
-
-      if (
-        existingCount + normalized.length > BUFFER_LIMIT_COUNT ||
-        existingBytes + newBytes > BUFFER_LIMIT_BYTES
-      ) {
-        throw new WorkflowError('Trace buffer full for step', {
-          code: 'BUFFER_FULL',
-          category: 'ENGINE',
-          agentAction: 'provide_input',
-          retryable: false,
-          details: { buffer_count: existingCount, buffer_bytes: existingBytes },
-        });
-      }
-
-      await appendFile(walPath, newLine + '\n', 'utf8');
-
-      const updatedCount = existingCount + normalized.length;
-      const updatedBytes = existingBytes + newBytes;
-      return {
-        buffer_count: updatedCount,
-        buffer_bytes: updatedBytes,
-        limit_count: BUFFER_LIMIT_COUNT,
-        limit_bytes: BUFFER_LIMIT_BYTES,
-        final_limit_entries: FINAL_LIMIT_ENTRIES,
-        final_limit_bytes: FINAL_LIMIT_BYTES,
-      };
+      release = await this.lockWal(walPath, APPEND_RETRIES);
+      return await this.appendWithinCS(walPath, entries);
     } finally {
       if (release !== undefined) {
         await release();
@@ -162,35 +267,91 @@ export class JsonTraceBufferStore
     }
   }
 
+  /**
+   * `guard` runs INSIDE the critical section, immediately before the physical write (issue #207)
+   * — see the interface doc for the full guard contract. NO pre-lock placeholder file: verified
+   * `lockfile.lock(path, { realpath: false })` acquires cleanly against a target that does not yet
+   * exist; the legacy `append()`'s placeholder above predates this and stays byte-identical there,
+   * but is not needed and is not replicated here — `appendFile`'s own `O_CREAT`, inside the
+   * critical section, is the sole creator of the WAL file on this path.
+   */
+  async appendFenced(
+    runId: string,
+    stepId: string,
+    entries: AgentTraceEntry[],
+    guard: () => Promise<void>,
+  ): Promise<AppendResult> {
+    const walPath = this.walPath(runId, stepId);
+    const release = await this.lockWal(walPath, APPEND_RETRIES);
+    try {
+      await guard();
+      return await this.appendWithinCS(walPath, entries);
+    } finally {
+      await release();
+    }
+  }
+
   async read(runId: string, stepId: string): Promise<BufferedEntry[]> {
     const walPath = this.walPath(runId, stepId);
-    const { lines } = await this.readWal(walPath);
-    return lines.flatMap((line) =>
-      line.entries.map((entry) => ({ ...entry, _internalTs: line.ts })),
-    );
+    const release = await this.lockWal(walPath);
+    try {
+      const { lines } = await this.readWal(walPath);
+      return lines.flatMap((line) =>
+        line.entries.map((entry) => ({ ...entry, _internalTs: line.ts })),
+      );
+    } finally {
+      await release();
+    }
   }
 
   async delete(runId: string, stepId: string): Promise<void> {
-    // issue #183: this single-step cleanup is best-effort BY CONVENTION at every call site (all
-    // four callers — execution-loop.ts ×3, reclaim-step.ts ×1 — already wrap this call in their
-    // own try/catch that converts a failure into a warning, never treating success as load-bearing
-    // the way deleteAllForRun/purge do). Converting the raw unlink to deleteIfExists here doesn't
-    // change that contract (delete() can still fail — callers already expect and handle it); it
-    // just stops a real I/O error from being invisibly swallowed with NO signal at all, which the
-    // source-text guard (store-fs-guard.test.ts) also requires (no raw unlink in this file).
+    // issue #207: now serialized on the same per-path critical section append/appendFenced use —
+    // declaring the fenced trio commits read/delete/deleteAllForRun to the same CS (see the
+    // interface doc).
+    //
+    // issue #183: this single-step cleanup is best-effort BY CONVENTION at MOST call sites — but
+    // NOT ALL FOUR: execution-loop.ts's :1857 success-settle call site does NOT wrap this call in
+    // a try/catch today (a follow-up PR fixes that site directly); the other three
+    // (execution-loop.ts's other two + reclaim-step.ts's one) do. Converting the raw unlink to
+    // deleteIfExists here doesn't change that contract — delete() can still fail; it just stops a
+    // real I/O error from being invisibly swallowed with NO signal at all, which the source-text
+    // guard (store-fs-guard.test.ts) also requires (no raw unlink in this file).
     const walPath = this.walPath(runId, stepId);
-    await deleteIfExists(walPath);
+    const release = await this.lockWal(walPath);
+    try {
+      await deleteIfExists(walPath);
+    } finally {
+      await release();
+    }
   }
 
   /**
-   * Deletes every orphaned WAL file for `runId` (issue #107).
-   *
-   * @param dirEntries Optional pre-scanned `readdir(runsDir)` listing supplied by a batch purge —
-   *   when present, this method filters it in-memory instead of re-scanning the directory itself
-   *   (O(N runs × readdir) → O(readdir) for a batch of N). Falls back to its own `readdir` when
-   *   omitted, exactly as before.
+   * `guard` runs INSIDE the same per-path critical section `append`/`appendFenced` use,
+   * immediately before the delete (issue #207) — see the interface doc for the full guard
+   * contract. Returns the number of entries actually deleted (`0` = buffer already absent; the
+   * guard still ran first). Counts via the already-open `readWal` internals — NEVER the public
+   * `read()`, which would re-acquire this same lock (a critical section must never be re-entered
+   * from within itself — `proper-lockfile` is not reentrant).
    */
-  async deleteAllForRun(runId: string, dirEntries?: readonly string[]): Promise<void> {
+  async deleteFenced(runId: string, stepId: string, guard: () => Promise<void>): Promise<number> {
+    const walPath = this.walPath(runId, stepId);
+    const release = await this.lockWal(walPath);
+    try {
+      await guard();
+      const { count } = await this.readWal(walPath);
+      await deleteIfExists(walPath);
+      return count;
+    } finally {
+      await release();
+    }
+  }
+
+  /** Resolves the candidate WAL files for `runId`, sorted deterministically — shared by
+   *  `deleteAllForRun` and `deleteAllForRunFenced` (issue #207). */
+  private async matchingWalFiles(
+    runId: string,
+    dirEntries: readonly string[] | undefined,
+  ): Promise<string[]> {
     const prefix = `trace-buffer-${runId}-`;
     let files: readonly string[];
     if (dirEntries !== undefined) {
@@ -206,14 +367,34 @@ export class JsonTraceBufferStore
         }
       }
     }
-
     // SORTED candidates — deterministic residue (which artifact fails first is reproducible
     // across retries/tests, not dependent on readdir's unspecified ordering).
-    const matching = [...files].filter((f) => f.startsWith(prefix) && f.endsWith('.jsonl')).sort();
+    return [...files].filter((f) => f.startsWith(prefix) && f.endsWith('.jsonl')).sort();
+  }
+
+  /**
+   * Deletes every orphaned WAL file for `runId` (issue #107). Now serialized per-file on the same
+   * critical section `appendFenced`/`deleteFenced` use (issue #207) — declaring the fenced trio
+   * commits this legacy method too.
+   *
+   * @param dirEntries Optional pre-scanned `readdir(runsDir)` listing supplied by a batch purge —
+   *   when present, this method filters it in-memory instead of re-scanning the directory itself
+   *   (O(N runs × readdir) → O(readdir) for a batch of N). Falls back to its own `readdir` when
+   *   omitted, exactly as before.
+   */
+  async deleteAllForRun(runId: string, dirEntries?: readonly string[]): Promise<void> {
+    const matching = await this.matchingWalFiles(runId, dirEntries);
 
     const deleted: string[] = [];
     for (const file of matching) {
       const path = join(this.runsDir, file);
+      let release: (() => Promise<void>) | undefined;
+      try {
+        release = await this.lockWal(path);
+      } catch (err) {
+        if (isLockContentionError(err)) throw lockBusyError(path);
+        throw err;
+      }
       try {
         const didDelete = await deleteIfExists(path);
         if (didDelete) deleted.push(file);
@@ -221,6 +402,59 @@ export class JsonTraceBufferStore
         // Sequential stop-on-first-hard-error: don't attempt the remaining candidates once one
         // has genuinely failed — report exactly what succeeded before the failure.
         throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', deleted, file, err);
+      } finally {
+        await release();
+      }
+    }
+  }
+
+  /**
+   * `guard` is RE-INVOKED inside EACH per-file critical section, immediately before that file's
+   * delete (issue #207) — a refusal on any one file aborts the whole sweep with that file's error
+   * (stop-on-first-error, matching the legacy method's own semantics). When zero files match
+   * `runId` at all, `guard` is still invoked once, before the (empty) scan. A guard rejection, and
+   * a per-file lock-contention failure (classified `STATE_RUN_BUSY`, mirroring `deleteAllForRun`'s
+   * own classification above), both propagate UNWRAPPED — never touched by
+   * `toArtifactDeleteFailedError`, which still wraps genuine unlink/I-O failures (the #183
+   * absence/unreachable/corrupt trichotomy, extended with this third, distinct guard-refusal
+   * outcome).
+   */
+  async deleteAllForRunFenced(
+    runId: string,
+    guard: () => Promise<void>,
+    dirEntries?: readonly string[],
+  ): Promise<void> {
+    const matching = await this.matchingWalFiles(runId, dirEntries);
+
+    if (matching.length === 0) {
+      await guard();
+      return;
+    }
+
+    const deleted: string[] = [];
+    for (const file of matching) {
+      const path = join(this.runsDir, file);
+      let release: (() => Promise<void>) | undefined;
+      try {
+        release = await this.lockWal(path);
+      } catch (err) {
+        if (isLockContentionError(err)) throw lockBusyError(path);
+        throw err;
+      }
+      try {
+        await guard();
+        const didDelete = await deleteIfExists(path);
+        if (didDelete) deleted.push(file);
+      } catch (err) {
+        // Only deleteIfExists's own failure mode (FsIoError) gets wrapped — a guard rejection
+        // (whatever type the caller's guard throws; typically a typed WorkflowError like
+        // STATE_RUN_BUSY, but never assumed) propagates exactly as thrown.
+        if (err instanceof FsIoError) {
+          throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', deleted, file, err);
+        }
+        throw err;
+      } finally {
+        await release();
       }
     }
   }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -14,6 +14,12 @@ export type {
   RunStoreFidelityContractCase,
   RunStoreFidelityContractAdapter,
 } from './store/run-store-fidelity-contract.js';
+export { fencedTraceBufferContract } from './store/fenced-trace-buffer-contract.js';
+export type {
+  FencedTraceBufferLaw,
+  FencedTraceBufferContractCase,
+  FencedTraceBufferContractAdapter,
+} from './store/fenced-trace-buffer-contract.js';
 
 // Fixtures
 export {

--- a/packages/testing/src/store/fenced-trace-buffer-contract.ts
+++ b/packages/testing/src/store/fenced-trace-buffer-contract.ts
@@ -12,7 +12,12 @@
 // attached before the law ever awaits anything else, the "drain" step never depends on the
 // latched call's own settlement, and the latch is always released before the law awaits the
 // latched call's result.
-import { WorkflowError, type TraceBufferStore, type AgentTraceEntry } from '@sensigo/realm';
+import {
+  WorkflowError,
+  FsIoError,
+  type TraceBufferStore,
+  type AgentTraceEntry,
+} from '@sensigo/realm';
 
 /** One of the five laws every fenced-trio-declaring `TraceBufferStore` must satisfy (issue #207). */
 export type FencedTraceBufferLaw =
@@ -190,7 +195,30 @@ async function startLatchedHolder(
   return { parkedP, latch };
 }
 
-/** Builds the CS_OCCUPANCY case for one `holder` kind (issue #207, D3 §7). */
+/**
+ * Builds the CS_OCCUPANCY case for one `holder` kind (issue #207, D3 §7).
+ *
+ * Honest guarantee this law provides (issue #207 correction): it is deterministic-no-false-red —
+ * a conforming store can never fail it by bad luck, only a genuinely non-serializing store fails
+ * it. It is NOT deterministic-no-false-green against every possible violator: a store whose
+ * read/delete merely SKIP the lock (rather than sharing no critical section at all) can, on a
+ * sufficiently loaded machine, false-green here — the lock-skipping concurrent call may simply
+ * not have reached its own I/O completion yet when the Phase-1 assertion runs, even though it
+ * never actually respected the CS. An in-memory (synchronous-scheduling) violator has no such
+ * escape and reddens deterministically. Empirically (mutation probe (b), issue #207 correction),
+ * the fs store's own lock-skipping mutation reddened deterministically 5/5 runs on a fast,
+ * unloaded machine — this does not contradict the caveat above; it shows the false-green risk is
+ * a loaded/slow-environment concern, not a claim that the fs law usually (or ever, on a given
+ * machine) false-greens.
+ *
+ * The single-waiter subcase (`buildCsOccupancySingleWaiterCase`, below) is this law's
+ * probabilistic net against a "CS-split" store — one that releases its lock/CS handle before the
+ * write it guards has actually completed (write-after-release). Such a store could conceivably
+ * survive the multi-op Phase 1 above by chance (three concurrent operations racing the same
+ * narrow post-release window), but a single, isolated concurrent read is a comparatively larger
+ * fraction of that same window to land inside — raising, not guaranteeing, the odds of catching a
+ * CS-split violator. Like the caveat above, this is a probabilistic, not deterministic, net.
+ */
 function buildCsOccupancyCase(
   adapter: FencedTraceBufferContractAdapter,
   holder: CsHolder,
@@ -218,8 +246,13 @@ function buildCsOccupancyCase(
       await drain(store);
 
       // Phase 1 (occupancy): NONE of the three may have completed SUCCESSFULLY yet — still
-      // pending, or a typed lock-contention rejection, both conform. Immediate success is the
-      // deterministic red.
+      // pending, or ANY rejection (not just a typed lock-contention error), both conform.
+      // Immediate success is the deterministic red. Tolerating any rejection type here (wider
+      // than requiring a specific typed lock-contention error) is deliberate (issue #207
+      // correction): widening what counts as "conforming" can only ever make this check
+      // false-green (a store rejecting for some unrelated reason still passes Phase 1), never
+      // false-red — consistent with Phase 1's own guarantee already being one-sided toward
+      // false-green, never false-red (see this function's own doc, above).
       for (const [label, rec] of [
         ['read', readRec],
         ['delete', deleteRec],
@@ -311,6 +344,22 @@ function buildPerKeyIndependenceCase(
   };
 }
 
+/**
+ * Builds the NO_SILENT_LOSS case (issue #207, D3 §7): a settle (read-then-delete) racing a
+ * still-parked `appendFenced` must adopt the full committed batch — never lose it silently.
+ *
+ * Scope note (issue #207 correction): this case only exercises the "settle wins the race, the
+ * guard is never asked to refuse" path. The complementary branch — the guard REFUSING because a
+ * settle already started (the `settledFlag` check inside this case's own guard) — is deliberately
+ * NOT separately re-asserted as its own top-level assertion here: it is absorbed by
+ * FENCE_REFUSES's own `appendFenced` refusal case above, which already asserts identical content
+ * (typed rejection, nothing written). Duplicating that assertion under this law's banner too would
+ * add no additional coverage.
+ *
+ * The one-sided fs caveat from `buildCsOccupancyCase`'s doc (above) applies here too: against a
+ * lock-skipping (rather than genuinely non-serializing) violator, false-green risk here is a
+ * loaded/slow-environment concern only, not a claim this case usually passes such a store.
+ */
 function buildNoSilentLossCase(
   adapter: FencedTraceBufferContractAdapter,
 ): FencedTraceBufferContractCase {
@@ -432,6 +481,15 @@ export function fencedTraceBufferContract(
   });
 
   // ── FENCE_REFUSES ───────────────────────────────────────────────────────────────────────────
+  // Accepted limits of this law (issue #207 correction): FENCE_REFUSES asserts that a guard
+  // rejection propagates typed/unwrapped with nothing written/deleted — it does NOT, and cannot,
+  // distinguish that outcome from a store that (a) performs the write/delete, THEN discovers the
+  // guard should have refused, and rolls the effect back via a compensating action
+  // (write-then-rollback); or (b) a genuine crash between the effect and its own bookkeeping
+  // happens to leave residue that looks, from this law's own read-after observation, like
+  // "nothing written". Both are indistinguishable from a true refusal by this law's assertions —
+  // a store relying on either is simply out of this TCK's detection range, not certified free of
+  // that residue by a green run here.
   cases.push({
     law: 'FENCE_REFUSES',
     name: 'appendFenced: guard rejection propagates typed with a populated reason category, nothing written',
@@ -512,21 +570,27 @@ export function fencedTraceBufferContract(
 
   cases.push({
     law: 'FENCE_REFUSES',
-    name: 'deleteAllForRunFenced: refusal with >=2 seeded files — ALL files intact',
+    name: 'deleteAllForRunFenced: refusal with >=2 seeded files — ALL files intact, error propagates exactly as the guard threw it',
     run: async () => {
       const { runId } = adapter.makeKey();
       const stepA = 'fenced-tck-step-a';
       const stepB = 'fenced-tck-step-b';
       await store.append(runId, stepA, [{ event: 'a' }]);
       await store.append(runId, stepB, [{ event: 'b' }]);
-      let threw = false;
+      let caught: unknown;
       try {
         await store.deleteAllForRunFenced!(runId, refusingGuard());
-      } catch {
-        threw = true;
+      } catch (err) {
+        caught = err;
       }
-      if (!threw) {
-        throw new Error('expected deleteAllForRunFenced to reject when the guard refuses');
+      // issue #207 correction: assert the propagated error IS the guard's own typed error —
+      // never something a wrapping layer (e.g. toArtifactDeleteFailedError) substituted in its
+      // place (that would surface as ENGINE_ARTIFACT_DELETE_FAILED instead of REFUSAL_CODE).
+      if (!(caught instanceof WorkflowError) || caught.code !== REFUSAL_CODE) {
+        throw new Error(
+          `expected deleteAllForRunFenced to reject with the guard's own typed error ` +
+            `(WorkflowError, code=${REFUSAL_CODE}) — never wrapped — got: ${caught}`,
+        );
       }
       const a = await store.read(runId, stepA);
       const b = await store.read(runId, stepB);
@@ -540,7 +604,7 @@ export function fencedTraceBufferContract(
 
   cases.push({
     law: 'FENCE_REFUSES',
-    name: 'deleteAllForRunFenced: zero-match sweep still invokes the guard at least once',
+    name: 'deleteAllForRunFenced: zero-match sweep still invokes the guard at least once, and its rejection propagates unwrapped',
     run: async () => {
       const { runId } = adapter.makeKey(); // never written — zero files match
       let guardCalls = 0;
@@ -553,20 +617,61 @@ export function fencedTraceBufferContract(
           retryable: true,
         });
       };
-      let threw = false;
+      let caught: unknown;
       try {
         await store.deleteAllForRunFenced!(runId, countingRefusingGuard);
-      } catch {
-        threw = true;
+      } catch (err) {
+        caught = err;
       }
-      if (!threw) {
+      // issue #207 correction: same exact-identity assertion as the >=2-file case above — a
+      // zero-match sweep is not a laxer case, it must reject with the guard's own typed error too.
+      if (!(caught instanceof WorkflowError) || caught.code !== REFUSAL_CODE) {
         throw new Error(
-          'expected a zero-match sweep with a refusing guard to still reject (guard consulted first)',
+          `expected a zero-match sweep with a refusing guard to reject with the guard's own typed ` +
+            `error (WorkflowError, code=${REFUSAL_CODE}) — never wrapped — got: ${caught}`,
         );
       }
       if (guardCalls < 1) {
         throw new Error(
           'expected the guard to be invoked at least once even for a zero-match sweep',
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: "deleteAllForRunFenced: a guard throwing FsIoError propagates it exactly — never mistaken for deleteIfExists's own failure and wrapped",
+    run: async () => {
+      // issue #207 correction, dedicated case (D3 §1's own demanded test): a realistic scenario
+      // is the guard's lock-free `runStore.get` itself hitting a filesystem error (e.g. EACCES on
+      // the run-record file) — since that surfaces as an FsIoError too, a sweep implementation
+      // that wraps "any FsIoError seen inside the per-file try" (rather than scoping the wrap to
+      // ONLY deleteIfExists's own failure) would incorrectly re-wrap the guard's own error as
+      // ENGINE_ARTIFACT_DELETE_FAILED, discarding its original identity.
+      const { runId } = adapter.makeKey();
+      const stepA = 'fenced-tck-step-fsio';
+      await store.append(runId, stepA, [{ event: 'seed' }]);
+      const cause = Object.assign(new Error('EACCES (simulated)'), { code: 'EACCES' });
+      const fsIoGuard = async (): Promise<void> => {
+        throw new FsIoError('read', '/fenced-tck/simulated-guard-path', cause);
+      };
+      let caught: unknown;
+      try {
+        await store.deleteAllForRunFenced!(runId, fsIoGuard);
+      } catch (err) {
+        caught = err;
+      }
+      if (!(caught instanceof FsIoError)) {
+        throw new Error(
+          `expected the guard's own FsIoError to propagate exactly (not wrapped as ` +
+            `ENGINE_ARTIFACT_DELETE_FAILED via toArtifactDeleteFailedError), got: ${caught}`,
+        );
+      }
+      const after = await store.read(runId, stepA);
+      if (after.length !== 1) {
+        throw new Error(
+          `expected the seeded file intact after a sweep refused by an FsIoError guard, got ${after.length}`,
         );
       }
     },

--- a/packages/testing/src/store/fenced-trace-buffer-contract.ts
+++ b/packages/testing/src/store/fenced-trace-buffer-contract.ts
@@ -1,0 +1,616 @@
+// fenced-trace-buffer-contract.ts — framework-agnostic Test Compatibility Kit (TCK) for the
+// TraceBufferStore fenced trio (issue #207, converged design D3 — plans/issue-207-design-d3.md
+// in the realm repo).
+//
+// Pure case descriptors, NOT describe/it/expect — mirrors per-run-artifact-store-contract.ts's
+// and run-store-fidelity-contract.ts's own precedent (importing vitest here would make it a
+// runtime dependency of this published package). Each calling test file supplies an adapter and
+// wires the returned descriptors into ITS OWN test framework.
+//
+// The choreography for CS_OCCUPANCY and NO_SILENT_LOSS is deadlock-free BY CONSTRUCTION (D3 §7 is
+// normative — implemented here as written, not improvised): every parked promise has a `.catch`
+// attached before the law ever awaits anything else, the "drain" step never depends on the
+// latched call's own settlement, and the latch is always released before the law awaits the
+// latched call's result.
+import { WorkflowError, type TraceBufferStore, type AgentTraceEntry } from '@sensigo/realm';
+
+/** One of the five laws every fenced-trio-declaring `TraceBufferStore` must satisfy (issue #207). */
+export type FencedTraceBufferLaw =
+  | 'STRUCTURAL'
+  | 'FENCE_REFUSES'
+  | 'CS_OCCUPANCY'
+  | 'PER_KEY_INDEPENDENCE'
+  | 'NO_SILENT_LOSS';
+
+/**
+ * A single, framework-agnostic contract case. `run()` throws (rejects) on failure — any test
+ * framework's `await run()` (rejecting fails the test) or `expect(run()).resolves...` /
+ * `expect(run()).rejects...` maps directly onto this.
+ */
+export interface FencedTraceBufferContractCase {
+  law: FencedTraceBufferLaw;
+  name: string;
+  run: () => Promise<void>;
+}
+
+/** Adapter a calling test file supplies to parameterize the contract against one concrete store. */
+export interface FencedTraceBufferContractAdapter {
+  /** The store under test — already declaring the fenced trio (`appendFenced`/`deleteFenced`/
+   *  `deleteAllForRunFenced`). For `fenceForm: 'guard-in-cs'` stores, this instance should already
+   *  be constructed with a sufficiently generous lock-acquisition profile (see `lockProfile`
+   *  below) so a deliberately-parked guard in the latch-based laws doesn't cause a concurrent
+   *  caller's own acquisition attempt to give up before the law's observation window completes. */
+  store: TraceBufferStore;
+  /** Returns a fresh, never-before-used (runId, stepId) pair for one case — callers should treat
+   *  every returned pair as belonging to a disjoint run from every other pair this returns. */
+  makeKey: () => { runId: string; stepId: string };
+  /**
+   * `'guard-in-cs'`: the store enforces the fence via an in-process critical section — the guard
+   * literally runs inside the same lock/mutex the destructive effect does. `'native-predicate'`:
+   * the store enforces the fence via a transaction-scoped SQL predicate instead (e.g. a future
+   * Postgres store) — the latch-based laws (`CS_OCCUPANCY`, `PER_KEY_INDEPENDENCE`,
+   * `NO_SILENT_LOSS`) do not apply to this fence form and produce an explicit, VISIBLE
+   * documented-skip case rather than a silent omission. **A green TCK run does NOT verify race
+   * closure for a native-predicate store** — that store's own in-transaction fencing suite must
+   * (the same posture `RunStore.claimStep`'s cross-host obligation already states for
+   * `CLAIM_SINGLE_OWNER`, issue #188).
+   */
+  fenceForm: 'guard-in-cs' | 'native-predicate';
+  /** Descriptive only (present for `'guard-in-cs'` adapters): the lock-acquisition profile the
+   *  `store` instance above was actually constructed with, for the calling test file's own
+   *  documentation — the TCK itself does not need to act on this value; it exists so a wiring
+   *  test can assert (and a reader can see) that a genuinely generous profile is in use. */
+  lockProfile?: unknown;
+}
+
+const REFUSAL_CODE = 'STATE_RUN_BUSY';
+
+/** A guard that always refuses with a typed, populated-category rejection — used by every
+ *  FENCE_REFUSES case. Deliberately a real `WorkflowError` (not a bare `Error`) so the law can
+ *  assert the reason category actually propagates, not just "something" propagates. */
+function refusingGuard(): () => Promise<void> {
+  return async () => {
+    throw new WorkflowError('fenced-tck: guard refused (simulated)', {
+      code: REFUSAL_CODE,
+      category: 'STATE',
+      agentAction: 'report_to_user',
+      retryable: true,
+    });
+  };
+}
+
+function passingGuard(): () => Promise<void> {
+  return async () => {};
+}
+
+function eventsOf(entries: readonly AgentTraceEntry[]): string[] {
+  return entries.map((e) => e.event);
+}
+
+function assertDeepEqualEvents(
+  actual: readonly AgentTraceEntry[],
+  expected: readonly AgentTraceEntry[],
+  label: string,
+): void {
+  const a = eventsOf(actual);
+  const e = eventsOf(expected);
+  const equal = a.length === e.length && a.every((v, i) => v === e[i]);
+  if (!equal) {
+    throw new Error(`${label}: expected events ${JSON.stringify(e)}, got ${JSON.stringify(a)}`);
+  }
+}
+
+/**
+ * Forces the event loop / I/O queue to advance without a fixed wall-clock sleep and without
+ * depending on the latched call's own settlement: ≥5 awaited round-trips of `store.read` against
+ * a DISJOINT sentinel key (never written by any other case), plus one trailing `setImmediate`
+ * (D3 §7's normative drain). Used before checking a latch-based law's "Phase 1" (occupancy)
+ * assertion.
+ */
+async function drain(store: TraceBufferStore): Promise<void> {
+  const sentinelRunId = `fenced-tck-sentinel-run-${Math.random().toString(36).slice(2)}`;
+  for (let i = 0; i < 5; i++) {
+    await store.read(sentinelRunId, 'fenced-tck-sentinel-step');
+  }
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+/** A guard that signals when it has been entered (parked) and blocks on an externally-released
+ *  latch — the core primitive both CS_OCCUPANCY and PER_KEY_INDEPENDENCE latch a CS open with. */
+function makeLatch(): {
+  guard: () => Promise<void>;
+  entered: Promise<void>;
+  release: () => void;
+} {
+  let releaseFn: () => void;
+  const latchPromise = new Promise<void>((resolve) => {
+    releaseFn = resolve;
+  });
+  let enteredResolve: () => void;
+  const entered = new Promise<void>((resolve) => {
+    enteredResolve = resolve;
+  });
+  const guard = async (): Promise<void> => {
+    enteredResolve();
+    await latchPromise;
+  };
+  return {
+    guard,
+    entered,
+    release: () => releaseFn(),
+  };
+}
+
+/** Settlement outcome recorder — lets a law check "has this promise ALREADY settled" without
+ *  awaiting it (which would just wait for eventual settlement, defeating the point of checking a
+ *  point-in-time occupancy snapshot after `drain`). The recorder promise itself is pre-attached
+ *  with a no-op catch so an eventual rejection observed only for BOOKKEEPING never produces an
+ *  unhandled-rejection warning. */
+function recordSettlement<T>(p: Promise<T>): {
+  outcome: () => 'pending' | 'fulfilled' | 'rejected';
+  error: () => unknown;
+} {
+  let state: 'pending' | 'fulfilled' | 'rejected' = 'pending';
+  let capturedError: unknown;
+  p.then(
+    () => {
+      state = 'fulfilled';
+    },
+    (err) => {
+      state = 'rejected';
+      capturedError = err;
+    },
+  );
+  return { outcome: () => state, error: () => capturedError };
+}
+
+type CsHolder = 'appendFenced' | 'deleteFenced' | 'deleteAllForRunFenced';
+
+/** Starts `holder` latched open on (runId, stepId), returning the parked promise + latch handle.
+ *  Every fenced method requires an existing store to hold — for delete/deleteAllForRunFenced, the
+ *  key is pre-seeded with a throwaway entry (the specific content doesn't matter; only that the
+ *  operation has something to act on). */
+async function startLatchedHolder(
+  store: TraceBufferStore,
+  holder: CsHolder,
+  runId: string,
+  stepId: string,
+  entriesForAppend: AgentTraceEntry[],
+): Promise<{ parkedP: Promise<unknown>; latch: ReturnType<typeof makeLatch> }> {
+  const latch = makeLatch();
+  let parkedP: Promise<unknown>;
+  if (holder === 'appendFenced') {
+    parkedP = store.appendFenced!(runId, stepId, entriesForAppend, latch.guard);
+  } else if (holder === 'deleteFenced') {
+    parkedP = store.deleteFenced!(runId, stepId, latch.guard);
+  } else {
+    parkedP = store.deleteAllForRunFenced!(runId, latch.guard);
+  }
+  await latch.entered;
+  return { parkedP, latch };
+}
+
+/** Builds the CS_OCCUPANCY case for one `holder` kind (issue #207, D3 §7). */
+function buildCsOccupancyCase(
+  adapter: FencedTraceBufferContractAdapter,
+  holder: CsHolder,
+): FencedTraceBufferContractCase {
+  return {
+    law: 'CS_OCCUPANCY',
+    name: `${holder} holding the CS: concurrent read/delete/deleteAllForRun neither succeed during occupancy nor corrupt state after release`,
+    run: async () => {
+      const { store } = adapter;
+      const { runId, stepId } = adapter.makeKey();
+      const B1: AgentTraceEntry[] = [{ event: 'b1-e0' }, { event: 'b1-e1' }];
+      await store.append(runId, stepId, B1);
+
+      const B2: AgentTraceEntry[] = [{ event: 'b2-e0' }];
+      const { parkedP, latch } = await startLatchedHolder(store, holder, runId, stepId, B2);
+
+      const readP = store.read(runId, stepId);
+      const deleteP = store.delete(runId, stepId);
+      const deleteAllP = store.deleteAllForRun(runId);
+      // Attach catches BEFORE draining — deadlock/unhandled-rejection-free by construction.
+      const readRec = recordSettlement(readP.catch((e) => Promise.reject(e)));
+      const deleteRec = recordSettlement(deleteP.catch((e) => Promise.reject(e)));
+      const deleteAllRec = recordSettlement(deleteAllP.catch((e) => Promise.reject(e)));
+
+      await drain(store);
+
+      // Phase 1 (occupancy): NONE of the three may have completed SUCCESSFULLY yet — still
+      // pending, or a typed lock-contention rejection, both conform. Immediate success is the
+      // deterministic red.
+      for (const [label, rec] of [
+        ['read', readRec],
+        ['delete', deleteRec],
+        ['deleteAllForRun', deleteAllRec],
+      ] as const) {
+        if (rec.outcome() === 'fulfilled') {
+          throw new Error(
+            `CS_OCCUPANCY violated (holder=${holder}): ${label}() completed successfully while ` +
+              'the CS was still latched open — it must remain pending or reject with a typed ' +
+              'lock-contention error until the latch releases.',
+          );
+        }
+      }
+
+      // Phase 2 (visibility): release the latch FIRST, then let everything settle.
+      latch.release();
+      await parkedP;
+      await Promise.allSettled([readP, deleteP, deleteAllP]);
+
+      const finalRead = await store.read(runId, stepId);
+      const fullBatch = holder === 'appendFenced' ? [...B1, ...B2] : B1;
+      const isFullBatch =
+        eventsOf(finalRead).length === eventsOf(fullBatch).length &&
+        eventsOf(finalRead).every((v, i) => v === eventsOf(fullBatch)[i]);
+      const isEmpty = finalRead.length === 0;
+      if (!isFullBatch && !isEmpty) {
+        throw new Error(
+          `CS_OCCUPANCY violated (holder=${holder}): expected exactly the full committed batch ` +
+            `or exactly [] after release, got ${JSON.stringify(eventsOf(finalRead))} — a partial/` +
+            'garbled result means the CS did not actually serialize these operations.',
+        );
+      }
+    },
+  };
+}
+
+/** The single-waiter subcase (issue #207, D3 §7): park a holder, start exactly ONE concurrent
+ *  `read()`, release — the read must show deterministic FULL-batch visibility (no "or []" arm,
+ *  since a read never destroys data — this is the case's whole point: with no concurrent
+ *  destroyer in the mix, visibility after release is unambiguous). */
+function buildCsOccupancySingleWaiterCase(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase {
+  return {
+    law: 'CS_OCCUPANCY',
+    name: 'single-waiter subcase: one concurrent read (no concurrent destroyer) sees deterministic full-batch visibility post-release',
+    run: async () => {
+      const { store } = adapter;
+      const { runId, stepId } = adapter.makeKey();
+      const B1: AgentTraceEntry[] = [{ event: 'b1-e0' }];
+      await store.append(runId, stepId, B1);
+
+      const B2: AgentTraceEntry[] = [{ event: 'b2-e0' }];
+      const { parkedP, latch } = await startLatchedHolder(store, 'appendFenced', runId, stepId, B2);
+
+      const readP = store.read(runId, stepId);
+      await drain(store);
+      latch.release();
+      await parkedP;
+
+      const result = await readP;
+      assertDeepEqualEvents(result, [...B1, ...B2], 'single-waiter subcase');
+    },
+  };
+}
+
+function buildPerKeyIndependenceCase(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase {
+  return {
+    law: 'PER_KEY_INDEPENDENCE',
+    name: 'a disjoint-run key completes a full append+read round-trip while another key is latched open (global-lock stores hang into the framework timeout — the intended red)',
+    run: async () => {
+      const { store } = adapter;
+      const { runId, stepId } = adapter.makeKey();
+      const other = adapter.makeKey();
+
+      const { parkedP, latch } = await startLatchedHolder(store, 'appendFenced', runId, stepId, [
+        { event: 'latched' },
+      ]);
+
+      await store.append(other.runId, other.stepId, [{ event: 'independent' }]);
+      const result = await store.read(other.runId, other.stepId);
+      assertDeepEqualEvents(result, [{ event: 'independent' }], 'PER_KEY_INDEPENDENCE');
+
+      latch.release();
+      await parkedP;
+    },
+  };
+}
+
+function buildNoSilentLossCase(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase {
+  return {
+    law: 'NO_SILENT_LOSS',
+    name: 'a settle (read-then-delete) starting while append is parked adopts the full committed batch — never silent loss',
+    run: async () => {
+      const { store } = adapter;
+      const { runId, stepId } = adapter.makeKey();
+      const B: AgentTraceEntry[] = [{ event: 'b0' }, { event: 'b1' }];
+
+      let settledFlag = false;
+      let releaseLatchFn: () => void;
+      const latch = new Promise<void>((resolve) => {
+        releaseLatchFn = resolve;
+      });
+      let enteredResolveFn: () => void;
+      const entered = new Promise<void>((resolve) => {
+        enteredResolveFn = resolve;
+      });
+
+      const guard = async (): Promise<void> => {
+        enteredResolveFn();
+        if (settledFlag) {
+          throw new WorkflowError('fenced-tck: refused (settled already)', {
+            code: REFUSAL_CODE,
+            category: 'STATE',
+            agentAction: 'report_to_user',
+            retryable: true,
+          });
+        }
+        await latch;
+      };
+
+      const appendP = store.appendFenced!(runId, stepId, B, guard);
+      // Detect (and safely ignore afterwards) a premature settlement — the conforming store must
+      // not settle appendP before its guard has been entered.
+      const prematureSettle = appendP.then(
+        () => {
+          throw new Error(
+            'appendFenced settled (fulfilled) before entering its guard — NO_SILENT_LOSS setup invariant violated',
+          );
+        },
+        () => {
+          throw new Error(
+            'appendFenced settled (rejected) before entering its guard — NO_SILENT_LOSS setup invariant violated',
+          );
+        },
+      );
+      prematureSettle.catch(() => {}); // only used for the race below; its later settlement is expected
+      await Promise.race([entered, prematureSettle]);
+
+      settledFlag = true;
+
+      // Start (never await) the settle sequence.
+      const settleP = store
+        .read(runId, stepId)
+        .then((adopted) => store.delete(runId, stepId).then(() => adopted));
+
+      await drain(store);
+      releaseLatchFn!();
+
+      const committed = await appendP;
+      if (committed.buffer_count !== B.length) {
+        throw new Error(
+          `NO_SILENT_LOSS: expected appendFenced to commit all ${B.length} entries, got ` +
+            `buffer_count=${committed.buffer_count}`,
+        );
+      }
+
+      const adopted = await settleP;
+      assertDeepEqualEvents(
+        adopted,
+        B,
+        'NO_SILENT_LOSS (an unlocked or CS-split settle yields [] with the append still committed)',
+      );
+
+      const finalRead = await store.read(runId, stepId);
+      if (finalRead.length !== 0) {
+        throw new Error(
+          `NO_SILENT_LOSS: expected the buffer empty after the settle's delete, got ${finalRead.length} entries`,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Builds the contract cases for `adapter`. See each law's own doc above (the `build*Case`
+ * functions) for what it asserts. For `fenceForm: 'native-predicate'` adapters, `CS_OCCUPANCY`,
+ * `PER_KEY_INDEPENDENCE`, and `NO_SILENT_LOSS` are replaced with an explicit, VISIBLE
+ * documented-skip case each (never a silent omission) — see the adapter's own `fenceForm` doc.
+ */
+export function fencedTraceBufferContract(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase[] {
+  const cases: FencedTraceBufferContractCase[] = [];
+  const { store } = adapter;
+
+  // ── STRUCTURAL ──────────────────────────────────────────────────────────────────────────────
+  cases.push({
+    law: 'STRUCTURAL',
+    name: 'declaring any fenced method requires declaring all three',
+    run: async () => {
+      const s = store as Partial<TraceBufferStore>;
+      const has = {
+        appendFenced: typeof s.appendFenced === 'function',
+        deleteFenced: typeof s.deleteFenced === 'function',
+        deleteAllForRunFenced: typeof s.deleteAllForRunFenced === 'function',
+      };
+      const anyDeclared = has.appendFenced || has.deleteFenced || has.deleteAllForRunFenced;
+      const allDeclared = has.appendFenced && has.deleteFenced && has.deleteAllForRunFenced;
+      if (anyDeclared && !allDeclared) {
+        throw new Error(
+          `store declares a SUBSET of the fenced trio (must be all-or-nothing): ${JSON.stringify(has)}`,
+        );
+      }
+    },
+  });
+
+  // ── FENCE_REFUSES ───────────────────────────────────────────────────────────────────────────
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: 'appendFenced: guard rejection propagates typed with a populated reason category, nothing written',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      let caught: unknown;
+      try {
+        await store.appendFenced!(runId, stepId, [{ event: 'e' }], refusingGuard());
+      } catch (err) {
+        caught = err;
+      }
+      if (!(caught instanceof WorkflowError) || caught.code !== REFUSAL_CODE || !caught.category) {
+        throw new Error(
+          `expected a typed WorkflowError(${REFUSAL_CODE}) with a populated category, got: ${caught}`,
+        );
+      }
+      const after = await store.read(runId, stepId);
+      if (after.length !== 0) {
+        throw new Error(
+          `expected nothing written after a refused appendFenced, got ${after.length} entries`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: 'deleteFenced: guard rejection propagates typed with a populated reason category, nothing deleted',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      await store.append(runId, stepId, [{ event: 'seed' }]);
+      let caught: unknown;
+      try {
+        await store.deleteFenced!(runId, stepId, refusingGuard());
+      } catch (err) {
+        caught = err;
+      }
+      if (!(caught instanceof WorkflowError) || caught.code !== REFUSAL_CODE || !caught.category) {
+        throw new Error(
+          `expected a typed WorkflowError(${REFUSAL_CODE}) with a populated category, got: ${caught}`,
+        );
+      }
+      const after = await store.read(runId, stepId);
+      if (after.length !== 1) {
+        throw new Error(
+          `expected the seeded entry to survive a refused deleteFenced, got ${after.length}`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: 'sequential two-call guard-caching kill: pass-guard append then refuse-guard append — second refuses, first entries intact',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      const r1 = await store.appendFenced!(runId, stepId, [{ event: 'first' }], passingGuard());
+      if (r1.buffer_count !== 1) {
+        throw new Error(
+          `expected the first append to commit 1 entry, got buffer_count=${r1.buffer_count}`,
+        );
+      }
+      let threw = false;
+      try {
+        await store.appendFenced!(runId, stepId, [{ event: 'second' }], refusingGuard());
+      } catch {
+        threw = true;
+      }
+      if (!threw) {
+        throw new Error(
+          'expected the second (refuse-guard) append to reject — guard-caching would make this incorrectly pass',
+        );
+      }
+      const after = await store.read(runId, stepId);
+      assertDeepEqualEvents(after, [{ event: 'first' }], 'sequential two-call guard-caching kill');
+    },
+  });
+
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: 'deleteAllForRunFenced: refusal with >=2 seeded files — ALL files intact',
+    run: async () => {
+      const { runId } = adapter.makeKey();
+      const stepA = 'fenced-tck-step-a';
+      const stepB = 'fenced-tck-step-b';
+      await store.append(runId, stepA, [{ event: 'a' }]);
+      await store.append(runId, stepB, [{ event: 'b' }]);
+      let threw = false;
+      try {
+        await store.deleteAllForRunFenced!(runId, refusingGuard());
+      } catch {
+        threw = true;
+      }
+      if (!threw) {
+        throw new Error('expected deleteAllForRunFenced to reject when the guard refuses');
+      }
+      const a = await store.read(runId, stepA);
+      const b = await store.read(runId, stepB);
+      if (a.length !== 1 || b.length !== 1) {
+        throw new Error(
+          `expected both seeded files intact after a refused sweep, got a=${a.length} b=${b.length}`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: 'deleteAllForRunFenced: zero-match sweep still invokes the guard at least once',
+    run: async () => {
+      const { runId } = adapter.makeKey(); // never written — zero files match
+      let guardCalls = 0;
+      const countingRefusingGuard = async (): Promise<void> => {
+        guardCalls++;
+        throw new WorkflowError('fenced-tck: guard refused (simulated)', {
+          code: REFUSAL_CODE,
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: true,
+        });
+      };
+      let threw = false;
+      try {
+        await store.deleteAllForRunFenced!(runId, countingRefusingGuard);
+      } catch {
+        threw = true;
+      }
+      if (!threw) {
+        throw new Error(
+          'expected a zero-match sweep with a refusing guard to still reject (guard consulted first)',
+        );
+      }
+      if (guardCalls < 1) {
+        throw new Error(
+          'expected the guard to be invoked at least once even for a zero-match sweep',
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'FENCE_REFUSES',
+    name: 'COUNT_FIDELITY: deleteFenced with a pass-guard returns exactly the seeded entry count',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      const N = 5;
+      for (let i = 0; i < N; i++) {
+        await store.append(runId, stepId, [{ event: `e${i}` }]);
+      }
+      const count = await store.deleteFenced!(runId, stepId, passingGuard());
+      if (count !== N) {
+        throw new Error(`expected deleteFenced to return exactly ${N}, got ${count}`);
+      }
+    },
+  });
+
+  // ── Latch-based laws: CS_OCCUPANCY, PER_KEY_INDEPENDENCE, NO_SILENT_LOSS ───────────────────
+  if (adapter.fenceForm === 'native-predicate') {
+    for (const law of ['CS_OCCUPANCY', 'PER_KEY_INDEPENDENCE', 'NO_SILENT_LOSS'] as const) {
+      cases.push({
+        law,
+        name:
+          `SKIPPED for native-predicate stores — TCK-green does NOT verify race closure; ` +
+          "the store's own in-transaction fencing suite must (issue #207; the same posture " +
+          "CLAIM_SINGLE_OWNER's own cross-host caveat states, issue #188). This case is an " +
+          'explicit, visible documented-skip, not a silent omission.',
+        run: async () => {
+          // Intentional no-op — see the case name for why.
+        },
+      });
+    }
+  } else {
+    cases.push(buildCsOccupancyCase(adapter, 'appendFenced'));
+    cases.push(buildCsOccupancyCase(adapter, 'deleteFenced'));
+    cases.push(buildCsOccupancyCase(adapter, 'deleteAllForRunFenced'));
+    cases.push(buildCsOccupancySingleWaiterCase(adapter));
+    cases.push(buildPerKeyIndependenceCase(adapter));
+    cases.push(buildNoSilentLossCase(adapter));
+  }
+
+  return cases;
+}

--- a/packages/testing/src/store/in-memory-store.ts
+++ b/packages/testing/src/store/in-memory-store.ts
@@ -5,6 +5,7 @@ import {
   deriveRunPhase,
   decideIdempotencyPolicy,
   computeClaimDeadline,
+  isStepSettledOrInFlight,
   type RunStore,
   type RunRecord,
   type CreateRunOptions,
@@ -129,6 +130,9 @@ export class InMemoryStore implements RunStore {
     // tick, during which a second `Promise.all`'d claimStep call's own (equally synchronous) read
     // can run BEFORE either call has written — verified empirically: two concurrent claimStep
     // calls for the same (runId, step) both resolved successfully before this fix.
+    // issue #207: `isStepSettledOrInFlight` (below) is pure/synchronous by design — it performs no
+    // I/O and awaits nothing, so calling it here does not reintroduce the microtask-yield point
+    // this fix removes; the no-await constraint above still holds.
     const run = this.runs.get(runId);
     if (run === undefined) {
       throw new WorkflowError(`Run '${runId}' not found`, {
@@ -138,13 +142,7 @@ export class InMemoryStore implements RunStore {
         retryable: false,
       });
     }
-    const alreadyDone = [
-      ...run.completed_steps,
-      ...run.in_progress_steps,
-      ...run.failed_steps,
-      ...run.skipped_steps,
-    ];
-    if (alreadyDone.includes(stepName)) {
+    if (isStepSettledOrInFlight(run, stepName)) {
       throw new WorkflowError(`Step '${stepName}' is already claimed or done`, {
         code: 'STATE_STEP_ALREADY_CLAIMED',
         category: 'STATE',


### PR DESCRIPTION
## Context

`TraceBufferStore.delete()` can race a concurrent `append()` to the same (runId, stepId) key and
silently destroy acknowledged trace data — a false attestation to the appending agent (issue
#207). `JsonTraceBufferStore.append()` takes a proper-lockfile lock; `read()`/`delete()`/
`deleteAllForRun()` never did. The converged design ("Serialized Adoption with a Fenced Trio +
Serialized Reads", D3 — eight design iterations, two multi-lens adversarial panels, a final
completeness verification, plus primary-source grounding in SQLite's WAL-reset discipline and
Kafka/Chubby/Kleppmann fencing) closes this in two PRs. **This is PR-1 of 2: the store layer and
conformance machinery only — dormant until PR-2 adopts it at the call sites.** No engine, tool,
or CLI call site changes here.

## Motivation

Six token-based designs (entry-count, persistent counter sidecar, content-embedded incarnation
ID, inode identity, Postgres xmin) all failed adversarial review on ABA/parser/leak grounds. The
correct mechanism, per both the research and the panels: fence writers against authoritative
`RunStore` state INSIDE the store's own per-key critical section (the caller supplies the guard;
the store stays run-ignorant), serialize adoption reads and deletes on that same critical
section, and force the whole contract with a deterministic TCK rather than documentation.

## Changes

- **Interface** (`packages/core/src/store/trace-buffer-store.ts`): optional fenced trio —
  `appendFenced`, `deleteFenced` (returns the deleted-entry count), `deleteAllForRunFenced`
  (per-file guard re-invocation) — declaring any requires declaring all three, and commits
  `read()`/`delete()`/`deleteAllForRun()` to the same per-key critical sections. Full guard
  contract + lock-ordering rule + two-obligation (native-predicate) form for transaction-scoped
  stores in the JSDoc.
- **Core helper**: exported `isStepSettledOrInFlight(run, stepId)`; replaces the four inlined
  four-array membership checks (eligibility ×2, `JsonFileStore.claimStep`, testing
  `InMemoryStore.claimStep`) — no behavior change at those sites (all four already covered
  `skipped_steps`; the latent omission in `append_trace` is closed in PR-2). A fifth textual
  match (`propagateSkips`) was verified NOT substitutable (local growing array) and left as-is.
- **fs store**: fenced trio + serialized read/delete/deleteAllForRun; single `lockWal` lock
  chokepoint (source-text-guarded to exactly one `lockfile.lock(` call site) with
  constructor-injectable profiles (default retries 6/50ms/1s; append paths keep retries 10) and
  an explicit `onCompromised` handler (loud warn with decoded runId — never the default
  throw-in-timer process crash); `appendFenced` creates no pre-lock placeholder; guard errors
  propagate unwrapped past `toArtifactDeleteFailedError` (wrap scoped to `deleteIfExists` alone);
  per-key ELOCKED inside sweeps classifies `STATE_RUN_BUSY`.
- **In-memory store**: per-key promise-chain mutex over all seven routed operations
  (`readAllForRun` deliberately excluded — #159's lock-free diagnostic posture), guard awaited
  under the mutex, chain-map entries identity-checked and freed on tail settlement.
- **Forcing TCK** (`@sensigo/realm-testing`, `fencedTraceBufferContract`): STRUCTURAL,
  FENCE_REFUSES (+ guard-caching two-call kill, seeded sweep refusal with typed unwrapped-error
  asserts, zero-match guard invocation, COUNT_FIDELITY, guard-thrown-FsIoError propagation),
  CS_OCCUPANCY (latch-guard two-phase, honest one-sided caveat documented),
  PER_KEY_INDEPENDENCE, NO_SILENT_LOSS (deadlock-free settled-flag protocol); explicit visible
  skips + normative caveat for native-predicate stores. Wired for both in-repo stores from
  `packages/cli`, with a Guard-3 coverage cross-reference (which also fixes, for itself, a
  self-scan false-positive latent in the Guard-2 pattern — Guard 2's own instance is flagged as
  a follow-up, not fixed here).

## Verification

- Full suite, forced: core 1710, mcp 195, testing 81, cli 721 — all green; lint clean; versions
  aligned; `npm audit` clean.
- Seven mutation probes (guard-removal, count-zero, onCompromised-removal, wiring-removal both
  directions, global-lock, unlocked-read, per-file-guard-skip) each red → restored byte-identical
  → green; five were additionally reproduced independently during Master Architect review, plus
  the wrap-guard-errors probe from the correction pass.
- Independent line-by-line cross-check of the TCK against the design's normative choreography.

## Rollback

Revert both commits (`794c49a`, `f392469`). The capability is additive and dormant — no call
site consumes it until PR-2, so reverting restores the exact pre-PR state with no data-format or
behavioral migration concerns.

## Related

- Issue #207 (this closes the store-layer half; call-site adoption lands in PR-2)
- Issues #183/#184/#185/#188 (the doctrine and precedents this builds on)
- Design record: `plans/issue-207-design-d3.md` (local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
