### PR TITLE
feat(engine): adopt the fenced trio at every call site — tool, engine, reclaim, purge, gc, CLI (#207 PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,42 @@ All notable changes to this project are documented here.
   latch-based laws rather than a silent omission (that store's own in-transaction suite must verify
   race closure — mirroring `CLAIM_SINGLE_OWNER`'s own cross-host caveat, issue #188). Semver:
   minor-additive.
+- **Envelope advisory on unfenced trace stores (issue #207, PR-2 of 2).** `append_trace` warns
+  (deduped per store-constructor-name, plus a `warnings` entry on every affected response) when
+  the configured `traceBufferStore` does not declare the fenced trio — appended entries are not
+  fenced against a concurrent settlement and may end up neither adopted nor refused. Auto-clears
+  once the store declares the trio.
+
+### Changed
+
+- **The fenced trio is now adopted everywhere (issue #207, PR-2 of 2 — closes the race PR-1's
+  interface made possible).** `append_trace`'s refusal taxonomy (`details.step_state` ∈
+  `{completed, failed, skipped, in_progress, run_terminal, run_not_found}`) replaces the old
+  lumped `already_claimed` value; the `in_progress` refusal's `agentAction` is now
+  `resolve_precondition` (was `report_to_user` — the same state must never yield two different
+  agent actions elsewhere, mirroring `claimStep`'s own `STATE_STEP_ALREADY_CLAIMED` precedent);
+  a `skipped` step now correctly refuses too (the latent omission #207 identified — previously a
+  skipped step could still accept a trace append). `execute_step`'s trace-store read failures now
+  return a typed, retryable `ENGINE_STORE_FAILED` envelope instead of throwing uncaught: a
+  pre-claim read failure consumes no claim; a post-claim read failure performs a compensating
+  un-claim (built from the engine's own claim record, CAS'd against its version — a concurrent
+  actor that already resolved the claim is never stomped). `reclaim`'s WAL clear now moves BEFORE
+  the un-claiming update on a declaring store, version-fenced against the reclaim decision (skips
+  - warns, buffer left intact, if the run changed since); it warns with the destroyed entry count
+    when it proceeds (the #198 delta — previously silent). `purge` maps a busy/resumed run's WAL
+    delete to its existing `blocked` bucket (extends #184's terminal-re-verify to the WAL artifact
+    layer); `gc`'s orphan-artifact sweep re-verifies run absence at destruction time, routing a
+    `save()`-re-import race to a new, exit-code-neutral `resurrected` bucket rather than reaping a
+    file that is no longer actually orphaned.
+
+### Fixed
+
+- **CLI executors (`realm run`, `realm agent`) now adopt streamed WAL trace (issue #207, PR-2 of
+  2).** Both constructed no `traceBufferStore` at all — an agent step's `append_trace` calls
+  under a CLI-driven run were silently neither adopted nor refused. A `execute_step` success
+  settlement's own WAL-cleanup failure (e.g. lock contention) no longer produces an error envelope
+  on an already-durably-completed step — it degrades to a warning, as the equivalent failure
+  cleanup on the failure-settle path already did.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,19 +48,19 @@ All notable changes to this project are documented here.
   pre-claim read failure consumes no claim; a post-claim read failure performs a compensating
   un-claim (built from the engine's own claim record, CAS'd against its version — a concurrent
   actor that already resolved the claim is never stomped). `reclaim`'s WAL clear now moves BEFORE
-  the un-claiming update on a declaring store, version-fenced against the reclaim decision (skips
-  - warns, buffer left intact, if the run changed since); it warns with the destroyed entry count
-    when it proceeds (the #198 delta — previously silent). `purge` maps a busy/resumed run's WAL
-    delete to its existing `blocked` bucket (extends #184's terminal-re-verify to the WAL artifact
-    layer); `gc`'s orphan-artifact sweep re-verifies run absence at destruction time, routing a
-    `save()`-re-import race to a new, exit-code-neutral `resurrected` bucket rather than reaping a
-    file that is no longer actually orphaned.
+  the un-claiming update on a declaring store, version-fenced against the reclaim decision
+  (skips and warns, buffer left intact, if the run changed since); it warns with the destroyed
+  entry count when it proceeds (the #198 delta — previously silent). `purge` maps a busy/resumed
+  run's WAL delete to its existing `blocked` bucket (extends #184's terminal-re-verify to the WAL
+  artifact layer); `gc`'s orphan-artifact sweep re-verifies run absence at destruction time,
+  routing a `save()`-re-import race to a new, exit-code-neutral `resurrected` bucket rather than
+  reaping a file that is no longer actually orphaned.
 
 ### Fixed
 
 - **CLI executors (`realm run`, `realm agent`) now adopt streamed WAL trace (issue #207, PR-2 of
   2).** Both constructed no `traceBufferStore` at all — an agent step's `append_trace` calls
-  under a CLI-driven run were silently neither adopted nor refused. A `execute_step` success
+  under a CLI-driven run were silently neither adopted nor refused. An `execute_step` success
   settlement's own WAL-cleanup failure (e.g. lock contention) no longer produces an error envelope
   on an already-durably-completed step — it degrades to a warning, as the equivalent failure
   cleanup on the failure-settle path already did.

--- a/packages/cli/src/agent/run-agent.test.ts
+++ b/packages/cli/src/agent/run-agent.test.ts
@@ -447,6 +447,93 @@ describe('runAgent — wedge detection on attach (#101, detect-only)', () => {
   });
 });
 
+describe('runAgent — traceBufferStore threading (issue #207 PR-2, mixed-wiring gap)', () => {
+  const walWf: WorkflowDefinition = {
+    id: 'wal-thread-wf',
+    name: 'WAL Thread WF',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    steps: {
+      summarize: {
+        description: 'Summarize',
+        execution: 'agent',
+        input_schema: {
+          type: 'object',
+          properties: { summary: { type: 'string' } },
+          required: ['summary'],
+        },
+      },
+    },
+  };
+
+  it('deps.traceBufferStore threads all the way into executeChain — a pre-seeded WAL entry is adopted into evidence (was silently dropped pre-#207)', async () => {
+    const store = new InMemoryStore();
+    const { run: initialRecord } = await store.create({
+      workflowId: 'wal-thread-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const runId = initialRecord.id;
+
+    const { InMemoryTraceBufferStore } = await import('@sensigo/realm');
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(runId, 'summarize', [{ event: 'streamed_before_execute' }]);
+
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({ summary: 'all good' });
+    })();
+    const deps: AgentDeps = {
+      store,
+      workflowStore: makeWorkflowStore(walWf),
+      provider,
+      registry: createDefaultRegistry(),
+      traceBufferStore,
+    };
+
+    const result = await runAgent(deps, {
+      existingRunId: runId,
+      definition: walWf,
+      params: {},
+    });
+
+    expect(result).toBe('completed');
+    const run = await store.get(runId);
+    const evidence = run.evidence.find((e) => e.step_id === 'summarize');
+    expect(evidence?.trace?.some((t) => t.event === 'streamed_before_execute')).toBe(true);
+    // The WAL was adopted then cleared on settlement — not left as orphaned residue.
+    expect(await traceBufferStore.read(runId, 'summarize')).toHaveLength(0);
+  });
+
+  it('omitting deps.traceBufferStore is unchanged — no trace adoption, no error (backward compatible)', async () => {
+    const store = new InMemoryStore();
+    const { run: initialRecord } = await store.create({
+      workflowId: 'wal-thread-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const runId = initialRecord.id;
+
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({ summary: 'all good' });
+    })();
+    const deps: AgentDeps = {
+      store,
+      workflowStore: makeWorkflowStore(walWf),
+      provider,
+      registry: createDefaultRegistry(),
+      // traceBufferStore intentionally omitted.
+    };
+
+    const result = await runAgent(deps, {
+      existingRunId: runId,
+      definition: walWf,
+      params: {},
+    });
+
+    expect(result).toBe('completed');
+  });
+});
+
 describe('runAgent — capability recovery (#134)', () => {
   const handlerWorkflow: WorkflowDefinition = {
     id: 'handler-agent',

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -19,6 +19,7 @@ import {
   type ExtensionRegistry,
   type McpServerConfig,
   type ToolCallRecord,
+  type TraceBufferStore,
 } from '@sensigo/realm';
 import type { WorkflowRegistrar } from '@sensigo/realm';
 import type { LlmProvider } from './providers/llm-provider.js';
@@ -51,6 +52,15 @@ export interface AgentDeps {
    * and would otherwise pass tool results/traces unredacted. Never persisted.
    */
   redactionValues?: readonly string[];
+  /**
+   * Trace-buffer WAL store (issue #207 PR-2, D3 §5) — threaded straight into every `executeChain`
+   * call below. Without this, `realm agent`'s driver never adopted/fenced a step's streamed
+   * `append_trace` WAL content at all (the mixed-wiring gap D3 identifies: CLI executors passed
+   * no `traceBufferStore`, so acknowledged appends were neither adopted nor refused when a CLI
+   * runner settled). Constructed in `agent.ts`, beside the concrete `JsonFileStore`. Optional so
+   * an existing caller that omits it keeps today's behavior exactly (no trace adoption at all).
+   */
+  traceBufferStore?: TraceBufferStore;
 }
 
 export interface AgentRunOptions {
@@ -495,6 +505,7 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         input: stepInput,
         dispatcher: async () => stepInput,
         registry: deps.registry,
+        ...(deps.traceBufferStore !== undefined ? { traceBufferStore: deps.traceBufferStore } : {}),
         ...(toolCallsForMeta !== undefined ? { stepMeta: { toolCalls: toolCallsForMeta } } : {}),
       });
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -116,6 +116,11 @@ export const agentCommand = new Command('agent')
       try {
         const workflowStore = new JsonWorkflowStore();
         const store = new JsonFileStore();
+        // issue #207 PR-2 (D3 §5, mixed-wiring gap): construct the trace-buffer store beside the
+        // concrete JsonFileStore (same runsDir), mirroring reclaim.ts's own wiring shape — without
+        // this, `realm agent`'s driver never adopted/fenced a step's streamed WAL trace at all.
+        const { JsonTraceBufferStore } = await import('@sensigo/realm-mcp');
+        const traceBufferStore = new JsonTraceBufferStore(store.runsDirPath);
         let provider: LlmProvider;
         if (opts.providerModule !== undefined) {
           if (
@@ -186,6 +191,7 @@ export const agentCommand = new Command('agent')
               workflowStore,
               provider,
               registry: loaded.registry,
+              traceBufferStore,
               ...(gateHandler ? { gateHandler } : {}),
               ...(loaded.secretValues !== undefined
                 ? { redactionValues: loaded.secretValues }
@@ -225,6 +231,7 @@ export const agentCommand = new Command('agent')
               workflowStore,
               provider,
               registry: loaded.registry,
+              traceBufferStore,
               ...(gateHandler ? { gateHandler } : {}),
               ...(loaded.secretValues !== undefined
                 ? { redactionValues: loaded.secretValues }

--- a/packages/cli/src/commands/gc.test.ts
+++ b/packages/cli/src/commands/gc.test.ts
@@ -6,7 +6,7 @@
 // either, consistent with cleanup.ts/reclaim.ts/purge.ts). The CLI wiring itself (--help, a
 // non-destructive dry-run, the not-reaped footer) is smoke-tested against the built binary — see
 // the implementation report — mirroring how purge.ts's own `.action()` has no dedicated test file.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mkdtemp, rm, writeFile, mkdir, symlink, utimes, stat, chmod } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -514,6 +514,126 @@ describe('sweepOrphanArtifacts (issue #163)', () => {
       expect(result.reaped.map((e) => e.path)).toEqual([orphanWalPath]);
       expect(existsSync(liveWalPath)).toBe(true); // the live run's WAL, despite the '-'-ending encoding, survives
       expect(existsSync(orphanWalPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('sweepOrphanArtifacts — fenced reap path (issue #207 PR-2)', () => {
+  it('orphan swept normally (run absent): routes through deleteAllForRunFenced (not the legacy per-file path) and is reaped', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      const runStore = new JsonFileStore(dir);
+
+      const orphanId = '11111111-1111-4111-8111-111111111111';
+      await traceBufferStore.append(orphanId, 'step-a', [{ event: 'x' }]);
+      const walPath = walPathFor(dir, orphanId, 'step-a');
+      const ancient = new Date(now.getTime() - (ONE_HOUR_MS + FIVE_MIN_MS));
+      await utimes(walPath, ancient, ancient);
+
+      const fencedSpy = vi.spyOn(traceBufferStore, 'deleteAllForRunFenced');
+      const legacySpy = vi.spyOn(traceBufferStore, 'deleteAllForRun');
+
+      const liveRunIds = await runStore.listRunIds();
+      const result = await sweepOrphanArtifacts(
+        [traceBufferStore],
+        liveRunIds,
+        { olderThanMs: ONE_HOUR_MS, dryRun: false, now },
+        runStore,
+      );
+
+      expect(result.reaped.map((e) => e.path)).toEqual([walPath]);
+      expect(result.resurrected).toEqual([]);
+      expect(result.failed).toEqual([]);
+      expect(fencedSpy).toHaveBeenCalledTimes(1);
+      expect(legacySpy).not.toHaveBeenCalled();
+      expect(existsSync(walPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resurrect race: a run re-imported between the sweep snapshot and the reap is SKIPPED (resurrected bucket), never failed — exit code unaffected, file survives', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      const runStore = new JsonFileStore(dir);
+
+      // Genuinely run-less at snapshot time (listRunIds below sees it as orphaned)...
+      const resurrectedId = '44444444-4444-4444-8444-444444444444';
+      await traceBufferStore.append(resurrectedId, 'step-a', [{ event: 'x' }]);
+      const walPath = walPathFor(dir, resurrectedId, 'step-a');
+      const ancient = new Date(now.getTime() - (ONE_HOUR_MS + FIVE_MIN_MS));
+      await utimes(walPath, ancient, ancient);
+      const liveRunIds = await runStore.listRunIds();
+      expect(liveRunIds.has(resurrectedId)).toBe(false);
+
+      // ...but a save() re-import lands (with that SAME id) before the fenced guard's own read —
+      // simulated by writing the run file directly between the snapshot above and the sweep call
+      // below (the guard's own runStore.get() runs INSIDE the sweep, after this).
+      await runStore.create({
+        workflowId: 'wf-1',
+        workflowVersion: 1,
+        params: {},
+        idempotencyKey: undefined,
+      });
+      // Force the re-imported run to have the EXACT id the WAL names (create() mints a fresh
+      // uuid; overwrite the file directly to land on resurrectedId, mirroring how save() would
+      // re-import a specific, already-known id).
+      const created = await runStore.list();
+      const justCreated = created.find((r) => r.workflow_id === 'wf-1')!;
+      await rm(join(dir, `${justCreated.id}.json`));
+      await writeFile(
+        join(dir, `${resurrectedId}.json`),
+        JSON.stringify({ ...justCreated, id: resurrectedId }, null, 2),
+        'utf8',
+      );
+
+      const result = await sweepOrphanArtifacts(
+        [traceBufferStore],
+        liveRunIds, // the SNAPSHOT taken before the re-import — still shows resurrectedId absent
+        { olderThanMs: ONE_HOUR_MS, dryRun: false, now },
+        runStore,
+      );
+
+      expect(result.reaped).toEqual([]);
+      expect(result.failed).toEqual([]);
+      expect(result.resurrected.map((e) => e.path)).toEqual([walPath]);
+      expect(existsSync(walPath)).toBe(true); // the WAL survives — never deleted
+      expect(existsSync(join(dir, `${resurrectedId}.json`))).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a store without deleteAllForRunFenced (or no runStore supplied) keeps the legacy per-file path — unaffected by the fenced adoption', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const failedAttemptStore = new FailedAttemptStore(dir);
+      const runStore = new JsonFileStore(dir);
+
+      const orphanId = '55555555-5555-4555-8555-555555555555';
+      await failedAttemptStore.append(orphanId, '{}');
+      const sidecarPath = sidecarPathFor(dir, orphanId);
+      const ancient = new Date(now.getTime() - (ONE_HOUR_MS + FIVE_MIN_MS));
+      await utimes(sidecarPath, ancient, ancient);
+
+      const liveRunIds = await runStore.listRunIds();
+      // runStore intentionally OMITTED — the legacy path must still work exactly as before.
+      const result = await sweepOrphanArtifacts([failedAttemptStore], liveRunIds, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: false,
+        now,
+      });
+
+      expect(result.reaped.map((e) => e.path)).toEqual([sidecarPath]);
+      expect(result.resurrected).toEqual([]);
+      expect(existsSync(sidecarPath)).toBe(false);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/gc.test.ts
+++ b/packages/cli/src/commands/gc.test.ts
@@ -556,6 +556,44 @@ describe('sweepOrphanArtifacts — fenced reap path (issue #207 PR-2)', () => {
     }
   });
 
+  it('floor-sibling scoping: of TWO orphan WALs for the SAME runId, only the one past the floor is reaped — the younger sibling survives (pins the dirEntries grouping against regression, issue #207 correction item 4c)', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      const runStore = new JsonFileStore(dir);
+
+      const orphanId = '22222222-3333-4444-8555-666677778888';
+      await traceBufferStore.append(orphanId, 'step-old', [{ event: 'old' }]);
+      await traceBufferStore.append(orphanId, 'step-young', [{ event: 'young' }]);
+      const oldWalPath = walPathFor(dir, orphanId, 'step-old');
+      const youngWalPath = walPathFor(dir, orphanId, 'step-young');
+
+      const ancient = new Date(now.getTime() - (ONE_HOUR_MS + FIVE_MIN_MS));
+      await utimes(oldWalPath, ancient, ancient);
+      const tooFresh = new Date(now.getTime() - (ONE_HOUR_MS - FIVE_MIN_MS));
+      await utimes(youngWalPath, tooFresh, tooFresh);
+
+      const liveRunIds = await runStore.listRunIds();
+      expect(liveRunIds.has(orphanId)).toBe(false);
+
+      const result = await sweepOrphanArtifacts(
+        [traceBufferStore],
+        liveRunIds,
+        { olderThanMs: ONE_HOUR_MS, dryRun: false, now },
+        runStore,
+      );
+
+      expect(result.reaped.map((e) => e.path)).toEqual([oldWalPath]);
+      expect(result.failed).toEqual([]);
+      expect(result.resurrected).toEqual([]);
+      expect(existsSync(oldWalPath)).toBe(false); // reaped
+      expect(existsSync(youngWalPath)).toBe(true); // survives — too fresh, excluded from dirEntries
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('resurrect race: a run re-imported between the sweep snapshot and the reap is SKIPPED (resurrected bucket), never failed — exit code unaffected, file survives', async () => {
     const dir = await makeTmpRunsDir();
     try {

--- a/packages/cli/src/commands/gc.ts
+++ b/packages/cli/src/commands/gc.ts
@@ -30,10 +30,10 @@
 // lock; only a purged-target's lock lingers, which is negligible). Neither is this command's job
 // yet — see the report footer.
 import { readdir, lstat, unlink, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import { Command } from 'commander';
 import { WorkflowError, deleteIfExists } from '@sensigo/realm';
-import type { OrphanSweepableStore, OrphanArtifact } from '@sensigo/realm';
+import type { OrphanSweepableStore, OrphanArtifact, RunStore } from '@sensigo/realm';
 import { parseDuration } from '../lib/parse-duration.js';
 
 /**
@@ -206,6 +206,17 @@ export interface OrphanArtifactSweepResult {
   already_gone: OrphanArtifactEntry[];
   /** A genuine delete failure (permissions, I/O) — loud, never silently swallowed. */
   failed: Array<{ path: string; runId: string; error: string }>;
+  /**
+   * A fenced candidate's guard refused because the run EXISTS AGAIN at destruction time — a
+   * `JsonFileStore.save()` re-import landing between this sweep's snapshot and the reap (issue
+   * #207 PR-2, D3 §5: the resurrect race gc's absent-guard closes, symmetric with purge's
+   * terminal-re-verify). Benign: these files are no longer orphans by definition, so this is
+   * NEVER an `artifactSweepError` and never affects `gcExitCode`. Only ever populated for a
+   * store that declares the fenced trio AND was reaped with a `runStore` reference — the legacy
+   * (non-declaring-store or no-runStore) fallback path can't detect this race at all and simply
+   * leaves such a file for the next sweep to re-evaluate.
+   */
+  resurrected: OrphanArtifactEntry[];
 }
 
 /**
@@ -231,54 +242,166 @@ export interface OrphanArtifactSweepResult {
  * THIS function too (uncaught here, deliberately): this sweep has nothing safe to report if it
  * cannot trust what "orphaned" even means for that store, so it aborts entirely rather than
  * reaping a partial, possibly-wrong candidate set.
+ *
+ * `runStore` (issue #207 PR-2, D3 §5): when supplied AND a given store declares
+ * `deleteAllForRunFenced`, force-mode reaping for that store routes through the fenced path —
+ * floor-passing candidates are grouped by `runId`, and one `deleteAllForRunFenced(runId, guard,
+ * dirEntries)` call is made per group, `dirEntries` scoped to EXACTLY that group's floor-passing
+ * basenames (never the whole directory). The guard is a lock-free `runStore.get(runId)`: absence
+ * (`STATE_RUN_NOT_FOUND`) means proceed; the run EXISTING again means a `JsonFileStore.save()`
+ * re-import raced this sweep (the resurrect race this closes, symmetric with purge's own
+ * terminal-re-verify) — the guard refuses, and that runId's files land in `resurrected`, never
+ * `failed` (benign, exit-code-neutral). A store that does NOT declare the fenced trio, or a call
+ * that omits `runStore`, keeps the original per-file `deleteIfExists` path unchanged — this is
+ * also why the per-file `already_gone` granularity is preserved for that path only: an aggregate
+ * `deleteAllForRunFenced` call reports its whole runId-group as `reaped` on success (the store's
+ * own absence-is-success contract already covers "some files in the group were already gone").
  */
 export async function sweepOrphanArtifacts(
   stores: readonly OrphanSweepableStore[],
   liveRunIds: ReadonlySet<string>,
   options: SweepOrphansOptions,
+  runStore?: Pick<RunStore, 'get'>,
 ): Promise<OrphanArtifactSweepResult> {
   assertOlderThanFloor(options.olderThanMs, 'orphaned artifacts');
 
   const now = options.now ?? new Date();
 
-  const candidates: OrphanArtifact[] = [];
+  // Per-store candidate lists (issue #207 PR-2) — kept associated with their originating store so
+  // the reap dispatch below can pick the fenced or legacy path per store, not globally.
+  const perStore: Array<{ store: OrphanSweepableStore; artifacts: OrphanArtifact[] }> = [];
   for (const store of stores) {
-    candidates.push(...(await store.listOrphans(liveRunIds)));
+    perStore.push({ store, artifacts: await store.listOrphans(liveRunIds) });
   }
 
-  const result: OrphanArtifactSweepResult = { reaped: [], already_gone: [], failed: [] };
-  const toReap: OrphanArtifact[] = [];
-
-  for (const artifact of candidates) {
+  const passesFloor = (artifact: OrphanArtifact): boolean => {
     const ageMs = now.getTime() - artifact.mtimeMs;
-    if (ageMs < 0) continue; // future mtime (clock skew) — skip, never reap
-    if (ageMs <= options.olderThanMs) continue; // too fresh — the create-temp-window guard above
+    if (ageMs < 0) return false; // future mtime (clock skew) — skip, never reap
+    return ageMs > options.olderThanMs; // too fresh — the create-temp-window guard above
+  };
 
-    toReap.push(artifact);
-  }
+  const result: OrphanArtifactSweepResult = {
+    reaped: [],
+    already_gone: [],
+    failed: [],
+    resurrected: [],
+  };
+
+  const toReapByStore = perStore
+    .map(({ store, artifacts }) => ({ store, artifacts: artifacts.filter(passesFloor) }))
+    .filter(({ artifacts }) => artifacts.length > 0);
 
   if (options.dryRun) {
-    result.reaped = toReap.map((a) => ({ path: a.path, runId: a.runId }));
+    result.reaped = toReapByStore.flatMap(({ artifacts }) =>
+      artifacts.map((a) => ({ path: a.path, runId: a.runId })),
+    );
     return result;
   }
 
-  for (const artifact of toReap) {
-    const entry = { path: artifact.path, runId: artifact.runId };
-    try {
-      // #183 discipline: deleteIfExists resolves false (not an error) on ENOENT — already gone
-      // is success, never a failure; any other errno throws.
-      const didDelete = await deleteIfExists(artifact.path);
-      if (didDelete) {
-        result.reaped.push(entry);
-      } else {
-        result.already_gone.push(entry);
+  for (const { store, artifacts } of toReapByStore) {
+    if (runStore !== undefined && hasDeleteAllForRunFenced(store)) {
+      const byRunId = new Map<string, OrphanArtifact[]>();
+      for (const artifact of artifacts) {
+        const group = byRunId.get(artifact.runId) ?? [];
+        group.push(artifact);
+        byRunId.set(artifact.runId, group);
       }
-    } catch (err) {
-      result.failed.push({ ...entry, error: err instanceof Error ? err.message : String(err) });
+      for (const [runId, group] of byRunId) {
+        const dirEntries = group.map((a) => basename(a.path));
+        const guard = buildGcResurrectGuard(runStore, runId);
+        try {
+          await store.deleteAllForRunFenced(runId, guard, dirEntries);
+          for (const a of group) result.reaped.push({ path: a.path, runId: a.runId });
+        } catch (err) {
+          if (err instanceof WorkflowError && err.code === 'STATE_RUN_RESURRECTED') {
+            for (const a of group) result.resurrected.push({ path: a.path, runId: a.runId });
+          } else {
+            for (const a of group) {
+              result.failed.push({
+                path: a.path,
+                runId: a.runId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+        }
+      }
+      continue;
+    }
+
+    // Non-declaring store (or no runStore supplied) — today's per-file deleteIfExists path,
+    // unchanged.
+    for (const artifact of artifacts) {
+      const entry = { path: artifact.path, runId: artifact.runId };
+      try {
+        // #183 discipline: deleteIfExists resolves false (not an error) on ENOENT — already gone
+        // is success, never a failure; any other errno throws.
+        const didDelete = await deleteIfExists(artifact.path);
+        if (didDelete) {
+          result.reaped.push(entry);
+        } else {
+          result.already_gone.push(entry);
+        }
+      } catch (err) {
+        result.failed.push({ ...entry, error: err instanceof Error ? err.message : String(err) });
+      }
     }
   }
 
   return result;
+}
+
+/** The subset of the fenced trio gc actually calls (issue #207 PR-2) — a store-shape check, not
+ *  an import from `@sensigo/realm`'s `TraceBufferStore`, since `OrphanSweepableStore` only
+ *  guarantees `listOrphans`; a concrete store (e.g. `JsonTraceBufferStore`) may additionally
+ *  implement this. */
+interface DeleteAllForRunFencedCapable {
+  deleteAllForRunFenced(
+    runId: string,
+    guard: () => Promise<void>,
+    dirEntries?: readonly string[],
+  ): Promise<void>;
+}
+
+function hasDeleteAllForRunFenced(
+  store: OrphanSweepableStore,
+): store is OrphanSweepableStore & DeleteAllForRunFencedCapable {
+  return (
+    typeof (store as Partial<DeleteAllForRunFencedCapable>).deleteAllForRunFenced === 'function'
+  );
+}
+
+/**
+ * The resurrect-race guard (issue #207 PR-2, D3 §5): a lock-free `runStore.get(runId)`,
+ * re-verified inside the artifact store's own critical section immediately before its delete.
+ * Proceeds (resolves) iff the run is still absent (`STATE_RUN_NOT_FOUND`); throws a typed,
+ * locally-recognized `STATE_RUN_RESURRECTED` refusal if the run EXISTS again (a `save()`
+ * re-import landed between this sweep's snapshot and the reap) — the sweep's own catch (above)
+ * routes that specific code to the `resurrected` bucket, never `failed`. Any OTHER read failure
+ * propagates unwrapped, landing in `failed` (fail-closed — same posture `listOrphans` itself
+ * already requires).
+ */
+function buildGcResurrectGuard(
+  runStore: Pick<RunStore, 'get'>,
+  runId: string,
+): () => Promise<void> {
+  return async () => {
+    try {
+      await runStore.get(runId);
+    } catch (err) {
+      if (err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND') {
+        return; // still absent — proceed
+      }
+      throw err;
+    }
+    throw new WorkflowError(`Run '${runId}' exists again — no longer an orphan`, {
+      code: 'STATE_RUN_RESURRECTED',
+      category: 'STATE',
+      agentAction: 'report_to_user',
+      retryable: false,
+      details: { runId },
+    });
+  };
 }
 
 /** Best-effort total bytes for a known list of paths — reporting-only, never gates reaping.
@@ -364,7 +487,8 @@ function printGcReport(
     const nothingToReportArtifacts =
       artifactResult.reaped.length === 0 &&
       artifactResult.already_gone.length === 0 &&
-      artifactResult.failed.length === 0;
+      artifactResult.failed.length === 0 &&
+      artifactResult.resurrected.length === 0;
 
     if (nothingToReportArtifacts) {
       console.log('\nNo run-less orphaned WAL/sidecar artifacts found to reap.');
@@ -384,6 +508,16 @@ function printGcReport(
           `${artifactResult.already_gone.length} already gone, ${artifactResult.failed.length} failed.`,
       );
       for (const a of artifactResult.reaped) console.log(`  • ${a.path}  (run ${a.runId})`);
+    }
+    // issue #207 PR-2: benign, exit-code-neutral — these files are no longer orphans (the run
+    // exists again), reported for operator visibility only, never as a failure.
+    if (artifactResult.resurrected.length > 0) {
+      console.log(
+        `(${artifactResult.resurrected.length} candidate(s) skipped — their run exists again, no longer orphaned.)`,
+      );
+      for (const a of artifactResult.resurrected) {
+        console.log(`  • ${a.path}  (run ${a.runId}, resurrected)`);
+      }
     }
     for (const f of artifactResult.failed) {
       console.error(`  ✗ ${f.path} (run ${f.runId}): ${f.error}`);
@@ -471,11 +605,16 @@ export const gcCommand = new Command('gc')
       let artifactSweepError: string | undefined;
       try {
         const liveRunIds = await runStore.listRunIds();
-        artifactPreview = await sweepOrphanArtifacts(orphanSweepableStores, liveRunIds, {
-          olderThanMs,
-          dryRun: true,
-          now,
-        });
+        artifactPreview = await sweepOrphanArtifacts(
+          orphanSweepableStores,
+          liveRunIds,
+          {
+            olderThanMs,
+            dryRun: true,
+            now,
+          },
+          runStore,
+        );
       } catch (err) {
         artifactSweepError = err instanceof Error ? err.message : String(err);
       }
@@ -498,11 +637,16 @@ export const gcCommand = new Command('gc')
         // shape the temp sweep's own preview/force split already accepts).
         try {
           const liveRunIds = await runStore.listRunIds();
-          artifactResult = await sweepOrphanArtifacts(orphanSweepableStores, liveRunIds, {
-            olderThanMs,
-            dryRun: false,
-            now,
-          });
+          artifactResult = await sweepOrphanArtifacts(
+            orphanSweepableStores,
+            liveRunIds,
+            {
+              olderThanMs,
+              dryRun: false,
+              now,
+            },
+            runStore,
+          );
         } catch (err) {
           artifactSweepError = err instanceof Error ? err.message : String(err);
         }

--- a/packages/cli/src/commands/purge-guard.test.ts
+++ b/packages/cli/src/commands/purge-guard.test.ts
@@ -167,4 +167,27 @@ describe('#107/#184 PerRunArtifactStore.deleteAllForRun — declarer enumeration
       .find((l) => l.trim().startsWith('deleteAllForRun') && l.trim().endsWith(';'));
     expect(interfaceLine, 'expected to find the interface declaration line').toBeDefined();
   });
+
+  it("the fenced variant (issue #207 PR-2) is called from WITHIN the same per-run artifact loop as the legacy fallback — the fenced call site does not bypass WIRED_ORDER's artifact-before-anchor structure", () => {
+    const purgeSrc = readFileSync(join(PACKAGES_DIR, 'cli', 'src', 'commands', 'purge.ts'), 'utf8');
+    // The fenced call must appear TEXTUALLY BETWEEN the per-run loop's `for (const store of
+    // artifactStores)` and the structural anchor call `anchorStore.deleteAllForRun(` — i.e.
+    // inside the same loop the legacy fallback (asserted by WIRED_ORDER/ANCHOR above) already
+    // lives in, never after the anchor delete.
+    const loopStart = purgeSrc.indexOf('for (const store of artifactStores)');
+    const fencedCall = purgeSrc.indexOf('store.deleteAllForRunFenced(');
+    const anchorDeleteCall = purgeSrc.indexOf(
+      'await anchorStore.deleteAllForRun(run.id, dirEntries);',
+    );
+    expect(loopStart, 'expected to find the per-run artifactStores loop').toBeGreaterThan(-1);
+    expect(fencedCall, 'expected to find a store.deleteAllForRunFenced( call site').toBeGreaterThan(
+      -1,
+    );
+    expect(
+      anchorDeleteCall,
+      'expected to find the structural anchor deleteAllForRun call',
+    ).toBeGreaterThan(-1);
+    expect(fencedCall).toBeGreaterThan(loopStart);
+    expect(fencedCall).toBeLessThan(anchorDeleteCall);
+  });
 });

--- a/packages/cli/src/commands/purge.test.ts
+++ b/packages/cli/src/commands/purge.test.ts
@@ -3,7 +3,7 @@
 // Mirrors cleanup.test.ts's style: the exported LOGIC (isPurgeEligible, purgeRuns) is tested
 // directly against real stores over a real tmp directory — no console/exit-code assertions (that
 // thin formatting layer isn't unit-tested here either, consistent with cleanup.ts/reclaim.ts).
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, readdir, writeFile, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
@@ -796,6 +796,105 @@ describe('purgeRuns — purge correctness (issue #184)', () => {
       for (const id of ids) {
         expect(existsSync(join(dir, `${id}.json`))).toBe(false);
       }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('purgeRuns — fenced WAL delete guard (issue #207 PR-2)', () => {
+  it('a declaring artifact store (JsonTraceBufferStore) routes through deleteAllForRunFenced, not the legacy deleteAllForRun, and still clears the WAL', async () => {
+    const { dir, runStore } = await makeStores();
+    try {
+      const run = makeRun({
+        id: 'fenced-happy-path',
+        run_phase: 'completed',
+        terminal_state: true,
+      });
+      await injectRun(dir, run);
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      await traceBufferStore.append(run.id, 'step-agent', [{ event: 'e' }]);
+      const fencedSpy = vi.spyOn(traceBufferStore, 'deleteAllForRunFenced');
+      const legacySpy = vi.spyOn(traceBufferStore, 'deleteAllForRun');
+
+      const result = await purgeRuns({ runId: 'fenced-happy-path', dryRun: false }, runStore, [
+        traceBufferStore,
+      ]);
+
+      expect(result.purged).toEqual(['fenced-happy-path']);
+      expect(fencedSpy).toHaveBeenCalledTimes(1);
+      expect(legacySpy).not.toHaveBeenCalled();
+      expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resumed-mid-purge: a run that becomes non-terminal between selection and the fenced guard is refused — bucketed blocked, anchor untouched, WAL intact', async () => {
+    const { dir, runStore } = await makeStores();
+    try {
+      const run = makeRun({
+        id: 'resumed-mid-purge',
+        run_phase: 'completed',
+        terminal_state: true,
+      });
+      await injectRun(dir, run);
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      await traceBufferStore.append(run.id, 'step-agent', [{ event: 'e' }]);
+
+      let getCalls = 0;
+      let anchorDeleteCalls = 0;
+      const anchorStub: Pick<RunStore, 'get' | 'list'> &
+        PerRunArtifactStore & { runsDirPath: string } = {
+        runsDirPath: runStore.runsDirPath,
+        get: async (id: string) => {
+          getCalls++;
+          // Calls 1-2 are purgeRuns's own selection + pre-delete re-check (both still terminal —
+          // unaffected by this test). Call 3+ is the fenced guard's OWN re-check, invoked from
+          // inside deleteAllForRunFenced — simulate a concurrent `realm resume` landing exactly
+          // there.
+          if (getCalls <= 2) return runStore.get(id);
+          const fresh = await runStore.get(id);
+          return { ...fresh, run_phase: 'running' as const, terminal_state: false };
+        },
+        list: (wf?: string) => runStore.list(wf),
+        deleteAllForRun: async (id: string, dirEntries?: readonly string[]) => {
+          anchorDeleteCalls++;
+          return runStore.deleteAllForRun(id, dirEntries);
+        },
+      };
+
+      const result = await purgeRuns({ runId: 'resumed-mid-purge', dryRun: false }, anchorStub, [
+        traceBufferStore,
+      ]);
+
+      expect(result.blocked).toHaveLength(1);
+      expect(result.blocked[0]?.runId).toBe('resumed-mid-purge');
+      expect(result.failed).toEqual([]);
+      expect(result.purged).toEqual([]);
+      expect(anchorDeleteCalls).toBe(0); // anchor never reached
+      expect(existsSync(join(dir, 'resumed-mid-purge.json'))).toBe(true);
+      // The WAL survives too — the guard refused before deleteIfExists ever ran.
+      expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a non-declaring artifact store (FailedAttemptStore) keeps the plain, unfenced deleteAllForRun call (named residual, D3 §8 residual 4)', async () => {
+    const { dir, runStore } = await makeStores();
+    try {
+      const run = makeRun({ id: 'sidecar-unfenced', run_phase: 'completed', terminal_state: true });
+      await injectRun(dir, run);
+      const failedAttemptStore = new FailedAttemptStore(dir);
+      await appendSidecarLine(failedAttemptStore, run.id);
+
+      const result = await purgeRuns({ runId: 'sidecar-unfenced', dryRun: false }, runStore, [
+        failedAttemptStore,
+      ]);
+
+      expect(result.purged).toEqual(['sidecar-unfenced']);
+      expect(existsSync(join(dir, `${run.id}.attempts.jsonl`))).toBe(false);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/purge.ts
+++ b/packages/cli/src/commands/purge.ts
@@ -322,13 +322,16 @@ function hasDeleteAllForRunFenced(
 /**
  * Builds the fenced-delete guard for one run (issue #207 PR-2, D3 §5): a lock-free
  * `anchorStore.get(runId)` re-verified INSIDE the artifact store's own critical section,
- * immediately before its WAL delete. Proceeds (resolves) iff the run is now genuinely gone
- * (`STATE_RUN_NOT_FOUND`) or is still terminal — both mean no live/resumed run depends on this
- * WAL anymore. Otherwise (a concurrent `realm resume` raced the purge, or ANY other read failure)
- * throws the SAME typed `STATE_RUN_BUSY` shape purge's own bucket mapping already routes to
- * `blocked` (verified by the extended purge-guard test, not rebuilt here) — extending #184's
- * terminal-re-verify from the anchor layer to the WAL artifact layer, closing the purge/resume
- * resurrect race for WALs too.
+ * immediately before its WAL delete. The real routing (issue #207 correction — this doc
+ * previously overclaimed that any read failure lands `blocked`, which is not what the code does):
+ * run genuinely gone (`STATE_RUN_NOT_FOUND`) → proceeds (resolves) — safe to purge its WAL; run
+ * still present but no longer terminal (a concurrent `realm resume` raced the purge) → throws the
+ * typed `STATE_RUN_BUSY` shape purge's own bucket mapping already routes to `blocked` (verified by
+ * the extended purge-guard test, not rebuilt here); ANY OTHER read failure (a genuine I/O error,
+ * not an absence or a resume race) → re-thrown UNWRAPPED, exactly as the guard contract requires —
+ * this is neither `STATE_RUN_NOT_FOUND` nor `STATE_RUN_BUSY`, so it falls through purge's own
+ * catch to the `failed` bucket, not `blocked`. Extends #184's terminal-re-verify from the anchor
+ * layer to the WAL artifact layer, closing the purge/resume resurrect race for WALs too.
  */
 function buildPurgeWalGuard(
   anchorStore: Pick<RunStore, 'get'>,

--- a/packages/cli/src/commands/purge.ts
+++ b/packages/cli/src/commands/purge.ts
@@ -257,7 +257,21 @@ export async function purgeRuns(
       // surfacing here means "already gone," which the catch below routes to already_purged.
       await anchorStore.get(run.id);
       for (const store of artifactStores) {
-        await store.deleteAllForRun(run.id, dirEntries);
+        if (hasDeleteAllForRunFenced(store)) {
+          // issue #207 PR-2 (D3 §5): fenced — re-verifies at destruction time, inside the
+          // store's own critical section, that the run is still gone/terminal.
+          await store.deleteAllForRunFenced(
+            run.id,
+            buildPurgeWalGuard(anchorStore, run.id),
+            dirEntries,
+          );
+        } else {
+          // Non-declaring artifact store (e.g. FailedAttemptStore — issue #207 PR-2, D3 §5
+          // residual 4): the sidecar delete remains UNFENCED, a named residual (telemetry-grade,
+          // best-effort by that store's own contract — not run-record evidence, not
+          // acknowledged-durable data; the anchor stays #184-protected regardless).
+          await store.deleteAllForRun(run.id, dirEntries);
+        }
       }
       // The anchor LAST, and only on total success (issue #184) — structural crash-anchor: any
       // throw above (from a non-anchor artifact store) never reaches this line, so the run file
@@ -283,6 +297,70 @@ export async function purgeRuns(
   }
 
   return result;
+}
+
+/** The subset of the fenced trio purge actually calls (issue #207 PR-2) — a store-shape check,
+ *  not an import from `@sensigo/realm`'s `TraceBufferStore`, since `artifactStores` is typed as
+ *  `PerRunArtifactStore[]` (narrower) and a concrete store (e.g. `JsonTraceBufferStore`) may
+ *  additionally implement this. */
+interface DeleteAllForRunFencedCapable {
+  deleteAllForRunFenced(
+    runId: string,
+    guard: () => Promise<void>,
+    dirEntries?: readonly string[],
+  ): Promise<void>;
+}
+
+function hasDeleteAllForRunFenced(
+  store: PerRunArtifactStore,
+): store is PerRunArtifactStore & DeleteAllForRunFencedCapable {
+  return (
+    typeof (store as Partial<DeleteAllForRunFencedCapable>).deleteAllForRunFenced === 'function'
+  );
+}
+
+/**
+ * Builds the fenced-delete guard for one run (issue #207 PR-2, D3 §5): a lock-free
+ * `anchorStore.get(runId)` re-verified INSIDE the artifact store's own critical section,
+ * immediately before its WAL delete. Proceeds (resolves) iff the run is now genuinely gone
+ * (`STATE_RUN_NOT_FOUND`) or is still terminal — both mean no live/resumed run depends on this
+ * WAL anymore. Otherwise (a concurrent `realm resume` raced the purge, or ANY other read failure)
+ * throws the SAME typed `STATE_RUN_BUSY` shape purge's own bucket mapping already routes to
+ * `blocked` (verified by the extended purge-guard test, not rebuilt here) — extending #184's
+ * terminal-re-verify from the anchor layer to the WAL artifact layer, closing the purge/resume
+ * resurrect race for WALs too.
+ */
+function buildPurgeWalGuard(
+  anchorStore: Pick<RunStore, 'get'>,
+  runId: string,
+): () => Promise<void> {
+  return async () => {
+    let fresh: RunRecord;
+    try {
+      fresh = await anchorStore.get(runId);
+    } catch (err) {
+      if (err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND') {
+        return; // gone — safe to purge its WAL
+      }
+      throw err;
+    }
+    if (!TERMINAL_PHASES.has(fresh.run_phase)) {
+      throw new WorkflowError(
+        `Run '${runId}' is no longer terminal — refusing to purge its trace buffer`,
+        {
+          code: 'STATE_RUN_BUSY',
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: true,
+          details: {
+            runId,
+            reason: `run '${runId}' is no longer terminal (resumed since selection) — refusing to purge its trace buffer`,
+          },
+        },
+      );
+    }
+    // Still gone or still terminal, same run — proceed.
+  };
 }
 
 function formatBytes(n: number): string {

--- a/packages/cli/src/commands/run-trace-buffer-store-wiring.test.ts
+++ b/packages/cli/src/commands/run-trace-buffer-store-wiring.test.ts
@@ -1,0 +1,48 @@
+// Source-text wiring check: the CLI executors (`realm run`, `realm agent`) construct a
+// JsonTraceBufferStore and thread it through to executeChain (issue #207 PR-2, D3 §5
+// mixed-wiring gap — CLI executors previously passed no `traceBufferStore` at all, so acknowledged
+// appends were neither adopted nor refused when a CLI runner settled). Both run.ts's and agent.ts's
+// action() bodies are inline Commander callback logic (run.ts additionally reads from
+// readline/stdin) — like purge.ts's own .action(), neither has a dedicated behavioral test file
+// (see purge-guard.test.ts's own precedent for this class of CLI action). A source-text check is
+// the proportionate, honest substitute: confirms the wiring exists without attempting to drive an
+// interactive session or a full provider/workflow resolution in a unit test. `run-agent.test.ts`
+// separately proves the DEEPER contract behaviorally (runAgent → executeChain actually adopts a
+// pre-seeded WAL entry when deps.traceBufferStore is supplied) — this file only proves the CLI
+// action sites actually supply it.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+
+describe("realm run's executeChain call receives a defined traceBufferStore (issue #207 PR-2)", () => {
+  const src = readFileSync(join(DIR, 'run.ts'), 'utf8');
+
+  it('constructs a JsonTraceBufferStore beside the run store', () => {
+    expect(src).toMatch(/new JsonTraceBufferStore\(store\.runsDirPath\)/);
+  });
+
+  it("passes traceBufferStore into executeChain's options", () => {
+    const callMatch = /executeChain\(store, definition, \{[\s\S]*?\}\)/.exec(src);
+    expect(callMatch, 'expected to find the executeChain(...) call site').not.toBeNull();
+    expect(callMatch![0]).toMatch(/\btraceBufferStore\b/);
+  });
+});
+
+describe("realm agent's runAgent calls receive a defined traceBufferStore (issue #207 PR-2)", () => {
+  const src = readFileSync(join(DIR, 'agent.ts'), 'utf8');
+
+  it('constructs a JsonTraceBufferStore beside the concrete JsonFileStore', () => {
+    expect(src).toMatch(/new JsonTraceBufferStore\(store\.runsDirPath\)/);
+  });
+
+  it('both runAgent(...) call sites (attach path and fresh-workflow path) pass traceBufferStore', () => {
+    const callMatches = [...src.matchAll(/runAgent\(\s*\{[\s\S]*?\},\s*\{/g)];
+    expect(callMatches.length, 'expected exactly 2 runAgent(...) call sites').toBe(2);
+    for (const m of callMatches) {
+      expect(m[0]).toMatch(/\btraceBufferStore\b/);
+    }
+  });
+});

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -75,6 +75,11 @@ export const runCommand = new Command('run')
 
       // 3. Create store and initial run record
       const store = new JsonFileStore();
+      // issue #207 PR-2 (D3 §5, mixed-wiring gap): construct a JsonTraceBufferStore beside the
+      // run store (same runsDir) and thread it into executeChain below — without this, `realm
+      // run`'s own dev-mode driver never adopted/fenced a step's streamed WAL trace at all.
+      const { JsonTraceBufferStore } = await import('@sensigo/realm-mcp');
+      const traceBufferStore = new JsonTraceBufferStore(store.runsDirPath);
 
       const { run: initialRecord } = await store.create({
         workflowId: definition.id,
@@ -165,6 +170,7 @@ export const runCommand = new Command('run')
             input: userOutput,
             dispatcher,
             registry,
+            traceBufferStore,
           });
 
           if (result.status === 'ok') {

--- a/packages/cli/src/commands/store-fs-guard.test.ts
+++ b/packages/cli/src/commands/store-fs-guard.test.ts
@@ -364,3 +364,87 @@ describe('store-fs-guard — exact-count allow-list for raw traceBufferStore del
     }
   });
 });
+
+// -----------------------------------------------------------------------------------------------
+// Guard 5: exact-count allow-list for every raw `traceBufferStore.append(` call site (D3 §7(a),
+// restored — issue #207 correction; same conventions as Guard 4)
+// -----------------------------------------------------------------------------------------------
+//
+// Scoped to core + mcp-server ONLY, same stable-receiver-name rationale as Guard 4. A raw
+// (unfenced) `traceBufferStore.append(` call site is a DELIBERATE, residual, unfenced write —
+// every one still standing after issue #207 PR-2 must be enumerated here with a one-line
+// contract-clause justification. A NEW raw call site appearing anywhere in-scope, or the count at
+// an existing site drifting, fails this test.
+const RAW_TRACE_BUFFER_STORE_APPEND = /\btraceBufferStore\??\.append\s*\(/;
+
+/** file (relative to PACKAGES_DIR) → exact expected raw call-site count, each with the one-line
+ *  contract-clause justification issue #207 (correction) requires. */
+const RAW_APPEND_ALLOW_LIST: Record<string, { count: number; reason: string }> = {
+  'mcp-server/src/tools/append-trace.ts': {
+    count: 2,
+    reason:
+      'the empty-entries probe (writes nothing — raw unlocked path, point-in-time semantics, ' +
+      'unconditional regardless of capability, D3 §2) and the capability-absent fallback ' +
+      '(Window A stays open for a non-declaring store; deduped console.warn + envelope advisory ' +
+      "disclose it — see this file's own capability-absent branch comment).",
+  },
+};
+
+function traceBufferStoreAppendScanFiles(): string[] {
+  return [
+    ...walkTsSourceFiles(join(PACKAGES_DIR, 'core', 'src')),
+    ...walkTsSourceFiles(join(PACKAGES_DIR, 'mcp-server', 'src')),
+  ];
+}
+
+function countRawTraceBufferStoreAppends(file: string): number {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  let count = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+    if (RAW_TRACE_BUFFER_STORE_APPEND.test(trimmed)) count++;
+  }
+  return count;
+}
+
+describe('store-fs-guard — exact-count allow-list for raw traceBufferStore.append( call sites (issue #207 correction, D3 §7(a))', () => {
+  it('at least one file is scanned (the scan is wired correctly)', () => {
+    expect(traceBufferStoreAppendScanFiles().length).toBeGreaterThan(0);
+  });
+
+  it('every RAW_APPEND_ALLOW_LIST entry still exists as a file', () => {
+    for (const rel of Object.keys(RAW_APPEND_ALLOW_LIST)) {
+      const full = join(PACKAGES_DIR, rel);
+      expect(statSync(full).isFile(), `allow-listed file no longer exists: ${rel}`).toBe(true);
+    }
+  });
+
+  it('every raw call site is inside the allow-list, at EXACTLY the expected count — no new site, no drifted count', () => {
+    const violations: string[] = [];
+    for (const file of traceBufferStoreAppendScanFiles()) {
+      const rel = relativeToPackages(file);
+      const actual = countRawTraceBufferStoreAppends(file);
+      const expected = RAW_APPEND_ALLOW_LIST[rel]?.count ?? 0;
+      if (actual !== expected) {
+        violations.push(`${rel}: expected ${expected}, found ${actual}`);
+      }
+    }
+    expect(
+      violations,
+      `Raw traceBufferStore.append( call-site count mismatch: ${violations.join('; ')}. A new ` +
+        `(or removed) call site must be reflected in RAW_APPEND_ALLOW_LIST with a one-line ` +
+        `contract-clause justification.`,
+    ).toEqual([]);
+  });
+
+  it('the allow-listed files THEMSELVES still contain their expected raw call sites (sanity — proves the matcher is not just vacuously passing)', () => {
+    for (const [rel, { count }] of Object.entries(RAW_APPEND_ALLOW_LIST)) {
+      const full = join(PACKAGES_DIR, rel);
+      const actual = countRawTraceBufferStoreAppends(full);
+      expect(actual, `expected exactly ${count} raw call site(s) in allow-listed ${rel}`).toBe(
+        count,
+      );
+    }
+  });
+});

--- a/packages/cli/src/commands/store-fs-guard.test.ts
+++ b/packages/cli/src/commands/store-fs-guard.test.ts
@@ -262,3 +262,105 @@ describe('store-fs-guard — every fenced-trio-declaring store has a fenced-TCK-
     ).toEqual([]);
   });
 });
+
+// -----------------------------------------------------------------------------------------------
+// Guard 4: exact-count allow-list for every raw `traceBufferStore.delete(`/`.deleteAllForRun(`
+// call site remaining after the fenced-trio adoption (issue #207 PR-2)
+// -----------------------------------------------------------------------------------------------
+//
+// Scoped to core + mcp-server ONLY (stable receiver name: a local variable or `options.` field
+// literally named `traceBufferStore`) — purge.ts/gc.ts use store-TYPED receivers (`store`,
+// looped over `artifactStores`/`OrphanSweepableStore[]`) and stay under their own orchestration
+// guards (purge-guard.test.ts's WIRED_ORDER, gc.ts's own fenced-dispatch tests), not this one.
+//
+// A raw (unfenced) `traceBufferStore.delete(`/`.deleteAllForRun(` call site is a DELIBERATE,
+// residual, unguarded destruction — every one still standing after issue #207 PR-2 must be
+// enumerated here with a one-line contract-clause justification. A NEW raw call site appearing
+// anywhere in-scope, the count at an existing site drifting, or (the specific regression this
+// guard exists to catch) the :1478 capability-block delete creeping back in, all fail this test.
+const RAW_TRACE_BUFFER_STORE_DELETE = /\btraceBufferStore\??\.(delete|deleteAllForRun)\s*\(/;
+
+/** file (relative to PACKAGES_DIR) → exact expected raw call-site count, each with the one-line
+ *  contract-clause justification issue #207 PR-2 requires. */
+const RAW_DELETE_ALLOW_LIST: Record<string, { count: number; reason: string }> = {
+  'core/src/engine/execution-loop.ts': {
+    count: 2,
+    reason:
+      'the failure-settle delete (persist-gated on store.update succeeding — #186 posture) and ' +
+      'the success-settle delete (clause (a) of the unified deletion contract: the settlement ' +
+      'already committed and is durably visible, so this delete never races an unsettled step) ' +
+      '— both intentionally UNFENCED: neither can race a concurrent append_trace once the run ' +
+      "is claimed (appends are refused once in_progress/settled, per append_trace.ts's own " +
+      'eligibility check). The capability-block delete (formerly a third site here) was REMOVED ' +
+      "entirely, not fenced — see execution-loop.ts's own comment at that call site.",
+  },
+  'core/src/engine/reclaim-step.ts': {
+    count: 1,
+    reason:
+      "the non-declaring-store fallback (clearStaleWal) — byte-frozen, today's order (after the " +
+      'un-claiming update, best-effort, warned) — the normative fallback for a store that cannot ' +
+      'fence the clear at all; the declaring-store path uses deleteFenced instead (see ' +
+      'clearStaleWalFenced, same file).',
+  },
+};
+
+function traceBufferStoreDeleteScanFiles(): string[] {
+  return [
+    ...walkTsSourceFiles(join(PACKAGES_DIR, 'core', 'src')),
+    ...walkTsSourceFiles(join(PACKAGES_DIR, 'mcp-server', 'src')),
+  ];
+}
+
+function countRawTraceBufferStoreDeletes(file: string): number {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  let count = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+    if (RAW_TRACE_BUFFER_STORE_DELETE.test(trimmed)) count++;
+  }
+  return count;
+}
+
+describe('store-fs-guard — exact-count allow-list for raw traceBufferStore delete/deleteAllForRun call sites (issue #207 PR-2)', () => {
+  it('at least one file is scanned (the scan is wired correctly)', () => {
+    expect(traceBufferStoreDeleteScanFiles().length).toBeGreaterThan(0);
+  });
+
+  it('every RAW_DELETE_ALLOW_LIST entry still exists as a file', () => {
+    for (const rel of Object.keys(RAW_DELETE_ALLOW_LIST)) {
+      const full = join(PACKAGES_DIR, rel);
+      expect(statSync(full).isFile(), `allow-listed file no longer exists: ${rel}`).toBe(true);
+    }
+  });
+
+  it('every raw call site is inside the allow-list, at EXACTLY the expected count — no new site, no drifted count, no :1478-style delete creeping back', () => {
+    const violations: string[] = [];
+    for (const file of traceBufferStoreDeleteScanFiles()) {
+      const rel = relativeToPackages(file);
+      const actual = countRawTraceBufferStoreDeletes(file);
+      const expected = RAW_DELETE_ALLOW_LIST[rel]?.count ?? 0;
+      if (actual !== expected) {
+        violations.push(`${rel}: expected ${expected}, found ${actual}`);
+      }
+    }
+    expect(
+      violations,
+      `Raw traceBufferStore delete/deleteAllForRun call-site count mismatch: ` +
+        `${violations.join('; ')}. A new (or removed) call site must be reflected in ` +
+        `RAW_DELETE_ALLOW_LIST with a one-line contract-clause justification — or, if this is the ` +
+        `:1478 capability-block delete creeping back, remove it (see execution-loop.ts's own ` +
+        `comment there for why it must not exist).`,
+    ).toEqual([]);
+  });
+
+  it('the allow-listed files THEMSELVES still contain their expected raw call sites (sanity — proves the matcher is not just vacuously passing)', () => {
+    for (const [rel, { count }] of Object.entries(RAW_DELETE_ALLOW_LIST)) {
+      const full = join(PACKAGES_DIR, rel);
+      const actual = countRawTraceBufferStoreDeletes(full);
+      expect(actual, `expected exactly ${count} raw call site(s) in allow-listed ${rel}`).toBe(
+        count,
+      );
+    }
+  });
+});

--- a/packages/core/src/engine/execution-loop-fenced-trio-adoption.test.ts
+++ b/packages/core/src/engine/execution-loop-fenced-trio-adoption.test.ts
@@ -138,6 +138,13 @@ describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)
     });
     const traceBufferStore = new InMemoryTraceBufferStore();
     const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
+    // issue #207 correction (item 4a): also spy on deleteFenced — InMemoryTraceBufferStore
+    // declares the fenced trio, so a hypothetically REINTRODUCED capability-block delete that
+    // used deleteFenced instead of the legacy delete would evade both the legacy-delete spy above
+    // AND Guard 4's regex (which deliberately does not match `deleteFenced(`, only `delete(`/
+    // `deleteAllForRun(`) — this assertion is the only thing that would catch that specific
+    // regression.
+    const deleteFencedSpy = vi.spyOn(traceBufferStore, 'deleteFenced');
 
     const env = await executeStep(store, handlerDef, {
       runId: run.id,
@@ -150,6 +157,7 @@ describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)
 
     expect(env.error_code).toBe('ENGINE_HANDLER_NOT_REGISTERED');
     expect(deleteSpy).not.toHaveBeenCalled();
+    expect(deleteFencedSpy).not.toHaveBeenCalled();
   });
 
   // ── :925-equivalent — pre-claim read envelope ────────────────────────────────────────────────
@@ -180,6 +188,16 @@ describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)
     const after = await store.get(run.id);
     expect(after.in_progress_steps).not.toContain('step-agent'); // no claim consumed
     expect(after.claims?.['step-agent']).toBeUndefined();
+    // issue #207 correction (item 4b): sharper than the membership checks above — those alone
+    // cannot distinguish "no claim was ever consumed" from "a claim was consumed and then
+    // compensated" (both leave in_progress_steps/claims looking identical afterward). The
+    // version being byte-identical to the pre-claim snapshot, plus the total absence of a
+    // compensating_unclaim audit entry, is what actually proves NO store mutation happened at
+    // all on this path (this is the pre-claim read failure — no claimStep ever ran).
+    expect(after.version).toBe(run.version);
+    expect(after.evidence.some((e) => e.output_summary['compensating_unclaim'] === true)).toBe(
+      false,
+    );
   });
 
   // ── :1041-equivalent — post-claim compensating un-claim ─────────────────────────────────────

--- a/packages/core/src/engine/execution-loop-fenced-trio-adoption.test.ts
+++ b/packages/core/src/engine/execution-loop-fenced-trio-adoption.test.ts
@@ -1,0 +1,263 @@
+// Deterministic stub tests for execution-loop.ts's engine call-site adoption of the fenced trio
+// (issue #207 PR-2, D3 §5 — the unified deletion contract). Each test targets exactly one of the
+// five call sites the design enumerates: the success-settle WAL-delete wrap, the failure-settle
+// persist-gate, the removed capability-block delete, the pre-claim read envelope, and the
+// post-claim read's compensating un-claim (including its version-mismatch stop branch and audit
+// entry).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeStep } from './execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { InMemoryTraceBufferStore } from '../store/trace-buffer-store.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { TraceBufferStore } from '../store/trace-buffer-store.js';
+import type { StepDispatcher } from './execution-loop.js';
+
+const agentDef: WorkflowDefinition = {
+  id: 'fenced-adoption-agent-wf',
+  name: 'Fenced Adoption Agent WF',
+  version: 1,
+  steps: {
+    'step-agent': { description: 'Agent step', execution: 'agent', depends_on: [] },
+  },
+};
+
+const handlerDef: WorkflowDefinition = {
+  id: 'fenced-adoption-handler-wf',
+  name: 'Fenced Adoption Handler WF',
+  version: 1,
+  steps: {
+    validate: { description: 'Validate', execution: 'auto', depends_on: [], handler: 'my_handler' },
+  },
+};
+
+const echo: StepDispatcher = async (_s, input) => ({ ...input });
+
+/** A minimal legacy-only TraceBufferStore double — no fenced trio (execution-loop.ts never calls
+ *  the fenced methods; only the legacy read/delete). Each field is overridable per test. */
+function stubTraceBufferStore(overrides: Partial<TraceBufferStore>): TraceBufferStore {
+  return {
+    append: async () => {
+      throw new Error('not used in this test');
+    },
+    read: async () => [],
+    delete: async () => {},
+    deleteAllForRun: async () => {},
+    readAllForRun: async () => ({}),
+    ...overrides,
+  };
+}
+
+describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-fenced-adoption-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // ── :1857-equivalent — success-settle WAL cleanup wrap ──────────────────────────────────────
+  it('success-settle: a WAL cleanup failure degrades to a warning, never an error envelope', async () => {
+    const { run } = await store.create({
+      workflowId: 'fenced-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = stubTraceBufferStore({
+      delete: async () => {
+        throw new Error('simulated lock-contention cleanup failure');
+      },
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('ok'); // NOT an error envelope — the step genuinely completed
+    expect(
+      envelope.warnings.some((w) =>
+        w.includes('Failed to clean up trace buffer after step completion'),
+      ),
+    ).toBe(true);
+    const after = await store.get(run.id);
+    expect(after.completed_steps).toContain('step-agent');
+  });
+
+  // ── :1566-equivalent — failure-settle persist-gate ──────────────────────────────────────────
+  it('failure-settle: WAL delete never fires when the preceding store.update itself fails (persist-gate)', async () => {
+    const { run } = await store.create({
+      workflowId: 'fenced-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'pre_failure_line' }]);
+    const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
+
+    const updateSpy = vi
+      .spyOn(store, 'update')
+      .mockRejectedValue(new Error('simulated persist failure'));
+
+    try {
+      const envelope = await executeStep(store, agentDef, {
+        runId: run.id,
+        command: 'step-agent',
+        input: {},
+        dispatcher: async () => {
+          throw new Error('handler boom');
+        },
+        traceBufferStore,
+      });
+
+      expect(envelope.status).toBe('error');
+      expect(deleteSpy).not.toHaveBeenCalled();
+      // The WAL survives — it is the sole remaining evidence copy until reclaim (#186 posture).
+      expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(1);
+    } finally {
+      updateSpy.mockRestore();
+    }
+  });
+
+  // ── :1478-equivalent — capability-block delete removed entirely ─────────────────────────────
+  it('capability-block settle: WAL delete is never invoked at all (removed entirely — disjoint auto/agent populations)', async () => {
+    const { run } = await store.create({
+      workflowId: 'fenced-adoption-handler-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
+
+    const env = await executeStep(store, handlerDef, {
+      runId: run.id,
+      command: 'validate',
+      input: {},
+      dispatcher: echo,
+      registry: new ExtensionRegistry(), // empty registry → ENGINE_HANDLER_NOT_REGISTERED
+      traceBufferStore,
+    });
+
+    expect(env.error_code).toBe('ENGINE_HANDLER_NOT_REGISTERED');
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  // ── :925-equivalent — pre-claim read envelope ────────────────────────────────────────────────
+  it('pre-claim WAL read failure returns a typed retryable ENGINE_STORE_FAILED envelope, no claim consumed', async () => {
+    const { run } = await store.create({
+      workflowId: 'fenced-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = stubTraceBufferStore({
+      read: async () => {
+        throw new Error('simulated pre-claim lock contention');
+      },
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
+    expect(envelope.agent_action).toBe('stop');
+
+    const after = await store.get(run.id);
+    expect(after.in_progress_steps).not.toContain('step-agent'); // no claim consumed
+    expect(after.claims?.['step-agent']).toBeUndefined();
+  });
+
+  // ── :1041-equivalent — post-claim compensating un-claim ─────────────────────────────────────
+  it('post-claim WAL read failure performs a compensating un-claim (claim released, audit entry recorded), returns a typed retryable envelope', async () => {
+    const { run } = await store.create({
+      workflowId: 'fenced-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    let readCallNum = 0;
+    const traceBufferStore = stubTraceBufferStore({
+      read: async () => {
+        readCallNum++;
+        if (readCallNum === 1) return []; // pre-claim read succeeds (nothing buffered)
+        throw new Error('simulated post-claim read failure');
+      },
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
+    expect(envelope.agent_action).toBe('stop');
+
+    const after = await store.get(run.id);
+    expect(after.in_progress_steps).not.toContain('step-agent'); // claim released
+    expect(after.claims?.['step-agent']).toBeUndefined();
+    const audit = after.evidence.find((e) => e.output_summary['compensating_unclaim'] === true);
+    expect(audit).toBeDefined();
+    expect(audit?.step_id).toBe('step-agent');
+  });
+
+  it('post-claim compensating un-claim CAS-mismatch: a concurrent actor already resolved the claim → left AS-IS, still returns the typed retryable envelope (never stomped)', async () => {
+    const { run } = await store.create({
+      workflowId: 'fenced-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    let readCallNum = 0;
+    const traceBufferStore = stubTraceBufferStore({
+      read: async () => {
+        readCallNum++;
+        if (readCallNum === 1) return [];
+        // Simulate a concurrent actor (e.g. a parallel reclaim) resolving this exact claim
+        // between our own claimStep and this post-claim read failing — a REAL version bump via
+        // a genuine store.update, out from under our own compensating un-claim's CAS baseline.
+        const current = await store.get(run.id);
+        await store.update({
+          ...current,
+          in_progress_steps: current.in_progress_steps.filter((s) => s !== 'step-agent'),
+          claims: {},
+          completed_steps: [...current.completed_steps, 'step-agent'],
+        });
+        throw new Error('simulated post-claim read failure');
+      },
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
+
+    const after = await store.get(run.id);
+    // The concurrent actor's own resolution survives EXACTLY as it made it — our compensating
+    // un-claim's CAS mismatch stopped us immediately rather than stomping it.
+    expect(after.completed_steps).toContain('step-agent');
+    expect(after.in_progress_steps).not.toContain('step-agent');
+  });
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -581,12 +581,52 @@ export function buildNextActions(definition: WorkflowDefinition, run: RunRecord)
 }
 
 /**
- * Merges call-scoped trace-schema warnings with an optional cleanup warning into
- * a single warnings array. Trace warnings are listed first (deterministic order).
+ * Merges call-scoped trace-schema warnings with any number of optional extra warnings into a
+ * single warnings array. Trace warnings are listed first (deterministic order); `extraWarnings`
+ * entries are appended in call order, `undefined` entries skipped. Variadic since issue #207
+ * PR-2 (the success-settle path now has TWO independent optional warnings to merge — a
+ * handler-level warning and a WAL-cleanup warning — where every earlier call site had at most
+ * one).
  */
-function mergeWarnings(traceWarnings: string[], cleanupWarning?: string): string[] {
-  if (traceWarnings.length === 0 && cleanupWarning === undefined) return [];
-  return cleanupWarning !== undefined ? [...traceWarnings, cleanupWarning] : [...traceWarnings];
+function mergeWarnings(
+  traceWarnings: string[],
+  ...extraWarnings: (string | undefined)[]
+): string[] {
+  const defined = extraWarnings.filter((w): w is string => w !== undefined);
+  if (traceWarnings.length === 0 && defined.length === 0) return [];
+  return [...traceWarnings, ...defined];
+}
+
+/**
+ * Compensating un-claim (issue #207 PR-2, D3 §5): built from `pendingRun` — the record OUR OWN
+ * `claimStep` call returned, never a fresh get — removing the step from `in_progress_steps` AND
+ * `claims[step]` in the SAME mutation (the settle-site invariant every other settle path in this
+ * file upholds), plus an audit-evidence entry. The caller CAS's this against `pendingRun.version`
+ * (by passing the returned record straight to `store.update`): any intervening write (a
+ * concurrent settle, reclaim, or second claim) bumps version, so this compensating un-claim can
+ * never stomp it — a CAS mismatch means some other actor already resolved the claim, and the
+ * caller must stop immediately rather than retry, leaving the claim exactly as that actor left
+ * it. A step already absent from `in_progress_steps` (should not happen here, but the filter is
+ * naturally idempotent) is simply a no-op mutation, not a special case.
+ */
+function buildCompensatingUnclaim(pendingRun: RunRecord, stepName: string, now: Date): RunRecord {
+  const auditEvidence = captureEvidence({
+    stepId: stepName,
+    startedAt: now,
+    completedAt: now,
+    input: {},
+    output: {
+      compensating_unclaim: true,
+      reason: 'adoption-read failure after claim',
+      unclaimed_at: now.toISOString(),
+    },
+  });
+  return {
+    ...pendingRun,
+    in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== stepName),
+    claims: omitClaim(pendingRun.claims, stepName),
+    evidence: [...pendingRun.evidence, auditEvidence],
+  };
 }
 
 /**
@@ -920,10 +960,31 @@ export async function executeStep(
     | undefined;
 
   if (stepDef?.execution === 'agent') {
-    walEntries =
-      options.traceBufferStore !== undefined
-        ? await options.traceBufferStore.read(options.runId, options.command)
-        : [];
+    // issue #207 PR-2 (D3 §5): wrapped — a rejection here (e.g. lock contention under a fenced
+    // trio's serialized reads) happens BEFORE claimStep, so no claim exists to compensate for;
+    // return a typed, retryable envelope instead of letting the read throw uncaught.
+    try {
+      walEntries =
+        options.traceBufferStore !== undefined
+          ? await options.traceBufferStore.read(options.runId, options.command)
+          : [];
+    } catch (err) {
+      return makeErrorEnvelope(
+        options,
+        run,
+        new WorkflowError('Failed to read trace buffer before claiming step', {
+          code: 'ENGINE_STORE_FAILED',
+          category: 'ENGINE',
+          agentAction: 'stop',
+          retryable: true,
+          details: {
+            step_id: options.command,
+            cause: err instanceof Error ? err.message : String(err),
+          },
+        }),
+        definition,
+      );
+    }
 
     const hasAnyTrace =
       walEntries.length > 0 || (options.trace !== undefined && options.trace.length > 0);
@@ -1036,10 +1097,42 @@ export async function executeStep(
   // complete, post-claim set, which is also what the captureEvidence call site further below
   // keys its `stepDef?.execution === 'agent' && walEntries.length > 0` check on.
   if (stepDef?.execution === 'agent') {
-    walEntries =
-      options.traceBufferStore !== undefined
-        ? await options.traceBufferStore.read(options.runId, options.command)
-        : [];
+    // issue #207 PR-2 (D3 §5): wrapped — a rejection here happens AFTER claimStep, so a claim IS
+    // outstanding. COMPENSATING UN-CLAIM: built from `pendingRun` (our own claimStep result,
+    // never a fresh get) and CAS'd against `pendingRun.version` — an intervening write (someone
+    // else already resolved this claim) makes the CAS fail with STATE_SNAPSHOT_MISMATCH, in
+    // which case we stop immediately and leave the claim exactly as it is. Either way (compensated
+    // or left in place), the caller always gets the same typed retryable envelope — see
+    // buildCompensatingUnclaim's own doc for the full contract.
+    try {
+      walEntries =
+        options.traceBufferStore !== undefined
+          ? await options.traceBufferStore.read(options.runId, options.command)
+          : [];
+    } catch (err) {
+      try {
+        await store.update(buildCompensatingUnclaim(pendingRun, options.command, new Date()));
+      } catch {
+        // CAS mismatch (someone else already resolved the claim) or any other failure to even
+        // un-claim: stop immediately, leave the claim exactly as it is — never retry here.
+      }
+      return makeErrorEnvelope(
+        options,
+        pendingRun,
+        new WorkflowError('Failed to read trace buffer after claiming step', {
+          code: 'ENGINE_STORE_FAILED',
+          category: 'ENGINE',
+          agentAction: 'stop',
+          retryable: true,
+          details: {
+            step_id: options.command,
+            cause: err instanceof Error ? err.message : String(err),
+          },
+        }),
+        definition,
+        traceWarnings.length > 0 ? traceWarnings : undefined,
+      );
+    }
 
     if (walEntries.length > 0 || (options.trace !== undefined && options.trace.length > 0)) {
       // issue #185 Fix 1: same budget-priority merge as the pre-claim pass, now over the
@@ -1472,13 +1565,15 @@ export async function executeStep(
       } catch (storeErr) {
         blockStoreWarning = `Failed to persist capability block: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
       }
-      let blockWalWarning: string | undefined;
-      try {
-        // Delete WAL after run state is written — the step's entries are now in evidence.
-        await options.traceBufferStore?.delete(options.runId, options.command);
-      } catch (walErr) {
-        blockWalWarning = `Failed to clean up trace buffer after capability block: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
-      }
+      // issue #207 PR-2 (D3 §5): NO WAL delete belongs on this capability-block settle path — the
+      // prior try/catch here was removed, not just gated. Contract-consistency hygiene, not a
+      // functional fix: capability-block is reachable ONLY for `execution: 'auto'` steps
+      // (ENGINE_HANDLER_NOT_REGISTERED/ENGINE_ADAPTER_NOT_REGISTERED mint only in the
+      // auto-dispatch branches), and a WAL only ever exists for `execution: 'agent'` steps
+      // (`append_trace` refuses non-agent steps) — DISJOINT populations; there is no in-repo
+      // blocked-path WAL to clean up. A custom embedder whose dispatcher throws NOT_REGISTERED
+      // for an agent step would leave WAL residue reaped at purge (an enumerated, accepted
+      // residue class — D3 §8 residual 6), never silently destroyed here.
 
       // Non-terminal 'stop' → 'report_to_user' via the existing mapping: a human must provision the
       // runner (or re-run on a capable one); no further progress is possible on THIS runner.
@@ -1504,7 +1599,7 @@ export async function executeStep(
         status: 'error',
         data: {},
         evidence: allEvidence,
-        warnings: mergeWarnings(traceWarnings, blockStoreWarning ?? blockWalWarning),
+        warnings: mergeWarnings(traceWarnings, blockStoreWarning),
         errors: [dispatchError.message],
         agent_action: blockedAction,
         error_code: recoverableCode,
@@ -1561,11 +1656,19 @@ export async function executeStep(
       storeCleanupWarning = `Failed to persist step failure: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
     }
     let walCleanupWarning: string | undefined;
-    try {
-      // Delete WAL after run state is written for failure — entries are now in evidence.
-      await options.traceBufferStore?.delete(options.runId, options.command);
-    } catch (walErr) {
-      walCleanupWarning = `Failed to clean up trace buffer after step failure: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
+    // issue #207 PR-2 (D3 §5): gate the WAL delete on the preceding store.update having actually
+    // SUCCEEDED (persistedRun defined) — a failed persist leaves the step in_progress with its
+    // trace already read into an evidence write that never landed anywhere durable; the WAL is
+    // the SOLE remaining evidence copy until reclaim recovers the wedge (#186 posture). Reclaim's
+    // own drain (reclaim-step.ts) warns with the destroyed entry count when it eventually clears
+    // this same buffer.
+    if (persistedRun !== undefined) {
+      try {
+        // Delete WAL after run state is written for failure — entries are now in evidence.
+        await options.traceBufferStore?.delete(options.runId, options.command);
+      } catch (walErr) {
+        walCleanupWarning = `Failed to clean up trace buffer after step failure: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
+      }
     }
 
     // Derive the agent_action from the error semantics and run termination state.
@@ -1853,8 +1956,17 @@ export async function executeStep(
     );
   }
 
-  // Delete WAL after successful run update — entries are now in evidence.
-  await options.traceBufferStore?.delete(options.runId, options.command);
+  // Delete WAL after successful run update — entries are now in evidence. issue #207 PR-2 (D3
+  // §5, clause (a) of the unified deletion contract): wrapped in try/catch-to-warning — the
+  // settlement already committed and is durably visible, so a cleanup failure here (e.g. lock
+  // contention) must degrade to a warning, never surface as though the STEP itself failed (this
+  // was previously unwrapped and would have thrown straight out of executeStep).
+  let successWalCleanupWarning: string | undefined;
+  try {
+    await options.traceBufferStore?.delete(options.runId, options.command);
+  } catch (err) {
+    successWalCleanupWarning = `Failed to clean up trace buffer after step completion: ${err instanceof Error ? err.message : String(err)}`;
+  }
 
   // Step 7: Build and return ResponseEnvelope.
   const nextActions = savedRun.terminal_state ? [] : buildNextActions(definition, savedRun);
@@ -1871,7 +1983,7 @@ export async function executeStep(
     status: 'ok',
     data: output,
     evidence: allEvidence,
-    warnings: mergeWarnings(traceWarnings, currentWarn),
+    warnings: mergeWarnings(traceWarnings, currentWarn, successWalCleanupWarning),
     errors: [],
     context_hint: orientation,
     run_phase: savedRun.run_phase,

--- a/packages/core/src/engine/reclaim-step.test.ts
+++ b/packages/core/src/engine/reclaim-step.test.ts
@@ -454,3 +454,166 @@ describe('reclaimStep — clearing the stale trace buffer (issue #198)', () => {
     expect(result.outcome).toBe('reclaimed');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fenced pre-update clear (issue #207 PR-2): a declaring store's WAL clear moves BEFORE the
+// un-claiming update, version-fenced against the decision read that made the reclaim call.
+// ---------------------------------------------------------------------------
+
+describe('reclaimStep — fenced pre-update clear (issue #207 PR-2)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-reclaim-fenced-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('call-order recorder: deleteFenced fires BEFORE the update on BOTH the primary and the CAS-retry path (forced first-update STATE_SNAPSHOT_MISMATCH), and warns with the destroyed count', async () => {
+    const { run } = await store.create({
+      workflowId: 'reclaim-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const claimed = await store.claimStep(run.id, 'step-agent', agentReclaimWf);
+    await store.update({ ...claimed, claims: { 'step-agent': { deadline: pastIso() } } });
+
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'dead_attempt_line' }]);
+
+    const calls: string[] = [];
+    const originalUpdate = store.update.bind(store);
+    let updateCallNum = 0;
+    vi.spyOn(store, 'update').mockImplementation(async (rec) => {
+      updateCallNum += 1;
+      if (updateCallNum === 1) {
+        calls.push('update#1(forced-reject)');
+        throw new WorkflowError('Version conflict — simulated', {
+          code: 'STATE_SNAPSHOT_MISMATCH',
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: true,
+        });
+      }
+      calls.push(`update#${updateCallNum}`);
+      return originalUpdate(rec);
+    });
+    const originalDeleteFenced = traceBufferStore.deleteFenced!.bind(traceBufferStore);
+    vi.spyOn(traceBufferStore, 'deleteFenced').mockImplementation(async (...args) => {
+      calls.push('deleteFenced');
+      return originalDeleteFenced(...args);
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await reclaimStep(store, run.id, 'step-agent', { traceBufferStore });
+      expect(result.outcome).toBe('reclaimed');
+      // Strict clear-before-update ordering, independently on EACH attempt.
+      expect(calls).toEqual([
+        'deleteFenced',
+        'update#1(forced-reject)',
+        'deleteFenced',
+        'update#2',
+      ]);
+      // The buffer was actually cleared (first deleteFenced call, before the forced-reject
+      // update, already drained it) — the second call is an idempotent no-op (already absent).
+      expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
+      // Drain-warn with count (the #198 delta): warns with the destroyed entry count > 0.
+      expect(
+        warnSpy.mock.calls.some(([msg]) =>
+          String(msg).includes('reclaim cleared 1 buffered trace entries'),
+        ),
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('version-fence refusal: a concurrent bump detected at EITHER clear-guard skips the clear (WAL intact) and warns — the state reclaim itself still proceeds via the existing CAS-retry machinery', async () => {
+    // A fully scripted store (mirrors the CAS-mismatch describe block above) — four DISTINCT
+    // get() calls occur in order: (1) the initial decision read, (2) the primary clear-guard's
+    // fresh get, (3) the CAS-retry's own reloaded re-evaluation read, (4) the retry clear-guard's
+    // fresh get. Scripting all four independently (rather than relying on the 2-record clamping
+    // shape the CAS-mismatch tests above use) lets this test force a version mismatch at BOTH
+    // clear-guard checkpoints deterministically, without also being forced through by the
+    // update() calls' own (separately scripted) CAS behavior.
+    const staleClaim = { deadline: pastIso() };
+    const decisionRead = makeRun({
+      in_progress_steps: ['work'],
+      claims: { work: staleClaim },
+      version: 5,
+    });
+    const primaryGuardSees = makeRun({
+      in_progress_steps: ['work'],
+      claims: { work: staleClaim },
+      version: 6,
+    });
+    const retryDecisionRead = makeRun({
+      in_progress_steps: ['work'],
+      claims: { work: staleClaim },
+      version: 6,
+    });
+    const retryGuardSees = makeRun({
+      in_progress_steps: ['work'],
+      claims: { work: staleClaim },
+      version: 9,
+    });
+    const records = [decisionRead, primaryGuardSees, retryDecisionRead, retryGuardSees];
+    let getIdx = 0;
+    const updateCalls: RunRecord[] = [];
+    let updateCallNum = 0;
+    const deleteFencedCalls: string[] = [];
+    const traceBufferStore: TraceBufferStore = {
+      append: async () => {
+        throw new Error('not used');
+      },
+      read: async () => [],
+      delete: async () => {
+        throw new Error('not used');
+      },
+      deleteAllForRun: async () => {},
+      readAllForRun: async () => ({}),
+      deleteFenced: async (_runId, _stepId, guard) => {
+        await guard(); // throws (refuses) at both checkpoints in this test — never reached below
+        deleteFencedCalls.push('cleared');
+        return 4;
+      },
+    };
+    const scriptedRunStore = {
+      persistsClaims: true,
+      get: async () => records[Math.min(getIdx++, records.length - 1)]!,
+      update: async (rec: RunRecord) => {
+        updateCallNum += 1;
+        if (updateCallNum === 1) {
+          throw new WorkflowError('Version conflict — simulated', {
+            code: 'STATE_SNAPSHOT_MISMATCH',
+            category: 'STATE',
+            agentAction: 'report_to_user',
+            retryable: true,
+          });
+        }
+        updateCalls.push(rec);
+        return { ...rec, version: rec.version + 1 };
+      },
+    } as unknown as RunStore;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await reclaimStep(scriptedRunStore, 'r1', 'work', { traceBufferStore });
+      // The state reclaim itself still proceeds — unaffected by either clear-guard refusal.
+      expect(result.outcome).toBe('reclaimed');
+      expect(updateCalls).toHaveLength(1); // re-applied once, on the reloaded record
+      // The WAL was NEVER cleared: both clear-guards refused.
+      expect(deleteFencedCalls).toHaveLength(0);
+      expect(
+        warnSpy.mock.calls.filter(([msg]) => String(msg).includes('version fence refused')),
+      ).toHaveLength(2); // once per refused attempt (primary + retry)
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/engine/reclaim-step.ts
+++ b/packages/core/src/engine/reclaim-step.ts
@@ -70,16 +70,26 @@ function applyReclaim(run: RunRecord, stepName: string, now: Date): RunRecord {
 }
 
 /**
- * Clears the reclaimed step's stale trace buffer (issue #198). This is correct, not merely
- * tidy: reclaim IS the recovery boundary for a dead claim — the buffer being cleared here was
- * never adopted into any settled evidence (the claim wedged before `execute_step` ever reached
- * its post-claim adoption read — see #185's execution-loop.ts), so nothing is being discarded
- * that any consumer has seen or could ever see. #185 already discards a losing attempt's WAL
- * lines at the WINNER's settlement time (whoever claims the step next adopts them, then they're
- * unlinked); #198 simply does the same discard EARLIER — at the moment the dead attempt is
- * declared dead, rather than leaving it on disk for the next attempt to silently adopt and then
- * have to caveat as "may include a prior writer" (`buffered_lines_adopted`). No SETTLED evidence
- * is ever touched by this function — only pre-claim, never-adopted buffer content.
+ * Clears the reclaimed step's stale trace buffer — the NON-declaring-store fallback (issue #198;
+ * superseded by `clearStaleWalFenced` below for any store declaring the fenced trio, issue #207
+ * PR-2). Order and behavior here are BYTE-FROZEN (called only after the un-claiming update,
+ * best-effort, warned-on-failure) — this is the normative fallback D3 §5 requires for a store
+ * that cannot fence the clear at all.
+ *
+ * Honest disposition (issue #207 PR-2 — this doc previously overclaimed a stronger guarantee than
+ * is actually true). It used to read: "nothing is being discarded that any consumer has seen or
+ * could ever see" — that is FALSE as of #207 PR-2's persist-gated failure-settle delete
+ * (execution-loop.ts: the WAL delete there now only fires once `store.update` has already
+ * SUCCEEDED). When that persist instead FAILS, the step is left in_progress with its trace
+ * ALREADY READ INTO an evidence write that never landed anywhere durable — reclaim is exactly the
+ * recovery path for that wedge, and this clear (fenced or not) destroys that adopted-but-
+ * unpersisted content too, same as it always destroyed pre-claim, never-adopted content. This is
+ * a DELIBERATE, WARNED policy (the #198 delta: reclaim always warns with the count it destroys),
+ * not a silent loss, and it is bounded: the destroyed content was never durable anywhere a future
+ * reader could find it (the failed `store.update` never committed), so this never destroys any
+ * consumer's already-durable view — only a write attempt that never took effect. Full
+ * preservation (a sidecar copy taken before this destructive clear) is #197's filed follow-up,
+ * not this function's job.
  *
  * Best-effort and non-blocking by design: a failed clear must never fail the reclaim itself (the
  * claim recovery is the important, safety-gated act; WAL hygiene is secondary) — but per the
@@ -99,6 +109,92 @@ async function clearStaleWal(
       `⚠ realm: failed to clear stale trace buffer for run '${runId}' step '${stepName}' during ` +
         `reclaim (${err instanceof Error ? err.message : String(err)}) — the reclaim itself ` +
         `still succeeded; the next attempt may adopt this buffer's lines.`,
+    );
+  }
+}
+
+/** Internal control-flow signal (issue #207 PR-2): thrown by `clearStaleWalFenced`'s own guard
+ *  when the run's version no longer matches the version captured at reclaim's decision read —
+ *  caught ONLY inside `clearStaleWalFenced`, immediately below; never propagates past this file.
+ *  A plain `Error` (deliberately NOT a `WorkflowError`) so no store's own error-classification
+ *  logic (e.g. a fenced fs store's `instanceof FsIoError` wrap-scoping) could ever mistake it for
+ *  something else — it exists purely as a private signal between the guard and its caller. */
+class ReclaimVersionChanged extends Error {}
+
+/** Outcome of `clearStaleWalFenced` (issue #207 PR-2) — what `reclaimStep` needs to decide what
+ *  to log; never surfaced to reclaim's own caller beyond the console.warn it drives. */
+interface FencedClearResult {
+  /** `true` iff the version fence refused (the clear was skipped, buffer left intact). */
+  skipped: boolean;
+  /** Entries actually cleared — meaningful only when `skipped` is `false`. */
+  count: number;
+}
+
+/**
+ * Fenced pre-update clear (issue #207 PR-2, D3 §5): clears the reclaimed step's trace buffer
+ * BEFORE the un-claiming `store.update`, guarded by a run-VERSION fence re-verified inside the
+ * SAME per-(runId, stepName) critical section `deleteFenced` uses. `expectedVersion` is the
+ * version captured at THIS call's own reclaim-decision read (the primary path's `run` at :133 —
+ * now above; the CAS-retry path's `reloaded` — never a fresh get taken here). Every `RunStore`
+ * mutation (claimStep, settle, reclaim) bumps `version`, so ANY intervening write on this run is
+ * detected — a concurrent claim/settle/reclaim of this exact step since the decision read means
+ * reclaim's premise ("this is a dead, still-in-progress claim") may no longer hold, and the guard
+ * refuses rather than risk destroying content a live/newer actor already adopted or is
+ * mid-adopting.
+ *
+ * A separate `step ∈ in_progress_steps` re-check is deliberately NOT added: since ANY store
+ * mutation bumps version, an unchanged version already implies a byte-identical record — the
+ * membership fact cannot have changed without the version changing too. D3 §5 states this
+ * explicitly: every agent `ClaimRecord` is `{deadline: null}`, so record identity/classification
+ * cannot discriminate further — the version fence alone is the whole guard.
+ *
+ * Returns `{skipped: true}` when the guard refused (the caller must skip-and-warn, never treat
+ * this as an error). Any OTHER thrown error (lock contention, genuine I/O failure) propagates to
+ * the caller UNCHANGED and must abort the reclaim entirely, BEFORE the un-claiming update — the
+ * decision table is total (guard-pass ⇒ drain-with-warned-count; guard-refusal ⇒ skip+warn;
+ * genuine throw ⇒ propagate, claim intact, retryable).
+ */
+async function clearStaleWalFenced(
+  store: RunStore,
+  traceBufferStore: TraceBufferStore,
+  runId: string,
+  stepName: string,
+  expectedVersion: number,
+): Promise<FencedClearResult> {
+  const guard = async (): Promise<void> => {
+    // Fresh lock-free read — never the record already in hand (`run`/`reloaded`), which is
+    // exactly what this guard exists to re-verify against.
+    const fresh = await store.get(runId);
+    if (fresh.version !== expectedVersion) {
+      throw new ReclaimVersionChanged(
+        `reclaim's version fence refused: run '${runId}' changed since the reclaim decision ` +
+          `(expected version ${expectedVersion}, observed ${fresh.version})`,
+      );
+    }
+  };
+  try {
+    const count = await traceBufferStore.deleteFenced!(runId, stepName, guard);
+    return { skipped: false, count };
+  } catch (err) {
+    if (err instanceof ReclaimVersionChanged) {
+      return { skipped: true, count: 0 };
+    }
+    throw err;
+  }
+}
+
+/** Logs the fenced clear's decision-table outcome (issue #207 PR-2) — the sole place this
+ *  console.warn is emitted, called from both reclaimStep call sites. */
+function warnFencedClearOutcome(runId: string, stepName: string, result: FencedClearResult): void {
+  if (result.skipped) {
+    console.warn(
+      `⚠ realm: skipped clearing the trace buffer for run '${runId}' step '${stepName}' during ` +
+        'reclaim — the run changed since the reclaim decision (version fence refused); the ' +
+        'buffer is left intact.',
+    );
+  } else if (result.count > 0) {
+    console.warn(
+      `reclaim cleared ${result.count} buffered trace entries for run '${runId}' step '${stepName}'.`,
     );
   }
 }
@@ -173,9 +269,30 @@ export async function reclaimStep(
     return { run, step: stepName, outcome: 'already_settled', priorState, priorDeadline };
   }
 
+  // issue #207 PR-2: a declaring store's clear moves BEFORE the un-claiming update, version-fenced
+  // against the decision read's own version (`run.version`, just above) — a non-declaring store
+  // falls back to the byte-frozen legacy order (after the update, best-effort). `fenced` decides
+  // which branch each call site below takes; a `deleteFenced`/lock/I-O throw from the fenced path
+  // propagates BEFORE any update runs (claim intact, reclaim aborts loudly, retryable).
+  const traceBufferStore = options?.traceBufferStore;
+  const fenced =
+    traceBufferStore !== undefined && typeof traceBufferStore.deleteFenced === 'function';
+
   try {
+    if (fenced) {
+      const clearResult = await clearStaleWalFenced(
+        store,
+        traceBufferStore,
+        runId,
+        stepName,
+        run.version,
+      );
+      warnFencedClearOutcome(runId, stepName, clearResult);
+    }
     const updated = await store.update(applyReclaim(run, stepName, now));
-    await clearStaleWal(options?.traceBufferStore, runId, stepName);
+    if (!fenced) {
+      await clearStaleWal(traceBufferStore, runId, stepName);
+    }
     return { run: updated, step: stepName, outcome: 'reclaimed', priorState, priorDeadline };
   } catch (err) {
     if (!(err instanceof WorkflowError) || err.code !== 'STATE_SNAPSHOT_MISMATCH') throw err;
@@ -202,8 +319,22 @@ export async function reclaimStep(
     }
     // Still a stale / unknown-age wedge after the concurrent write → re-apply ONCE on the fresh
     // record. A second mismatch propagates (reclaim loses, abandon-style — no retry loop).
+    // issue #207 PR-2: same fenced-clear-before-update shape as the primary path above, but
+    // version-fenced against THIS path's own decision read (`reloaded.version`) — never `run`'s.
+    if (fenced) {
+      const clearResult = await clearStaleWalFenced(
+        store,
+        traceBufferStore,
+        runId,
+        stepName,
+        reloaded.version,
+      );
+      warnFencedClearOutcome(runId, stepName, clearResult);
+    }
     const updated = await store.update(applyReclaim(reloaded, stepName, now));
-    await clearStaleWal(options?.traceBufferStore, runId, stepName);
+    if (!fenced) {
+      await clearStaleWal(traceBufferStore, runId, stepName);
+    }
     return { run: updated, step: stepName, outcome: 'reclaimed', priorState, priorDeadline };
   }
 }

--- a/packages/core/src/types/workflow-error.ts
+++ b/packages/core/src/types/workflow-error.ts
@@ -38,6 +38,12 @@ export type ErrorCode =
   // Retryable: a live writer self-heals, and a stale lock is eventually stolen (issue #184).
   | 'STATE_RUN_BUSY'
   | 'STATE_TRANSITION_DENIED'
+  // gc's orphan-artifact sweep (issue #207 PR-2): a fenced destroy-guard's fresh read found the
+  // run EXISTS AGAIN — a JsonFileStore.save() re-import landed between the sweep's snapshot and
+  // the reap. Purely an internal signal between that guard and gc's own catch (routes it to the
+  // `resurrected` bucket, never `failed`/an aborted sweep) — not expected to surface in any
+  // envelope.
+  | 'STATE_RUN_RESURRECTED'
   | 'STATE_LEGACY_FORMAT'
   | 'STATE_STEP_ALREADY_CLAIMED'
   | 'STATE_STEP_NOT_ELIGIBLE'

--- a/packages/mcp-server/src/tools/append-trace-fenced-adoption.test.ts
+++ b/packages/mcp-server/src/tools/append-trace-fenced-adoption.test.ts
@@ -1,0 +1,223 @@
+// Behavioral spy tests for append_trace's fenced-trio adoption (issue #207 PR-2, D3 §2).
+//
+// Confirms the actual DISPATCH behavior, not just outcomes: capability-present routes through
+// appendFenced (never raw append) for non-empty entries, with no advisory; capability-absent
+// routes through raw append with the envelope advisory present; empty entries always use the raw
+// unlocked path regardless of capability (D3 §2: unchanged, no advisory either way).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  InMemoryTraceBufferStore,
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+} from '@sensigo/realm';
+import type {
+  WorkflowDefinition,
+  AppendResult,
+  BufferedEntry,
+  AgentTraceEntry,
+  TraceBufferStore,
+} from '@sensigo/realm';
+import { handleAppendTrace, resetUnfencedTraceStoreWarnings } from './append-trace.js';
+
+function makeWorkflowDef(): WorkflowDefinition {
+  return {
+    id: 'append-trace-spy-wf',
+    name: 'Append Trace Spy Test Workflow',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    steps: {
+      'step-auto': { description: 'Auto step', execution: 'auto', depends_on: [] },
+      'step-agent': { description: 'Agent step', execution: 'agent', depends_on: ['step-auto'] },
+    },
+  };
+}
+
+/** Minimal legacy-only TraceBufferStore stub (issue #207 PR-2): implements ONLY the four legacy
+ *  methods — no fenced trio declared at all, so `typeof store.appendFenced === 'function'` is
+ *  false and append_trace's capability-absent branch is exercised. Call-counted for the spy
+ *  assertions below (deliberately simple — not a conformance-grade store). */
+class LegacyOnlyTraceBufferStore {
+  appendCalls = 0;
+  private buffers = new Map<string, BufferedEntry[]>();
+
+  async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
+    this.appendCalls++;
+    const k = `${runId}:${stepId}`;
+    const existing = this.buffers.get(k) ?? [];
+    const updated = [...existing, ...entries.map((e) => ({ ...e, _internalTs: 0 }))];
+    this.buffers.set(k, updated);
+    return {
+      buffer_count: updated.length,
+      buffer_bytes: 0,
+      limit_count: 200,
+      limit_bytes: 100 * 1024,
+      final_limit_entries: 100,
+      final_limit_bytes: 50 * 1024,
+    };
+  }
+
+  async read(runId: string, stepId: string): Promise<BufferedEntry[]> {
+    return this.buffers.get(`${runId}:${stepId}`) ?? [];
+  }
+
+  async delete(runId: string, stepId: string): Promise<void> {
+    this.buffers.delete(`${runId}:${stepId}`);
+  }
+
+  async deleteAllForRun(runId: string): Promise<void> {
+    for (const k of [...this.buffers.keys()]) {
+      if (k.startsWith(`${runId}:`)) this.buffers.delete(k);
+    }
+  }
+
+  async readAllForRun(runId: string): Promise<Record<string, unknown[]>> {
+    const result: Record<string, unknown[]> = {};
+    for (const [k, v] of this.buffers.entries()) {
+      if (k.startsWith(`${runId}:`)) result[k.slice(runId.length + 1)] = v;
+    }
+    return result;
+  }
+}
+
+describe('append_trace fenced-trio adoption — behavioral spy (issue #207 PR-2)', () => {
+  let runDir: string;
+  let workflowDir: string;
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    runDir = await mkdtemp(join(tmpdir(), 'realm-append-trace-spy-runs-'));
+    workflowDir = await mkdtemp(join(tmpdir(), 'realm-append-trace-spy-wf-'));
+    runStore = new JsonFileStore(runDir);
+    workflowStore = new JsonWorkflowStore(workflowDir);
+    const def = makeWorkflowDef();
+    await writeFile(join(workflowDir, `${def.id}.json`), JSON.stringify(def, null, 2), 'utf8');
+    resetUnfencedTraceStoreWarnings();
+  });
+
+  it('capability present + non-empty entries: appendFenced exactly once, raw append never, no advisory', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-spy-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    const appendFencedSpy = vi.spyOn(traceBufferStore, 'appendFenced');
+    const appendSpy = vi.spyOn(traceBufferStore, 'append');
+
+    const result = await handleAppendTrace(
+      { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'x' }] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    expect(appendFencedSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy).not.toHaveBeenCalled();
+    expect(result.status).toBe('ok');
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('empty entries: raw append exactly once regardless of capability (capability present)', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-spy-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    const appendFencedSpy = vi.spyOn(traceBufferStore, 'appendFenced');
+    const appendSpy = vi.spyOn(traceBufferStore, 'append');
+
+    const result = await handleAppendTrace(
+      { run_id: run.id, step_id: 'step-agent', entries: [] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(appendFencedSpy).not.toHaveBeenCalled();
+    expect(result.status).toBe('ok');
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('empty entries: raw append exactly once regardless of capability (capability absent)', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-spy-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new LegacyOnlyTraceBufferStore();
+
+    const result = await handleAppendTrace(
+      { run_id: run.id, step_id: 'step-agent', entries: [] },
+      {
+        runStore,
+        workflowStore,
+        traceBufferStore: traceBufferStore as unknown as TraceBufferStore,
+      },
+    );
+
+    expect(traceBufferStore.appendCalls).toBe(1);
+    expect(result.status).toBe('ok');
+    // Empty-entries probe never advises, even capability-absent (D3 §2: unchanged either way).
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('capability absent + non-empty entries: raw append exactly once, envelope advisory present', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-spy-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new LegacyOnlyTraceBufferStore();
+
+    const result = await handleAppendTrace(
+      { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'x' }] },
+      {
+        runStore,
+        workflowStore,
+        traceBufferStore: traceBufferStore as unknown as TraceBufferStore,
+      },
+    );
+
+    expect(traceBufferStore.appendCalls).toBe(1);
+    expect(result.status).toBe('ok');
+    expect(result.warnings).toEqual([
+      'this store does not fence trace appends against concurrent settlement; entries ' +
+        'acknowledged here may not be adopted',
+    ]);
+  });
+
+  it('capability-absent console.warn is deduped per store constructor name across calls', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-spy-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new LegacyOnlyTraceBufferStore();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'x' }] },
+        {
+          runStore,
+          workflowStore,
+          traceBufferStore: traceBufferStore as unknown as TraceBufferStore,
+        },
+      );
+      await handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'y' }] },
+        {
+          runStore,
+          workflowStore,
+          traceBufferStore: traceBufferStore as unknown as TraceBufferStore,
+        },
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/append-trace.test.ts
+++ b/packages/mcp-server/src/tools/append-trace.test.ts
@@ -102,7 +102,7 @@ describe('handleAppendTrace', () => {
     });
   });
 
-  it('throws STATE_STEP_NOT_ELIGIBLE when step is in completed_steps', async () => {
+  it('throws STATE_STEP_NOT_ELIGIBLE (step_state: completed) when step is in completed_steps', async () => {
     const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
@@ -121,11 +121,57 @@ describe('handleAppendTrace', () => {
     ).rejects.toMatchObject({
       code: 'STATE_STEP_NOT_ELIGIBLE',
       agentAction: 'report_to_user',
-      details: { step_state: 'already_claimed' },
+      // issue #207 PR-2: the granular taxonomy replaces the old lumped 'already_claimed' value.
+      details: { step_state: 'completed' },
     });
   });
 
-  it('throws STATE_STEP_NOT_ELIGIBLE when step is in in_progress_steps', async () => {
+  it('throws STATE_STEP_NOT_ELIGIBLE (step_state: failed) when step is in failed_steps', async () => {
+    const { run: run } = await runStore.create({
+      workflowId: 'append-trace-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await runStore.update({
+      ...run,
+      failed_steps: ['step-agent'],
+      in_progress_steps: [],
+    });
+    await expect(
+      handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'test' }] },
+        { runStore, workflowStore, traceBufferStore },
+      ),
+    ).rejects.toMatchObject({
+      code: 'STATE_STEP_NOT_ELIGIBLE',
+      agentAction: 'report_to_user',
+      details: { step_state: 'failed' },
+    });
+  });
+
+  it('throws STATE_STEP_NOT_ELIGIBLE (step_state: skipped) when step is in skipped_steps (issue #207, the latent omission)', async () => {
+    const { run: run } = await runStore.create({
+      workflowId: 'append-trace-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await runStore.update({
+      ...run,
+      skipped_steps: ['step-agent'],
+    });
+    await expect(
+      handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'test' }] },
+        { runStore, workflowStore, traceBufferStore },
+      ),
+    ).rejects.toMatchObject({
+      code: 'STATE_STEP_NOT_ELIGIBLE',
+      agentAction: 'report_to_user',
+      details: { step_state: 'skipped' },
+    });
+  });
+
+  it('throws STATE_STEP_NOT_ELIGIBLE (step_state: in_progress, agentAction: resolve_precondition) when step is in in_progress_steps', async () => {
     const { run: run } = await runStore.create({
       workflowId: 'append-trace-wf',
       workflowVersion: 1,
@@ -142,7 +188,9 @@ describe('handleAppendTrace', () => {
       ),
     ).rejects.toMatchObject({
       code: 'STATE_STEP_NOT_ELIGIBLE',
-      agentAction: 'report_to_user',
+      // issue #207 PR-2: aligned to claimStep's STATE_STEP_ALREADY_CLAIMED precedent — the same
+      // in_progress state must never yield two different agent actions across tools.
+      agentAction: 'resolve_precondition',
       details: { step_state: 'in_progress' },
     });
   });

--- a/packages/mcp-server/src/tools/append-trace.ts
+++ b/packages/mcp-server/src/tools/append-trace.ts
@@ -12,6 +12,7 @@ import {
   type AgentTraceEntry,
   type ResponseEnvelope,
   type RunStore,
+  type RunRecord,
 } from '@sensigo/realm';
 import { traceEntrySchema } from './execute-step.js';
 import { sseJsonStringify } from '../sse-json.js';
@@ -23,7 +24,81 @@ export interface HandleAppendTraceStores {
   traceBufferStore?: TraceBufferStore;
 }
 
-export type AppendTraceOkResult = { status: 'ok' } & AppendResult;
+export type AppendTraceOkResult = { status: 'ok' } & AppendResult & {
+    /**
+     * Advisory only, never a gate (#119) — present only when the configured `traceBufferStore`
+     * does NOT declare the fenced trio (issue #207 PR-2): this append was not fenced against a
+     * concurrent settlement, so the entries acknowledged here may end up neither adopted nor
+     * refused (silently orphaned WAL content). Absent entirely once the store declares the trio.
+     */
+    warnings?: string[];
+  };
+
+/** The specific settled/in-flight state for a step, or `undefined` if none apply — the granular
+ *  counterpart to `isStepSettledOrInFlight` (issue #207 PR-2). `append_trace`'s refusal detail
+ *  must name WHICH state applies: agent guidance differs by state (`in_progress` invites a retry
+ *  once `execute_step` finishes; `completed`/`failed`/`skipped` are permanent). Checked in a fixed
+ *  priority order, reused identically pre-CS and inside the `appendFenced` guard so both paths
+ *  agree on the same taxonomy. */
+function stepStateOf(
+  run: RunRecord,
+  stepId: string,
+): 'completed' | 'failed' | 'skipped' | 'in_progress' | undefined {
+  if (run.completed_steps.includes(stepId)) return 'completed';
+  if (run.failed_steps.includes(stepId)) return 'failed';
+  if (run.skipped_steps.includes(stepId)) return 'skipped';
+  if (run.in_progress_steps.includes(stepId)) return 'in_progress';
+  return undefined;
+}
+
+/** The full `append_trace` refusal taxonomy (issue #207 PR-2): every reason a trace append can be
+ *  refused, pre-CS or from inside the `appendFenced` guard, is one of these six — always code
+ *  `STATE_STEP_NOT_ELIGIBLE`, distinguished by `details.step_state`. `in_progress` is the only
+ *  RESOLVABLE state (the claim will eventually settle) so it alone gets `agentAction:
+ *  'resolve_precondition'` — matching `claimStep`'s own `STATE_STEP_ALREADY_CLAIMED` precedent
+ *  (the same state must never yield two different agent actions depending on which tool observed
+ *  it). The other five are permanent from this call's perspective and stay `report_to_user`. */
+type StepEligibilityState =
+  | 'completed'
+  | 'failed'
+  | 'skipped'
+  | 'in_progress'
+  | 'run_terminal'
+  | 'run_not_found';
+
+function stepNotEligibleError(
+  stepId: string,
+  runVersion: number,
+  stepState: StepEligibilityState,
+  extraDetails?: Record<string, unknown>,
+): WorkflowError {
+  const messages: Record<StepEligibilityState, string> = {
+    completed: `Step '${stepId}' has already completed.`,
+    failed: `Step '${stepId}' has already failed.`,
+    skipped: `Step '${stepId}' was skipped.`,
+    in_progress: `Step '${stepId}' is currently being executed by execute_step.`,
+    run_terminal: `Run is terminal — trace entries can no longer be adopted by any step.`,
+    run_not_found: `Run not found at write time — trace entries can no longer be adopted.`,
+  };
+  return new WorkflowError(messages[stepState], {
+    code: 'STATE_STEP_NOT_ELIGIBLE',
+    category: 'STATE',
+    agentAction: stepState === 'in_progress' ? 'resolve_precondition' : 'report_to_user',
+    retryable: false,
+    details: { step_id: stepId, step_state: stepState, run_version: runVersion, ...extraDetails },
+  });
+}
+
+/** Store-constructor names already warned about lacking the fenced trio (issue #207 PR-2) —
+ *  module-level so a long-lived process warns once per store type, not once per call. Exported
+ *  ONLY for test isolation (`resetUnfencedTraceStoreWarnings`) — production code never calls it. */
+const warnedUnfencedStoreNames = new Set<string>();
+
+/** Test-only reset hook (issue #207 PR-2): clears the dedup set so a test can assert the
+ *  console.warn fires fresh, independent of any earlier test's use of a same-named store class. */
+export function resetUnfencedTraceStoreWarnings(): void {
+  warnedUnfencedStoreNames.clear();
+}
 
 /**
  * Business logic for the append_trace tool.
@@ -102,27 +177,14 @@ export async function handleAppendTrace(
     );
   }
 
-  // 5. Check step eligibility — must not be completed, failed, or in-progress.
-  if (run.completed_steps.includes(args.step_id) || run.failed_steps.includes(args.step_id)) {
-    throw new WorkflowError(
-      `Step '${args.step_id}' has already been claimed (completed or failed).`,
-      {
-        code: 'STATE_STEP_NOT_ELIGIBLE',
-        category: 'STATE',
-        agentAction: 'report_to_user',
-        retryable: false,
-        details: { step_id: args.step_id, step_state: 'already_claimed', run_version: run.version },
-      },
-    );
-  }
-  if (run.in_progress_steps.includes(args.step_id)) {
-    throw new WorkflowError(`Step '${args.step_id}' is currently being executed by execute_step.`, {
-      code: 'STATE_STEP_NOT_ELIGIBLE',
-      category: 'STATE',
-      agentAction: 'report_to_user',
-      retryable: false,
-      details: { step_id: args.step_id, step_state: 'in_progress', run_version: run.version },
-    });
+  // 5. Pre-CS fast-fail eligibility check (issue #207 PR-2): granular step_state values aligned
+  // to the guard taxonomy (stepStateOf/stepNotEligibleError, above) — 'skipped' is a NEW check
+  // (the latent omission D3 identified: a skipped step could previously still accept a trace
+  // append). Race-invariant: step existence and execution === 'agent' were already closed over
+  // above: this check only reads the four step-membership arrays off the SAME pre-CS `run` load.
+  const preCsState = stepStateOf(run, args.step_id);
+  if (preCsState !== undefined) {
+    throw stepNotEligibleError(args.step_id, run.version, preCsState);
   }
 
   // Steps 6 + 7: Require buffer store for any append_trace operation.
@@ -135,15 +197,72 @@ export async function handleAppendTrace(
     });
   }
 
-  // 6. Empty entries — return current buffer state without writing.
+  // 6. Empty entries — return current buffer state without writing. Stays on the raw unlocked
+  // path UNCONDITIONALLY (issue #207 PR-2, D3 §2) — writes nothing, so there is no settlement
+  // race to fence against and no advisory to add, regardless of what the store declares.
   if (args.entries.length === 0) {
     const result = await traceBufferStore.append(args.run_id, args.step_id, []);
     return { status: 'ok', ...result };
   }
 
   // 7. Append entries to the buffer.
+  if (typeof traceBufferStore.appendFenced === 'function') {
+    // Capability present (issue #207 PR-2): guard = ONE fresh lock-free runStore.get,
+    // re-verifying the exact same premise the pre-CS check above already established, but at
+    // write time — this is what closes append-trace.ts's Window A (D3 problem statement): a
+    // concurrent execute_step claiming/settling the step between the pre-CS load and the
+    // physical write. The guard performs exactly one store read and nothing else, per the fenced
+    // trio's own contract.
+    const appendFenced = traceBufferStore.appendFenced.bind(traceBufferStore);
+    const guard = async (): Promise<void> => {
+      let freshRun: RunRecord;
+      try {
+        freshRun = await runStore.get(args.run_id);
+      } catch (err) {
+        if (err instanceof WorkflowError && err.code === 'STATE_RUN_NOT_FOUND') {
+          throw stepNotEligibleError(args.step_id, run.version, 'run_not_found');
+        }
+        // Any other failure propagates UNWRAPPED, per the fenced trio's own guard contract —
+        // never assume every guard failure fits this tool's own eligibility taxonomy.
+        throw err;
+      }
+      if (isTerminalPhase(freshRun.run_phase)) {
+        throw stepNotEligibleError(args.step_id, freshRun.version, 'run_terminal', {
+          run_phase: freshRun.run_phase,
+        });
+      }
+      const freshState = stepStateOf(freshRun, args.step_id);
+      if (freshState !== undefined) {
+        throw stepNotEligibleError(args.step_id, freshRun.version, freshState);
+      }
+    };
+    const result = await appendFenced(args.run_id, args.step_id, args.entries, guard);
+    return { status: 'ok', ...result };
+  }
+
+  // Capability absent (issue #207 PR-2): legacy unfenced append() — Window A stays open for this
+  // store. Deduped console.warn (once per store constructor name, not once per call) plus an
+  // envelope advisory on every success response — advisory only, never gates (#119); this branch
+  // is unreachable once the store declares the trio.
+  const storeName = traceBufferStore.constructor.name;
+  if (!warnedUnfencedStoreNames.has(storeName)) {
+    warnedUnfencedStoreNames.add(storeName);
+    console.warn(
+      `[append_trace] trace buffer store '${storeName}' does not declare the fenced trio (issue ` +
+        '#207) — appended entries are not fenced against a concurrent settlement and may end up ' +
+        'neither adopted nor refused. See the response envelope\'s "warnings" field for the ' +
+        'same caveat on every affected call.',
+    );
+  }
   const result = await traceBufferStore.append(args.run_id, args.step_id, args.entries);
-  return { status: 'ok', ...result };
+  return {
+    status: 'ok',
+    ...result,
+    warnings: [
+      'this store does not fence trace appends against concurrent settlement; entries ' +
+        'acknowledged here may not be adopted',
+    ],
+  };
 }
 
 /** Registers the append_trace MCP tool on the server. */


### PR DESCRIPTION
## Context

PR-2 of 2 for issue #207 (PR-1: #209, merged — the fenced trio interface, both conforming store
implementations, and the deterministic forcing TCK, dormant). This PR adopts the capability at
every in-repo call site, completing the "Serialized Adoption with a Fenced Trio + Serialized
Reads" design (D3 — eight design iterations, two multi-lens adversarial panels, a final
completeness verification).

## Motivation

With PR-1 dormant, every destructive WAL path still ran unfenced: `append_trace` raced
settlement through a stale eligibility snapshot (silently destroying acknowledged trace data — a
false attestation), reclaim's `--force` cleared live WALs after un-claiming, purge/gc could
destroy a resumed/re-imported run's buffers, and CLI-driven runs never adopted streamed trace at
all. This PR closes all of it per D3 §2/§5's unified deletion contract: "a WAL may be destroyed
only after settlement (fence refuses all subsequent appends), or under an in-CS guard that
re-verifies the destroyer's premise at destruction time — never while the step is claimable
without a guard."

## Changes

- **`append_trace`**: write-time fence via `appendFenced` (guard = one fresh lock-free
  `runStore.get` + full refusal taxonomy in `details.step_state`, six values); pre-CS checks gain
  `skipped_steps` (a latent omission) and align `in_progress`'s `agentAction` to
  `resolve_precondition`; capability-absent stores get a per-response envelope advisory + a
  deduped console warning.
- **`execution-loop.ts`**: success-settle delete wrapped (cleanup failure degrades to a warning
  on a completed run, never an error envelope); failure-settle delete gated on the update
  actually persisting (WAL survives as sole evidence copy otherwise); capability-block delete
  removed (auto-only vs agent-only — disjoint populations); both WAL reads wrapped — pre-claim
  returns a typed retryable envelope, post-claim performs a compensating un-claim built from the
  claim's own record (CAS against its own version — can never release a successor's claim) with
  an audit-evidence entry.
- **`reclaim-step.ts`**: both clear sites move BEFORE the un-claiming update via `deleteFenced`,
  guarded by a run-version fence (skip + warn when the run changed since the reclaim decision);
  drains warn with the destroyed entry count (the #198 delta — warned instead of silent);
  non-declaring stores keep the byte-frozen legacy order; the stale doc block's false claim
  rewritten.
- **`purge`**: WAL deletes via `deleteAllForRunFenced` with an absent-or-still-terminal guard —
  #184's terminal-re-verify extended to the artifact layer; refusals land in the existing
  `blocked` bucket. The failed-attempt sidecar stays legacy (named residual, telemetry-grade).
- **`gc`**: orphan reaps re-verify run absence at destruction time (closing the `save()`
  re-import resurrect race); a resurrected run's files land in a new exit-code-neutral
  `resurrected` bucket.
- **CLI executors** (`realm run`, `realm agent`): now construct and pass `JsonTraceBufferStore`
  — streamed trace from a co-deployed MCP server is adopted into evidence (previously silently
  neither adopted nor refused).
- **Source-text guards**: exact-count allow-lists for raw `delete`/`deleteAllForRun` (Guard 4)
  and raw `append` (Guard 5) call sites — a new unfenced call site turns a test red.
- New `ErrorCode` `STATE_RUN_RESURRECTED` (additive; gc-internal guard signal).

## Verification

- Full suite, forced: core 1718, mcp 202, testing 81, cli 743 — all green; lint/versions/audit
  clean.
- 13 mutation probes (12 required + 1 bonus) each red → restored byte-identical → green; five
  reproduced independently during Master Architect review (compensating un-claim, version-fence,
  resurrect guard, Guard-5 count, and the fenced-delete-reintroduction blind-spot proof).
- Two independent line-by-line deep reviews (engine half, tool/CLI half) against the normative
  design — zero mechanical defects; all deviations disclosed and verified sound.
- End-to-end behavioral test: WAL seeded before a CLI-driven run is adopted into evidence and
  cleared on settlement.

## Rollback

Revert the three commits (`515c430`, `831c0b8`; PR-1's `8ff8451`/`e9b98af` can stay — the trio
reverts to dormant). No data-format migrations; the WAL file format is unchanged throughout.

## Related

- Closes #207 (with PR-1 #209)
- #198 (clear behavior narrowed — now warned + version-fenced), #185 (provenance caveats
  unchanged), #184 (terminal-re-verify extended to artifacts), #163 (gc resurrect guard), #187
  (terminal refusal now enforced at write time), #197 (full preservation sidecar — still the
  deferred completion)
- Design record: `plans/issue-207-design-d3.md` (local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
