### PR TITLE
feat(mcp): advisory capacity early-warning on append_trace (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ All notable changes to this project are documented here.
   the configured `traceBufferStore` does not declare the fenced trio — appended entries are not
   fenced against a concurrent settlement and may end up neither adopted nor refused. Auto-clears
   once the store declares the trio.
+- **`append_trace` capacity early-warning (issue #208).** Responses now carry an advisory
+  `warnings` entry once the step's trace buffer crosses 80% of either ceiling (entry count or
+  bytes, whichever is closer to its own limit) — actionable before the buffer hits `BUFFER_FULL`
+  outright. Purely advisory (never gates, never changes `status`) and store-agnostic (reads only
+  `AppendResult`'s already-returned fields; works identically regardless of which
+  `TraceBufferStore` implementation is injected).
 
 ### Changed
 

--- a/packages/mcp-server/src/tools/append-trace-capacity-warning.test.ts
+++ b/packages/mcp-server/src/tools/append-trace-capacity-warning.test.ts
@@ -1,0 +1,281 @@
+// Tests for append_trace's capacity early-warning (issue #208).
+//
+// AC 3: covered entirely against InMemoryTraceBufferStore (store-agnostic by construction — the
+// helper reads only AppendResult's already-returned fields, never store internals). AC 4 (works
+// identically regardless of which store is injected) is exercised by the "unfenced store" test
+// using a second, independent store stub — both stores produce the same warning shape from the
+// same fill ratios.
+//
+// Crossing scenarios deliberately loop appending one entry at a time (rather than hand-computing
+// an exact seed count) and stop the moment `warnings` first appears — this is fully deterministic
+// (no randomness, no timing dependence: the same entry-generator always crosses at the same
+// iteration) while avoiding brittle hand-arithmetic over JSON.stringify's exact byte overhead.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  InMemoryTraceBufferStore,
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+  BUFFER_LIMIT_COUNT,
+} from '@sensigo/realm';
+import type {
+  WorkflowDefinition,
+  AppendResult,
+  BufferedEntry,
+  AgentTraceEntry,
+  TraceBufferStore,
+} from '@sensigo/realm';
+import { handleAppendTrace } from './append-trace.js';
+
+function makeWorkflowDef(): WorkflowDefinition {
+  return {
+    id: 'append-trace-capacity-wf',
+    name: 'Append Trace Capacity Test Workflow',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    steps: {
+      'step-agent': { description: 'Agent step', execution: 'agent', depends_on: [] },
+    },
+  };
+}
+
+/** A tiny entry — negligible bytes, so repeated appends drive the COUNT ratio toward its ceiling
+ *  long before the BYTES ratio moves at all. */
+function tinyEntry(seed: number): AgentTraceEntry {
+  return { event: `e${seed}` };
+}
+
+/** A large-data entry — 20 keys (MAX_DATA_KEYS) of 500 chars each (MAX_STRING_VALUE), so the
+ *  normalizer never caps/distorts it — each one contributes ~10KB, driving the BYTES ratio toward
+ *  its ceiling in a handful of appends while the COUNT ratio (denominator 200) stays negligible. */
+function bigDataEntry(seed: number): AgentTraceEntry {
+  const data: Record<string, string> = {};
+  for (let i = 0; i < 20; i++) {
+    data[`k${i}`] = `${seed}-` + 'x'.repeat(495);
+  }
+  return { event: `big${seed}`, data };
+}
+
+/** Minimal legacy-only TraceBufferStore stub (no fenced trio declared) — exercises the
+ *  capability-absent branch, mirroring append-trace-fenced-adoption.test.ts's own local stub
+ *  (each test file keeps its own, per this repo's established per-file-stub convention). */
+class LegacyOnlyTraceBufferStore {
+  private buffers = new Map<string, BufferedEntry[]>();
+
+  async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
+    const k = `${runId}:${stepId}`;
+    const existing = this.buffers.get(k) ?? [];
+    const updated = [...existing, ...entries.map((e) => ({ ...e, _internalTs: 0 }))];
+    this.buffers.set(k, updated);
+    return {
+      buffer_count: updated.length,
+      buffer_bytes: Buffer.byteLength(JSON.stringify(updated)),
+      limit_count: 200,
+      limit_bytes: 100 * 1024,
+      final_limit_entries: 100,
+      final_limit_bytes: 50 * 1024,
+    };
+  }
+
+  async read(runId: string, stepId: string): Promise<BufferedEntry[]> {
+    return this.buffers.get(`${runId}:${stepId}`) ?? [];
+  }
+
+  async delete(runId: string, stepId: string): Promise<void> {
+    this.buffers.delete(`${runId}:${stepId}`);
+  }
+
+  async deleteAllForRun(runId: string): Promise<void> {
+    for (const k of [...this.buffers.keys()]) {
+      if (k.startsWith(`${runId}:`)) this.buffers.delete(k);
+    }
+  }
+
+  async readAllForRun(runId: string): Promise<Record<string, unknown[]>> {
+    const result: Record<string, unknown[]> = {};
+    for (const [k, v] of this.buffers.entries()) {
+      if (k.startsWith(`${runId}:`)) result[k.slice(runId.length + 1)] = v;
+    }
+    return result;
+  }
+}
+
+describe('append_trace capacity early-warning (issue #208)', () => {
+  let runDir: string;
+  let workflowDir: string;
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  async function setup(): Promise<{ runId: string }> {
+    runDir = await mkdtemp(join(tmpdir(), 'realm-capacity-warn-runs-'));
+    workflowDir = await mkdtemp(join(tmpdir(), 'realm-capacity-warn-wf-'));
+    runStore = new JsonFileStore(runDir);
+    workflowStore = new JsonWorkflowStore(workflowDir);
+    const def = makeWorkflowDef();
+    await writeFile(join(workflowDir, `${def.id}.json`), JSON.stringify(def, null, 2), 'utf8');
+    const { run } = await runStore.create({
+      workflowId: 'append-trace-capacity-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    return { runId: run.id };
+  }
+
+  // 1. Below threshold -> no warnings field at all (fenced store).
+  it('below threshold: no warnings field (fenced store)', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new InMemoryTraceBufferStore();
+
+    const result = await handleAppendTrace(
+      { run_id: runId, step_id: 'step-agent', entries: [{ event: 'tiny' }] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    expect(result.status).toBe('ok');
+    expect(result.warnings).toBeUndefined();
+  });
+
+  // 2. Count-driven crossing.
+  it('count-driven crossing: warning present, names entries as the binding dimension, correct numbers', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new InMemoryTraceBufferStore();
+
+    let result: Awaited<ReturnType<typeof handleAppendTrace>> | undefined;
+    let seed = 0;
+    do {
+      result = await handleAppendTrace(
+        { run_id: runId, step_id: 'step-agent', entries: [tinyEntry(seed++)] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+    } while (result.warnings === undefined && seed < BUFFER_LIMIT_COUNT);
+
+    expect(seed).toBeLessThan(BUFFER_LIMIT_COUNT); // sanity: it actually crossed
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    const [warning] = result.warnings!;
+    expect(warning).toContain('entries');
+    expect(warning).toContain(`${result.buffer_count}/${result.limit_count}`);
+    expect(warning).not.toMatch(/\d+\/\d+ bytes/); // bytes is NOT the binding dimension here
+    // Well under the bytes ceiling — tiny entries never move the bytes ratio meaningfully.
+    expect(result.buffer_bytes / result.limit_bytes).toBeLessThan(0.5);
+  });
+
+  // 3. Bytes-driven crossing.
+  it('bytes-driven crossing: entries low, bytes >= 80% -> warning present, names bytes', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new InMemoryTraceBufferStore();
+
+    let result: Awaited<ReturnType<typeof handleAppendTrace>> | undefined;
+    let seed = 0;
+    do {
+      result = await handleAppendTrace(
+        { run_id: runId, step_id: 'step-agent', entries: [bigDataEntry(seed++)] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+    } while (result.warnings === undefined && seed < 30);
+
+    expect(seed).toBeLessThan(30); // sanity: it actually crossed, well before the count ceiling
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    const [warning] = result.warnings!;
+    expect(warning).toContain('bytes');
+    expect(warning).toContain(`${result.buffer_bytes}/${result.limit_bytes}`);
+    expect(warning).not.toMatch(/\d+\/\d+ entries/); // entries is NOT the binding dimension here
+    // Entries count stays a small fraction of the count ceiling (200) — proves this crossing is
+    // genuinely bytes-driven, not count-driven.
+    expect(result.buffer_count).toBeLessThan(BUFFER_LIMIT_COUNT * 0.2);
+  });
+
+  // 4. Unfenced store at >= 80%: BOTH warnings present, in the specified order.
+  it('unfenced store at >= 80%: both the unfenced-store advisory AND the capacity warning are present, in order', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new LegacyOnlyTraceBufferStore();
+
+    let result: Awaited<ReturnType<typeof handleAppendTrace>> | undefined;
+    let seed = 0;
+    do {
+      result = await handleAppendTrace(
+        { run_id: runId, step_id: 'step-agent', entries: [tinyEntry(seed++)] },
+        {
+          runStore,
+          workflowStore,
+          traceBufferStore: traceBufferStore as unknown as TraceBufferStore,
+        },
+      );
+    } while (result.warnings!.length < 2 && seed < BUFFER_LIMIT_COUNT);
+
+    expect(seed).toBeLessThan(BUFFER_LIMIT_COUNT);
+    expect(result.warnings).toHaveLength(2);
+    // Order: unfenced-store advisory FIRST, capacity SECOND.
+    expect(result.warnings![0]).toContain('does not fence trace appends');
+    expect(result.warnings![1]).toContain('entries');
+  });
+
+  // 5. Empty-entries probe.
+  it('empty-entries probe against a buffer already >= 80%: warning present', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new InMemoryTraceBufferStore();
+
+    let seeded: Awaited<ReturnType<typeof handleAppendTrace>> | undefined;
+    let seed = 0;
+    do {
+      seeded = await handleAppendTrace(
+        { run_id: runId, step_id: 'step-agent', entries: [tinyEntry(seed++)] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+    } while (seeded.warnings === undefined && seed < BUFFER_LIMIT_COUNT);
+    expect(seeded.warnings).toBeDefined(); // sanity: the seed actually crossed
+
+    const probe = await handleAppendTrace(
+      { run_id: runId, step_id: 'step-agent', entries: [] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    expect(probe.warnings).toBeDefined();
+    expect(probe.warnings).toHaveLength(1);
+    expect(probe.warnings![0]).toContain('entries');
+  });
+
+  it('empty-entries probe against a small buffer: no warnings', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await handleAppendTrace(
+      { run_id: runId, step_id: 'step-agent', entries: [tinyEntry(0)] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    const probe = await handleAppendTrace(
+      { run_id: runId, step_id: 'step-agent', entries: [] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    expect(probe.warnings).toBeUndefined();
+  });
+
+  // 6. Boundary: exactly at the threshold.
+  it('boundary: exactly at the 80% threshold (160/200 entries) -> warning present (>=, not >)', async () => {
+    const { runId } = await setup();
+    const traceBufferStore = new InMemoryTraceBufferStore();
+
+    // Seed 159 directly (bypassing the tool — InMemoryTraceBufferStore.append applies the exact
+    // same normalization the tool's own call would), then the 160th via the tool — landing at
+    // EXACTLY 160/200 = 0.8. 160/200 and the literal 0.8 round to the identical IEEE754 double
+    // (both are the nearest representable value to the mathematical 4/5), so this genuinely
+    // exercises the boundary, not an approximation of it.
+    const seedEntries = Array.from({ length: 159 }, (_, i) => tinyEntry(i));
+    await traceBufferStore.append(runId, 'step-agent', seedEntries);
+
+    const result = await handleAppendTrace(
+      { run_id: runId, step_id: 'step-agent', entries: [tinyEntry(159)] },
+      { runStore, workflowStore, traceBufferStore },
+    );
+
+    expect(result.buffer_count).toBe(160);
+    expect(result.buffer_count / result.limit_count).toBe(0.8); // exact boundary, asserted explicitly
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings![0]).toContain('160/200 entries');
+  });
+});

--- a/packages/mcp-server/src/tools/append-trace.ts
+++ b/packages/mcp-server/src/tools/append-trace.ts
@@ -26,13 +26,53 @@ export interface HandleAppendTraceStores {
 
 export type AppendTraceOkResult = { status: 'ok' } & AppendResult & {
     /**
-     * Advisory only, never a gate (#119) — present only when the configured `traceBufferStore`
-     * does NOT declare the fenced trio (issue #207 PR-2): this append was not fenced against a
-     * concurrent settlement, so the entries acknowledged here may end up neither adopted nor
-     * refused (silently orphaned WAL content). Absent entirely once the store declares the trio.
+     * Advisory only, never a gate (#119). May carry the unfenced-store caveat (issue #207 PR-2,
+     * present only when the configured `traceBufferStore` does NOT declare the fenced trio) and/or
+     * the capacity early-warning (issue #208, present once the post-append fill ratio crosses
+     * `CAPACITY_WARNING_THRESHOLD` — see `capacityWarning`, below). Absent entirely (`undefined`,
+     * never `[]`) when neither applies.
      */
     warnings?: string[];
   };
+
+/**
+ * Fill-ratio threshold (issue #208) at which `append_trace` starts advising the calling agent
+ * that this step's trace buffer is approaching `BUFFER_FULL` — a concrete instantiation of the
+ * issue's own "e.g. 80%" motivation. Advisory only (#119): never gates, never changes `status`.
+ * Chosen at 0.8 as the balance point: early enough that an agent can still act (trim tracing
+ * verbosity, or call `execute_step` to finalize the step) before the ceiling is hit, but late
+ * enough that it doesn't nag on every ordinary append.
+ */
+const CAPACITY_WARNING_THRESHOLD = 0.8;
+
+/**
+ * Pure, store-agnostic capacity-warning helper (issue #208, AC 1/3/4) — every `AppendResult`
+ * already carries `buffer_count`/`limit_count`/`buffer_bytes`/`limit_bytes` regardless of which
+ * `TraceBufferStore` implementation produced it, so this needs no store-specific knowledge at all
+ * (the fix genuinely lives at the tool layer, not in any store). Returns `undefined` strictly
+ * below `CAPACITY_WARNING_THRESHOLD`; AT OR ABOVE it (`>=`, deliberately not `>` — hitting the
+ * threshold exactly still warns) returns ONE deterministic message naming whichever dimension
+ * (entries or bytes) is closer to its own ceiling, the actual numbers and percentage, and the
+ * issue's own actionable guidance.
+ */
+function capacityWarning(result: AppendResult): string | undefined {
+  const countRatio = result.buffer_count / result.limit_count;
+  const bytesRatio = result.buffer_bytes / result.limit_bytes;
+  const ratio = Math.max(countRatio, bytesRatio);
+  if (ratio < CAPACITY_WARNING_THRESHOLD) return undefined;
+
+  const binding = countRatio >= bytesRatio ? 'entries' : 'bytes';
+  const detail =
+    binding === 'entries'
+      ? `${result.buffer_count}/${result.limit_count} entries (${Math.round(countRatio * 100)}%)`
+      : `${result.buffer_bytes}/${result.limit_bytes} bytes (${Math.round(bytesRatio * 100)}%)`;
+
+  return (
+    `trace buffer for this step is at ${detail} of capacity, approaching the limit — reduce ` +
+    'tracing verbosity or call execute_step to finalize the step before further appends are ' +
+    'refused with BUFFER_FULL'
+  );
+}
 
 /** The specific settled/in-flight state for a step, or `undefined` if none apply — the granular
  *  counterpart to `isStepSettledOrInFlight` (issue #207 PR-2). `append_trace`'s refusal detail
@@ -199,10 +239,18 @@ export async function handleAppendTrace(
 
   // 6. Empty entries — return current buffer state without writing. Stays on the raw unlocked
   // path UNCONDITIONALLY (issue #207 PR-2, D3 §2) — writes nothing, so there is no settlement
-  // race to fence against and no advisory to add, regardless of what the store declares.
+  // race to fence against and no unfenced-store advisory to add here, regardless of what the
+  // store declares. The CAPACITY warning (issue #208) still applies: this is the natural
+  // read-your-capacity call — an agent probing at 85% full should see it just as a real append
+  // would show it.
   if (args.entries.length === 0) {
     const result = await traceBufferStore.append(args.run_id, args.step_id, []);
-    return { status: 'ok', ...result };
+    const capacity = capacityWarning(result);
+    return {
+      status: 'ok',
+      ...result,
+      ...(capacity !== undefined ? { warnings: [capacity] } : {}),
+    };
   }
 
   // 7. Append entries to the buffer.
@@ -237,7 +285,12 @@ export async function handleAppendTrace(
       }
     };
     const result = await appendFenced(args.run_id, args.step_id, args.entries, guard);
-    return { status: 'ok', ...result };
+    const capacity = capacityWarning(result);
+    return {
+      status: 'ok',
+      ...result,
+      ...(capacity !== undefined ? { warnings: [capacity] } : {}),
+    };
   }
 
   // Capability absent (issue #207 PR-2): legacy unfenced append() — Window A stays open for this
@@ -255,12 +308,16 @@ export async function handleAppendTrace(
     );
   }
   const result = await traceBufferStore.append(args.run_id, args.step_id, args.entries);
+  const capacity = capacityWarning(result);
   return {
     status: 'ok',
     ...result,
+    // issue #208: capacity SECOND, after the pre-existing unfenced-store advisory — both may be
+    // present at once (the store's fenced-ness and its fill level are independent facts).
     warnings: [
       'this store does not fence trace appends against concurrent settlement; entries ' +
         'acknowledged here may not be adopted',
+      ...(capacity !== undefined ? [capacity] : []),
     ],
   };
 }


### PR DESCRIPTION
## Context

Issue #208 (filed during the #207 program): every successful `append_trace` already returns
`buffer_count`/`limit_count`/`buffer_bytes`/`limit_bytes`, but the calling agent's first signal
of an approaching ceiling was the hard, non-retryable `BUFFER_FULL` refusal itself.

## Motivation

An agent streaming trace during a long step should be able to act — trim verbosity or finalize
via `execute_step` — before losing the ability to append. All the data needed was already in the
response; only the interpretation was missing. Store-agnostic by construction, so the fix lives
entirely at the MCP tool layer (issue AC 3/4).

## Changes

- `packages/mcp-server/src/tools/append-trace.ts`: a pure `capacityWarning(result)` helper —
  fill ratio = max(entries, bytes) vs the buffer ceilings; at ≥ 80% (`CAPACITY_WARNING_THRESHOLD`,
  documented; deliberately `>=`) the response's existing `warnings` field gains one deterministic
  advisory naming the binding dimension, the numbers, and the actionable next step. Applied at
  all three success-response sites: fenced append, legacy unfenced append (capacity appends after
  the existing unfenced-store advisory — both can be present), and the empty-entries probe (the
  natural read-your-capacity call). Purely advisory (#119): never gates, never changes `status`;
  `warnings` stays absent when there is nothing to say.
- New test file (7 cases): below-threshold silence, count-driven and bytes-driven crossings (each
  proving the OTHER dimension stayed low), unfenced-store dual-warning ordering, probe at high/low
  fill, and an exact-boundary case (159 seeded + 1 via the tool = 160/200 ≡ 0.8, IEEE754-exact)
  pinning the `>=` semantics.
- CHANGELOG `Added` entry.

## Verification

- Full suite, forced: core 1718, mcp 209, testing 81, cli 743 — all green; lint/versions/audit
  clean; zero regressions to the 24 pre-existing append-trace tests.
- Both mutation probes red → restored byte-identical → green (threshold removal reds all five
  warning-expecting tests; max()→count-only reds exactly the bytes-driven test, proving both
  dimensions load-bearing). Probe (b) additionally reproduced independently during Master
  Architect review.

## Rollback

Revert the single commit. Additive response-shaping only — no store, interface, or engine change;
no data-format concerns.

## Related

- Closes #208
- #207 / #209 / #210 (the fenced-trio program that shipped the `warnings` envelope field and the
  per-store `AppendResult` fidelity this builds on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
