### PR TITLE
feat(store): trace-buffer capability ladder, sealed-WAL preservation, writer-nonce carriage (#197 PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,34 @@ All notable changes to this project are documented here.
   outright. Purely advisory (never gates, never changes `status`) and store-agnostic (reads only
   `AppendResult`'s already-returned fields; works identically regardless of which
   `TraceBufferStore` implementation is injected).
+- **`TraceBufferStore` capability ladder + sealed-WAL preservation + writer-nonce carriage (issue
+  #197, PR-1 of 2 — store layer only, behaviorally INERT in production until PR-2 wires it into any
+  call site).** Two new OPTIONAL, independently-declarable capability-ladder rungs a fenced-trio
+  store may additionally implement — `traceCapabilities?: ReadonlySet<'seal' | 'writer_nonce_carriage'>`
+  — with one authoritative predicate module (`storeDeclaresSeal`, `storeDeclaresNonceCarriage`,
+  `validateTraceCapabilities`) as the only way any caller may check them: `writer_nonce_carriage`
+  requires `seal` requires the fenced trio; the trio alone stays fully legal (undeclared is always
+  the honest floor, never an error). `sealFenced(runId, stepId, guard)` atomically retires a live
+  WAL to a new sealed artifact under the SAME per-key critical section the fenced trio uses — a
+  no-clobber `link`-then-`unlink` move (never `rename`, which would silently overwrite), bytes moved
+  verbatim, bounded by a new `SEALED_ARTIFACTS_LIMIT_PER_STEP` (falls back to the existing
+  destructive drain on cap); `listSealedForRun(runId)` reads them back. `append`/`appendFenced` grow
+  a trailing `options?: {writerNonce?: string}` — an opaque, client-minted writer identity carried
+  through to `read()`'s already-existing `BufferedEntry._nonce` (never fabricated for a genuinely
+  bare line). New per-WRITER budget enforcement (today's `BUFFER_LIMIT_COUNT`/`BUFFER_LIMIT_BYTES`,
+  values unchanged, now documented as per-writer) alongside a new, additive whole-FILE backstop
+  (`BUFFER_BACKSTOP_COUNT`/`BUFFER_BACKSTOP_BYTES`, 2×) — a `BUFFER_FULL` refusal's `details` now
+  carries a structured `scope`/`binding_dimension`/count+bytes triples/file-scope occupancy
+  evidence shape. **Compat law: for all-bare traffic every existing `AppendResult` field is
+  numerically byte-identical to before this capability existed** (the file backstop is
+  arithmetically unreachable with a single writer — emergent, not special-cased); new `file_*`
+  fields are additive-only. Both in-repo stores (`JsonTraceBufferStore`, `InMemoryTraceBufferStore`)
+  now declare both rungs. The fenced-trio conformance TCK (`@sensigo/realm-testing`) grows five new
+  laws (`CARRIAGE_ROUND_TRIP`, `SEAL`, `SEAL_BUDGET`, `PER_WRITER_BUDGET`, `VERBATIM`), each
+  producing an explicit, visible documented-skip for a store that doesn't declare the relevant
+  rung — never a silent omission (mirroring the existing `fenceForm: 'native-predicate'` skip
+  precedent). **Nothing in this PR mints or reads a nonce at any real call site, and no engine/
+  MCP-tool/CLI behavior changes** — that adoption is PR-2.
 
 ### Changed
 

--- a/packages/cli/src/commands/store-fs-guard.test.ts
+++ b/packages/cli/src/commands/store-fs-guard.test.ts
@@ -166,16 +166,28 @@ describe('store-fs-guard — no raw unlink outside fs-io.ts / the atomic-write.t
 // coupling the two guards' internals together).
 const WIRED_STORES = ['JsonTraceBufferStore', 'FailedAttemptStore', 'JsonFileStore'];
 
-/** Every `.test.ts` file anywhere in the repo that calls `perRunArtifactStoreContract(`,
- *  cross-referenced against which WIRED store class name(s) it also imports/references — a
- *  same-file co-occurrence proxy for "this store was actually run through the TCK" (source-text,
- *  not type-reflection, matching this repo's established anti-recurrence convention). */
+/** This guard's OWN file — excluded from its own scan below (issue #197 PR-1, design §12: fixing
+ *  the self-scan false positive that was DISCOVERED but deliberately left unfixed during issue
+ *  #207, per Guard 3's own doc below). Without this, the guard trivially "covers" every store
+ *  forever: this file's own doc comments and the `WIRED_STORES` array literal contain both the
+ *  store class name strings AND the literal substring `perRunArtifactStoreContract(` (inside the
+ *  string-literal argument to `.includes(...)` a few lines below), so scanning this file always
+ *  finds a false co-occurrence regardless of whether any REAL wiring test exists — the same
+ *  self-exclusion technique Guard 3 already uses for the analogous fenced-TCK scan. */
+const THIS_GUARD_FILE_ISSUE_183 = fileURLToPath(import.meta.url);
+
+/** Every `.test.ts` file anywhere in the repo (other than this guard's own file) that calls
+ *  `perRunArtifactStoreContract(`, cross-referenced against which WIRED store class name(s) it
+ *  also imports/references — a same-file co-occurrence proxy for "this store was actually run
+ *  through the TCK" (source-text, not type-reflection, matching this repo's established
+ *  anti-recurrence convention). */
 function tckCoveredStores(): Set<string> {
   const covered = new Set<string>();
   const packages = ['core', 'cli', 'mcp-server', 'testing'];
   for (const pkg of packages) {
     const root = join(PACKAGES_DIR, pkg, 'src');
     for (const file of walkTestFiles(root)) {
+      if (file === THIS_GUARD_FILE_ISSUE_183) continue;
       const src = readFileSync(file, 'utf8');
       if (!src.includes('perRunArtifactStoreContract(')) continue;
       for (const storeName of WIRED_STORES) {
@@ -217,10 +229,10 @@ const WIRED_FENCED_STORES = ['JsonTraceBufferStore', 'InMemoryTraceBufferStore']
  *  `WIRED_FENCED_STORES` array literal itself contain both the store class name strings AND the
  *  literal substring `fencedTraceBufferContract(` (inside the string-literal argument to
  *  `.includes(...)` a few lines below), so scanning this file would always find a false
- *  co-occurrence regardless of whether any REAL wiring test exists. Confirmed this same
- *  self-referential gap already existed, unnoticed, in Guard 2's `tckCoveredStores` above (it
- *  scans its own file too, for the same reason) — not fixed there (out of this task's scope,
- *  pre-existing and unrelated to issue #207), but not repeated here. */
+ *  co-occurrence regardless of whether any REAL wiring test exists. This same self-referential gap
+ *  existed, unnoticed, in Guard 2's `tckCoveredStores` above too — left unfixed at the time (out of
+ *  issue #207's scope) but FIXED in issue #197 PR-1 (design §12 scheduled it with this PR; see
+ *  `THIS_GUARD_FILE_ISSUE_183` above, the same technique applied there). */
 const THIS_GUARD_FILE = fileURLToPath(import.meta.url);
 
 /** Every `.test.ts` file anywhere in the repo (other than this guard's own file) that calls

--- a/packages/cli/src/store-contracts/in-memory-trace-buffer-store-fenced.contract.test.ts
+++ b/packages/cli/src/store-contracts/in-memory-trace-buffer-store-fenced.contract.test.ts
@@ -17,6 +17,18 @@ const LAWS: FencedTraceBufferLaw[] = [
   'CS_OCCUPANCY',
   'PER_KEY_INDEPENDENCE',
   'NO_SILENT_LOSS',
+  // issue #197 PR-1: InMemoryTraceBufferStore declares both capability-ladder rungs (`seal` and
+  // `writer_nonce_carriage`), so every one of these five laws has real (non-skip) cases here —
+  // the PER_WRITER_BUDGET byte-exactness and VERBATIM raw-byte sub-cases are the ONLY ones that
+  // render as a visible skip (no `bytesOracle`/`rawWalAccess` supplied below — see their own doc:
+  // "bytes" for an in-memory structure has no independent ground truth to check against the way a
+  // physical file's on-disk size does, so a pseudo-oracle here would just re-derive the same
+  // formula and verify nothing new).
+  'CARRIAGE_ROUND_TRIP',
+  'SEAL',
+  'SEAL_BUDGET',
+  'PER_WRITER_BUDGET',
+  'VERBATIM',
 ];
 
 function makeKey(): { runId: string; stepId: string } {

--- a/packages/cli/src/store-contracts/json-trace-buffer-store-fenced.contract.test.ts
+++ b/packages/cli/src/store-contracts/json-trace-buffer-store-fenced.contract.test.ts
@@ -6,7 +6,7 @@
 // conformance tests co-located (this directory already depends on both @sensigo/realm and
 // @sensigo/realm-mcp) is simpler than splitting across packages for no benefit.
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -19,7 +19,91 @@ const LAWS: FencedTraceBufferLaw[] = [
   'CS_OCCUPANCY',
   'PER_KEY_INDEPENDENCE',
   'NO_SILENT_LOSS',
+  // issue #197 PR-1: JsonTraceBufferStore declares both capability-ladder rungs — every one of
+  // these five laws runs real (non-skip) cases here, INCLUDING the byte-exactness (bytesOracle)
+  // and raw-byte (rawWalAccess) sub-cases the in-memory store's wiring test above leaves skipped
+  // (a physical file's on-disk bytes ARE an independent ground truth to check against, unlike an
+  // in-memory structure's own accounting).
+  'CARRIAGE_ROUND_TRIP',
+  'SEAL',
+  'SEAL_BUDGET',
+  'PER_WRITER_BUDGET',
+  'VERBATIM',
 ];
+
+/** Recomputes the exact on-disk WAL filename `JsonTraceBufferStore`'s private `walPath` uses —
+ *  test-side only, mirroring the same helper in json-trace-buffer-store.test.ts. */
+function walFileName(runId: string, stepId: string): string {
+  return `trace-buffer-${runId}-${Buffer.from(stepId).toString('base64url')}.jsonl`;
+}
+
+/** Recomputes the exact on-disk sealed-artifact filename `JsonTraceBufferStore`'s private
+ *  `sealedWalPath` uses (issue #197 PR-1) — test-side only. */
+function sealedFileName(runId: string, stepId: string, seq: number): string {
+  return `sealed-trace-${runId}-${Buffer.from(stepId).toString('base64url')}.${seq}.jsonl`;
+}
+
+/** Reads `path`, returning `undefined` on ENOENT (mirrors `readIfExists`'s absence convention) —
+ *  test-side raw-bytes access, independent of the store's own internal `readWal`. */
+async function readRawIfExists(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
+/**
+ * Independently computes writer-partitioned count + bytes DIRECTLY from the raw on-disk WAL file
+ * (issue #197 PR-1) — a genuinely separate code path from the store's own internal `readWal` +
+ * `partitionStats` (fresh `readFile`, raw per-line text sliced straight from disk content rather
+ * than re-serializing a parsed object), so this can catch a drift between what the store REPORTS
+ * and what is ACTUALLY persisted. Mirrors the store's own byte-attribution rule (there is no more
+ * primitive "ground truth" for "this writer's own bytes" than "sum of its own lines' bytes" and
+ * "⊥ = the whole-file residual" — that rule IS the definition, not an incidental implementation
+ * detail this oracle could sidestep).
+ */
+async function bytesOracle(
+  dir: string,
+  runId: string,
+  stepId: string,
+  writerNonce: string | undefined,
+): Promise<{ count: number; bytes: number }> {
+  const content = await readRawIfExists(join(dir, walFileName(runId, stepId)));
+  if (content === undefined) return { count: 0, bytes: 0 };
+
+  const fileBytes = Buffer.byteLength(content);
+  let noncedBytes = 0;
+  let bareCount = 0;
+  let ownCount = 0;
+  let ownBytes = 0;
+
+  for (const raw of content.split('\n')) {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    let parsed: { entries: unknown[]; nonce?: string };
+    try {
+      parsed = JSON.parse(trimmed) as { entries: unknown[]; nonce?: string };
+    } catch {
+      continue; // torn line — never attributable to any nonced partition (excluded here too)
+    }
+    const lineBytes = Buffer.byteLength(trimmed + '\n');
+    if (parsed.nonce !== undefined) {
+      noncedBytes += lineBytes;
+      if (writerNonce !== undefined && parsed.nonce === writerNonce) {
+        ownCount += parsed.entries.length;
+        ownBytes += lineBytes;
+      }
+    } else if (writerNonce === undefined) {
+      bareCount += parsed.entries.length;
+    }
+  }
+
+  return writerNonce !== undefined
+    ? { count: ownCount, bytes: ownBytes }
+    : { count: bareCount, bytes: fileBytes - noncedBytes };
+}
 
 /**
  * A deliberately generous lock profile for this TCK's own store instance (issue #207) — the
@@ -49,6 +133,14 @@ async function makeAdapter(): Promise<{
       makeKey: () => ({ runId: randomUUID(), stepId: 'fenced-tck-step' }),
       fenceForm: 'guard-in-cs',
       lockProfile: GENEROUS_LOCK_PROFILE,
+      // issue #197 PR-1: a physical file's on-disk bytes are an independent ground truth (unlike
+      // the in-memory store's own accounting) — see each helper's own doc above.
+      bytesOracle: (runId, stepId, writerNonce) => bytesOracle(dir, runId, stepId, writerNonce),
+      rawWalAccess: {
+        readLiveRaw: (runId, stepId) => readRawIfExists(join(dir, walFileName(runId, stepId))),
+        readSealedRaw: (runId, stepId, seq) =>
+          readRawIfExists(join(dir, sealedFileName(runId, stepId, seq))),
+      },
     },
     cleanup: () => rm(dir, { recursive: true, force: true }),
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ export {
   isRetryableArtifactErrno,
   artifactDeleteFailedError,
   toArtifactDeleteFailedError,
+  errnoCode,
+  linkNoClobberThenUnlink,
 } from './store/fs-io.js';
 export type { ArtifactDeleteFailure } from './store/fs-io.js';
 export { hashParams, canonicalJson } from './store/params-hash.js';
@@ -202,7 +204,17 @@ export { countResults } from './handlers/primitives/count-results.js';
 export { compareStrings } from './handlers/primitives/compare-strings.js';
 
 // Trace buffer store (B-lite)
-export type { TraceBufferStore, BufferedEntry, AppendResult } from './store/trace-buffer-store.js';
+export type {
+  TraceBufferStore,
+  BufferedEntry,
+  AppendResult,
+  AppendOptions,
+  TraceCapability,
+  SealResult,
+  SealedWalLine,
+  SealedArtifact,
+  BufferFullDetails,
+} from './store/trace-buffer-store.js';
 export {
   InMemoryTraceBufferStore,
   normalizeEntryForBuffer,
@@ -210,4 +222,13 @@ export {
   BUFFER_LIMIT_BYTES,
   FINAL_LIMIT_ENTRIES,
   FINAL_LIMIT_BYTES,
+  BUFFER_BACKSTOP_COUNT,
+  BUFFER_BACKSTOP_BYTES,
+  SEALED_ARTIFACTS_LIMIT_PER_STEP,
+  storeDeclaresSeal,
+  storeDeclaresNonceCarriage,
+  validateTraceCapabilities,
+  checkBufferBudget,
+  bufferFullError,
+  flattenWalBatches,
 } from './store/trace-buffer-store.js';

--- a/packages/core/src/store/fs-io.ts
+++ b/packages/core/src/store/fs-io.ts
@@ -14,7 +14,7 @@
 // file-locking (an antivirus scan, an open handle from another process) can make a delete/read
 // transiently fail where POSIX would succeed immediately. No retry/delay on POSIX: a genuine
 // EACCES there is not transient, and retrying would only slow down a real permission failure.
-import { unlink, readFile, stat } from 'node:fs/promises';
+import { unlink, readFile, stat, link } from 'node:fs/promises';
 import type { Stats } from 'node:fs';
 import { WorkflowError } from '../types/workflow-error.js';
 
@@ -30,7 +30,11 @@ const RETRYABLE_ARTIFACT_ERRNO = new Set(['EBUSY', 'EIO']);
  *  stays the conservative `false` — never advertise a retry that might not help. */
 const NON_RETRYABLE_ARTIFACT_ERRNO = new Set(['EACCES', 'EISDIR', 'EPERM', 'EROFS']);
 
-function errnoCode(err: unknown): string | undefined {
+/** Exported so callers outside this module (e.g. a store's `sealFenced`) can classify a thrown
+ *  error's errno themselves — most usefully to detect `'EEXIST'` on {@link linkNoClobberThenUnlink}
+ *  without this module needing to know anything about what a caller does with that fact (issue
+ *  #197 PR-1: the seq-bump-and-retry decision belongs to the store, not to this primitive). */
+export function errnoCode(err: unknown): string | undefined {
   return (err as NodeJS.ErrnoException | undefined)?.code;
 }
 
@@ -176,4 +180,34 @@ export function toArtifactDeleteFailedError(
   const code = err instanceof FsIoError ? err.code : (errnoCode(err) ?? 'UNKNOWN');
   const message = err instanceof Error ? err.message : String(err);
   return artifactDeleteFailedError(runId, store, deleted, [{ artifact, code, message }]);
+}
+
+/**
+ * No-clobber "move" of `src` to `dest` (issue #197 PR-1, the `seal` rung's seal-by-rename — design
+ * §4). Plain POSIX `rename()` is FORBIDDEN for this use: it silently overwrites an existing `dest`,
+ * which is exactly the destructive behavior a seal must never risk (a seq collision must be
+ * detected, never silently clobbered). Implemented as the standard POSIX no-clobber trick instead:
+ *
+ *   1. `link(src, dest)` — creates a second directory entry for `src`'s existing inode at `dest`.
+ *      This step is ATOMIC and CANNOT overwrite an existing `dest`: if `dest` already exists,
+ *      `link` fails with `EEXIST` and `src` is left completely untouched (raw bytes, wherever they
+ *      already were). This is also the intended SEQ-PROBE mechanism (design §4) — a caller doing
+ *      the link-attempt-IS-the-probe pattern retries with the next `seq` on `EEXIST`, with no
+ *      separate pre-listing/TOCTOU window.
+ *   2. `deleteIfExists(src)` — removes the original directory entry, leaving `dest` as the sole
+ *      remaining reference to the SAME inode (same bytes, byte-for-byte, never re-copied/parsed).
+ *
+ * `EEXIST` from step 1 propagates RAW (undecorated, not wrapped in {@link FsIoError}) so a caller
+ * can distinguish "seq already taken — bump and retry" from every other failure via
+ * `errnoCode(err) === 'EEXIST'`. Any other errno from step 1, or any errno from step 2, is a
+ * genuine I/O failure and throws {@link FsIoError} per the module's usual discipline.
+ */
+export async function linkNoClobberThenUnlink(src: string, dest: string): Promise<void> {
+  try {
+    await withWin32Retry(() => link(src, dest));
+  } catch (err) {
+    if (errnoCode(err) === 'EEXIST') throw err;
+    throw new FsIoError('link', src, err);
+  }
+  await deleteIfExists(src);
 }

--- a/packages/core/src/store/trace-buffer-store.ts
+++ b/packages/core/src/store/trace-buffer-store.ts
@@ -2,28 +2,163 @@
 import type { AgentTraceEntry } from '../types/run-record.js';
 import { WorkflowError } from '../types/workflow-error.js';
 
+/**
+ * The store-layer capability ladder (issue #197 PR-1, design record `plans/issue-197-design.md`
+ * §3). Implication runs **upward-requires-downward ONLY**: `writer_nonce_carriage` requires
+ * `seal`; `seal` requires the fenced trio (issue #207). **The fenced trio ALONE stays fully
+ * legal** — a store declaring neither rung is still a fully conforming implementation (the
+ * shipped realm-cloud Postgres state; non-seal trio stores keep the #207 destructive-drain
+ * posture forever, not a transitional gap). `TraceBufferStore.traceCapabilities` below is the
+ * declaration; `storeDeclaresSeal`/`storeDeclaresNonceCarriage`/`validateTraceCapabilities`
+ * (this file) are the ONLY authoritative way to check a rung — no ad-hoc `typeof` checks for
+ * these two rungs anywhere else in the codebase (TCK, tools, or engine).
+ */
+export type TraceCapability = 'seal' | 'writer_nonce_carriage';
+
+/** Outcome of `sealFenced` (issue #197 PR-1, the `seal` rung — see `TraceBufferStore.sealFenced`
+ *  for the full contract). */
+export type SealResult =
+  | { sealed: true }
+  | {
+      sealed: false;
+      /** `'absent'`: no live WAL existed for (runId, stepId) at all — #183 absence-is-success,
+       *  not a failure. `'capped'`: this key already holds `SEALED_ARTIFACTS_LIMIT_PER_STEP`
+       *  sealed artifacts — the caller must fall back to the existing destructive drain (bounded,
+       *  loud, never silent eviction of a sealed artifact to make room). */
+      reason: 'absent' | 'capped';
+    };
+
+/**
+ * One line of a WAL, as read back — live or sealed (issue #197 PR-1). Defined in CORE, not
+ * mcp-server (where the fs store's own file-local `WalLine` type lives), because
+ * `listSealedForRun`'s return type must be usable without any core-adjacent caller importing an
+ * mcp-server-local type. The fs store's `WalLine` gains the identical optional `nonce` field and
+ * stays structurally assignable to this type (never a separate, divergent shape).
+ */
+export interface SealedWalLine {
+  ts: number;
+  entries: AgentTraceEntry[];
+  /** The writer nonce active when this line was appended, if any (issue #197 PR-1) — absent for
+   *  a bare/anonymous append. NEVER fabricated for a line that was genuinely bare. */
+  nonce?: string;
+}
+
+/** One sealed artifact for a single (runId, stepId) key — issue #197 PR-1, part of the `seal`
+ *  rung. A key may accumulate several sealed artifacts (repeated reclaim/settle-time seals),
+ *  distinguished by ascending `seq`. */
+export interface SealedArtifact {
+  step_id: string;
+  /** Ascending, per-key sequence number (0-based) — distinguishes repeated seals of the same
+   *  (runId, stepId) key from one another. */
+  seq: number;
+  lines: SealedWalLine[];
+}
+
+/**
+ * Structured `BUFFER_FULL` refusal detail shape (issue #197 PR-1, design §5) — every
+ * `TraceBufferStore.append`/`appendFenced` implementation populates this as the thrown
+ * `WorkflowError`'s `details`. `scope` names which budget bound the refusal: `'writer'` (this
+ * call's own writer — the nonce that made it, or ⊥ for a bare call — exceeded its per-writer
+ * `BUFFER_LIMIT_COUNT`/`BUFFER_LIMIT_BYTES` share) or `'file'` (the whole-file, all-writers-combined
+ * `BUFFER_BACKSTOP_COUNT`/`BUFFER_BACKSTOP_BYTES` ceiling). `binding_dimension` names which of the
+ * two triples actually caused the refusal — `count`/`bytes` are ALWAYS both populated (a caller
+ * can see the whole picture, not just the half that bound). `your_*`/`total_*` (file scope only)
+ * are the occupancy evidence: this writer's own share vs. the whole file's combined share —
+ * foreign share is stated as an observable FACT; crash causation for that foreign residue is
+ * NEVER asserted (design §5's corrected message framing — a foreign writer's residue might be a
+ * live concurrent step, not a crash).
+ */
+export interface BufferFullDetails {
+  scope: 'writer' | 'file';
+  binding_dimension: 'count' | 'bytes';
+  count: { requested: number; used: number; limit: number };
+  bytes: { requested: number; used: number; limit: number };
+  your_count?: number;
+  your_bytes?: number;
+  total_count?: number;
+  total_bytes?: number;
+}
+
 export interface AppendResult {
+  /**
+   * WRITER-scope numbers (issue #197 PR-1 re-documentation — values and meaning UNCHANGED for
+   * bare-only traffic, the compat law, design §5): this call's own writer (the nonce that made
+   * it, or ⊥ for a bare call) against the per-writer `BUFFER_LIMIT_COUNT`/`BUFFER_LIMIT_BYTES`
+   * ceiling. An all-bare WAL has exactly one writer (⊥), so writer-scope and file-scope coincide
+   * there and these fields are numerically IDENTICAL to before this capability existed.
+   */
   buffer_count: number;
   buffer_bytes: number;
   limit_count: number;
   limit_bytes: number;
   final_limit_entries: number;
   final_limit_bytes: number;
+  /**
+   * Whole-FILE scope numbers (issue #197 PR-1, additive) — populated ONLY by a store that
+   * declares `writer_nonce_carriage` (a non-declaring store never sets these; they stay
+   * `undefined`, never fabricated as `0`). Ride the new `BUFFER_BACKSTOP_COUNT`/
+   * `BUFFER_BACKSTOP_BYTES` ceiling — combined usage across every writer sharing this key.
+   */
+  file_count?: number;
+  file_limit_count?: number;
+  file_bytes?: number;
+  file_limit_bytes?: number;
+}
+
+/**
+ * Optional trailing options bag for `append`/`appendFenced` (issue #197 PR-1, the
+ * `writer_nonce_carriage` rung). Declaration-only: adding this parameter is NOT a separate
+ * method-presence check in `storeDeclaresNonceCarriage` (there is no way to detect "did this
+ * store implementation read the options bag" other than declared capability + behavior) — a
+ * non-declaring implementation is contractually required to IGNORE it, never throw or otherwise
+ * error on receiving one; the tool layer (PR-2) is responsible for never passing a nonce to a
+ * non-declaring store.
+ */
+export interface AppendOptions {
+  /** Client-minted, opaque per-step-attempt writer identity. Absent ⇒ the bare/anonymous writer
+   *  class (⊥) — today's behavior, byte-identical. NEVER validated/shaped by the store itself
+   *  (opaque string, store-agnostic) — protocol-level shape validation is a PR-2/tool-layer
+   *  concern (design §6). */
+  writerNonce?: string;
 }
 
 export interface TraceBufferStore {
   /**
+   * Declares which of the two optional capability-ladder rungs (issue #197 PR-1) this store
+   * implements: `'seal'` and/or `'writer_nonce_carriage'`. See `TraceCapability`'s own doc for
+   * the ladder rule (carriage requires seal requires the fenced trio; trio alone stays legal).
+   *
+   * **Immutability**: this set MUST NOT change after construction — a reader may read it once and
+   * cache the result forever (the TCK's STRUCTURAL law asserts two reads are content-identical).
+   *
+   * **Authoritative only in conjunction with method presence**: a declared rung whose required
+   * methods are NOT actually present (or vice versa) is a construction-time defect, not a runtime
+   * condition — see `validateTraceCapabilities`. Absent entirely (`undefined`) is equivalent to
+   * declaring neither rung (the honest floor — trio-alone, or no fenced trio at all, both legal).
+   */
+  readonly traceCapabilities?: ReadonlySet<TraceCapability>;
+
+  /**
    * Appends normalized entries to the buffer for (runId, stepId).
    * Each entry is per-entry normalized at append time (reserved prefix drop, field caps).
    * Batch timestamp (_internalTs) is assigned at write time.
-   * Throws BUFFER_FULL WorkflowError if the WAL limit would be exceeded.
+   * Throws BUFFER_FULL WorkflowError if the WAL limit would be exceeded (issue #197 PR-1: see
+   * `BufferFullDetails` for the refusal's structured `details` shape).
+   *
+   * @param options Optional trailing options bag (issue #197 PR-1) — see `AppendOptions`.
    */
-  append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult>;
+  append(
+    runId: string,
+    stepId: string,
+    entries: AgentTraceEntry[],
+    options?: AppendOptions,
+  ): Promise<AppendResult>;
 
   /**
    * Reads all buffered entries for (runId, stepId) with their batch timestamps attached.
    * Returns empty array if no buffer exists.
-   * Entries carry _internalTs for ordering at finalization.
+   * Entries carry _internalTs for ordering at finalization, and (issue #197 PR-1) an optional
+   * `_nonce` re-attached from the line that carried them — see `BufferedEntry._nonce`.
    */
   read(runId: string, stepId: string): Promise<BufferedEntry[]>;
 
@@ -93,6 +228,7 @@ export interface TraceBufferStore {
     stepId: string,
     entries: AgentTraceEntry[],
     guard: () => Promise<void>,
+    options?: AppendOptions,
   ): Promise<AppendResult>;
 
   /**
@@ -133,17 +269,80 @@ export interface TraceBufferStore {
     guard: () => Promise<void>,
     dirEntries?: readonly string[],
   ): Promise<void>;
+
+  /**
+   * **`sealFenced` (issue #197 PR-1, the `seal` rung — design §4).** Atomically retires the
+   * ENTIRE live WAL for (runId, stepId) to a sealed artifact, under the SAME per-key critical
+   * section the fenced trio uses. `guard` runs IN-CS, immediately BEFORE the move (same guard
+   * contract as the trio: at-least-once invocation, completes before the mutating effect, exactly
+   * one lock-free `runStore.get`, never acquires its own lock, a rejection propagates UNWRAPPED —
+   * nothing is moved).
+   *
+   * Semantics:
+   * - Absent live WAL ⇒ `{sealed: false, reason: 'absent'}` — #183 absence-is-success, not an
+   *   error.
+   * - This key already at the per-key seal-budget cap (`SEALED_ARTIFACTS_LIMIT_PER_STEP`) ⇒
+   *   `{sealed: false, reason: 'capped'}` — the caller falls back to the existing destructive
+   *   drain (`deleteFenced`); bounded, loud, never a silent eviction of an existing sealed
+   *   artifact to make room.
+   * - Otherwise ⇒ raw bytes move VERBATIM to the sealed artifact — no parse, no copy, no
+   *   truncation, no dedup. A torn/corrupt trailing line moves as bytes too (readers of the
+   *   sealed artifact skip + warn on it, mirroring the live WAL reader's own #183 corruption
+   *   posture) ⇒ `{sealed: true}`.
+   * - Any OTHER I/O errno (not absence) ⇒ a typed throw (#183) — the caller warns; this is
+   *   residue-not-loss (the live WAL is left exactly as it was; nothing moved).
+   *
+   * A store implements this ONLY as part of declaring the `seal` rung (`storeDeclaresSeal`) —
+   * requires the full fenced trio to already be declared (the ladder).
+   */
+  sealFenced?(runId: string, stepId: string, guard: () => Promise<void>): Promise<SealResult>;
+
+  /**
+   * **`listSealedForRun` (issue #197 PR-1, part of the `seal` rung — design §4).** Returns every
+   * sealed artifact for `runId`, across all steps — descriptors plus their parsed lines
+   * (torn-tolerant: a corrupt line inside a sealed artifact is skipped + a loud warning emitted,
+   * mirroring the live WAL reader's own discipline; the corrupt bytes stay on disk untouched).
+   * Absence of any sealed artifacts for this run ⇒ `[]`, never a throw. Lock-free, point-in-time
+   * (mirrors `readAllForRun`'s own posture, issue #159) — never mutates.
+   */
+  listSealedForRun?(runId: string): Promise<SealedArtifact[]>;
 }
 
-/** An AgentTraceEntry extended with engine-assigned ordering timestamp (milliseconds). */
+/** An AgentTraceEntry extended with engine-assigned ordering timestamp (milliseconds), and
+ *  (issue #197 PR-1) the writer nonce that carried it, if any — re-attached from the line the
+ *  entry was originally appended in. NEVER fabricated for a genuinely bare line. */
 export interface BufferedEntry extends AgentTraceEntry {
   _internalTs: number;
+  _nonce?: string;
 }
 
+/** PER-WRITER budget (issue #197 PR-1 re-documentation — value unchanged): the ceiling for ONE
+ *  writer's own share of a (runId, stepId) buffer — the nonce that made the call, or ⊥ (the
+ *  bare/anonymous writer class) for a call with no nonce. An all-bare WAL has exactly one writer
+ *  (⊥), so this is the ONLY ceiling that can ever bind there — byte-identity with pre-#197
+ *  behavior is emergent from that fact, not a special case. */
 export const BUFFER_LIMIT_COUNT = 200;
+/** See `BUFFER_LIMIT_COUNT` — the per-writer BYTE ceiling. */
 export const BUFFER_LIMIT_BYTES = 100 * 1024; // 100 KB
 export const FINAL_LIMIT_ENTRIES = 100;
 export const FINAL_LIMIT_BYTES = 50 * 1024; // 50 KB (must match MAX_BYTES in trace-normalizer.ts)
+
+/** Whole-FILE backstop (issue #197 PR-1, additive, design §5): the ceiling across EVERY writer
+ *  sharing a (runId, stepId) key combined, regardless of nonce — 2× the per-writer ceiling.
+ *  Unconditional: enforced even on a store that hasn't seen a single nonced append, though it is
+ *  UNREACHABLE in the all-bare case (the lone writer ⊥ already refuses at the per-writer ceiling,
+ *  which is half the backstop — the backstop only ever binds when at least one OTHER writer's
+ *  residue is sharing the file). */
+export const BUFFER_BACKSTOP_COUNT = 2 * BUFFER_LIMIT_COUNT;
+/** See `BUFFER_BACKSTOP_COUNT` — the whole-file BYTE backstop. */
+export const BUFFER_BACKSTOP_BYTES = 2 * BUFFER_LIMIT_BYTES;
+
+/** Per-(runId, stepId) seal budget (issue #197 PR-1, the `seal` rung, design §4): the maximum
+ *  number of sealed artifacts one key may accumulate. On reaching the cap, `sealFenced` returns
+ *  `{sealed: false, reason: 'capped'}` — the caller falls back to the existing destructive drain
+ *  (`deleteFenced`), bounded and loud, rather than silently evicting an existing sealed artifact
+ *  to make room. */
+export const SEALED_ARTIFACTS_LIMIT_PER_STEP = 8;
 
 const MAX_EVENT_LENGTH = 100;
 const RESERVED_PREFIX = 'trace.';
@@ -188,21 +387,244 @@ export function normalizeEntryForBuffer(entry: AgentTraceEntry): AgentTraceEntry
   };
 }
 
+// ---------------------------------------------------------------------------------------------
+// Capability-ladder predicates (issue #197 PR-1, design §3) — the ONLY authoritative way to check
+// a rung. TCK, tools, and engine (PR-2) must all use these; no ad-hoc `typeof` checks for the new
+// rungs anywhere else. Each predicate = declared in `traceCapabilities` AND every method that
+// rung (and every rung beneath it) requires is actually present — declaration alone, or method
+// presence alone, is never sufficient.
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * True iff `store` both DECLARES the `seal` rung (in `traceCapabilities`) AND actually implements
+ * every method that rung requires: the full fenced trio (`appendFenced`/`deleteFenced`/
+ * `deleteAllForRunFenced`, issue #207) PLUS `sealFenced` PLUS `listSealedForRun` (the ladder: seal
+ * requires the trio). This is the ONLY authoritative `seal` predicate.
+ */
+export function storeDeclaresSeal(store: TraceBufferStore): boolean {
+  const declared = store.traceCapabilities?.has('seal') ?? false;
+  const methodsPresent =
+    typeof store.appendFenced === 'function' &&
+    typeof store.deleteFenced === 'function' &&
+    typeof store.deleteAllForRunFenced === 'function' &&
+    typeof store.sealFenced === 'function' &&
+    typeof store.listSealedForRun === 'function';
+  return declared && methodsPresent;
+}
+
+/**
+ * True iff `store` both DECLARES `writer_nonce_carriage` (in `traceCapabilities`) AND satisfies
+ * `storeDeclaresSeal` (the ladder: carriage requires seal requires the trio). Carriage itself
+ * adds no NEW required method — the `options` bag on `append`/`appendFenced` is declaration-only
+ * (there is no way to detect "does this implementation actually read the options bag" other than
+ * declared capability + behavior), so this predicate is exactly "declared AND seal holds". This
+ * is the ONLY authoritative `writer_nonce_carriage` predicate.
+ */
+export function storeDeclaresNonceCarriage(store: TraceBufferStore): boolean {
+  const declared = store.traceCapabilities?.has('writer_nonce_carriage') ?? false;
+  return declared && storeDeclaresSeal(store);
+}
+
+/**
+ * Wiring-time validation MECHANISM (issue #197 PR-1, design §3/§12 — INVOKING this at the
+ * injection seams, e.g. `server.ts`/CLI executors, is deliberately PR-2's job, not this one's).
+ * Typed fail-loud (a `TRACE_CAPABILITY_INCONSISTENT` `WorkflowError`) when a rung is DECLARED but
+ * its predicate does not hold (declared-but-inconsistent — a construction-time wiring defect,
+ * never a runtime condition worth retrying). Silent success when a rung is simply undeclared —
+ * the honest floor: trio-alone, or no capabilities at all, are both fully legal and never an
+ * error.
+ */
+export function validateTraceCapabilities(store: TraceBufferStore): void {
+  const caps = store.traceCapabilities;
+  if (caps === undefined) return;
+
+  if (caps.has('seal') && !storeDeclaresSeal(store)) {
+    throw new WorkflowError(
+      "TraceBufferStore declares the 'seal' capability but does not implement all of its " +
+        'required methods (the fenced trio + sealFenced + listSealedForRun) — declared but ' +
+        'inconsistent.',
+      {
+        code: 'TRACE_CAPABILITY_INCONSISTENT',
+        category: 'ENGINE',
+        agentAction: 'stop',
+        retryable: false,
+        details: { capability: 'seal' },
+      },
+    );
+  }
+
+  if (caps.has('writer_nonce_carriage') && !storeDeclaresNonceCarriage(store)) {
+    throw new WorkflowError(
+      "TraceBufferStore declares the 'writer_nonce_carriage' capability but its 'seal' " +
+        'predicate does not hold (carriage requires seal requires the fenced trio) — declared ' +
+        'but inconsistent.',
+      {
+        code: 'TRACE_CAPABILITY_INCONSISTENT',
+        category: 'ENGINE',
+        agentAction: 'stop',
+        retryable: false,
+        details: { capability: 'writer_nonce_carriage' },
+      },
+    );
+  }
+}
+
+/**
+ * Pure per-writer + whole-file budget decision (issue #197 PR-1, design §5) — shared by every
+ * `TraceBufferStore` implementation enforcing this pair, so the decision logic and the
+ * `BufferFullDetails` shape live in exactly ONE place rather than being independently
+ * (and riskily divergently) reimplemented per store. Deliberately takes BEFORE-and-AFTER pairs
+ * (rather than a "delta" this call would add) because the two shipped stores compute "after"
+ * differently and both must stay exact: the fs store's JSONL format is genuinely additive (byte
+ * delta = the one new line's own serialized size), but the in-memory store's byte-identity
+ * constraint requires re-serializing the WHOLE flattened array exactly as its pre-#197 formula
+ * always did — forcing a shared "delta" abstraction on top of that would risk being byte-inexact
+ * for one of the two stores. Returns `undefined` when neither ceiling would be exceeded.
+ *
+ * Writer scope is checked FIRST: if the appender's own share alone would exceed the per-writer
+ * ceiling, that is what gets reported — a caller whose own share already exceeds the (smaller)
+ * per-writer ceiling should be told that specifically, not the (less actionable, and in that
+ * case also necessarily true) whole-file ceiling. This ordering is also what makes the compat
+ * law hold: an all-bare file's lone writer (⊥) hits `scope:'writer'` at exactly today's legacy
+ * limits — the file backstop (2×) is arithmetically unreachable for a single writer alone.
+ */
+export function checkBufferBudget(params: {
+  writerCountBefore: number;
+  writerBytesBefore: number;
+  writerCountAfter: number;
+  writerBytesAfter: number;
+  fileCountBefore: number;
+  fileBytesBefore: number;
+  fileCountAfter: number;
+  fileBytesAfter: number;
+}): BufferFullDetails | undefined {
+  const writerCountOver = params.writerCountAfter > BUFFER_LIMIT_COUNT;
+  const writerBytesOver = params.writerBytesAfter > BUFFER_LIMIT_BYTES;
+  if (writerCountOver || writerBytesOver) {
+    return {
+      scope: 'writer',
+      binding_dimension: writerCountOver ? 'count' : 'bytes',
+      count: {
+        requested: params.writerCountAfter,
+        used: params.writerCountBefore,
+        limit: BUFFER_LIMIT_COUNT,
+      },
+      bytes: {
+        requested: params.writerBytesAfter,
+        used: params.writerBytesBefore,
+        limit: BUFFER_LIMIT_BYTES,
+      },
+    };
+  }
+
+  const fileCountOver = params.fileCountAfter > BUFFER_BACKSTOP_COUNT;
+  const fileBytesOver = params.fileBytesAfter > BUFFER_BACKSTOP_BYTES;
+  if (fileCountOver || fileBytesOver) {
+    return {
+      scope: 'file',
+      binding_dimension: fileCountOver ? 'count' : 'bytes',
+      count: {
+        requested: params.fileCountAfter,
+        used: params.fileCountBefore,
+        limit: BUFFER_BACKSTOP_COUNT,
+      },
+      bytes: {
+        requested: params.fileBytesAfter,
+        used: params.fileBytesBefore,
+        limit: BUFFER_BACKSTOP_BYTES,
+      },
+      your_count: params.writerCountAfter,
+      your_bytes: params.writerBytesAfter,
+      total_count: params.fileCountAfter,
+      total_bytes: params.fileBytesAfter,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Builds the `BUFFER_FULL` `WorkflowError` from a `BufferFullDetails` (issue #197 PR-1, design
+ * §5) — the SAME message wording, error code, category, and `agentAction` every store uses, so
+ * the only thing that ever varies between stores is which concrete numbers went into `details`.
+ * Guidance wording is deliberate: foreign share (file scope's `your_*`/`total_*`) is stated as an
+ * observable FACT; crash causation for that foreign residue is NEVER asserted (design §5's
+ * corrected framing — foreign residue might be a live concurrent writer, not a crash). Code stays
+ * `BUFFER_FULL`, category `ENGINE`, `agentAction: 'provide_input'` — unchanged from before this
+ * capability existed.
+ */
+export function bufferFullError(details: BufferFullDetails): WorkflowError {
+  const scopeClause =
+    details.scope === 'writer'
+      ? `this writer's own share of the buffer (${details.binding_dimension} ceiling reached)`
+      : `the whole-file ${details.binding_dimension} ceiling (${details.total_count ?? 0} ` +
+        `entries / ${details.total_bytes ?? 0} bytes combined across every writer sharing this ` +
+        `step; this writer's own share is ${details.your_count ?? 0} entries / ` +
+        `${details.your_bytes ?? 0} bytes)`;
+  return new WorkflowError(
+    `Trace buffer full for step: ${scopeClause} reached. Settle the step to drain residue — ` +
+      'it is preserved (sealed) where the store supports it, and your options.trace always ' +
+      'survives.',
+    {
+      code: 'BUFFER_FULL',
+      category: 'ENGINE',
+      agentAction: 'provide_input',
+      retryable: false,
+      details: { ...details },
+    },
+  );
+}
+
+/**
+ * Flattens WAL batches (`{ts, entries, nonce?}`, issue #197 PR-1's internal batch shape — see
+ * `SealedWalLine`) into the read-back `BufferedEntry[]` shape, in batch order: `_internalTs` from
+ * the batch's `ts`; `_nonce` re-attached ONLY when the batch actually carried one (never
+ * fabricated for a bare batch — the key byte-identity property: a flattened all-bare batch list
+ * produces EXACTLY the same shape/bytes as the pre-#197 flat representation always did).
+ */
+export function flattenWalBatches(batches: readonly SealedWalLine[]): BufferedEntry[] {
+  return batches.flatMap((batch) =>
+    batch.entries.map((entry) => ({
+      ...entry,
+      _internalTs: batch.ts,
+      ...(batch.nonce !== undefined ? { _nonce: batch.nonce } : {}),
+    })),
+  );
+}
+
 /**
  * In-memory TraceBufferStore for use in tests and non-persistent environments.
  * Entries are lost on process restart (no file I/O).
  *
  * Declares the fenced trio (issue #207): `append`, `read`, `delete`, and `deleteAllForRun` all
  * serialize on the SAME per-(runId, stepId) critical section `appendFenced`/`deleteFenced` use,
- * via a per-key async mutex (a promise-chain map) — every one of the seven operations (the four
- * legacy methods plus the three fenced ones) for a given key runs strictly after the previous
- * operation on THAT SAME key has settled (success or failure). Liveness posture: a hung guard hangs only that key's chain — a different key's chain
- * is untouched and proceeds normally (this per-key granularity is load-bearing; see the TCK's
+ * via a per-key async mutex (a promise-chain map) — every one of the operations for a given key
+ * runs strictly after the previous operation on THAT SAME key has settled (success or failure).
+ * Liveness posture: a hung guard hangs only that key's chain — a different key's chain is
+ * untouched and proceeds normally (this per-key granularity is load-bearing; see the TCK's
  * PER_KEY_INDEPENDENCE law). The chain map's entry for a key is deleted once its own tail
  * settles and no newer call has chained after it, so an idle key holds no Map entry (no leak).
+ *
+ * Issue #197 PR-1 additionally declares BOTH capability-ladder rungs (`seal` and
+ * `writer_nonce_carriage`, `traceCapabilities`). The live-WAL internal representation is
+ * BATCH-preserving (`Map<string, SealedWalLine[]>`, one entry per `append`/`appendFenced` call) —
+ * NOT flattened — because `sealFenced` must be able to retire a key's exact batch history as one
+ * unit, and each batch's own (possibly absent) writer nonce must survive independently for
+ * carriage/budget partitioning. Every flattening surface (`read`, `readAllForRun`, `deleteFenced`'s
+ * count, the byte-budget arithmetic) derives its answer from this representation via
+ * `flattenWalBatches` (or direct batch arithmetic over it), reproducing the exact pre-#197
+ * observable shape and byte formula for all-bare traffic — see `appendUnlocked`.
  */
 export class InMemoryTraceBufferStore implements TraceBufferStore {
-  private buffers = new Map<string, BufferedEntry[]>();
+  readonly traceCapabilities: ReadonlySet<TraceCapability> = new Set([
+    'seal',
+    'writer_nonce_carriage',
+  ]);
+
+  // Live WAL per key, in append order — see the class doc for why this stays batch-shaped.
+  private buffers = new Map<string, SealedWalLine[]>();
+  // Sealed artifacts per key, in ascending `seq` order (issue #197 PR-1, the `seal` rung).
+  private sealed = new Map<string, SealedArtifact[]>();
   private chains = new Map<string, Promise<void>>();
 
   private key(runId: string, stepId: string): string {
@@ -238,18 +660,51 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
     return result;
   }
 
-  private appendUnlocked(k: string, entries: AgentTraceEntry[]): AppendResult {
-    const existing = this.buffers.get(k) ?? [];
+  /**
+   * Count + bytes for exactly the batches belonging to `writerNonce` (`undefined` = ⊥, the bare
+   * writer class) — computed by flattening JUST that writer's own batches and re-stringifying,
+   * so the byte number for a single-writer (all-bare) file is bit-for-bit the old whole-array
+   * formula. Equality is plain `===` over `batch.nonce ?? undefined`, which implements the
+   * design's `adopted(line) ⇔ line.nonce ≡ claimant.nonce, with absent ≡ absent` rule with no
+   * special-casing (`undefined === undefined` is `true`).
+   */
+  private partitionStats(
+    batches: readonly SealedWalLine[],
+    writerNonce: string | undefined,
+  ): { count: number; bytes: number } {
+    const own = batches.filter((b) => (b.nonce ?? undefined) === writerNonce);
+    const flattened = flattenWalBatches(own);
+    return { count: flattened.length, bytes: Buffer.byteLength(JSON.stringify(flattened)) };
+  }
+
+  /** Whole-file count + bytes across every writer combined — the pre-#197 formula, applied to
+   *  the full batch list regardless of how many distinct writers contributed to it. */
+  private fileStats(batches: readonly SealedWalLine[]): { count: number; bytes: number } {
+    const flattened = flattenWalBatches(batches);
+    return { count: flattened.length, bytes: Buffer.byteLength(JSON.stringify(flattened)) };
+  }
+
+  private appendUnlocked(
+    k: string,
+    entries: AgentTraceEntry[],
+    writerNonce: string | undefined,
+  ): AppendResult {
+    const existingBatches = this.buffers.get(k) ?? [];
+    const writerBefore = this.partitionStats(existingBatches, writerNonce);
+    const fileBefore = this.fileStats(existingBatches);
 
     if (entries.length === 0) {
-      const bytes = Buffer.byteLength(JSON.stringify(existing));
       return {
-        buffer_count: existing.length,
-        buffer_bytes: bytes,
+        buffer_count: writerBefore.count,
+        buffer_bytes: writerBefore.bytes,
         limit_count: BUFFER_LIMIT_COUNT,
         limit_bytes: BUFFER_LIMIT_BYTES,
         final_limit_entries: FINAL_LIMIT_ENTRIES,
         final_limit_bytes: FINAL_LIMIT_BYTES,
+        file_count: fileBefore.count,
+        file_bytes: fileBefore.bytes,
+        file_limit_count: BUFFER_BACKSTOP_COUNT,
+        file_limit_bytes: BUFFER_BACKSTOP_BYTES,
       };
     }
 
@@ -259,34 +714,52 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
       .filter((e): e is AgentTraceEntry => e !== null)
       .map((e) => ({ ...e, _internalTs: ts }));
 
-    const proposed = [...existing, ...normalized];
-    const proposedBytes = Buffer.byteLength(JSON.stringify(proposed));
-    if (proposed.length > BUFFER_LIMIT_COUNT || proposedBytes > BUFFER_LIMIT_BYTES) {
-      const existingBytes = Buffer.byteLength(JSON.stringify(existing));
-      throw new WorkflowError('Trace buffer full for step', {
-        code: 'BUFFER_FULL',
-        category: 'ENGINE',
-        agentAction: 'provide_input',
-        retryable: false,
-        details: { buffer_count: existing.length, buffer_bytes: existingBytes },
-      });
+    const newBatch: SealedWalLine =
+      writerNonce !== undefined
+        ? { ts, entries: normalized, nonce: writerNonce }
+        : { ts, entries: normalized };
+    const proposedBatches = [...existingBatches, newBatch];
+
+    const writerAfter = this.partitionStats(proposedBatches, writerNonce);
+    const fileAfter = this.fileStats(proposedBatches);
+
+    const overflow = checkBufferBudget({
+      writerCountBefore: writerBefore.count,
+      writerBytesBefore: writerBefore.bytes,
+      writerCountAfter: writerAfter.count,
+      writerBytesAfter: writerAfter.bytes,
+      fileCountBefore: fileBefore.count,
+      fileBytesBefore: fileBefore.bytes,
+      fileCountAfter: fileAfter.count,
+      fileBytesAfter: fileAfter.bytes,
+    });
+    if (overflow) {
+      throw bufferFullError(overflow);
     }
 
-    this.buffers.set(k, proposed);
-    const bytes = Buffer.byteLength(JSON.stringify(proposed));
+    this.buffers.set(k, proposedBatches);
     return {
-      buffer_count: proposed.length,
-      buffer_bytes: bytes,
+      buffer_count: writerAfter.count,
+      buffer_bytes: writerAfter.bytes,
       limit_count: BUFFER_LIMIT_COUNT,
       limit_bytes: BUFFER_LIMIT_BYTES,
       final_limit_entries: FINAL_LIMIT_ENTRIES,
       final_limit_bytes: FINAL_LIMIT_BYTES,
+      file_count: fileAfter.count,
+      file_bytes: fileAfter.bytes,
+      file_limit_count: BUFFER_BACKSTOP_COUNT,
+      file_limit_bytes: BUFFER_BACKSTOP_BYTES,
     };
   }
 
-  async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
+  async append(
+    runId: string,
+    stepId: string,
+    entries: AgentTraceEntry[],
+    options?: AppendOptions,
+  ): Promise<AppendResult> {
     const k = this.key(runId, stepId);
-    return this.withKeyLock(k, async () => this.appendUnlocked(k, entries));
+    return this.withKeyLock(k, async () => this.appendUnlocked(k, entries, options?.writerNonce));
   }
 
   /** guard runs INSIDE the per-key critical section, immediately before the write — see the
@@ -296,17 +769,18 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
     stepId: string,
     entries: AgentTraceEntry[],
     guard: () => Promise<void>,
+    options?: AppendOptions,
   ): Promise<AppendResult> {
     const k = this.key(runId, stepId);
     return this.withKeyLock(k, async () => {
       await guard();
-      return this.appendUnlocked(k, entries);
+      return this.appendUnlocked(k, entries, options?.writerNonce);
     });
   }
 
   async read(runId: string, stepId: string): Promise<BufferedEntry[]> {
     const k = this.key(runId, stepId);
-    return this.withKeyLock(k, async () => this.buffers.get(k) ?? []);
+    return this.withKeyLock(k, async () => flattenWalBatches(this.buffers.get(k) ?? []));
   }
 
   async delete(runId: string, stepId: string): Promise<void> {
@@ -318,23 +792,29 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
 
   /** guard runs INSIDE the same per-key critical section `appendFenced` uses, immediately before
    *  the delete — see the interface doc for the full guard contract. Returns the number of
-   *  entries actually deleted (0 = buffer already absent; the guard still ran first). */
+   *  entries actually deleted, summed across every live batch (0 = buffer already absent; the
+   *  guard still ran first). Sealed artifacts for this key are NOT touched — sealing exists
+   *  precisely to move content out of this destructive drain's reach; only `deleteAllForRun*`
+   *  (run-level bulk delete) also retires sealed artifacts. */
   async deleteFenced(runId: string, stepId: string, guard: () => Promise<void>): Promise<number> {
     const k = this.key(runId, stepId);
     return this.withKeyLock(k, async () => {
       await guard();
       const existing = this.buffers.get(k);
       this.buffers.delete(k);
-      return existing?.length ?? 0;
+      return existing !== undefined ? flattenWalBatches(existing).length : 0;
     });
   }
 
   async deleteAllForRun(runId: string, _dirEntries?: readonly string[]): Promise<void> {
     const prefix = `${runId}:`;
-    const keys = [...this.buffers.keys()].filter((k) => k.startsWith(prefix));
+    const keys = new Set(
+      [...this.buffers.keys(), ...this.sealed.keys()].filter((k) => k.startsWith(prefix)),
+    );
     for (const k of keys) {
       await this.withKeyLock(k, async () => {
         this.buffers.delete(k);
+        this.sealed.delete(k);
       });
     }
   }
@@ -342,15 +822,18 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
   /** guard is RE-INVOKED inside EACH per-(runId, stepId) critical section, immediately before
    *  that key's delete — see the interface doc for the full guard contract, including the
    *  zero-match-sweep invocation requirement (handled below: the guard still runs at least once
-   *  even when this run has no buffers at all). */
+   *  even when this run has no buffers at all). Sealed artifacts join this run-level bulk delete
+   *  (design §4 — a sealed artifact is retained ONLY until its owning run itself is purged). */
   async deleteAllForRunFenced(
     runId: string,
     guard: () => Promise<void>,
     _dirEntries?: readonly string[],
   ): Promise<void> {
     const prefix = `${runId}:`;
-    const keys = [...this.buffers.keys()].filter((k) => k.startsWith(prefix));
-    if (keys.length === 0) {
+    const keys = new Set(
+      [...this.buffers.keys(), ...this.sealed.keys()].filter((k) => k.startsWith(prefix)),
+    );
+    if (keys.size === 0) {
       await guard();
       return;
     }
@@ -358,20 +841,61 @@ export class InMemoryTraceBufferStore implements TraceBufferStore {
       await this.withKeyLock(k, async () => {
         await guard();
         this.buffers.delete(k);
+        this.sealed.delete(k);
       });
     }
   }
 
-  /** Returns each in-memory buffer for the run, keyed by stepId, as its stored `BufferedEntry[]`
-   *  (already-flattened individual entries — this store's own natural shape; see `append`).
-   *  Lock-free point-in-time diagnostic, matching #159's shipped `export`/`readAllForRun` posture
-   *  — deliberately NOT serialized through the per-key mutex (see D3 residual 9). */
+  /** guard runs INSIDE the per-key critical section, immediately before the seal-move — see the
+   *  interface doc for the full contract. Atomically retires the ENTIRE live batch history for
+   *  (runId, stepId) into a new sealed artifact (ascending `seq`), clearing the live buffer in
+   *  the same step — the in-memory analogue of the fs store's no-clobber rename-based seal
+   *  (there is no filesystem race to guard against here; the per-key mutex already serializes
+   *  every operation on this key, so `seq` can simply be the next array index). */
+  async sealFenced(runId: string, stepId: string, guard: () => Promise<void>): Promise<SealResult> {
+    const k = this.key(runId, stepId);
+    return this.withKeyLock(k, async () => {
+      await guard();
+      const live = this.buffers.get(k);
+      if (live === undefined || live.length === 0) {
+        return { sealed: false, reason: 'absent' };
+      }
+      const existingSealed = this.sealed.get(k) ?? [];
+      if (existingSealed.length >= SEALED_ARTIFACTS_LIMIT_PER_STEP) {
+        return { sealed: false, reason: 'capped' };
+      }
+      const artifact: SealedArtifact = { step_id: stepId, seq: existingSealed.length, lines: live };
+      this.sealed.set(k, [...existingSealed, artifact]);
+      this.buffers.delete(k);
+      return { sealed: true };
+    });
+  }
+
+  /** Lock-free point-in-time snapshot of every sealed artifact for a run, across all its steps —
+   *  matches `readAllForRun`'s deliberately-unlocked posture (see D3 residual 9). */
+  async listSealedForRun(runId: string): Promise<SealedArtifact[]> {
+    const prefix = `${runId}:`;
+    const result: SealedArtifact[] = [];
+    for (const [k, artifacts] of this.sealed.entries()) {
+      if (k.startsWith(prefix)) {
+        result.push(...artifacts);
+      }
+    }
+    return result;
+  }
+
+  /** Returns each in-memory LIVE buffer for the run, keyed by stepId, flattened to
+   *  `BufferedEntry[]` (this store's own natural read shape; see `read`). Lock-free
+   *  point-in-time diagnostic, matching #159's shipped `export`/`readAllForRun` posture —
+   *  deliberately NOT serialized through the per-key mutex (see D3 residual 9). Sealed artifacts
+   *  are NOT included (see `listSealedForRun`) — unchanged scope from before this capability
+   *  existed; PR-2 decides how/whether call sites merge the two. */
   async readAllForRun(runId: string): Promise<Record<string, unknown[]>> {
     const result: Record<string, unknown[]> = {};
     const prefix = `${runId}:`;
-    for (const [key, entries] of this.buffers.entries()) {
+    for (const [key, batches] of this.buffers.entries()) {
       if (key.startsWith(prefix)) {
-        result[key.slice(prefix.length)] = entries;
+        result[key.slice(prefix.length)] = flattenWalBatches(batches);
       }
     }
     return result;

--- a/packages/core/src/types/workflow-error.ts
+++ b/packages/core/src/types/workflow-error.ts
@@ -97,6 +97,12 @@ export type ErrorCode =
   | 'RESOURCE_NOT_ACCESSIBLE'
   // TRACE BUFFER
   | 'BUFFER_FULL'
+  // issue #197 PR-1: validateTraceCapabilities' typed fail-loud when a TraceBufferStore declares
+  // a capability-ladder rung ('seal'/'writer_nonce_carriage') whose required methods are NOT
+  // actually all present (declared-but-inconsistent) — a construction-time wiring defect, never
+  // a runtime condition. Undeclared is always silent success (the honest floor); this code is
+  // reserved for the declared-but-lying case only.
+  | 'TRACE_CAPABILITY_INCONSISTENT'
   // MCP
   | 'MCP_CONNECTION_FAILED'
   | 'MCP_TOOL_NOT_FOUND'

--- a/packages/mcp-server/src/json-trace-buffer-store.test.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.test.ts
@@ -2,15 +2,22 @@
 // #107). append/read/delete are exercised indirectly elsewhere (execution-loop finalization); this
 // file did not previously have dedicated coverage, so a handful of sanity tests are included too.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readdir, writeFile, appendFile } from 'node:fs/promises';
+import { mkdtemp, rm, readdir, writeFile, appendFile, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { storeDeclaresSeal, storeDeclaresNonceCarriage } from '@sensigo/realm';
 import { JsonTraceBufferStore } from './json-trace-buffer-store.js';
 
 /** Recomputes the exact on-disk WAL filename `walPath` uses — test-side only. */
 function walFileName(runId: string, stepId: string): string {
   return `trace-buffer-${runId}-${Buffer.from(stepId).toString('base64url')}.jsonl`;
+}
+
+/** Recomputes the exact on-disk SEALED artifact filename `sealedWalPath` uses (issue #197 PR-1)
+ *  — test-side only. */
+function sealedFileName(runId: string, stepId: string, seq: number): string {
+  return `sealed-trace-${runId}-${Buffer.from(stepId).toString('base64url')}.${seq}.jsonl`;
 }
 
 describe('JsonTraceBufferStore', () => {
@@ -273,6 +280,205 @@ describe('JsonTraceBufferStore', () => {
       await writeFile(join(dir, `${ORPHAN}.attempts.jsonl`), 'x');
       const orphans = await store.listOrphans(new Set());
       expect(orphans).toEqual([]);
+    });
+
+    it('a sealed artifact whose run is NOT live is also reported as an orphan (issue #197 PR-1)', async () => {
+      await store.append(ORPHAN, 'step-a', [{ event: 'x' }]);
+      const sealed = await store.sealFenced(ORPHAN, 'step-a', async () => {});
+      expect(sealed).toEqual({ sealed: true });
+
+      const orphans = await store.listOrphans(new Set());
+
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0]?.runId).toBe(ORPHAN);
+      expect(orphans[0]?.path).toBe(join(dir, sealedFileName(ORPHAN, 'step-a', 0)));
+    });
+
+    it('a sealed artifact whose run IS live is not reported', async () => {
+      await store.append(LIVE, 'step-a', [{ event: 'x' }]);
+      await store.sealFenced(LIVE, 'step-a', async () => {});
+
+      const orphans = await store.listOrphans(new Set([LIVE]));
+
+      expect(orphans).toEqual([]);
+    });
+  });
+
+  describe('capability declaration (issue #197 PR-1)', () => {
+    it('declares BOTH the seal and writer_nonce_carriage rungs, and both predicates hold', () => {
+      expect(store.traceCapabilities).toEqual(new Set(['seal', 'writer_nonce_carriage']));
+      expect(storeDeclaresSeal(store)).toBe(true);
+      expect(storeDeclaresNonceCarriage(store)).toBe(true);
+    });
+
+    it('traceCapabilities is immutable across reads (same reference, content-identical)', () => {
+      const first = store.traceCapabilities;
+      const second = store.traceCapabilities;
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('filename collision (issue #197 PR-1 — sealed vs live-WAL matchers)', () => {
+    it('a sealed artifact filename never matches the live-WAL matcher, and vice versa', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a' }]);
+      await store.sealFenced('run-1', 'step-a', async () => {});
+
+      const files = await readdir(dir);
+      const liveMatches = files.filter(
+        (f) => f.startsWith('trace-buffer-') && f.endsWith('.jsonl'),
+      );
+      const sealedMatches = files.filter(
+        (f) => f.startsWith('sealed-trace-') && f.endsWith('.jsonl'),
+      );
+
+      // The live WAL was moved (sealed), so it no longer exists as a live-matcher hit; the sealed
+      // artifact exists and matches ONLY the sealed prefix, never both.
+      expect(liveMatches).toEqual([]);
+      expect(sealedMatches).toEqual([sealedFileName('run-1', 'step-a', 0)]);
+      for (const f of sealedMatches) {
+        expect(f.startsWith('trace-buffer-')).toBe(false);
+      }
+    });
+  });
+
+  describe('sealFenced (issue #197 PR-1, the seal rung)', () => {
+    it('seals a live WAL: the live file is gone, a sealed artifact exists with the same lines', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a1' }]);
+      await store.append('run-1', 'step-a', [{ event: 'a2' }]);
+
+      const result = await store.sealFenced('run-1', 'step-a', async () => {});
+
+      expect(result).toEqual({ sealed: true });
+      expect(existsSync(join(dir, walFileName('run-1', 'step-a')))).toBe(false);
+      const sealedArtifacts = await store.listSealedForRun('run-1');
+      expect(sealedArtifacts).toHaveLength(1);
+      expect(sealedArtifacts[0]?.seq).toBe(0);
+      expect(sealedArtifacts[0]?.lines.flatMap((l) => l.entries)).toEqual([
+        { event: 'a1' },
+        { event: 'a2' },
+      ]);
+    });
+
+    it('returns {sealed:false, reason:"absent"} when no live WAL exists for this key', async () => {
+      const result = await store.sealFenced('run-1', 'never-appended', async () => {});
+      expect(result).toEqual({ sealed: false, reason: 'absent' });
+    });
+
+    it('repeated seals of the same key get ascending seq numbers', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a1' }]);
+      await store.sealFenced('run-1', 'step-a', async () => {});
+      await store.append('run-1', 'step-a', [{ event: 'a2' }]);
+      await store.sealFenced('run-1', 'step-a', async () => {});
+
+      const sealedArtifacts = await store.listSealedForRun('run-1');
+      expect(sealedArtifacts.map((a) => a.seq).sort()).toEqual([0, 1]);
+    });
+
+    it('returns {sealed:false, reason:"capped"} once SEALED_ARTIFACTS_LIMIT_PER_STEP is reached', async () => {
+      for (let i = 0; i < 8; i++) {
+        await store.append('run-1', 'step-a', [{ event: `a${i}` }]);
+        const result = await store.sealFenced('run-1', 'step-a', async () => {});
+        expect(result).toEqual({ sealed: true });
+      }
+      await store.append('run-1', 'step-a', [{ event: 'one-too-many' }]);
+      const result = await store.sealFenced('run-1', 'step-a', async () => {});
+      expect(result).toEqual({ sealed: false, reason: 'capped' });
+    });
+
+    it('no-clobber: a pre-existing file at seq 0 is never overwritten — the seal bumps to seq 1 and the sentinel bytes survive byte-for-byte (issue #197 PR-1)', async () => {
+      const sentinelPath = join(dir, sealedFileName('run-1', 'step-a', 0));
+      const sentinelBytes = 'SENTINEL-DO-NOT-CLOBBER- -bytes\n';
+      await writeFile(sentinelPath, sentinelBytes);
+
+      await store.append('run-1', 'step-a', [{ event: 'a' }]);
+      const result = await store.sealFenced('run-1', 'step-a', async () => {});
+
+      expect(result).toEqual({ sealed: true });
+      const sentinelAfter = await readFile(sentinelPath, 'utf8');
+      expect(sentinelAfter).toBe(sentinelBytes); // byte-for-byte untouched
+
+      const sealedArtifacts = await store.listSealedForRun('run-1');
+      const bumpedArtifact = sealedArtifacts.find((a) => a.step_id === 'step-a' && a.seq === 1);
+      expect(bumpedArtifact).toBeDefined(); // the real seal landed at seq 1, not seq 0
+      expect(bumpedArtifact?.lines.flatMap((l) => l.entries)).toEqual([{ event: 'a' }]);
+    });
+
+    it('the guard runs even when the result is "absent" (guard-in-CS, not conditional on presence)', async () => {
+      let guardCalls = 0;
+      await store.sealFenced('run-1', 'never-appended', async () => {
+        guardCalls++;
+      });
+      expect(guardCalls).toBe(1);
+    });
+
+    it('a refusing guard rejects the whole call — no seal happens', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a' }]);
+      await expect(
+        store.sealFenced('run-1', 'step-a', async () => {
+          throw new Error('refused');
+        }),
+      ).rejects.toThrow('refused');
+      expect(existsSync(join(dir, walFileName('run-1', 'step-a')))).toBe(true); // untouched
+    });
+  });
+
+  describe('writer nonce carriage + per-writer/file budgets (issue #197 PR-1)', () => {
+    it('append/appendFenced accept an options.writerNonce and read() re-attaches it as _nonce', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'nonced' }], { writerNonce: 'nonce-x' });
+      await store.append('run-1', 'step-a', [{ event: 'bare' }]);
+
+      const entries = await store.read('run-1', 'step-a');
+
+      const nonced = entries.find((e) => e.event === 'nonced');
+      const bare = entries.find((e) => e.event === 'bare');
+      expect(nonced?._nonce).toBe('nonce-x');
+      expect(bare).not.toHaveProperty('_nonce'); // never fabricated for a bare line
+    });
+
+    it('AppendResult reports separate writer-scope (buffer_*) and file-scope (file_*) numbers', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a' }, { event: 'b' }], {
+        writerNonce: 'nonce-x',
+      });
+      const result = await store.append('run-1', 'step-a', [{ event: 'c' }]); // bare, second writer
+
+      expect(result.buffer_count).toBe(1); // this (bare) writer's own share only
+      expect(result.file_count).toBe(3); // whole file, both writers combined
+      expect(result.file_limit_count).toBeGreaterThan(result.limit_count); // backstop > per-writer
+    });
+
+    it('a lone bare writer is byte-identical to the pre-#197 whole-file numbers (compat law)', async () => {
+      const r1 = await store.append('run-1', 'step-a', [{ event: 'a' }]);
+      const r2 = await store.append('run-1', 'step-a', [{ event: 'b' }]);
+
+      expect(r1.buffer_count).toBe(r1.file_count);
+      expect(r1.buffer_bytes).toBe(r1.file_bytes);
+      expect(r2.buffer_count).toBe(r2.file_count);
+      expect(r2.buffer_bytes).toBe(r2.file_bytes);
+    });
+  });
+
+  describe('sealed artifacts join deleteAllForRun (issue #197 PR-1)', () => {
+    it('deleteAllForRun removes sealed artifacts for the run alongside live WAL files', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a' }]);
+      await store.sealFenced('run-1', 'step-a', async () => {});
+      await store.append('run-1', 'step-b', [{ event: 'b' }]); // stays live, unset
+
+      await store.deleteAllForRun('run-1');
+
+      expect(await store.listSealedForRun('run-1')).toEqual([]);
+      expect(existsSync(join(dir, walFileName('run-1', 'step-b')))).toBe(false);
+    });
+
+    it('leaves a different run’s sealed artifacts untouched', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'a' }]);
+      await store.sealFenced('run-1', 'step-a', async () => {});
+      await store.append('run-2', 'step-a', [{ event: 'b' }]);
+      await store.sealFenced('run-2', 'step-a', async () => {});
+
+      await store.deleteAllForRun('run-1');
+
+      expect(await store.listSealedForRun('run-1')).toEqual([]);
+      expect(await store.listSealedForRun('run-2')).toHaveLength(1);
     });
   });
 });

--- a/packages/mcp-server/src/json-trace-buffer-store.test.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.test.ts
@@ -455,6 +455,72 @@ describe('JsonTraceBufferStore', () => {
       expect(r2.buffer_count).toBe(r2.file_count);
       expect(r2.buffer_bytes).toBe(r2.file_bytes);
     });
+
+    it('all-bare + torn line ⇒ ⊥ reports the whole file (byte-attribution rule pinned, correction)', async () => {
+      // The ⊥ (bare) partition's byte count is a RESIDUAL (whole-file bytes minus every nonced
+      // partition's own bytes) — never a direct sum over parsed bare lines — precisely so a
+      // torn/unparseable line's raw bytes (which never parse into ANY partition) still land
+      // somewhere: on ⊥, by construction of the subtraction, rather than vanishing. With no
+      // nonced partition at all here, the residual is arithmetically the WHOLE raw file — this
+      // pins that a torn line's bytes are not silently dropped from ⊥'s own count.
+      await store.append('run-1', 'step-a', [{ event: 'bare' }]);
+      const path = join(dir, walFileName('run-1', 'step-a'));
+      await appendFile(path, '{ this is not valid json\n', 'utf8');
+
+      // Independent ground truth: raw on-disk bytes, measured directly — never derived from the
+      // store's own return values.
+      const rawContent = await readFile(path, 'utf8');
+      const rawBytes = Buffer.byteLength(rawContent);
+
+      const probe = await store.append('run-1', 'step-a', []); // empty-entries probe, bare (⊥)
+
+      expect(probe.buffer_bytes).toBe(probe.file_bytes);
+      expect(probe.buffer_bytes).toBe(rawBytes);
+      expect(probe.file_bytes).toBe(rawBytes);
+    });
+
+    it('mixed (nonced + bare) + torn line ⇒ torn bytes belong to ⊥, never the nonced writer (correction)', async () => {
+      await store.append('run-1', 'step-a', [{ event: 'nonced' }], { writerNonce: 'N' });
+      await store.append('run-1', 'step-a', [{ event: 'bare' }]);
+      const path = join(dir, walFileName('run-1', 'step-a'));
+      await appendFile(path, '{ this is not valid json\n', 'utf8');
+
+      const rawContent = await readFile(path, 'utf8');
+      const rawBytes = Buffer.byteLength(rawContent);
+
+      // Recover the nonced line's EXACT on-disk shape (including its real `ts`, never guessed) so
+      // its expected serialized size can be computed independently of the store's own bookkeeping.
+      const parsedLines = rawContent
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+        .map((l) => {
+          try {
+            return JSON.parse(l) as { ts: number; entries: unknown[]; nonce?: string };
+          } catch {
+            return undefined;
+          }
+        });
+      const noncedLine = parsedLines.find((l) => l?.nonce === 'N');
+      expect(noncedLine).toBeDefined();
+      const expectedNoncedBytes = Buffer.byteLength(
+        JSON.stringify({
+          ts: noncedLine!.ts,
+          entries: noncedLine!.entries,
+          nonce: noncedLine!.nonce,
+        }) + '\n',
+      );
+
+      const noncedProbe = await store.append('run-1', 'step-a', [], { writerNonce: 'N' });
+      expect(noncedProbe.buffer_bytes).toBe(expectedNoncedBytes); // exactly its own line, nothing borrowed from ⊥
+      expect(noncedProbe.file_bytes).toBe(rawBytes);
+
+      const bareProbe = await store.append('run-1', 'step-a', []); // ⊥
+      // ⊥ = whole file minus the nonced partition's own bytes ⇒ its own bare line PLUS the torn
+      // line's bytes (never attributable to the nonced writer).
+      expect(bareProbe.buffer_bytes).toBe(rawBytes - expectedNoncedBytes);
+      expect(bareProbe.file_bytes).toBe(rawBytes);
+    });
   });
 
   describe('sealed artifacts join deleteAllForRun (issue #197 PR-1)', () => {

--- a/packages/mcp-server/src/json-trace-buffer-store.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.ts
@@ -7,6 +7,11 @@ import {
   type TraceBufferStore,
   type BufferedEntry,
   type AppendResult,
+  type AppendOptions,
+  type TraceCapability,
+  type SealResult,
+  type SealedWalLine,
+  type SealedArtifact,
   type PerRunArtifactStore,
   type OrphanSweepableStore,
   type OrphanArtifact,
@@ -15,20 +20,27 @@ import {
   BUFFER_LIMIT_BYTES,
   FINAL_LIMIT_ENTRIES,
   FINAL_LIMIT_BYTES,
+  BUFFER_BACKSTOP_COUNT,
+  BUFFER_BACKSTOP_BYTES,
+  SEALED_ARTIFACTS_LIMIT_PER_STEP,
+  checkBufferBudget,
+  bufferFullError,
+  flattenWalBatches,
   readIfExists,
   deleteIfExists,
   statIfExists,
   toArtifactDeleteFailedError,
+  linkNoClobberThenUnlink,
+  errnoCode,
   FsIoError,
 } from '@sensigo/realm';
 import type { AgentTraceEntry } from '@sensigo/realm';
 import { WorkflowError } from '@sensigo/realm';
 
-/** Line format stored in the JSONL WAL file. */
-interface WalLine {
-  ts: number;
-  entries: AgentTraceEntry[];
-}
+/** Line format stored in the JSONL WAL file — literally `SealedWalLine` (issue #197 PR-1: a
+ *  sealed artifact is exactly "the WAL, moved", so both the live and sealed representations share
+ *  one shape rather than two structurally-identical types). */
+type WalLine = SealedWalLine;
 
 /** WAL filename shape: `trace-buffer-<runId>-<base64url(stepId)>.jsonl`. `runId` is a
  *  server-generated UUIDv4 — always exactly 36 characters (8-4-4-4-12 hex, RFC 4122 string
@@ -38,6 +50,35 @@ interface WalLine {
 const WAL_PREFIX = 'trace-buffer-';
 const WAL_SUFFIX = '.jsonl';
 const RUN_ID_LENGTH = 36;
+
+/** Sealed-artifact filename shape (issue #197 PR-1, the `seal` rung — design §4):
+ *  `sealed-trace-<runId>-<base64url(stepId)>.<seq>.jsonl`. Distinct, non-overlapping prefix from
+ *  `WAL_PREFIX` (`'sealed-trace-'` vs `'trace-buffer-'` — neither is a prefix of the other, so no
+ *  filename can ever satisfy both matchers — see the collision test in the co-located spec). The
+ *  `.`-delimited `seq` is unambiguous against the rest of the name: neither a UUID nor the
+ *  base64url alphabet ever contains a literal `.`, so the LAST `.` in the middle segment is always
+ *  the seq separator, never part of the runId or step segment. */
+const SEALED_PREFIX = 'sealed-trace-';
+
+/** Parses a sealed-artifact filename back into its constituent parts, mirroring
+ *  `runIdFromWalPath`'s fixed-length-36 discipline for the runId portion. Returns `undefined` for
+ *  anything that doesn't match the shape this store itself ever writes (defensive — never throws,
+ *  never guesses) rather than a malformed/foreign file being mis-parsed. */
+function parseSealedFilename(
+  name: string,
+): { runId: string; safeStepId: string; seq: number } | undefined {
+  if (!name.startsWith(SEALED_PREFIX) || !name.endsWith(WAL_SUFFIX)) return undefined;
+  const middle = name.slice(SEALED_PREFIX.length, -WAL_SUFFIX.length); // "<runId>-<safeStepId>.<seq>"
+  const lastDot = middle.lastIndexOf('.');
+  if (lastDot === -1) return undefined;
+  const beforeSeq = middle.slice(0, lastDot);
+  const seqStr = middle.slice(lastDot + 1);
+  if (!/^\d+$/.test(seqStr)) return undefined;
+  if (beforeSeq.length <= RUN_ID_LENGTH || beforeSeq[RUN_ID_LENGTH] !== '-') return undefined;
+  const runId = beforeSeq.slice(0, RUN_ID_LENGTH);
+  const safeStepId = beforeSeq.slice(RUN_ID_LENGTH + 1);
+  return { runId, safeStepId, seq: Number(seqStr) };
+}
 
 /** A `proper-lockfile` retry policy: either a bare retry count (its own simple default backoff)
  *  or an explicit `retry`-module-compatible options object. */
@@ -115,10 +156,21 @@ function lockBusyError(walPath: string): WorkflowError {
  * the SAME per-(runId, stepId) critical section (a `proper-lockfile` lock on the WAL path)
  * `appendFenced`/`deleteFenced`/`deleteAllForRunFenced` use — see `lockWal` and the interface's
  * own doc for the full contract.
+ *
+ * Issue #197 PR-1 additionally declares BOTH capability-ladder rungs (`seal` and
+ * `writer_nonce_carriage`, `traceCapabilities`). `sealFenced` retires a live WAL file to a sealed
+ * artifact (`sealed-trace-<runId>-<base64url(stepId)>.<seq>.jsonl`) via the SAME `lockWal`
+ * chokepoint every other operation uses — see `sealFenced`'s own doc for the no-clobber move
+ * mechanics.
  */
 export class JsonTraceBufferStore
   implements TraceBufferStore, PerRunArtifactStore, OrphanSweepableStore
 {
+  readonly traceCapabilities: ReadonlySet<TraceCapability> = new Set([
+    'seal',
+    'writer_nonce_carriage',
+  ]);
+
   private readonly runsDir: string;
   private readonly lockProfile: TraceBufferLockProfile;
 
@@ -130,6 +182,13 @@ export class JsonTraceBufferStore
   private walPath(runId: string, stepId: string): string {
     const safeStepId = Buffer.from(stepId).toString('base64url');
     return join(this.runsDir, `trace-buffer-${runId}-${safeStepId}.jsonl`);
+  }
+
+  /** Builds the on-disk path for one sealed artifact — see `SEALED_PREFIX`'s doc for the shape
+   *  and why it never collides with a live WAL path. */
+  private sealedWalPath(runId: string, stepId: string, seq: number): string {
+    const safeStepId = Buffer.from(stepId).toString('base64url');
+    return join(this.runsDir, `${SEALED_PREFIX}${runId}-${safeStepId}.${seq}.jsonl`);
   }
 
   /**
@@ -205,12 +264,61 @@ export class JsonTraceBufferStore
   }
 
   /**
+   * Count + bytes for exactly the batches belonging to `writerNonce` (issue #197 PR-1, design §5's
+   * byte-attribution rule) — `undefined` = ⊥, the bare/anonymous writer class.
+   *
+   * A NONCED writer's stats are computed DIRECTLY: sum the `entries.length` and re-serialized
+   * byte size of exactly its own successfully-parsed lines. `JSON.stringify` of a parsed
+   * `WalLine` reproduces its ORIGINAL on-disk bytes exactly — this file only ever writes lines via
+   * `JSON.stringify({ts, entries[, nonce]})`, and V8 preserves string-key insertion order through
+   * parse→re-stringify, so re-serializing a parsed line is bit-for-bit identical to how it was
+   * actually written.
+   *
+   * ⊥'s stats are a RESIDUAL, not a direct sum: `bytes = fileBytes - Σ(every DISTINCT nonced
+   * partition's own bytes)`. This is what makes ⊥ "inherit all unattributable bytes" — a
+   * torn/unparseable line's raw bytes are captured in `fileBytes` (computed from the whole raw
+   * file content, not from re-stringifying parsed lines) but can never be subtracted out as part
+   * of any nonced partition (it never parsed into one), so they remain in ⊥'s residual exactly as
+   * they always silently were before this capability existed. For an all-bare file (no nonced
+   * lines at all), the residual is arithmetically the WHOLE file — byte-identical to the pre-#197
+   * formula, emergent rather than special-cased.
+   */
+  private partitionStats(
+    lines: readonly WalLine[],
+    fileBytes: number,
+    writerNonce: string | undefined,
+  ): { count: number; bytes: number } {
+    if (writerNonce !== undefined) {
+      const own = lines.filter((l) => l.nonce === writerNonce);
+      const count = own.reduce((acc, l) => acc + l.entries.length, 0);
+      const bytes = own.reduce((acc, l) => acc + Buffer.byteLength(JSON.stringify(l) + '\n'), 0);
+      return { count, bytes };
+    }
+    const noncedLines = lines.filter((l) => l.nonce !== undefined);
+    const noncedBytes = noncedLines.reduce(
+      (acc, l) => acc + Buffer.byteLength(JSON.stringify(l) + '\n'),
+      0,
+    );
+    const bareCount = lines
+      .filter((l) => l.nonce === undefined)
+      .reduce((acc, l) => acc + l.entries.length, 0);
+    return { count: bareCount, bytes: fileBytes - noncedBytes };
+  }
+
+  /**
    * The actual write logic, shared by `append` and `appendFenced` (issue #207) so BUFFER_FULL /
    * normalization / `AppendResult` shape live in exactly one place. Assumes the caller already
-   * holds the per-path critical section.
+   * holds the per-path critical section. `writerNonce` (issue #197 PR-1) is `undefined` for a bare
+   * call — the byte-identical legacy path (this file's own `newLine` shape omits the `nonce` key
+   * entirely when so, exactly matching the pre-#197 JSONL bytes for all-bare traffic).
    */
-  private async appendWithinCS(walPath: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
-    const { count: existingCount, bytes: existingBytes } = await this.readWal(walPath);
+  private async appendWithinCS(
+    walPath: string,
+    entries: AgentTraceEntry[],
+    writerNonce: string | undefined,
+  ): Promise<AppendResult> {
+    const { count: fileCountBefore, bytes: fileBytesBefore, lines } = await this.readWal(walPath);
+    const writerBefore = this.partitionStats(lines, fileBytesBefore, writerNonce);
 
     const normalized = entries
       .map((e) => normalizeEntryForBuffer(e))
@@ -218,57 +326,86 @@ export class JsonTraceBufferStore
 
     if (normalized.length === 0) {
       return {
-        buffer_count: existingCount,
-        buffer_bytes: existingBytes,
+        buffer_count: writerBefore.count,
+        buffer_bytes: writerBefore.bytes,
         limit_count: BUFFER_LIMIT_COUNT,
         limit_bytes: BUFFER_LIMIT_BYTES,
         final_limit_entries: FINAL_LIMIT_ENTRIES,
         final_limit_bytes: FINAL_LIMIT_BYTES,
+        file_count: fileCountBefore,
+        file_bytes: fileBytesBefore,
+        file_limit_count: BUFFER_BACKSTOP_COUNT,
+        file_limit_bytes: BUFFER_BACKSTOP_BYTES,
       };
     }
 
-    const newLine = JSON.stringify({ ts: Date.now(), entries: normalized });
+    const newLineObj: WalLine =
+      writerNonce !== undefined
+        ? { ts: Date.now(), entries: normalized, nonce: writerNonce }
+        : { ts: Date.now(), entries: normalized };
+    const newLine = JSON.stringify(newLineObj);
     const newBytes = Buffer.byteLength(newLine + '\n');
 
-    if (
-      existingCount + normalized.length > BUFFER_LIMIT_COUNT ||
-      existingBytes + newBytes > BUFFER_LIMIT_BYTES
-    ) {
-      throw new WorkflowError('Trace buffer full for step', {
-        code: 'BUFFER_FULL',
-        category: 'ENGINE',
-        agentAction: 'provide_input',
-        retryable: false,
-        details: { buffer_count: existingCount, buffer_bytes: existingBytes },
-      });
+    // JSONL is genuinely additive (unlike the in-memory store's whole-array restringify): the
+    // file-scope and this-writer's-own "after" numbers are simply "before" plus this one new
+    // line's own contribution — see `partitionStats`'s doc for why this holds for ⊥ too.
+    const writerCountAfter = writerBefore.count + normalized.length;
+    const writerBytesAfter = writerBefore.bytes + newBytes;
+    const fileCountAfter = fileCountBefore + normalized.length;
+    const fileBytesAfter = fileBytesBefore + newBytes;
+
+    const overflow = checkBufferBudget({
+      writerCountBefore: writerBefore.count,
+      writerBytesBefore: writerBefore.bytes,
+      writerCountAfter,
+      writerBytesAfter,
+      fileCountBefore,
+      fileBytesBefore,
+      fileCountAfter,
+      fileBytesAfter,
+    });
+    if (overflow) {
+      throw bufferFullError(overflow);
     }
 
     await appendFile(walPath, newLine + '\n', 'utf8');
 
-    const updatedCount = existingCount + normalized.length;
-    const updatedBytes = existingBytes + newBytes;
     return {
-      buffer_count: updatedCount,
-      buffer_bytes: updatedBytes,
+      buffer_count: writerCountAfter,
+      buffer_bytes: writerBytesAfter,
       limit_count: BUFFER_LIMIT_COUNT,
       limit_bytes: BUFFER_LIMIT_BYTES,
       final_limit_entries: FINAL_LIMIT_ENTRIES,
       final_limit_bytes: FINAL_LIMIT_BYTES,
+      file_count: fileCountAfter,
+      file_bytes: fileBytesAfter,
+      file_limit_count: BUFFER_BACKSTOP_COUNT,
+      file_limit_bytes: BUFFER_BACKSTOP_BYTES,
     };
   }
 
-  async append(runId: string, stepId: string, entries: AgentTraceEntry[]): Promise<AppendResult> {
+  async append(
+    runId: string,
+    stepId: string,
+    entries: AgentTraceEntry[],
+    options?: AppendOptions,
+  ): Promise<AppendResult> {
     const walPath = this.walPath(runId, stepId);
 
     if (entries.length === 0) {
-      const { count, bytes } = await this.readWal(walPath);
+      const { count: fileCount, bytes: fileBytes, lines } = await this.readWal(walPath);
+      const writer = this.partitionStats(lines, fileBytes, options?.writerNonce);
       return {
-        buffer_count: count,
-        buffer_bytes: bytes,
+        buffer_count: writer.count,
+        buffer_bytes: writer.bytes,
         limit_count: BUFFER_LIMIT_COUNT,
         limit_bytes: BUFFER_LIMIT_BYTES,
         final_limit_entries: FINAL_LIMIT_ENTRIES,
         final_limit_bytes: FINAL_LIMIT_BYTES,
+        file_count: fileCount,
+        file_bytes: fileBytes,
+        file_limit_count: BUFFER_BACKSTOP_COUNT,
+        file_limit_bytes: BUFFER_BACKSTOP_BYTES,
       };
     }
 
@@ -281,7 +418,7 @@ export class JsonTraceBufferStore
     let release: (() => Promise<void>) | undefined;
     try {
       release = await this.lockWal(walPath, APPEND_RETRIES);
-      return await this.appendWithinCS(walPath, entries);
+      return await this.appendWithinCS(walPath, entries, options?.writerNonce);
     } finally {
       if (release !== undefined) {
         await release();
@@ -302,25 +439,27 @@ export class JsonTraceBufferStore
     stepId: string,
     entries: AgentTraceEntry[],
     guard: () => Promise<void>,
+    options?: AppendOptions,
   ): Promise<AppendResult> {
     const walPath = this.walPath(runId, stepId);
     const release = await this.lockWal(walPath, APPEND_RETRIES);
     try {
       await guard();
-      return await this.appendWithinCS(walPath, entries);
+      return await this.appendWithinCS(walPath, entries, options?.writerNonce);
     } finally {
       await release();
     }
   }
 
+  /** `_nonce` is re-attached per-line ONLY when that line actually carried one — via the SAME
+   *  `flattenWalBatches` core helper the in-memory store uses, so "never fabricate `_nonce` for a
+   *  bare line" is enforced from exactly one shared code path rather than reimplemented twice. */
   async read(runId: string, stepId: string): Promise<BufferedEntry[]> {
     const walPath = this.walPath(runId, stepId);
     const release = await this.lockWal(walPath);
     try {
       const { lines } = await this.readWal(walPath);
-      return lines.flatMap((line) =>
-        line.entries.map((entry) => ({ ...entry, _internalTs: line.ts })),
-      );
+      return flattenWalBatches(lines);
     } finally {
       await release();
     }
@@ -368,6 +507,113 @@ export class JsonTraceBufferStore
     }
   }
 
+  /**
+   * `guard` runs INSIDE the SAME per-path critical section every other operation on this key
+   * uses (issue #197 PR-1, the `seal` rung — design §4: "no second locking path"), immediately
+   * before the seal-move. Atomically retires the live WAL file to a new sealed artifact via the
+   * no-clobber `link`-then-`unlink` primitive (`linkNoClobberThenUnlink`) — plain `rename()` is
+   * FORBIDDEN here, since it would silently overwrite an existing sealed artifact at the same
+   * `seq`.
+   *
+   * `seq` is probed by the link attempt ITSELF (no pre-listing, no separate TOCTOU-prone scan):
+   * starting at 0, an `EEXIST` on the link means that `seq` is already taken by an earlier seal —
+   * bump and retry, bounded by `SEALED_ARTIFACTS_LIMIT_PER_STEP`. Exhausting the bound without
+   * success returns `{sealed: false, reason: 'capped'}` — the caller falls back to the existing
+   * destructive drain (`deleteFenced`), never a silent eviction of an already-sealed artifact.
+   *
+   * `{sealed: false, reason: 'absent'}` when no live WAL file exists for this key AT ALL (checked
+   * via `statIfExists` — #183's ENOENT-is-absence discipline) — nothing to seal is success, not a
+   * failure. A present-but-empty file (e.g. `append()`'s legacy placeholder) is NOT "absent" — it
+   * gets sealed like any other live WAL (a harmless, if pointless, empty sealed artifact).
+   */
+  async sealFenced(runId: string, stepId: string, guard: () => Promise<void>): Promise<SealResult> {
+    const walPath = this.walPath(runId, stepId);
+    const release = await this.lockWal(walPath);
+    try {
+      await guard();
+
+      const stat = await statIfExists(walPath);
+      if (stat === undefined) {
+        return { sealed: false, reason: 'absent' };
+      }
+
+      for (let seq = 0; seq < SEALED_ARTIFACTS_LIMIT_PER_STEP; seq++) {
+        const sealedPath = this.sealedWalPath(runId, stepId, seq);
+        try {
+          await linkNoClobberThenUnlink(walPath, sealedPath);
+          return { sealed: true };
+        } catch (err) {
+          if (errnoCode(err) === 'EEXIST') continue; // this seq already taken — bump and retry
+          throw err;
+        }
+      }
+      return { sealed: false, reason: 'capped' };
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Lock-free point-in-time read of every sealed artifact for `runId`, across all its steps
+   * (issue #197 PR-1, the `seal` rung) — matches `readAllForRun`'s deliberately-unlocked posture.
+   * Parses each sealed file torn-tolerant, per-line, exactly like `readWal`/`readAllForRun` (a
+   * sealed artifact's raw bytes moved verbatim from the live WAL, including any trailing torn
+   * line it already had at seal time — this is a READ concern, not something sealing fixes).
+   */
+  async listSealedForRun(runId: string): Promise<SealedArtifact[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.runsDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+
+    // Unlike `listOrphans` (which must DISCOVER an unknown runId from an arbitrary filename, and
+    // so needs `parseSealedFilename`'s fixed-length-36 recovery), `runId` here is already KNOWN —
+    // filtering by literal prefix is both sufficient and correct regardless of whether `runId`
+    // happens to be UUID-shaped (real server-generated runIds always are; test doubles need not
+    // be). Only the step + seq portion (genuinely unknown) needs parsing out of each match.
+    const prefix = `${SEALED_PREFIX}${runId}-`;
+    const matching = entries.filter((f) => f.startsWith(prefix) && f.endsWith(WAL_SUFFIX)).sort();
+
+    const result: SealedArtifact[] = [];
+    for (const file of matching) {
+      const afterPrefix = file.slice(prefix.length, -WAL_SUFFIX.length); // "<safeStepId>.<seq>"
+      const lastDot = afterPrefix.lastIndexOf('.');
+      if (lastDot === -1) continue;
+      const safeStepId = afterPrefix.slice(0, lastDot);
+      const seqStr = afterPrefix.slice(lastDot + 1);
+      if (!/^\d+$/.test(seqStr)) continue;
+      const seq = Number(seqStr);
+
+      let stepId: string;
+      try {
+        stepId = Buffer.from(safeStepId, 'base64url').toString('utf8');
+      } catch {
+        continue; // malformed filename — skip this one artifact, not the whole listing
+      }
+
+      // issue #183: readIfExists discriminates ENOENT (vanished between readdir and this read —
+      // a benign race) from a genuine I/O failure (now throws).
+      const content = await readIfExists(join(this.runsDir, file));
+      if (content === undefined) continue;
+
+      const lines: SealedWalLine[] = [];
+      for (const raw of content.split('\n')) {
+        const trimmed = raw.trim();
+        if (trimmed.length === 0) continue;
+        try {
+          lines.push(JSON.parse(trimmed) as SealedWalLine);
+        } catch {
+          console.warn(`⚠ realm: skipping unparseable sealed-trace WAL line in '${file}'`);
+        }
+      }
+      result.push({ step_id: stepId, seq, lines });
+    }
+    return result;
+  }
+
   /** Resolves the candidate WAL files for `runId`, sorted deterministically — shared by
    *  `deleteAllForRun` and `deleteAllForRunFenced` (issue #207). */
   private async matchingWalFiles(
@@ -394,10 +640,36 @@ export class JsonTraceBufferStore
     return [...files].filter((f) => f.startsWith(prefix) && f.endsWith('.jsonl')).sort();
   }
 
+  /** Resolves the candidate SEALED artifact files for `runId`, sorted deterministically — the
+   *  same shared-`dirEntries`-or-own-`readdir` shape as `matchingWalFiles` (issue #197 PR-1: a
+   *  sealed artifact is retained only until its owning run itself is purged — design §4). */
+  private async matchingSealedFiles(
+    runId: string,
+    dirEntries: readonly string[] | undefined,
+  ): Promise<string[]> {
+    const prefix = `${SEALED_PREFIX}${runId}-`;
+    let files: readonly string[];
+    if (dirEntries !== undefined) {
+      files = dirEntries;
+    } else {
+      try {
+        files = await readdir(this.runsDir);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          files = [];
+        } else {
+          throw toArtifactDeleteFailedError(runId, 'JsonTraceBufferStore', [], this.runsDir, err);
+        }
+      }
+    }
+    return [...files].filter((f) => f.startsWith(prefix) && f.endsWith(WAL_SUFFIX)).sort();
+  }
+
   /**
    * Deletes every orphaned WAL file for `runId` (issue #107). Now serialized per-file on the same
    * critical section `appendFenced`/`deleteFenced` use (issue #207) — declaring the fenced trio
-   * commits this legacy method too.
+   * commits this legacy method too. Issue #197 PR-1: sealed artifacts for this run join the same
+   * sweep (`matchingSealedFiles`) — a sealed artifact outlives its step but not its run.
    *
    * @param dirEntries Optional pre-scanned `readdir(runsDir)` listing supplied by a batch purge —
    *   when present, this method filters it in-memory instead of re-scanning the directory itself
@@ -405,7 +677,10 @@ export class JsonTraceBufferStore
    *   omitted, exactly as before.
    */
   async deleteAllForRun(runId: string, dirEntries?: readonly string[]): Promise<void> {
-    const matching = await this.matchingWalFiles(runId, dirEntries);
+    const matching = [
+      ...(await this.matchingWalFiles(runId, dirEntries)),
+      ...(await this.matchingSealedFiles(runId, dirEntries)),
+    ];
 
     const deleted: string[] = [];
     for (const file of matching) {
@@ -447,13 +722,19 @@ export class JsonTraceBufferStore
    * outcome). The guard call itself sits OUTSIDE the try/catch scope that performs this wrapping
    * (see the loop body below) — so a guard that happens to throw an `FsIoError` (e.g. its own
    * lock-free `runStore.get` hitting EACCES) is never mistaken for `deleteIfExists`'s own failure.
+   *
+   * Issue #197 PR-1: sealed artifacts for this run join the same fenced sweep, same as the
+   * unfenced `deleteAllForRun` above.
    */
   async deleteAllForRunFenced(
     runId: string,
     guard: () => Promise<void>,
     dirEntries?: readonly string[],
   ): Promise<void> {
-    const matching = await this.matchingWalFiles(runId, dirEntries);
+    const matching = [
+      ...(await this.matchingWalFiles(runId, dirEntries)),
+      ...(await this.matchingSealedFiles(runId, dirEntries)),
+    ];
 
     if (matching.length === 0) {
       await guard();
@@ -585,17 +866,28 @@ export class JsonTraceBufferStore
 
     const orphans: OrphanArtifact[] = [];
     for (const name of entries) {
-      if (!name.startsWith(WAL_PREFIX) || !name.endsWith(WAL_SUFFIX)) continue;
+      let runId: string | undefined;
 
-      // Everything between the fixed prefix and suffix is "<uuid>-<b64url step>" — slice the
-      // UUID off by its KNOWN length, then require the very next character to be the '-'
-      // separator `walPath` always writes. A name that's too short, or missing that separator
-      // at exactly this position, is malformed (never produced by this store) — skip it rather
-      // than guess.
-      const afterPrefix = name.slice(WAL_PREFIX.length, -WAL_SUFFIX.length);
-      if (afterPrefix.length <= RUN_ID_LENGTH || afterPrefix[RUN_ID_LENGTH] !== '-') continue;
-      const runId = afterPrefix.slice(0, RUN_ID_LENGTH);
-      if (liveRunIds.has(runId)) continue;
+      if (name.startsWith(WAL_PREFIX) && name.endsWith(WAL_SUFFIX)) {
+        // Everything between the fixed prefix and suffix is "<uuid>-<b64url step>" — slice the
+        // UUID off by its KNOWN length, then require the very next character to be the '-'
+        // separator `walPath` always writes. A name that's too short, or missing that separator
+        // at exactly this position, is malformed (never produced by this store) — skip it rather
+        // than guess.
+        const afterPrefix = name.slice(WAL_PREFIX.length, -WAL_SUFFIX.length);
+        if (afterPrefix.length > RUN_ID_LENGTH && afterPrefix[RUN_ID_LENGTH] === '-') {
+          runId = afterPrefix.slice(0, RUN_ID_LENGTH);
+        }
+      } else if (name.startsWith(SEALED_PREFIX) && name.endsWith(WAL_SUFFIX)) {
+        // issue #197 PR-1: a sealed artifact is an orphan candidate too — same run-liveness rule,
+        // parsed via `parseSealedFilename` instead (distinct, non-overlapping prefix — see its
+        // doc — so this branch and the one above are mutually exclusive for any given `name`).
+        runId = parseSealedFilename(name)?.runId;
+      } else {
+        continue;
+      }
+
+      if (runId === undefined || liveRunIds.has(runId)) continue;
 
       const path = join(this.runsDir, name);
       // #183 discipline: statIfExists returns undefined only on ENOENT (a benign vanished-

--- a/packages/testing/src/store/fenced-trace-buffer-contract.ts
+++ b/packages/testing/src/store/fenced-trace-buffer-contract.ts
@@ -17,15 +17,35 @@ import {
   FsIoError,
   type TraceBufferStore,
   type AgentTraceEntry,
+  type TraceCapability,
+  storeDeclaresSeal,
+  storeDeclaresNonceCarriage,
+  validateTraceCapabilities,
+  BUFFER_LIMIT_COUNT,
+  BUFFER_BACKSTOP_COUNT,
+  SEALED_ARTIFACTS_LIMIT_PER_STEP,
 } from '@sensigo/realm';
 
-/** One of the five laws every fenced-trio-declaring `TraceBufferStore` must satisfy (issue #207). */
+/**
+ * One of the laws every fenced-trio-declaring `TraceBufferStore` must satisfy. The original five
+ * (issue #207) cover the fenced trio itself; the remaining five (issue #197 PR-1) cover the
+ * optional capability-ladder rungs a trio-declaring store MAY additionally declare (`seal` and
+ * `writer_nonce_carriage`) — each of those five produces an explicit, VISIBLE documented-skip case
+ * (never a silent omission) for a store that does not declare the relevant rung, mirroring the
+ * `fenceForm: 'native-predicate'` skip precedent already established for the latch-based trio
+ * laws below.
+ */
 export type FencedTraceBufferLaw =
   | 'STRUCTURAL'
   | 'FENCE_REFUSES'
   | 'CS_OCCUPANCY'
   | 'PER_KEY_INDEPENDENCE'
-  | 'NO_SILENT_LOSS';
+  | 'NO_SILENT_LOSS'
+  | 'CARRIAGE_ROUND_TRIP'
+  | 'SEAL'
+  | 'SEAL_BUDGET'
+  | 'PER_WRITER_BUDGET'
+  | 'VERBATIM';
 
 /**
  * A single, framework-agnostic contract case. `run()` throws (rejects) on failure — any test
@@ -66,6 +86,35 @@ export interface FencedTraceBufferContractAdapter {
    *  documentation — the TCK itself does not need to act on this value; it exists so a wiring
    *  test can assert (and a reader can see) that a genuinely generous profile is in use. */
   lockProfile?: unknown;
+
+  /**
+   * Per-adapter byte oracle for `PER_WRITER_BUDGET` (issue #197 PR-1) — since the in-memory and fs
+   * stores compute "bytes" via genuinely different formulas (whole-array restringify vs
+   * JSONL-additive), this TCK can only assert exact ENTRY COUNTS store-agnostically; exact BYTE
+   * equality needs each adapter to supply its own oracle, computed however that concrete store's
+   * own `AppendResult.buffer_bytes`/`file_bytes` are actually derived. Optional — a store without
+   * this hook still runs every count-based `PER_WRITER_BUDGET` assertion; only the byte-exactness
+   * sub-assertion is skipped (visibly, never silently) for that adapter.
+   */
+  bytesOracle?: (
+    runId: string,
+    stepId: string,
+    writerNonce: string | undefined,
+  ) => Promise<{ count: number; bytes: number }>;
+
+  /**
+   * fs-scoped raw on-disk byte access for `VERBATIM` (issue #197 PR-1) — reads the RAW bytes of a
+   * live WAL path and of one sealed artifact (`seq`), so the law can assert a seal moves bytes
+   * byte-for-byte (no parse/re-copy/truncation/dedup). `undefined` from either function means "no
+   * file at that path" (mirrors `readIfExists`'s absence convention). Optional — a store without
+   * this hook (e.g. the in-memory store, which has no on-disk representation at all) skips ONLY
+   * the raw-byte-exactness case; the shape-tolerant sibling case still runs unconditionally for
+   * every `seal`-declaring store.
+   */
+  rawWalAccess?: {
+    readLiveRaw: (runId: string, stepId: string) => Promise<string | undefined>;
+    readSealedRaw: (runId: string, stepId: string, seq: number) => Promise<string | undefined>;
+  };
 }
 
 const REFUSAL_CODE = 'STATE_RUN_BUSY';
@@ -86,6 +135,59 @@ function refusingGuard(): () => Promise<void> {
 
 function passingGuard(): () => Promise<void> {
   return async () => {};
+}
+
+/**
+ * A minimal, otherwise-legal `TraceBufferStore` STUB (issue #197 PR-1) — implements only the four
+ * mandatory legacy methods (never actually called by these cases) plus a HAND-SET
+ * `traceCapabilities`, deliberately WITHOUT any of the fenced-trio/seal methods regardless of what
+ * `caps` declares. Used exclusively to exercise `validateTraceCapabilities` against a
+ * declared-but-inconsistent shape — never mixed with the real adapter store, which always
+ * satisfies its OWN declaration (see the "internally consistent" STRUCTURAL case instead).
+ */
+function minimalStubStore(caps: ReadonlySet<TraceCapability> | undefined): TraceBufferStore {
+  return {
+    ...(caps !== undefined ? { traceCapabilities: caps } : {}),
+    append: async () => ({
+      buffer_count: 0,
+      buffer_bytes: 0,
+      limit_count: 0,
+      limit_bytes: 0,
+      final_limit_entries: 0,
+      final_limit_bytes: 0,
+    }),
+    read: async () => [],
+    delete: async () => {},
+    deleteAllForRun: async () => {},
+    readAllForRun: async () => ({}),
+  };
+}
+
+/** Runs a SYNCHRONOUS throwing function and returns what it threw, or `undefined` if it didn't —
+ *  `validateTraceCapabilities` is synchronous, so this avoids an unnecessary async try/catch at
+ *  every call site above. */
+function catchSync(fn: () => void): unknown {
+  try {
+    fn();
+    return undefined;
+  } catch (err) {
+    return err;
+  }
+}
+
+/** Asserts `err` is exactly the typed `TRACE_CAPABILITY_INCONSISTENT` `WorkflowError`
+ *  `validateTraceCapabilities` throws for a declared-but-inconsistent rung, naming `capability` in
+ *  its `details` — never some other error shape. */
+function assertCapabilityInconsistent(err: unknown, capability: TraceCapability): void {
+  if (
+    !(err instanceof WorkflowError) ||
+    err.code !== 'TRACE_CAPABILITY_INCONSISTENT' ||
+    err.details.capability !== capability
+  ) {
+    throw new Error(
+      `expected a typed WorkflowError(TRACE_CAPABILITY_INCONSISTENT, details.capability=${capability}), got: ${err instanceof Error ? err.message : err}`,
+    );
+  }
 }
 
 function eventsOf(entries: readonly AgentTraceEntry[]): string[] {
@@ -447,6 +549,422 @@ function buildNoSilentLossCase(
   };
 }
 
+/** A visible, non-silent documented-skip case for a law that a store's declared capabilities
+ *  don't reach — mirrors the `fenceForm: 'native-predicate'` skip precedent for the latch-based
+ *  trio laws. `reason` names exactly why (e.g. "store does not declare 'seal'"). */
+function skipCase(
+  law: FencedTraceBufferLaw,
+  name: string,
+  reason: string,
+): FencedTraceBufferContractCase {
+  return {
+    law,
+    name: `SKIPPED — ${reason}: ${name}`,
+    run: async () => {
+      // Intentional no-op — see the case name for why.
+    },
+  };
+}
+
+// ── CARRIAGE_ROUND_TRIP (issue #197 PR-1, the writer_nonce_carriage rung) ────────────────────────
+function buildCarriageRoundTripCases(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase[] {
+  const { store } = adapter;
+  if (!storeDeclaresNonceCarriage(store)) {
+    return [
+      skipCase(
+        'CARRIAGE_ROUND_TRIP',
+        "nonce round-trip via options.writerNonce and read()'s _nonce",
+        "store does not declare 'writer_nonce_carriage'",
+      ),
+    ];
+  }
+  return [
+    {
+      law: 'CARRIAGE_ROUND_TRIP',
+      name: 'a nonced append round-trips _nonce on read(); a bare append NEVER has _nonce fabricated',
+      run: async () => {
+        const { runId, stepId } = adapter.makeKey();
+        const NONCE = 'carriage-tck-nonce-1';
+        await store.append(runId, stepId, [{ event: 'nonced' }], { writerNonce: NONCE });
+        await store.append(runId, stepId, [{ event: 'bare' }]);
+
+        const entries = await store.read(runId, stepId);
+        const nonced = entries.find((e) => e.event === 'nonced');
+        const bare = entries.find((e) => e.event === 'bare');
+
+        if (nonced?._nonce !== NONCE) {
+          throw new Error(
+            `expected the nonced entry's _nonce to round-trip as '${NONCE}', got: ${nonced?._nonce}`,
+          );
+        }
+        if (bare !== undefined && Object.prototype.hasOwnProperty.call(bare, '_nonce')) {
+          throw new Error(
+            `expected the bare entry to have NO _nonce property at all (never fabricated), got: ${JSON.stringify(bare)}`,
+          );
+        }
+      },
+    },
+  ];
+}
+
+// ── SEAL + SEAL_BUDGET (issue #197 PR-1, the seal rung) ──────────────────────────────────────────
+function buildSealCases(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase[] {
+  const { store } = adapter;
+  if (!storeDeclaresSeal(store)) {
+    return [
+      skipCase(
+        'SEAL',
+        'sealFenced retires a live WAL to a sealed artifact',
+        "store does not declare 'seal'",
+      ),
+      skipCase(
+        'SEAL_BUDGET',
+        'repeated seals up to SEALED_ARTIFACTS_LIMIT_PER_STEP, then capped',
+        "store does not declare 'seal'",
+      ),
+    ];
+  }
+
+  const cases: FencedTraceBufferContractCase[] = [];
+
+  cases.push({
+    law: 'SEAL',
+    name: 'sealFenced on an absent key returns {sealed:false, reason:"absent"}; the guard still runs',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      let guardCalls = 0;
+      const result = await store.sealFenced!(runId, stepId, async () => {
+        guardCalls++;
+      });
+      if (!(result.sealed === false && result.reason === 'absent')) {
+        throw new Error(`expected {sealed:false, reason:'absent'}, got: ${JSON.stringify(result)}`);
+      }
+      if (guardCalls < 1) {
+        throw new Error('expected the guard to run at least once even for an absent key');
+      }
+    },
+  });
+
+  cases.push({
+    law: 'SEAL',
+    name: 'sealFenced retires the live WAL: read() goes empty, listSealedForRun reports the same lines',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      await store.append(runId, stepId, [{ event: 'a1' }]);
+      await store.append(runId, stepId, [{ event: 'a2' }]);
+
+      const result = await store.sealFenced!(runId, stepId, passingGuard());
+      if (result.sealed !== true) {
+        throw new Error(`expected {sealed:true}, got: ${JSON.stringify(result)}`);
+      }
+
+      const afterLive = await store.read(runId, stepId);
+      if (afterLive.length !== 0) {
+        throw new Error(
+          `expected the live WAL empty after sealing, got ${afterLive.length} entries`,
+        );
+      }
+
+      const sealedArtifacts = await store.listSealedForRun!(runId);
+      const thisKeyArtifacts = sealedArtifacts.filter((a) => a.step_id === stepId);
+      if (thisKeyArtifacts.length !== 1) {
+        throw new Error(
+          `expected exactly 1 sealed artifact for this key, got ${thisKeyArtifacts.length}`,
+        );
+      }
+      const sealedEvents = thisKeyArtifacts[0]!.lines.flatMap((l) => l.entries.map((e) => e.event));
+      if (JSON.stringify(sealedEvents) !== JSON.stringify(['a1', 'a2'])) {
+        throw new Error(
+          `expected sealed lines to preserve ['a1','a2'] in order, got ${JSON.stringify(sealedEvents)}`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'SEAL',
+    name: 'a refusing guard rejects sealFenced — nothing is moved (live content survives, no new sealed artifact)',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      await store.append(runId, stepId, [{ event: 'a' }]);
+      const before = await store.listSealedForRun!(runId);
+
+      let caught: unknown;
+      try {
+        await store.sealFenced!(runId, stepId, refusingGuard());
+      } catch (err) {
+        caught = err;
+      }
+      if (!(caught instanceof WorkflowError) || caught.code !== REFUSAL_CODE) {
+        throw new Error(`expected a typed WorkflowError(${REFUSAL_CODE}), got: ${caught}`);
+      }
+
+      const afterLive = await store.read(runId, stepId);
+      if (afterLive.length !== 1) {
+        throw new Error(
+          `expected the live WAL untouched after a refused seal, got ${afterLive.length} entries`,
+        );
+      }
+      const after = await store.listSealedForRun!(runId);
+      if (after.length !== before.length) {
+        throw new Error('expected no new sealed artifact after a refused seal');
+      }
+    },
+  });
+
+  cases.push({
+    law: 'SEAL',
+    name: 'deleteAllForRun retires sealed artifacts for the run too, not just the live WAL',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      await store.append(runId, stepId, [{ event: 'a' }]);
+      await store.sealFenced!(runId, stepId, passingGuard());
+      const beforeCount = (await store.listSealedForRun!(runId)).length;
+      if (beforeCount < 1) {
+        throw new Error(
+          'setup invariant violated: expected at least one sealed artifact before deleteAllForRun',
+        );
+      }
+
+      await store.deleteAllForRun(runId);
+
+      const after = await store.listSealedForRun!(runId);
+      if (after.length !== 0) {
+        throw new Error(
+          `expected deleteAllForRun to also remove sealed artifacts, got ${after.length} remaining`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'SEAL_BUDGET',
+    name: 'repeated seals of the same key succeed up to SEALED_ARTIFACTS_LIMIT_PER_STEP, then return {sealed:false, reason:"capped"} without evicting or losing data',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      for (let i = 0; i < SEALED_ARTIFACTS_LIMIT_PER_STEP; i++) {
+        await store.append(runId, stepId, [{ event: `e${i}` }]);
+        const result = await store.sealFenced!(runId, stepId, passingGuard());
+        if (result.sealed !== true) {
+          throw new Error(`expected seal #${i} to succeed, got: ${JSON.stringify(result)}`);
+        }
+      }
+      const atCap = (await store.listSealedForRun!(runId)).filter((a) => a.step_id === stepId);
+      if (atCap.length !== SEALED_ARTIFACTS_LIMIT_PER_STEP) {
+        throw new Error(
+          `expected exactly SEALED_ARTIFACTS_LIMIT_PER_STEP (${SEALED_ARTIFACTS_LIMIT_PER_STEP}) sealed artifacts, got ${atCap.length}`,
+        );
+      }
+
+      await store.append(runId, stepId, [{ event: 'one-too-many' }]);
+      const capped = await store.sealFenced!(runId, stepId, passingGuard());
+      if (!(capped.sealed === false && capped.reason === 'capped')) {
+        throw new Error(`expected {sealed:false, reason:'capped'}, got: ${JSON.stringify(capped)}`);
+      }
+
+      // No silent eviction: still exactly the same N sealed artifacts, and the live content that
+      // failed to seal is still readable (the caller's fallback path — destructive drain — remains
+      // available; this law only asserts nothing was silently lost yet).
+      const stillAtCap = (await store.listSealedForRun!(runId)).filter((a) => a.step_id === stepId);
+      if (stillAtCap.length !== SEALED_ARTIFACTS_LIMIT_PER_STEP) {
+        throw new Error(
+          `expected the cap to hold at exactly ${SEALED_ARTIFACTS_LIMIT_PER_STEP} (no eviction), got ${stillAtCap.length}`,
+        );
+      }
+      const liveAfterCapped = await store.read(runId, stepId);
+      if (liveAfterCapped.length !== 1 || liveAfterCapped[0]?.event !== 'one-too-many') {
+        throw new Error(
+          'expected the un-sealable live content to remain readable (fallback-eligible), got: ' +
+            JSON.stringify(liveAfterCapped),
+        );
+      }
+    },
+  });
+
+  return cases;
+}
+
+// ── PER_WRITER_BUDGET (issue #197 PR-1, design §5) ────────────────────────────────────────────────
+function buildPerWriterBudgetCases(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase[] {
+  const { store } = adapter;
+  const batch = (n: number, label: string): AgentTraceEntry[] =>
+    Array.from({ length: n }, (_, i) => ({ event: `${label}-${i}` }));
+
+  const cases: FencedTraceBufferContractCase[] = [];
+
+  cases.push({
+    law: 'PER_WRITER_BUDGET',
+    name: "theft-fixed: one writer's near-full own partition does not steal another writer's independent budget on the SAME key",
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      const NEAR_LIMIT = BUFFER_LIMIT_COUNT - 1;
+      await store.append(runId, stepId, batch(NEAR_LIMIT, 'w1'), { writerNonce: 'w1' });
+      const r2 = await store.append(runId, stepId, batch(NEAR_LIMIT, 'w2'), { writerNonce: 'w2' });
+      // A "theft" bug (partitioning by whole-file instead of by writer) would see w1's NEAR_LIMIT
+      // already committed and refuse w2's own NEAR_LIMIT-sized append (combined > BUFFER_LIMIT_COUNT
+      // if mistakenly compared against the PER-WRITER ceiling) — a conforming store must not.
+      if (r2.buffer_count !== NEAR_LIMIT) {
+        throw new Error(
+          `expected writer 'w2' to independently commit its own ${NEAR_LIMIT} entries regardless ` +
+            `of writer 'w1's own near-full partition on the same key, got buffer_count=${r2.buffer_count}`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'PER_WRITER_BUDGET',
+    name: 'the whole-file backstop binds across combined writers even when no single writer exceeds its own per-writer ceiling',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      const THIRD = Math.floor(BUFFER_BACKSTOP_COUNT / 3) + 10; // 3× exceeds the backstop; each alone is well under BUFFER_LIMIT_COUNT
+      await store.append(runId, stepId, batch(THIRD, 'a'), { writerNonce: 'a' });
+      await store.append(runId, stepId, batch(THIRD, 'b'), { writerNonce: 'b' });
+
+      let caught: unknown;
+      try {
+        await store.append(runId, stepId, batch(THIRD, 'c'), { writerNonce: 'c' });
+      } catch (err) {
+        caught = err;
+      }
+      if (!(caught instanceof WorkflowError) || caught.code !== 'BUFFER_FULL') {
+        throw new Error(
+          `expected a BUFFER_FULL WorkflowError once the combined file exceeds the backstop, got: ${caught}`,
+        );
+      }
+      const details = caught.details as { scope?: string };
+      if (details.scope !== 'file') {
+        throw new Error(
+          `expected details.scope === 'file' for a whole-file-backstop refusal, got: ${JSON.stringify(details)}`,
+        );
+      }
+    },
+  });
+
+  if (adapter.bytesOracle !== undefined) {
+    cases.push({
+      law: 'PER_WRITER_BUDGET',
+      name: "byte-exactness (adapter-supplied oracle): AppendResult's writer/file byte numbers match the oracle's own independent computation",
+      run: async () => {
+        const { runId, stepId } = adapter.makeKey();
+        const NONCE = 'byte-oracle-writer';
+        const result = await store.append(runId, stepId, [{ event: 'e1' }, { event: 'e2' }], {
+          writerNonce: NONCE,
+        });
+        const oracle = await adapter.bytesOracle!(runId, stepId, NONCE);
+        if (result.buffer_bytes !== oracle.bytes || result.buffer_count !== oracle.count) {
+          throw new Error(
+            `expected AppendResult writer-scope {count:${oracle.count}, bytes:${oracle.bytes}} per the ` +
+              `oracle, got {count:${result.buffer_count}, bytes:${result.buffer_bytes}}`,
+          );
+        }
+      },
+    });
+  } else {
+    cases.push(
+      skipCase(
+        'PER_WRITER_BUDGET',
+        'byte-exactness against an adapter-supplied oracle',
+        'adapter did not supply bytesOracle (count-based assertions above still ran)',
+      ),
+    );
+  }
+
+  return cases;
+}
+
+// ── VERBATIM (issue #197 PR-1, the seal rung's byte-fidelity guarantee) ──────────────────────────
+function buildVerbatimCases(
+  adapter: FencedTraceBufferContractAdapter,
+): FencedTraceBufferContractCase[] {
+  const { store } = adapter;
+  if (!storeDeclaresSeal(store)) {
+    return [
+      skipCase(
+        'VERBATIM',
+        'a seal moves bytes/shape without loss',
+        "store does not declare 'seal'",
+      ),
+    ];
+  }
+
+  const cases: FencedTraceBufferContractCase[] = [];
+
+  // Shape-tolerant sibling — runs UNCONDITIONALLY for every seal-declaring store (in-memory has no
+  // on-disk representation at all, so only logical content/order can be asserted for it).
+  cases.push({
+    law: 'VERBATIM',
+    name: 'shape-tolerant: sealed content preserves every entry, in order, with no duplication or loss',
+    run: async () => {
+      const { runId, stepId } = adapter.makeKey();
+      const B: AgentTraceEntry[] = [{ event: 'v0' }, { event: 'v1' }, { event: 'v2' }];
+      await store.append(runId, stepId, B);
+      await store.sealFenced!(runId, stepId, passingGuard());
+
+      const sealedArtifacts = (await store.listSealedForRun!(runId)).filter(
+        (a) => a.step_id === stepId,
+      );
+      const events = sealedArtifacts.flatMap((a) =>
+        a.lines.flatMap((l) => l.entries.map((e) => e.event)),
+      );
+      if (JSON.stringify(events) !== JSON.stringify(['v0', 'v1', 'v2'])) {
+        throw new Error(
+          `expected sealed content ['v0','v1','v2'] in order, got ${JSON.stringify(events)}`,
+        );
+      }
+    },
+  });
+
+  if (adapter.rawWalAccess !== undefined) {
+    cases.push({
+      law: 'VERBATIM',
+      name: 'fs-scoped: a seal moves the live WAL bytes to the sealed artifact byte-for-byte (no parse/re-copy)',
+      run: async () => {
+        const { runId, stepId } = adapter.makeKey();
+        await store.append(runId, stepId, [{ event: 'raw1' }, { event: 'raw2' }]);
+        const rawBefore = await adapter.rawWalAccess!.readLiveRaw(runId, stepId);
+        if (rawBefore === undefined) {
+          throw new Error('expected the live WAL to exist (raw bytes) before sealing');
+        }
+
+        const result = await store.sealFenced!(runId, stepId, passingGuard());
+        if (result.sealed !== true) {
+          throw new Error(`expected {sealed:true}, got: ${JSON.stringify(result)}`);
+        }
+
+        const rawAfter = await adapter.rawWalAccess!.readSealedRaw(runId, stepId, 0);
+        if (rawAfter === undefined) {
+          throw new Error(
+            'expected the sealed artifact to exist (raw bytes) at seq 0 after sealing',
+          );
+        }
+        if (rawAfter !== rawBefore) {
+          throw new Error(
+            'expected the sealed artifact bytes to be byte-for-byte identical to the pre-seal live ' +
+              `WAL bytes, got a difference (before=${JSON.stringify(rawBefore)}, after=${JSON.stringify(rawAfter)})`,
+          );
+        }
+      },
+    });
+  } else {
+    cases.push(
+      skipCase(
+        'VERBATIM',
+        'byte-for-byte raw comparison against an adapter-supplied rawWalAccess hook',
+        'adapter did not supply rawWalAccess (the shape-tolerant sibling case above still ran)',
+      ),
+    );
+  }
+
+  return cases;
+}
+
 /**
  * Builds the contract cases for `adapter`. See each law's own doc above (the `build*Case`
  * functions) for what it asserts. For `fenceForm: 'native-predicate'` adapters, `CS_OCCUPANCY`,
@@ -475,6 +993,77 @@ export function fencedTraceBufferContract(
       if (anyDeclared && !allDeclared) {
         throw new Error(
           `store declares a SUBSET of the fenced trio (must be all-or-nothing): ${JSON.stringify(has)}`,
+        );
+      }
+    },
+  });
+
+  // issue #197 PR-1: the capability-ladder STRUCTURAL cases below. The first three exercise
+  // `validateTraceCapabilities` against hand-built STUB stores (never the real adapter store) —
+  // this is deliberately a MECHANISM test: PR-1 ships `validateTraceCapabilities` itself, but
+  // invoking it at real injection seams is PR-2's job, so there is no real call site yet whose
+  // behavior this could observe indirectly.
+  cases.push({
+    law: 'STRUCTURAL',
+    name: 'validateTraceCapabilities: declaring writer_nonce_carriage without seal methods throws TRACE_CAPABILITY_INCONSISTENT',
+    run: async () => {
+      const stub = minimalStubStore(new Set<TraceCapability>(['writer_nonce_carriage']));
+      const err = catchSync(() => validateTraceCapabilities(stub));
+      assertCapabilityInconsistent(err, 'writer_nonce_carriage');
+    },
+  });
+
+  cases.push({
+    law: 'STRUCTURAL',
+    name: 'validateTraceCapabilities: declaring seal without the fenced trio + sealFenced/listSealedForRun throws TRACE_CAPABILITY_INCONSISTENT',
+    run: async () => {
+      const stub = minimalStubStore(new Set<TraceCapability>(['seal'])); // no fenced trio, no sealFenced
+      const err = catchSync(() => validateTraceCapabilities(stub));
+      assertCapabilityInconsistent(err, 'seal');
+    },
+  });
+
+  cases.push({
+    law: 'STRUCTURAL',
+    name: 'validateTraceCapabilities: an undeclared store (no traceCapabilities at all) is a silent no-op — trio-alone stays legal',
+    run: async () => {
+      const stub = minimalStubStore(undefined);
+      const err = catchSync(() => validateTraceCapabilities(stub));
+      if (err !== undefined) {
+        throw new Error(`expected no throw for an undeclared store, got: ${err}`);
+      }
+    },
+  });
+
+  cases.push({
+    law: 'STRUCTURAL',
+    name: "traceCapabilities is immutable: two reads of the REAL adapter store's declaration are content-identical",
+    run: async () => {
+      const first = store.traceCapabilities;
+      const second = store.traceCapabilities;
+      const firstArr = [...(first ?? [])].sort();
+      const secondArr = [...(second ?? [])].sort();
+      if (JSON.stringify(firstArr) !== JSON.stringify(secondArr)) {
+        throw new Error(
+          `expected two reads of traceCapabilities to be content-identical, got ${JSON.stringify(firstArr)} then ${JSON.stringify(secondArr)}`,
+        );
+      }
+    },
+  });
+
+  cases.push({
+    law: 'STRUCTURAL',
+    name: "the REAL adapter store's own declaration is internally consistent (ladder holds for what it actually declares)",
+    run: async () => {
+      const caps = store.traceCapabilities;
+      if (caps?.has('seal') === true && !storeDeclaresSeal(store)) {
+        throw new Error(
+          "adapter store declares 'seal' but storeDeclaresSeal(store) is false — declared but inconsistent",
+        );
+      }
+      if (caps?.has('writer_nonce_carriage') === true && !storeDeclaresNonceCarriage(store)) {
+        throw new Error(
+          "adapter store declares 'writer_nonce_carriage' but storeDeclaresNonceCarriage(store) is false — declared but inconsistent",
         );
       }
     },
@@ -716,6 +1305,15 @@ export function fencedTraceBufferContract(
     cases.push(buildPerKeyIndependenceCase(adapter));
     cases.push(buildNoSilentLossCase(adapter));
   }
+
+  // ── Capability-ladder laws (issue #197 PR-1): CARRIAGE_ROUND_TRIP, SEAL, SEAL_BUDGET,
+  // PER_WRITER_BUDGET, VERBATIM. Each produces a visible documented-skip (never a silent
+  // omission) for a store that doesn't declare the relevant rung — see each build*Cases
+  // function's own doc.
+  cases.push(...buildCarriageRoundTripCases(adapter));
+  cases.push(...buildSealCases(adapter));
+  cases.push(...buildPerWriterBudgetCases(adapter));
+  cases.push(...buildVerbatimCases(adapter));
 
   return cases;
 }


### PR DESCRIPTION
## Context

Issue #197 (filed 2026-07-15 as the deferred completion of the #185 trace-buffer arc) — the trace WAL has no writer identity: a crashed prior attempt's buffered lines are folded into the next driver's canonical evidence (false attribution, honest-labeled since #185, destroyed-with-warning at reclaim since #207), and a dead writer's residue consumes a live writer's `BUFFER_FULL` budget. The full design debate (2-round peer exploration, 3-round design review, 14-agent prior-art sweep) converged on "Attributed Adoption with Sealed-WAL Preservation" — normative record in the local design plan; user-ratified 2026-07-18.

## Motivation

This is **PR-1 of 2: the store layer only, behaviorally inert in production** — nothing mints or passes a nonce at any real call site yet; all appends remain bare, so budgets and adoption stay byte-identical (emergent, verified). It lands the substrate PR-2's engine/tool adoption will wire: a declarable capability ladder, an atomic preservation primitive grounded in Kafka/journald's never-copy-refused-content discipline, and per-writer budgets that end the dead-writer budget-theft class.

## Changes

- **Capability ladder** (`traceCapabilities?: ReadonlySet<'seal' | 'writer_nonce_carriage'>`): implication runs upward-requires-downward only (carriage ⇒ seal ⇒ fenced trio; trio alone stays fully legal). One authoritative predicate module — `storeDeclaresSeal` / `storeDeclaresNonceCarriage` / `validateTraceCapabilities` (typed `TRACE_CAPABILITY_INCONSISTENT` fail-loud on declared-but-inconsistent; undeclared = honest floor, never an error). Declaration immutability documented + TCK-asserted.
- **`sealFenced(runId, stepId, guard)`** — atomically retires the entire live WAL to a sealed artifact (`sealed-trace-<runId>-<b64url(stepId)>.<seq>.jsonl`) under the same per-key critical section the fenced trio uses: no-clobber `link`-then-`unlink` move via a new #183-typed `fs-io.ts` primitive (`rename` clobbers and is forbidden; the link attempt IS the seq probe — seed 0, `EEXIST` ⇒ bump), raw bytes verbatim (no parse/copy/truncation), bounded by `SEALED_ARTIFACTS_LIMIT_PER_STEP` (cap ⇒ caller falls back to the destructive drain). `listSealedForRun` reads artifacts back torn-tolerant. Sealed artifacts join per-run deletion (purge) and orphan enumeration (gc).
- **Writer-nonce carriage**: `append`/`appendFenced` grow a trailing `options?: {writerNonce?: string}`; the WAL line gains `nonce?`; `read()` re-attaches `BufferedEntry._nonce` (never fabricated for a bare line — enforced from the one shared `flattenWalBatches` path).
- **Per-writer budgets + file backstop**: `BUFFER_LIMIT_*` re-documented per-writer (values unchanged); additive `BUFFER_BACKSTOP_*` (2×). `BUFFER_FULL` details gain `scope`/`binding_dimension`/per-dimension `{requested, used, limit}` triples/file-scope occupancy evidence. ⊥ (bare) inherits all unattributable bytes (torn lines) — all-bare traffic reports numbers byte-identical to before (compat law, tested exactly).
- **`InMemoryTraceBufferStore`** becomes batch-preserving internally with full parity (both rungs, seal, budgets); all flattening surfaces preserve their prior observable behavior exactly.
- **TCK**: five new laws (`CARRIAGE_ROUND_TRIP`, `SEAL`, `SEAL_BUDGET`, `PER_WRITER_BUDGET`, `VERBATIM`) with visible documented-skips for non-declaring stores; fs adapter supplies `bytesOracle` + `rawWalAccess` hooks.
- **Guard-2 self-scan false-positive fixed** (pre-existing, discovered during #207) via the Guard-3 `import.meta.url` self-exclusion; Guard-3's stale doc comment corrected.
- Correction commit: two tests pinning the ⊥ torn-byte inheritance rule (found unpinned by an architect-side mutation probe).

## Verification

```bash
npx turbo run build test lint --force   # core 1718 / mcp 228 / testing 81 / cli 753 — all green
npm run check:versions                  # all 0.26.0
```

Mutation probes (all red→restore→green, transcripts in the local reports): whole-file partition mutation ⇒ `PER_WRITER_BUDGET` red; `_nonce` fabrication ⇒ `CARRIAGE_ROUND_TRIP` red (both stores, one shared path); guard skip in `sealFenced` ⇒ `SEAL` red; ladder check dropped ⇒ `STRUCTURAL` red; primitive swapped to `rename` ⇒ 3 tests red incl. the pre-placed-sentinel no-clobber test; ⊥ residual broken ⇒ the 2 correction tests red, 39 others green.

## Rollback

```bash
git revert c2057f4 93155a3
```

No data migrations; the new WAL `nonce` field and sealed artifacts are ignored by older readers (unknown-field/unknown-file tolerant — verified downgrade posture).

## Related

Issue #197 (PR-1 of 2 — do **not** auto-close; PR-2 delivers the engine/tool adoption). Builds on #207 (fenced trio) and #183 (fs contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
