### PR TITLE
feat(engine): attributed adoption with sealed-WAL preservation — nonce partition, seal call-sites, protocol surface, export v3 (#197 PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,52 @@ All notable changes to this project are documented here.
   rung — never a silent omission (mirroring the existing `fenceForm: 'native-predicate'` skip
   precedent). **Nothing in this PR mints or reads a nonce at any real call site, and no engine/
   MCP-tool/CLI behavior changes** — that adoption is PR-2.
+- **Attributed adoption: the writer-nonce ladder wired everywhere (issue #197, PR-2 of 2 — the
+  adoption this program exists for).** `append_trace` and `execute_step` gain an optional
+  `writer_nonce` argument (opaque, client-minted, 1–128 chars, no leading/trailing whitespace —
+  every shape violation routes through one typed `VALIDATION_EMPTY_VALUE` refusal, never a bare
+  zod/SDK error). A new core module, `trace-adoption.ts`, exports the ONE authoritative predicate
+  (`adoptsLine`/`partitionBufferedEntries`: `adopted(line) ⇔ line.nonce ≡ claimant.nonce, absent ≡
+absent`) — used identically by the pre-claim `trace_schema` enforce-gate and the post-claim
+  adoption split (ADOPTION_CONGRUENCE: a foreign-nonce-only WAL can never gate a nonced claimant).
+  The claimant's nonce is honored ONLY when the configured `traceBufferStore` declares
+  `writer_nonce_carriage` (the activation gate) — on a lesser store it is IGNORED entirely (the
+  honest #185 adopt-all floor) plus a loud advisory naming the missing leg. Three-way honest split
+  on `trace_summary`: `buffered_lines_adopted` (⊥-adopted, existing caveat, narrowed to bare-only —
+  numerically unchanged for all-bare traffic), new `attributed_lines_adopted` (own-nonce adopted,
+  NO caveat — "writer continuity verified, strength conditional on nonce secrecy", never "faithful"),
+  new `foreign_lines_preserved` (a different writer's lines, preserved not adopted, with a pointer
+  to `realm run export` — foreign nonce VALUES never appear in any warning/envelope). Mirrored as
+  additive `adopted_own`/`adopted_anonymous`/`preserved_foreign` on the `execute_step`
+  `ResponseEnvelope`, set by the engine (the MCP layer never sees per-line nonces); a half-minted
+  advisory fires when a nonced claimant finds only bare lines, or a bare claimant finds every
+  foreign line under one shared nonce (signature heuristics — no same-attempt rescue, ever).
+  `append_trace` gains a downgrade-detector marker, `writer_nonce_applied: true`, present only when
+  a nonce was both supplied and actually carried. At settle time (success and failure), a step
+  whose post-claim read found foreign lines now SEALS the WAL (via PR-1's `sealFenced`) instead of
+  destroying it, on any seal-declaring store — `preserved_foreign === 0` (the common case, and the
+  only case on a non-seal store) keeps today's plain `delete()`, byte-identical; the run record
+  carries detection counts only, never the seal outcome (that rides the envelope warning only).
+  Reclaim now preserves too: on a seal-declaring store, both fenced call sites `sealFenced` the
+  ENTIRE stale WAL (zero-cooperation, no partitioning) instead of draining it, with the existing
+  version fence unchanged; a non-seal (trio-only) store keeps the #207 destructive drain, byte-frozen.
+  `realm run`/`realm agent` gain `--mint-writer-nonce` (mints a fresh UUIDv4 per step-attempt; no
+  caller-fixed value is ever accepted). `realm run export`'s bundle bumps to
+  `realm_export_version: 3`, adding `sealed: Record<stepId, SealedArtifact[]> | null` (`null` =
+  the store doesn't declare `seal`; `{}` = declares it but this run has none) via the new
+  `listSealedForRun`; a non-terminal export redacts every `nonce` value belonging to a step
+  currently in `in_progress_steps` with a fixed `"[redacted-live-claim]"` marker (claims never
+  persist their own nonce, so this stateless step-liveness proxy is the only disclosure control
+  available — terminal exports are always verbatim). `purge`/`gc` needed NO code changes — PR-1
+  already routed sealed artifacts through `deleteAllForRun`/`listOrphans`; verified with new tests,
+  not just trusted. A new dormant strict posture, `REALM_REQUIRE_WRITER_NONCE` (env, read per call,
+  default off), refuses a bare agent-step call on `append_trace`/`execute_step` and force-enables
+  CLI minting when set — zero behavior change while unset. `get_workflow_protocol` gains one
+  affordance line teaching cooperating agents to mint a nonce (opt-in, mirroring `append_trace`'s
+  own posture). **Zero-cooperation byte-identity holds for all-bare traffic through every changed
+  path** (modulo additive fields appearing only when a nonce was provided) — the sole deliberate
+  carve-out is reclaim, which now seals rather than drains an all-bare WAL on a seal-declaring
+  store (preserve-ALL is the point, not a violation).
 
 ### Changed
 

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -61,6 +61,26 @@ export interface AgentDeps {
    * an existing caller that omits it keeps today's behavior exactly (no trace adoption at all).
    */
   traceBufferStore?: TraceBufferStore;
+  /**
+   * Mint a FRESH `writer_nonce` (UUIDv4) per step-attempt (issue #197 PR-2) — resolved once in
+   * `agent.ts` from `--mint-writer-nonce` OR'd with the `REALM_REQUIRE_WRITER_NONCE` strict-flip
+   * (design §8: the strict posture force-enables minting even without the flag). Default `false`/
+   * absent ⇒ today's byte-identical ⊥ (bare) behavior. Never a caller-fixed value — a fresh
+   * `crypto.randomUUID()` is minted independently for EVERY step-attempt in the loop below.
+   */
+  mintWriterNonce?: boolean;
+}
+
+/**
+ * Dormant strict posture (issue #197 PR-2, design §6 — the #169→#170 template): read PER CALL,
+ * never cached at module load (a test flips the env var mid-process). "on" = set to any
+ * non-empty value other than `'0'`/`'false'`. A strict-flip force-enables minting even without
+ * `--mint-writer-nonce` (design §8).
+ */
+function shouldMintWriterNonce(deps: Pick<AgentDeps, 'mintWriterNonce'>): boolean {
+  const v = process.env['REALM_REQUIRE_WRITER_NONCE'];
+  const required = v !== undefined && v !== '' && v !== '0' && v !== 'false';
+  return deps.mintWriterNonce === true || required;
 }
 
 export interface AgentRunOptions {
@@ -507,6 +527,10 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         registry: deps.registry,
         ...(deps.traceBufferStore !== undefined ? { traceBufferStore: deps.traceBufferStore } : {}),
         ...(toolCallsForMeta !== undefined ? { stepMeta: { toolCalls: toolCallsForMeta } } : {}),
+        // issue #197 PR-2: a FRESH nonce per step-attempt — resolved per call, never cached, so
+        // the strict-flip (checked inside shouldMintWriterNonce) is honored even if the env var
+        // changes mid-process (tests flip it).
+        ...(shouldMintWriterNonce(deps) ? { writerNonce: crypto.randomUUID() } : {}),
       });
 
       if (result.status === 'error') {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -86,6 +86,12 @@ export const agentCommand = new Command('agent')
     '--project <dir>',
     'CONFIG anchor: deployment root whose realm.yaml applies to definitions without a stored trust_root (default: current directory)',
   )
+  .option(
+    '--mint-writer-nonce',
+    'Mint a fresh writer_nonce (UUIDv4) per step-attempt for faithful trace attribution (issue ' +
+      "#197) — opt-in; default OFF (today's behavior). No caller-supplied value is accepted.",
+    false,
+  )
   .action(
     async (opts: {
       workflow?: string;
@@ -98,6 +104,7 @@ export const agentCommand = new Command('agent')
       register?: boolean;
       extensionsModule?: string;
       project?: string;
+      mintWriterNonce?: boolean;
     }) => {
       if (!opts.workflow && !opts.runId) {
         console.error('Error: one of --workflow or --run-id is required');
@@ -192,6 +199,9 @@ export const agentCommand = new Command('agent')
               provider,
               registry: loaded.registry,
               traceBufferStore,
+              // issue #197 PR-2: default OFF; the strict-flip (REALM_REQUIRE_WRITER_NONCE) force-
+              // enables minting even without the flag — resolved once in run-agent.ts's loop.
+              mintWriterNonce: opts.mintWriterNonce === true,
               ...(gateHandler ? { gateHandler } : {}),
               ...(loaded.secretValues !== undefined
                 ? { redactionValues: loaded.secretValues }
@@ -232,6 +242,9 @@ export const agentCommand = new Command('agent')
               provider,
               registry: loaded.registry,
               traceBufferStore,
+              // issue #197 PR-2: default OFF; the strict-flip (REALM_REQUIRE_WRITER_NONCE) force-
+              // enables minting even without the flag — resolved once in run-agent.ts's loop.
+              mintWriterNonce: opts.mintWriterNonce === true,
               ...(gateHandler ? { gateHandler } : {}),
               ...(loaded.secretValues !== undefined
                 ? { redactionValues: loaded.secretValues }

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -94,7 +94,7 @@ describe('buildExportBundle', () => {
       );
 
       expect(warning).toBeUndefined(); // terminal — no best-effort warning
-      expect(bundle.realm_export_version).toBe(2);
+      expect(bundle.realm_export_version).toBe(3);
       expect(bundle.exported_at).toBe(now.toISOString());
       expect(bundle.run).toEqual(run);
       expect(bundle.attempts).toHaveLength(1);
@@ -498,6 +498,217 @@ describe('buildExportBundle', () => {
 
       const after = await readdir(dir);
       expect(after.sort()).toEqual(before.sort()); // no new file, no temp, nothing removed
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('sealed trace artifacts (issue #197 PR-2)', () => {
+  it('sealed is null when the configured traceBufferStore does not declare listSealedForRun (incapability)', async () => {
+    const { dir, runStore, failedAttemptStore } = await makeStores();
+    try {
+      const run = makeRun({ run_phase: 'completed', terminal_state: true });
+      await injectRun(dir, run);
+
+      const incapableTraceBufferStore = { readAllForRun: async () => ({}) };
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore: incapableTraceBufferStore,
+      });
+
+      expect(bundle.sealed).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('sealed is {} (not null) when the store declares seal but this run genuinely has no sealed artifacts', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({ run_phase: 'completed', terminal_state: true });
+      await injectRun(dir, run);
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      expect(bundle.sealed).toEqual({});
+      expect(bundle.sealed).not.toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('sealed is populated, grouped by step_id, when sealed artifacts genuinely exist', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({ run_phase: 'completed', terminal_state: true });
+      await injectRun(dir, run);
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'stale' }]);
+      await traceBufferStore.sealFenced!(run.id, 'step-a', async () => {});
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      expect(bundle.sealed).not.toBeNull();
+      expect(Object.keys(bundle.sealed!)).toEqual(['step-a']);
+      expect(bundle.sealed!['step-a']).toHaveLength(1);
+      expect(
+        bundle.sealed!['step-a']![0]!.lines.flatMap((l) => l.entries.map((e) => e.event)),
+      ).toEqual(['stale']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a listSealedForRun failure joins artifact_errors + complete: false (the #186 posture)', async () => {
+    const { dir, runStore, failedAttemptStore } = await makeStores();
+    try {
+      const run = makeRun({ run_phase: 'completed', terminal_state: true });
+      await injectRun(dir, run);
+
+      const brokenTraceBufferStore = {
+        readAllForRun: async () => ({}),
+        listSealedForRun: async () => {
+          throw new FsIoError(
+            'readFile',
+            '/fake/sealed.jsonl',
+            Object.assign(new Error('sealed-boom'), { code: 'EIO' }),
+          );
+        },
+      };
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore: brokenTraceBufferStore,
+      });
+
+      expect(bundle.complete).toBe(false);
+      expect(bundle.sealed).toEqual({});
+      expect(bundle.artifact_errors).toContainEqual({
+        artifact: 'sealed trace artifacts',
+        code: 'EIO',
+        message: expect.stringContaining('sealed-boom'),
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('non-disclosure redaction (issue #197 PR-2, design §6)', () => {
+  it('non-terminal export redacts nonce values on WAL lines belonging to an in-progress step', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({
+        run_phase: 'running',
+        terminal_state: false,
+        in_progress_steps: ['step-a'],
+      });
+      await injectRun(dir, run);
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'nonced' }], {
+        writerNonce: 'live-nonce-value',
+      });
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'bare' }]);
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      const lines = bundle.wal['step-a'] as Array<{ nonce?: string; entries: { event: string }[] }>;
+      const noncedLine = lines.find((l) => l.entries.some((e) => e.event === 'nonced'))!;
+      const bareLine = lines.find((l) => l.entries.some((e) => e.event === 'bare'))!;
+      expect(noncedLine.nonce).toBe('[redacted-live-claim]');
+      expect(bareLine).not.toHaveProperty('nonce'); // bare — nothing to redact
+      expect(JSON.stringify(bundle)).not.toContain('live-nonce-value');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a step NOT in in_progress_steps (already settled) is verbatim even on a non-terminal export', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({
+        run_phase: 'running',
+        terminal_state: false,
+        in_progress_steps: ['step-b'], // step-a is NOT live
+      });
+      await injectRun(dir, run);
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'settled' }], {
+        writerNonce: 'settled-nonce-value',
+      });
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      const lines = bundle.wal['step-a'] as Array<{ nonce?: string }>;
+      expect(lines[0]?.nonce).toBe('settled-nonce-value');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('terminal export is verbatim — no redaction even for a nonce that WOULD match a (now-irrelevant) in_progress_steps entry', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({ run_phase: 'completed', terminal_state: true, in_progress_steps: [] });
+      await injectRun(dir, run);
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'nonced' }], {
+        writerNonce: 'terminal-nonce-value',
+      });
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      const lines = bundle.wal['step-a'] as Array<{ nonce?: string }>;
+      expect(lines[0]?.nonce).toBe('terminal-nonce-value');
+      expect(JSON.stringify(bundle)).toContain('terminal-nonce-value');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('non-terminal export redacts sealed-artifact nonces for a live step too', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({
+        run_phase: 'running',
+        terminal_state: false,
+        in_progress_steps: ['step-a'],
+      });
+      await injectRun(dir, run);
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'stale' }], {
+        writerNonce: 'sealed-live-nonce',
+      });
+      await traceBufferStore.sealFenced!(run.id, 'step-a', async () => {});
+
+      const { bundle } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      const artifact = bundle.sealed!['step-a']![0]!;
+      expect(artifact.lines[0]?.nonce).toBe('[redacted-live-claim]');
+      expect(JSON.stringify(bundle)).not.toContain('sealed-live-nonce');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -20,8 +20,20 @@ import { existsSync, statSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { Command } from 'commander';
-import type { RunRecord, RunStore, FailedAttemptRecord, TraceBufferStore } from '@sensigo/realm';
+import type {
+  RunRecord,
+  RunStore,
+  FailedAttemptRecord,
+  TraceBufferStore,
+  SealedArtifact,
+} from '@sensigo/realm';
 import { WorkflowError, isTerminalPhase, FsIoError } from '@sensigo/realm';
+
+/** Fixed redaction marker (issue #197 PR-2, design §6) — replaces every `nonce` value belonging
+ *  to a step currently in `in_progress_steps` on a NON-terminal export (the claimant-nonce
+ *  disclosure channel: `get_run_state` never leaks it, but an export of a live run otherwise
+ *  would). Terminal exports are always verbatim — nothing is still claimable once a run is done. */
+const REDACTED_LIVE_CLAIM_NONCE = '[redacted-live-claim]';
 
 /** One artifact `buildExportBundle` could not read (issue #186) — never silently omitted. */
 export interface ExportArtifactError {
@@ -39,9 +51,9 @@ export interface ExportBundle {
    * v1 bundle's completeness is UNKNOWN to a reader — it was written back when export was
    * all-or-nothing (any read failure meant no bundle at all), so v1's mere existence was itself a
    * (weaker) completeness signal, but nothing in a v1 bundle states it explicitly. v2 always
-   * states it explicitly via `complete`.
+   * states it explicitly via `complete`. Bumped 2 → 3 (issue #197 PR-2): adds `sealed`.
    */
-  realm_export_version: 2;
+  realm_export_version: 3;
   /** ISO-8601, stamped by the CLI at assembly time. */
   exported_at: string;
   /** The full RunRecord — steps, evidence, skip_details, claims, etc. */
@@ -56,12 +68,23 @@ export interface ExportBundle {
    *  truncation) — that is a different signal from a read that failed outright. */
   attempts_capped: boolean;
   /** `{ <stepId>: [...] }` — every buffered/WAL entry for the run, across all steps; `{}` if none
-   *  OR if the WAL read failed (see `artifact_errors` — check `complete` first). */
+   *  OR if the WAL read failed (see `artifact_errors` — check `complete` first). On a NON-terminal
+   *  export, any `nonce` field on a line belonging to a step in `run.in_progress_steps` is
+   *  replaced with `"[redacted-live-claim]"` (issue #197 PR-2, design §6 — the claimant-nonce
+   *  disclosure channel); terminal exports are verbatim. */
   wal: Record<string, unknown[]>;
   /**
-   * False iff any artifact below (`attempts`/`wal`) could not be read (issue #186) — a real I/O
-   * failure, not a genuine ENOENT absence (an absent artifact is legitimately `[]`/`{}` and
-   * `complete: true`). The bundle NEVER lies by omission: every readable artifact is still
+   * Every sealed trace artifact for the run, keyed by stepId (issue #197 PR-2, the `seal` rung).
+   * `null` = the configured trace-buffer store does NOT declare `seal` (incapability — there is
+   * nothing to enumerate, ever, on this store). `{}` = the store DOES declare `seal` but this run
+   * genuinely has none (capable, empty). Same redaction rule as `wal` applies to sealed lines
+   * belonging to an in-progress step on a non-terminal export.
+   */
+  sealed: Record<string, SealedArtifact[]> | null;
+  /**
+   * False iff any artifact below (`attempts`/`wal`/`sealed`) could not be read (issue #186) — a
+   * real I/O failure, not a genuine ENOENT absence (an absent artifact is legitimately `[]`/`{}`
+   * and `complete: true`). The bundle NEVER lies by omission: every readable artifact is still
    * written, and the run record itself is always present when `complete` is `false` (a run-record
    * read failure means no bundle is written at all — see `buildExportBundle`).
    */
@@ -87,7 +110,17 @@ export interface ExportStores {
   failedAttemptStore: {
     read(runId: string): Promise<{ records: FailedAttemptRecord[]; capped: boolean }>;
   };
-  traceBufferStore: Pick<TraceBufferStore, 'readAllForRun'>;
+  /**
+   * `listSealedForRun` (issue #197 PR-2) is OPTIONAL on the Pick, not required — its mere
+   * presence as a function is this command's own incapability signal (`sealed: null` when
+   * absent), deliberately NOT the store-layer's `storeDeclaresSeal` predicate: that predicate
+   * additionally requires the full fenced-trio surface, which would force this deliberately
+   * minimal, read-only Pick to widen far beyond what export actually calls. The construction-time
+   * `validateTraceCapabilities` gate (server.ts) is what keeps a real store's declaration
+   * internally consistent; this command only ever needs to know whether the ONE method it calls
+   * exists.
+   */
+  traceBufferStore: Pick<TraceBufferStore, 'readAllForRun' | 'listSealedForRun'>;
 }
 
 /** Extracts an errno/FsIoError code from a thrown value; `'UNKNOWN'` if it carries none. */
@@ -95,6 +128,62 @@ function errnoCodeOf(err: unknown): string {
   if (err instanceof FsIoError) return err.code;
   const code = (err as { code?: unknown } | undefined)?.code;
   return typeof code === 'string' ? code : 'UNKNOWN';
+}
+
+/** True iff `line` is a plain object carrying a genuine (non-`undefined`) `nonce` value — the
+ *  WAL's raw parsed-line shape is `unknown` (readAllForRun's own contract), so this is a runtime
+ *  narrowing check, never a cast. A bare line (no `nonce` at all) is untouched — there is nothing
+ *  to redact for it. */
+function hasNonce(line: unknown): line is { nonce: string } {
+  return (
+    typeof line === 'object' &&
+    line !== null &&
+    'nonce' in line &&
+    (line as { nonce?: unknown }).nonce !== undefined
+  );
+}
+
+/**
+ * Redacts every genuine `nonce` value on a WAL line or sealed-artifact line belonging to a step
+ * in `liveSteps` (issue #197 PR-2, design §6) — the claimant-nonce disclosure channel a
+ * non-terminal export would otherwise open (a run's own `ClaimRecord` never persists its nonce,
+ * so this stateless step-liveness proxy is the only signal available). Steps NOT in `liveSteps`
+ * (settled, or the run has none) pass through completely untouched — including bare lines, which
+ * have no `nonce` to redact in the first place.
+ */
+function redactLiveClaimNonces(
+  wal: Record<string, unknown[]>,
+  sealed: Record<string, SealedArtifact[]> | null,
+  inProgressSteps: readonly string[],
+): { wal: Record<string, unknown[]>; sealed: Record<string, SealedArtifact[]> | null } {
+  const liveSteps = new Set(inProgressSteps);
+  if (liveSteps.size === 0) return { wal, sealed };
+
+  const redactedWal: Record<string, unknown[]> = {};
+  for (const [stepId, lines] of Object.entries(wal)) {
+    redactedWal[stepId] = liveSteps.has(stepId)
+      ? lines.map((line) => (hasNonce(line) ? { ...line, nonce: REDACTED_LIVE_CLAIM_NONCE } : line))
+      : lines;
+  }
+
+  const redactedSealed: Record<string, SealedArtifact[]> | null =
+    sealed === null
+      ? null
+      : Object.fromEntries(
+          Object.entries(sealed).map(([stepId, artifacts]) => [
+            stepId,
+            liveSteps.has(stepId)
+              ? artifacts.map((artifact) => ({
+                  ...artifact,
+                  lines: artifact.lines.map((line) =>
+                    line.nonce !== undefined ? { ...line, nonce: REDACTED_LIVE_CLAIM_NONCE } : line,
+                  ),
+                }))
+              : artifacts,
+          ]),
+        );
+
+  return { wal: redactedWal, sealed: redactedSealed };
 }
 
 /**
@@ -145,18 +234,53 @@ export async function buildExportBundle(
     });
   }
 
+  // issue #197 PR-2: `listSealedForRun` is OPTIONAL on the (deliberately minimal) Pick above —
+  // its mere presence as a function is this command's own incapability signal. `null` (never
+  // touched) = incapable; `{}` (the loop below simply finds nothing to push) = capable, empty; a
+  // read failure defaults to `{}` too (matching `attempts`/`wal`'s own on-failure convention) —
+  // `complete: false` + `artifact_errors` is what actually signals "the read failed", not the
+  // shape of `sealed` itself.
+  let sealed: Record<string, SealedArtifact[]> | null = null;
+  if (typeof stores.traceBufferStore.listSealedForRun === 'function') {
+    sealed = {};
+    try {
+      const artifacts = await stores.traceBufferStore.listSealedForRun(runId);
+      for (const artifact of artifacts) {
+        (sealed[artifact.step_id] ??= []).push(artifact);
+      }
+    } catch (err) {
+      sealed = {};
+      artifactErrors.push({
+        artifact: 'sealed trace artifacts',
+        code: errnoCodeOf(err),
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // issue #197 PR-2 (design §6, the implementation pin): claims never persist their nonce (only
+  // the stateless step-liveness proxy is available), so a NON-terminal export redacts every
+  // `nonce` on a line belonging to a step CURRENTLY in `run.in_progress_steps` — conservative
+  // over-redaction of a dead foreign nonce on a re-driven live step is accepted (verbatim once
+  // the run goes terminal). A terminal export is always verbatim — nothing is still claimable.
+  const nonTerminal = !isTerminalPhase(run.run_phase);
+  const { wal: finalWal, sealed: finalSealed } = nonTerminal
+    ? redactLiveClaimNonces(wal, sealed, run.in_progress_steps)
+    : { wal, sealed };
+
   const bundle: ExportBundle = {
-    realm_export_version: 2,
+    realm_export_version: 3,
     exported_at: now.toISOString(),
     run,
     attempts,
     attempts_capped: attemptsCapped,
-    wal,
+    wal: finalWal,
+    sealed: finalSealed,
     complete: artifactErrors.length === 0,
     artifact_errors: artifactErrors,
   };
 
-  const warning = !isTerminalPhase(run.run_phase)
+  const warning = nonTerminal
     ? `best-effort snapshot: run '${runId}' is still ${run.run_phase}; its artifacts are read at ` +
       `slightly different instants and may be mid-flight`
     : undefined;
@@ -280,9 +404,15 @@ export const exportCommand = new Command('export')
       }
 
       const walStepCount = Object.keys(bundle.wal).length;
+      // issue #197 PR-2: sealed is null (incapable store) vs {} (capable, empty) vs non-empty —
+      // report all three distinctly rather than collapsing null/empty into the same "0".
+      const sealedSummary =
+        bundle.sealed === null
+          ? 'n/a (store does not declare seal)'
+          : `${Object.values(bundle.sealed).reduce((n, arr) => n + arr.length, 0)}`;
       console.log(
         `Exported run '${runId}' to '${target}' (${formatBytes(Buffer.byteLength(json))}).\n` +
-          `  phase: ${bundle.run.run_phase}, attempts: ${bundle.attempts.length}, WAL steps: ${walStepCount}`,
+          `  phase: ${bundle.run.run_phase}, attempts: ${bundle.attempts.length}, WAL steps: ${walStepCount}, sealed artifacts: ${sealedSummary}`,
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));

--- a/packages/cli/src/commands/gc.test.ts
+++ b/packages/cli/src/commands/gc.test.ts
@@ -520,6 +520,91 @@ describe('sweepOrphanArtifacts (issue #163)', () => {
   });
 });
 
+/** Recomputes the exact on-disk SEALED artifact filename `JsonTraceBufferStore`'s private
+ *  `sealedWalPath` uses (issue #197 PR-2) — test-side only, mirroring `walPathFor` above. */
+function sealedPathFor(dir: string, runId: string, stepId: string, seq: number): string {
+  return join(
+    dir,
+    `sealed-trace-${runId}-${Buffer.from(stepId).toString('base64url')}.${seq}.jsonl`,
+  );
+}
+
+describe('sweepOrphanArtifacts — sealed artifacts (issue #197 PR-2, deliverable 3b: VERIFYING no gc.ts code change was needed)', () => {
+  it('gc reaps a run-less SEALED artifact older than the floor, in --force mode', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      const runStore = new JsonFileStore(dir);
+
+      // No run file is ever created for this id — it is run-less from the start.
+      const orphanId = '33333333-3333-4333-8333-333333333333';
+      await traceBufferStore.append(orphanId, 'step-a', [{ event: 'x' }]);
+      const sealResult = await traceBufferStore.sealFenced!(orphanId, 'step-a', async () => {});
+      expect(sealResult).toEqual({ sealed: true });
+
+      const sealedPath = sealedPathFor(dir, orphanId, 'step-a', 0);
+      expect(existsSync(sealedPath)).toBe(true);
+      const backdated = new Date(now.getTime() - (ONE_HOUR_MS + FIVE_MIN_MS));
+      await utimes(sealedPath, backdated, backdated);
+
+      const liveRunIds = await runStore.listRunIds();
+      expect(liveRunIds.has(orphanId)).toBe(false);
+
+      const preview = await sweepOrphanArtifacts([traceBufferStore], liveRunIds, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: true,
+        now,
+      });
+      expect(preview.reaped.map((e) => e.path)).toContain(sealedPath);
+      expect(existsSync(sealedPath)).toBe(true); // dry-run never mutates
+
+      const result = await sweepOrphanArtifacts([traceBufferStore], liveRunIds, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: false,
+        now,
+      });
+
+      expect(result.reaped.map((e) => e.path)).toContain(sealedPath);
+      expect(result.failed).toEqual([]);
+      expect(existsSync(sealedPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a SEALED artifact whose run file EXISTS is never reaped, no matter how old', async () => {
+    const dir = await makeTmpRunsDir();
+    try {
+      const now = new Date();
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      const runStore = new JsonFileStore(dir);
+
+      const { run } = await runStore.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      await traceBufferStore.append(run.id, 'step-a', [{ event: 'x' }]);
+      await traceBufferStore.sealFenced!(run.id, 'step-a', async () => {});
+
+      const sealedPath = sealedPathFor(dir, run.id, 'step-a', 0);
+      const backdated = new Date(now.getTime() - (ONE_HOUR_MS + FIVE_MIN_MS));
+      await utimes(sealedPath, backdated, backdated);
+
+      const liveRunIds = await runStore.listRunIds();
+      expect(liveRunIds.has(run.id)).toBe(true);
+
+      const result = await sweepOrphanArtifacts([traceBufferStore], liveRunIds, {
+        olderThanMs: ONE_HOUR_MS,
+        dryRun: false,
+        now,
+      });
+
+      expect(result.reaped).toEqual([]);
+      expect(existsSync(sealedPath)).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('sweepOrphanArtifacts — fenced reap path (issue #207 PR-2)', () => {
   it('orphan swept normally (run absent): routes through deleteAllForRunFenced (not the legacy per-file path) and is reaped', async () => {
     const dir = await makeTmpRunsDir();

--- a/packages/cli/src/commands/purge.test.ts
+++ b/packages/cli/src/commands/purge.test.ts
@@ -900,3 +900,33 @@ describe('purgeRuns — fenced WAL delete guard (issue #207 PR-2)', () => {
     }
   });
 });
+
+describe('purgeRuns — sealed artifacts (issue #197 PR-2, deliverable 3b: VERIFYING no purge.ts code change was needed)', () => {
+  it('purge of a terminal run with a sealed artifact removes it too, alongside the live-WAL/anchor cleanup', async () => {
+    const { dir, runStore } = await makeStores();
+    try {
+      const run = makeRun({
+        id: 'sealed-purge-target',
+        run_phase: 'completed',
+        terminal_state: true,
+      });
+      await injectRun(dir, run);
+      const traceBufferStore = new JsonTraceBufferStore(dir);
+      await traceBufferStore.append(run.id, 'step-agent', [{ event: 'stale' }]);
+      const sealResult = await traceBufferStore.sealFenced!(run.id, 'step-agent', async () => {});
+      expect(sealResult).toEqual({ sealed: true });
+      // Confirm the sealed artifact exists on disk BEFORE purging (the premise this test proves).
+      expect((await traceBufferStore.listSealedForRun!(run.id)).length).toBe(1);
+
+      const result = await purgeRuns({ runId: 'sealed-purge-target', dryRun: false }, runStore, [
+        traceBufferStore,
+      ]);
+
+      expect(result.purged).toEqual(['sealed-purge-target']);
+      expect(existsSync(join(dir, `${run.id}.json`))).toBe(false); // anchor gone
+      expect(await traceBufferStore.listSealedForRun!(run.id)).toEqual([]); // sealed artifact gone too
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -15,6 +15,16 @@ import type { WorkflowDefinition, StepDefinition, ExtensionRegistry } from '@sen
 import type { StepDispatcher } from '@sensigo/realm';
 import { loadProjectExtensions } from '../extensions/load-project-extensions.js';
 
+/**
+ * Dormant strict posture (issue #197 PR-2, design §6 — the #169→#170 template): read PER CALL,
+ * never cached at module load. "on" = set to any non-empty value other than `'0'`/`'false'`. A
+ * strict-flip force-enables minting even without `--mint-writer-nonce` (design §8).
+ */
+function isWriterNonceRequired(): boolean {
+  const v = process.env['REALM_REQUIRE_WRITER_NONCE'];
+  return v !== undefined && v !== '' && v !== '0' && v !== 'false';
+}
+
 export const runCommand = new Command('run')
   .argument('<path>', 'Path to workflow directory or workflow.yaml file')
   .option('--params <json>', 'Initial run parameters as JSON string', '{}')
@@ -26,12 +36,25 @@ export const runCommand = new Command('run')
     '--project <dir>',
     'CONFIG anchor: deployment root whose realm.yaml applies to definitions without a stored trust_root (default: current directory)',
   )
+  .option(
+    '--mint-writer-nonce',
+    'Mint a fresh writer_nonce (UUIDv4) per step-attempt for faithful trace attribution (issue ' +
+      "#197) — opt-in; default OFF (today's behavior). No caller-supplied value is accepted.",
+    false,
+  )
   .description('Run a workflow interactively (development mode)')
   .action(
     async (
       inputPath: string,
-      options: { params: string; extensionsModule?: string; project?: string },
+      options: {
+        params: string;
+        extensionsModule?: string;
+        project?: string;
+        mintWriterNonce?: boolean;
+      },
     ) => {
+      // issue #197 PR-2 (design §8): the strict-flip force-enables minting even without the flag.
+      const mintWriterNonce = options.mintWriterNonce === true || isWriterNonceRequired();
       const filePath =
         inputPath.endsWith('.yaml') || inputPath.endsWith('.yml')
           ? inputPath
@@ -171,6 +194,9 @@ export const runCommand = new Command('run')
             dispatcher,
             registry,
             traceBufferStore,
+            // issue #197 PR-2: a FRESH nonce per step-attempt (never a caller-fixed value —
+            // reusing one across attempts converts the honest caveat into false self-attribution).
+            ...(mintWriterNonce ? { writerNonce: crypto.randomUUID() } : {}),
           });
 
           if (result.status === 'ok') {

--- a/packages/core/src/engine/execution-loop-attributed-adoption.test.ts
+++ b/packages/core/src/engine/execution-loop-attributed-adoption.test.ts
@@ -1,0 +1,495 @@
+// Deterministic tests for execution-loop.ts's attributed-adoption call sites (issue #197 PR-2,
+// design record `plans/issue-197-design.md`). Mirrors execution-loop-fenced-trio-adoption.test.ts's
+// style: each test targets exactly one deliverable — the activation-gate floor law, the
+// enforce-gate/adoption congruence, the three-way honest split, and the settle-time seal decision
+// table (ordering, each outcome branch, detection-counts-only attestation).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeStep } from './execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import {
+  InMemoryTraceBufferStore,
+  SEALED_ARTIFACTS_LIMIT_PER_STEP,
+} from '../store/trace-buffer-store.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { TraceBufferStore } from '../store/trace-buffer-store.js';
+
+const agentDef: WorkflowDefinition = {
+  id: 'attributed-adoption-agent-wf',
+  name: 'Attributed Adoption Agent WF',
+  version: 1,
+  steps: {
+    'step-agent': { description: 'Agent step', execution: 'agent', depends_on: [] },
+  },
+};
+
+const congruenceDef: WorkflowDefinition = {
+  id: 'attributed-adoption-congruence-wf',
+  name: 'Attributed Adoption Congruence WF',
+  version: 1,
+  steps: {
+    'step-agent': {
+      description: 'Agent step with an enforce-mode trace_schema',
+      execution: 'agent',
+      depends_on: [],
+      trace_schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { event: { const: 'expected_event' } },
+          required: ['event'],
+        },
+      },
+      trace_validation_mode: 'enforce',
+    },
+  },
+};
+
+/**
+ * A trio-only `TraceBufferStore` wrapper (issue #197 PR-2): forwards every call to a REAL
+ * `InMemoryTraceBufferStore` (so the fenced trio genuinely works), but exposes NEITHER
+ * `traceCapabilities` NOR `sealFenced`/`listSealedForRun` — `storeDeclaresSeal`/
+ * `storeDeclaresNonceCarriage` both correctly evaluate `false` against this shape, exactly
+ * modeling "a store declaring the fenced trio alone" (the shipped realm-cloud Postgres state,
+ * design §3) for the floor-law test below.
+ */
+function trioOnlyStore(): { store: TraceBufferStore; inner: InMemoryTraceBufferStore } {
+  const inner = new InMemoryTraceBufferStore();
+  const store: TraceBufferStore = {
+    append: (runId, stepId, entries, options) => inner.append(runId, stepId, entries, options),
+    read: (runId, stepId) => inner.read(runId, stepId),
+    delete: (runId, stepId) => inner.delete(runId, stepId),
+    deleteAllForRun: (runId, dirEntries) => inner.deleteAllForRun(runId, dirEntries),
+    readAllForRun: (runId) => inner.readAllForRun(runId),
+    appendFenced: (runId, stepId, entries, guard, options) =>
+      inner.appendFenced(runId, stepId, entries, guard, options),
+    deleteFenced: (runId, stepId, guard) => inner.deleteFenced(runId, stepId, guard),
+    deleteAllForRunFenced: (runId, guard, dirEntries) =>
+      inner.deleteAllForRunFenced(runId, guard, dirEntries),
+  };
+  return { store, inner };
+}
+
+describe('execution-loop.ts — activation-gate floor law (issue #197 PR-2, design §3)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-adoption-floor-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('a trio-only store (no seal, no carriage) + a nonced claimant ⇒ adopt-all floor + the missing-leg warning fires', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const { store: traceBufferStore } = trioOnlyStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }, { event: 'b' }]);
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+    });
+
+    expect(envelope.status).toBe('ok');
+    // Floor: everything adopted under ⊥ (the store can't carry the nonce at all).
+    const summary = envelope.evidence[0]?.trace_summary;
+    expect(summary?.buffered_lines_adopted).toBe(2);
+    expect(summary?.attributed_lines_adopted).toBeUndefined();
+    expect(summary?.foreign_lines_preserved).toBeUndefined();
+    // The missing-leg advisory fires exactly once.
+    expect(
+      envelope.warnings.some(
+        (w) => w.includes('writer_nonce ignored') && w.includes('writer_nonce_carriage'),
+      ),
+    ).toBe(true);
+    // Envelope adoption counts are ABSENT entirely — "bare-floor store", not merely zeroed.
+    expect(envelope.adopted_own).toBeUndefined();
+    expect(envelope.adopted_anonymous).toBeUndefined();
+    expect(envelope.preserved_foreign).toBeUndefined();
+  });
+
+  it('the full store (seal + carriage) + a nonced claimant ⇒ selective adoption (no missing-leg warning, envelope counts present)', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'own' }], {
+      writerNonce: 'my-nonce',
+    });
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign' }], {
+      writerNonce: 'other-writer',
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(envelope.warnings.some((w) => w.includes('writer_nonce ignored'))).toBe(false);
+    expect(envelope.adopted_own).toBe(1);
+    expect(envelope.adopted_anonymous).toBe(0);
+    expect(envelope.preserved_foreign).toBe(1);
+  });
+});
+
+describe('execution-loop.ts — ADOPTION_CONGRUENCE (issue #197 PR-2, design §2)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-adoption-congruence-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('a foreign-nonce-only WAL under trace_schema enforce mode does NOT gate a nonced claimant', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-congruence-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    // A foreign line that would FAIL the schema if it were validated (event !== 'expected_event').
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'other_writers_event' }], {
+      writerNonce: 'other-writer',
+    });
+
+    const envelope = await executeStep(store, congruenceDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+      // The claimant's OWN conclusion satisfies the schema — congruence means only THIS is
+      // validated pre-claim, not the foreign line above.
+      trace: [{ event: 'expected_event' }],
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(envelope.error_code).toBeUndefined();
+    // The foreign line was preserved, not adopted — confirms it genuinely existed and was
+    // genuinely excluded, not merely absent from the test setup.
+    expect(envelope.preserved_foreign).toBe(1);
+  });
+});
+
+describe('execution-loop.ts — the three-way honest split (issue #197 PR-2, design §2/§6)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-adoption-threeway-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('⊥ claimant + bare lines ⇒ buffered_lines_adopted, existing caveat, numerically identical to today', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }, { event: 'b' }]);
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      // no writerNonce — the ⊥ claimant
+    });
+
+    const summary = envelope.evidence[0]?.trace_summary;
+    expect(summary?.buffered_lines_adopted).toBe(2);
+    expect(summary?.attributed_lines_adopted).toBeUndefined();
+    expect(summary?.foreign_lines_preserved).toBeUndefined();
+    expect(envelope.adopted_anonymous).toBe(2);
+    expect(envelope.adopted_own).toBe(0);
+    expect(envelope.preserved_foreign).toBe(0);
+  });
+
+  it('nonced claimant + own lines ⇒ attributed_lines_adopted, NO caveat', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }, { event: 'b' }], {
+      writerNonce: 'my-nonce',
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+    });
+
+    const summary = envelope.evidence[0]?.trace_summary;
+    expect(summary?.attributed_lines_adopted).toBe(2);
+    expect(summary?.buffered_lines_adopted).toBeUndefined();
+    expect(summary?.foreign_lines_preserved).toBeUndefined();
+    expect(envelope.adopted_own).toBe(2);
+    expect(envelope.adopted_anonymous).toBe(0);
+    expect(envelope.preserved_foreign).toBe(0);
+  });
+
+  it('mixed: own + bare + foreign ⇒ all three counts populated, pointer warning fires, foreign nonce VALUE never appears anywhere', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'own' }], {
+      writerNonce: 'my-nonce',
+    });
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'bare' }]);
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign' }], {
+      writerNonce: 'SECRET-OTHER-NONCE',
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+    });
+
+    const summary = envelope.evidence[0]?.trace_summary;
+    expect(summary?.attributed_lines_adopted).toBe(1);
+    expect(summary?.foreign_lines_preserved).toBe(2); // bare AND the foreign-nonce line: both foreign to a nonced claimant
+    expect(envelope.adopted_own).toBe(1);
+    expect(envelope.adopted_anonymous).toBe(0);
+    expect(envelope.preserved_foreign).toBe(2);
+    expect(
+      envelope.warnings.some(
+        (w) => w.includes('preserved, not adopted') && w.includes('realm run export'),
+      ),
+    ).toBe(true);
+    // Non-disclosure pin: the foreign nonce VALUE never appears anywhere in the envelope.
+    expect(JSON.stringify(envelope)).not.toContain('SECRET-OTHER-NONCE');
+  });
+});
+
+describe('execution-loop.ts — settle-time seal decision (issue #197 PR-2, deliverable 1f)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-adoption-seal-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('sealed:true ⇒ the live WAL is retired to a sealed artifact (not deleted), warns "preserved (sealed)", and the seal happens AFTER store.update (ordering)', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign' }], {
+      writerNonce: 'other-writer',
+    });
+
+    const calls: string[] = [];
+    const originalUpdate = store.update.bind(store);
+    vi.spyOn(store, 'update').mockImplementation(async (rec) => {
+      calls.push('update');
+      return originalUpdate(rec);
+    });
+    const originalSeal = traceBufferStore.sealFenced.bind(traceBufferStore);
+    vi.spyOn(traceBufferStore, 'sealFenced').mockImplementation(async (...args) => {
+      calls.push('sealFenced');
+      return originalSeal(...args);
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      // ⊥ claimant sees the foreign-nonced line as foreign — preserved, not adopted.
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(calls).toEqual(['update', 'sealFenced']); // seal strictly AFTER the settling update
+    expect(
+      envelope.warnings.some(
+        (w) => w.includes('foreign line(s) preserved (sealed)') && w.includes('realm run export'),
+      ),
+    ).toBe(true);
+    // The live WAL is gone, but the content is PRESERVED (sealed), not destroyed.
+    expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
+    const sealedArtifacts = await traceBufferStore.listSealedForRun(run.id);
+    expect(sealedArtifacts).toHaveLength(1);
+
+    // Detection-counts-only attestation (post-R3 B1): the PERSISTED run record's trace_summary
+    // carries counts only — never the seal OUTCOME. The seal outcome exists only in this
+    // envelope's warnings (already asserted above), never written back to the run record.
+    const persisted = await store.get(run.id);
+    const summaryJson = JSON.stringify(persisted.evidence[0]?.trace_summary ?? {});
+    expect(summaryJson).not.toMatch(/sealed/i);
+    expect(persisted.evidence[0]?.trace_summary?.foreign_lines_preserved).toBe(1);
+  });
+
+  it('capped ⇒ falls back to the existing delete() + a loud "cap reached" warning (no silent eviction of an already-sealed artifact)', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    // Fill the per-key seal budget completely BEFORE this step ever settles.
+    for (let i = 0; i < SEALED_ARTIFACTS_LIMIT_PER_STEP; i++) {
+      await traceBufferStore.append(run.id, 'step-agent', [{ event: `filler-${i}` }]);
+      const result = await traceBufferStore.sealFenced(run.id, 'step-agent', async () => {});
+      expect(result).toEqual({ sealed: true });
+    }
+    // Now the step's OWN settle-time seal attempt will find the budget exhausted.
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign' }], {
+      writerNonce: 'other-writer',
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(
+      envelope.warnings.some(
+        (w) => w.includes('preservation cap reached') && w.includes('destroyed, not preserved'),
+      ),
+    ).toBe(true);
+    // The live WAL was DESTROYED (fell back to delete), not left behind — and the sealed count
+    // stayed at exactly the cap (no silent eviction to squeeze in a 9th).
+    expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
+    expect(await traceBufferStore.listSealedForRun(run.id)).toHaveLength(
+      SEALED_ARTIFACTS_LIMIT_PER_STEP,
+    );
+  });
+
+  it('a THROW from sealFenced ⇒ warn + SKIP the delete (residue-not-loss) — the live WAL survives intact', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign' }], {
+      writerNonce: 'other-writer',
+    });
+    vi.spyOn(traceBufferStore, 'sealFenced').mockRejectedValue(
+      new Error('simulated lock-contention seal failure'),
+    );
+    const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('ok'); // the STEP still completed
+    expect(
+      envelope.warnings.some((w) =>
+        w.includes('Failed to seal trace buffer after step completion'),
+      ),
+    ).toBe(true);
+    expect(deleteSpy).not.toHaveBeenCalled(); // never fell back to delete — residue-not-loss
+    expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(1); // WAL intact
+  });
+
+  it('absent ⇒ nothing happens (no delete, no warning) — the live WAL vanished before the seal attempt', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign' }], {
+      writerNonce: 'other-writer',
+    });
+    vi.spyOn(traceBufferStore, 'sealFenced').mockResolvedValue({ sealed: false, reason: 'absent' });
+    const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(
+      envelope.warnings.some((w) => w.includes('preserved (sealed)') || w.includes('cap reached')),
+    ).toBe(false);
+  });
+
+  it('preserved_foreign === 0 ⇒ plain delete() exactly as today (zero behavior change) — sealFenced is never even called', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }]); // bare only — all-bare traffic
+    const sealSpy = vi.spyOn(traceBufferStore, 'sealFenced');
+    const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(sealSpy).not.toHaveBeenCalled();
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/engine/execution-loop-attributed-adoption.test.ts
+++ b/packages/core/src/engine/execution-loop-attributed-adoption.test.ts
@@ -493,3 +493,147 @@ describe('execution-loop.ts — settle-time seal decision (issue #197 PR-2, deli
     expect(deleteSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('execution-loop.ts — half-minted advisory heuristics (issue #197 PR-2 correction, design §6)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-adoption-half-minted-'));
+    store = new JsonFileStore(dir);
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('heuristic (i) fires: nonced claimant + a WAL containing ONLY bare lines ⇒ the "minted inconsistently" advisory, count matches, no nonce value leaked', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    // Full store (seal + carriage) so the partition genuinely runs.
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    // Two BARE lines only — no own-nonce line, no other-writer-nonce line.
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }, { event: 'b' }]);
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(
+      envelope.warnings.some(
+        (w) =>
+          w.includes('were bare and were preserved, not adopted') &&
+          w.includes('minted inconsistently (mint on both calls, or neither)'),
+      ),
+    ).toBe(true);
+    // The count in the warning text equals the bare-line count (2).
+    expect(envelope.warnings.some((w) => w.includes('the 2 buffered line(s) were bare'))).toBe(
+      true,
+    );
+    // No nonce value (the claimant's own, or otherwise) appears in any warning.
+    expect(envelope.warnings.some((w) => w.includes('my-nonce'))).toBe(false);
+  });
+
+  it('heuristic (ii) fires: bare claimant + a WAL whose foreign lines all carry EXACTLY ONE distinct nonce ⇒ the "minted inconsistently" advisory, foreign nonce VALUE never leaked', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    // Two lines, BOTH under the SAME foreign nonce — exactly one distinct foreign nonce.
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }, { event: 'b' }], {
+      writerNonce: 'the-only-foreign-writer',
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      // no writerNonce — the ⊥ (bare) claimant
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(
+      envelope.warnings.some(
+        (w) =>
+          w.includes('under a different writer_nonce were preserved, not adopted') &&
+          w.includes('minted inconsistently'),
+      ),
+    ).toBe(true);
+    // Non-disclosure pin: the foreign nonce VALUE never appears anywhere in the envelope.
+    expect(JSON.stringify(envelope)).not.toContain('the-only-foreign-writer');
+  });
+
+  it('heuristic (ii) precision (negative): bare claimant + foreign lines under TWO distinct nonces ⇒ NO "minted inconsistently" warning (the pointer warning from foreign_lines_preserved still fires, asserted independently so the two are not conflated)', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'a' }], {
+      writerNonce: 'writer-a',
+    });
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'b' }], {
+      writerNonce: 'writer-b',
+    });
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      // no writerNonce — the ⊥ (bare) claimant
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(envelope.warnings.some((w) => w.includes('minted inconsistently'))).toBe(false);
+    // The unrelated pointer warning (from foreign_lines_preserved) still fires — asserted
+    // independently so it is never mistaken for the (absent) half-minted advisory.
+    expect(envelope.preserved_foreign).toBe(2);
+    expect(
+      envelope.warnings.some(
+        (w) => w.includes('preserved, not adopted') && w.includes('realm run export'),
+      ),
+    ).toBe(true);
+  });
+
+  it('heuristic (i) precision (negative): nonced claimant + a WAL with at least one own-nonce line (mixed own+bare) ⇒ NO "minted inconsistently" warning (the every-line-bare condition is load-bearing)', async () => {
+    const { run } = await store.create({
+      workflowId: 'attributed-adoption-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'own' }], {
+      writerNonce: 'my-nonce',
+    });
+    await traceBufferStore.append(run.id, 'step-agent', [{ event: 'bare' }]);
+
+    const envelope = await executeStep(store, agentDef, {
+      runId: run.id,
+      command: 'step-agent',
+      input: {},
+      dispatcher: async () => ({}),
+      traceBufferStore,
+      writerNonce: 'my-nonce',
+    });
+
+    expect(envelope.status).toBe('ok');
+    expect(envelope.adopted_own).toBe(1);
+    expect(envelope.preserved_foreign).toBe(1);
+    expect(envelope.warnings.some((w) => w.includes('minted inconsistently'))).toBe(false);
+  });
+});

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -25,6 +25,8 @@ import type {
 import type { RunStore } from '../store/store-interface.js';
 import { persistsField } from '../store/store-fidelity.js';
 import type { TraceBufferStore, BufferedEntry } from '../store/trace-buffer-store.js';
+import { storeDeclaresSeal, storeDeclaresNonceCarriage } from '../store/trace-buffer-store.js';
+import { partitionBufferedEntries, type BufferedEntryPartition } from './trace-adoption.js';
 import { captureEvidence } from '../evidence/snapshot.js';
 import {
   validateInputSchema,
@@ -101,6 +103,17 @@ export interface ExecuteStepOptions {
    * When absent, behaviour is identical to the pre-B-lite path.
    */
   traceBufferStore?: TraceBufferStore;
+  /**
+   * Client-minted, opaque per-step-attempt writer identity (issue #197 PR-2, design §2) — pre-
+   * validated at the tool/CLI layer (shape, presence-on-non-agent-step); the engine never
+   * validates its shape, only uses it as an opaque comparison key. Honored ONLY when the
+   * configured `traceBufferStore` declares `writer_nonce_carriage` (the activation gate,
+   * design §3) — on a lesser store this is IGNORED entirely (the honest #185 adopt-all floor),
+   * since that store's WAL entries are bare too and honoring a real nonce there would self-demote
+   * the claimant's own bare evidence to "foreign". Absent ⇒ ⊥ (bare/anonymous writer class),
+   * today's byte-identical behavior.
+   */
+  writerNonce?: string;
 }
 
 export interface SubmitGateOptions {
@@ -134,6 +147,8 @@ export interface ExecuteChainOptions {
   trace?: AgentTraceEntry[];
   /** @see ExecuteStepOptions.traceBufferStore */
   traceBufferStore?: TraceBufferStore;
+  /** @see ExecuteStepOptions.writerNonce */
+  writerNonce?: string;
 }
 
 function delayMs(ms: number): Promise<void> {
@@ -630,6 +645,40 @@ function buildCompensatingUnclaim(pendingRun: RunRecord, stepName: string, now: 
 }
 
 /**
+ * Guard for the settle-time seal attempt (issue #197 PR-2, deliverable 1f) — ONE lock-free
+ * `store.get` re-verifying the run exists and this step has actually LEFT `in_progress_steps`
+ * (i.e. our own settling `store.update` already landed) — the "purge-guard shape" (mirrors
+ * #184's terminal-re-verify-under-lock precedent). In the normal case this always passes: by the
+ * time either settle site calls `sealFenced`, the settling update has already committed
+ * synchronously just above it. A run genuinely gone (e.g. concurrently purged) surfaces as
+ * `store.get`'s own typed `STATE_RUN_NOT_FOUND` throw — deliberately NOT special-cased here; it
+ * propagates as an ordinary guard THROW, which the caller's uniform "a throw ⇒ warn + skip the
+ * delete" handling already covers correctly (residue-not-loss either way).
+ */
+function buildSettleSealGuard(
+  store: RunStore,
+  runId: string,
+  stepName: string,
+): () => Promise<void> {
+  return async () => {
+    const fresh = await store.get(runId);
+    if (fresh.in_progress_steps.includes(stepName)) {
+      throw new WorkflowError(
+        `Refusing to seal trace buffer for run '${runId}' step '${stepName}': the step is still ` +
+          'in_progress (the settling update has not yet landed) — residue-not-loss, the live WAL ' +
+          'is left intact.',
+        {
+          code: 'STATE_STEP_PENDING',
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: true,
+        },
+      );
+    }
+  };
+}
+
+/**
  * Issue #185 Fix 1 (budget-priority): builds the merged, canonicalized trace for an agent step,
  * giving `traceInput` (the `execute_step` conclusion — unambiguously THIS execution's own)
  * priority into the truncation budget over `bufferEntries` (buffer/WAL lines, which may
@@ -959,6 +1008,19 @@ export async function executeStep(
       }
     | undefined;
 
+  // issue #197 PR-2 (design §3, the activation gate): computed once — options.traceBufferStore
+  // is invariant for this whole call. `carriageActive` also gates whether the NEW
+  // adopted_own/adopted_anonymous/preserved_foreign fields are surfaced on the 'ok' envelope
+  // (absent entirely on a bare-floor store, never just zeroed) — see the settle-site comment.
+  const carriageActive =
+    options.traceBufferStore !== undefined && storeDeclaresNonceCarriage(options.traceBufferStore);
+  const effectiveClaimantNonce = carriageActive ? options.writerNonce : undefined;
+  // Post-claim adoption partition (issue #197 PR-2) — lifted to this outer scope because it is
+  // read again at the settle sites (seal-vs-delete decision) and at 'ok' envelope build, both far
+  // below the post-claim block that computes it. `undefined` for a non-agent step (never computed
+  // there) — the settle sites and envelope build both treat that as "nothing to preserve/report".
+  let adoptionPartition: BufferedEntryPartition | undefined;
+
   if (stepDef?.execution === 'agent') {
     // issue #207 PR-2 (D3 §5): wrapped — a rejection here (e.g. lock contention under a fenced
     // trio's serialized reads) happens BEFORE claimStep, so no claim exists to compensate for;
@@ -986,14 +1048,29 @@ export async function executeStep(
       );
     }
 
+    // issue #197 PR-2 (design §3, missing-leg advisory): a caller-supplied nonce this store
+    // cannot carry is IGNORED for adoption purposes (carriageActive is false) — loudly, once per
+    // call, so a minting client discovers the silent floor rather than assuming attribution.
+    if (options.writerNonce !== undefined && !carriageActive) {
+      traceWarnings.push(
+        'writer_nonce ignored: the trace-buffer store does not declare writer_nonce_carriage — ' +
+          'adoption falls back to the honest floor',
+      );
+    }
+
     const hasAnyTrace =
       walEntries.length > 0 || (options.trace !== undefined && options.trace.length > 0);
 
     if (hasAnyTrace) {
+      // issue #197 PR-2 (design §2, ADOPTION_CONGRUENCE): the pre-claim enforce-gate validates
+      // ONLY the adopted subset — a foreign-nonce-only WAL must never gate a (nonced) claimant.
+      // Congruence with the post-claim partition below is mandatory: both call the SAME
+      // `partitionBufferedEntries` helper against the SAME `effectiveClaimantNonce`.
+      const prClaimPartition = partitionBufferedEntries(walEntries, effectiveClaimantNonce);
       // issue #185 Fix 1: budget-priority merge (see buildPriorityMergedTrace's own doc) — this
       // pre-claim pass exists only to feed validateTraceSchema below; its RESULT is discarded
       // (not stored into the outer preNormalizedTrace) once the enforce-gate decision is made.
-      const preClaimNormalized = buildPriorityMergedTrace(walEntries, options.trace);
+      const preClaimNormalized = buildPriorityMergedTrace(prClaimPartition.adopted, options.trace);
 
       // Validate trace schema if configured (unchanged call site).
       if (stepDef.trace_schema !== undefined) {
@@ -1134,10 +1211,20 @@ export async function executeStep(
       );
     }
 
+    // issue #197 PR-2 (design §2): the SAME predicate as the pre-claim pass, now over the
+    // complete post-claim set. Lifted to `adoptionPartition` (outer scope) — read again at the
+    // settle sites (seal-vs-delete) and at 'ok' envelope build, both below this block.
+    adoptionPartition = partitionBufferedEntries(walEntries, effectiveClaimantNonce);
+
+    // issue #197 PR-2 (design §2, the "keying pin"): this condition stays keyed on the FULL
+    // post-claim WAL set, NOT the adopted subset — a foreign-only WAL (adoptionPartition.adopted
+    // empty) with no options.trace must still enter this block so foreign_lines_preserved below
+    // is captured into trace_summary; otherwise that count is silently lost.
     if (walEntries.length > 0 || (options.trace !== undefined && options.trace.length > 0)) {
       // issue #185 Fix 1: same budget-priority merge as the pre-claim pass, now over the
-      // complete post-claim set — this is the value captured into evidence.
-      preNormalizedTrace = buildPriorityMergedTrace(walEntries, options.trace);
+      // complete post-claim ADOPTED subset only — a foreign line never reaches canonical
+      // evidence (issue #197 PR-2, design §2).
+      preNormalizedTrace = buildPriorityMergedTrace(adoptionPartition.adopted, options.trace);
 
       // Carry over the enforce-gate's schema-validation result (computed pre-claim against a
       // possibly-incomplete set) rather than re-validating here — Fix 2 deliberately keeps
@@ -1149,13 +1236,56 @@ export async function executeStep(
         preNormalizedTrace.summary.validation_errors = preClaimSchemaResult.validation_errors;
       }
 
-      // issue #185 Fix 3: the honest label. Any buffer/WAL line adopted here is NOT attributable
-      // to this execution — the agent trace buffer has no single owner, so an adopted line may
-      // originate from a prior attempt (e.g. a crashed run this one resumed) or a concurrent one
-      // racing on the same (run, step). Present only when buffer lines were actually adopted;
-      // an options.trace-only execution carries no caveat.
-      if (walEntries.length > 0) {
-        preNormalizedTrace.summary.buffered_lines_adopted = walEntries.length;
+      // issue #185 Fix 3 / issue #197 PR-2 (design §2/§6): the three-way honest split.
+      // buffered_lines_adopted now counts ONLY the adopted-ANONYMOUS entries (bare-adopted by a
+      // ⊥ claimant) — for all-bare traffic this is numerically IDENTICAL to before #197 (every
+      // adopted line was, and still is, bare). attributed_lines_adopted counts own-nonce
+      // adoptions — NO caveat (design §6 wording, verbatim below). foreign_lines_preserved counts
+      // lines from a different writer, preserved (sealed where supported) but never adopted —
+      // its accompanying pointer warning is the only way an agent learns to retrieve them.
+      if (adoptionPartition.adopted_anonymous > 0) {
+        preNormalizedTrace.summary.buffered_lines_adopted = adoptionPartition.adopted_anonymous;
+      }
+      if (adoptionPartition.adopted_own > 0) {
+        preNormalizedTrace.summary.attributed_lines_adopted = adoptionPartition.adopted_own;
+      }
+      if (adoptionPartition.preserved_foreign > 0) {
+        preNormalizedTrace.summary.foreign_lines_preserved = adoptionPartition.preserved_foreign;
+        traceWarnings.push(
+          `${adoptionPartition.preserved_foreign} buffered line(s) from a different writer were ` +
+            'preserved, not adopted — retrieve via `realm run export`',
+        );
+      }
+
+      // issue #197 PR-2 (design §6, the half-minted advisory): signature heuristics over the RAW
+      // walEntries/foreign set (never the adopted subset — these two cases are both about
+      // content this claimant did NOT adopt), neutral phrasing, values never echoed. Mutually
+      // exclusive by claimant type (nonced vs ⊥), so an if/else-if is exact, not a simplification.
+      if (
+        effectiveClaimantNonce !== undefined &&
+        walEntries.length > 0 &&
+        walEntries.every((e) => e._nonce === undefined)
+      ) {
+        // A nonced claimant found nothing but bare lines — if those are this SAME attempt's own
+        // earlier append() calls, the client minted inconsistently (nonce on execute_step but not
+        // on the preceding append_trace calls, or vice versa).
+        traceWarnings.push(
+          `the ${walEntries.length} buffered line(s) were bare and were preserved, not adopted — ` +
+            'if they are yours from this same attempt, you minted inconsistently (mint on both ' +
+            'calls, or neither)',
+        );
+      } else if (effectiveClaimantNonce === undefined && adoptionPartition.foreign.length > 0) {
+        const distinctForeignNonces = new Set(adoptionPartition.foreign.map((e) => e._nonce));
+        if (distinctForeignNonces.size === 1) {
+          // A bare claimant found every foreign line under exactly ONE other nonce — if that
+          // nonce is this SAME attempt's own (minted on append_trace but the execute_step call
+          // stayed bare), the client minted inconsistently.
+          traceWarnings.push(
+            `${adoptionPartition.foreign.length} line(s) under a different writer_nonce were ` +
+              'preserved, not adopted — if these are yours from this same attempt, you minted ' +
+              'inconsistently',
+          );
+        }
       }
     }
   }
@@ -1656,18 +1786,61 @@ export async function executeStep(
       storeCleanupWarning = `Failed to persist step failure: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
     }
     let walCleanupWarning: string | undefined;
-    // issue #207 PR-2 (D3 §5): gate the WAL delete on the preceding store.update having actually
+    // issue #207 PR-2 (D3 §5): gate the WAL cleanup on the preceding store.update having actually
     // SUCCEEDED (persistedRun defined) — a failed persist leaves the step in_progress with its
     // trace already read into an evidence write that never landed anywhere durable; the WAL is
     // the SOLE remaining evidence copy until reclaim recovers the wedge (#186 posture). Reclaim's
     // own drain (reclaim-step.ts) warns with the destroyed entry count when it eventually clears
     // this same buffer.
+    //
+    // issue #197 PR-2 (deliverable 1f): when this step's post-claim read found foreign (preserved,
+    // not adopted) lines AND the store declares `seal`, retire the WAL to a sealed artifact
+    // instead of destroying it — `preserved_foreign === 0` (the overwhelming common case, and the
+    // ONLY case on a non-seal-declaring store, since carriage requires seal by the ladder) takes
+    // the exact same plain `delete()` this always has, below, byte-identical.
     if (persistedRun !== undefined) {
-      try {
-        // Delete WAL after run state is written for failure — entries are now in evidence.
-        await options.traceBufferStore?.delete(options.runId, options.command);
-      } catch (walErr) {
-        walCleanupWarning = `Failed to clean up trace buffer after step failure: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
+      let performPlainDelete = true;
+      if (
+        adoptionPartition !== undefined &&
+        adoptionPartition.preserved_foreign > 0 &&
+        options.traceBufferStore !== undefined &&
+        storeDeclaresSeal(options.traceBufferStore)
+      ) {
+        try {
+          const sealResult = await options.traceBufferStore.sealFenced!(
+            options.runId,
+            options.command,
+            buildSettleSealGuard(store, options.runId, options.command),
+          );
+          if (sealResult.sealed) {
+            performPlainDelete = false;
+            walCleanupWarning =
+              `${adoptionPartition.preserved_foreign} foreign line(s) preserved (sealed) — ` +
+              'retrieve via `realm run export`';
+          } else if (sealResult.reason === 'capped') {
+            // Fall back to the SAME plain delete below (loud + bounded, never a silent eviction
+            // of an already-sealed artifact to make room) — the destroyed-count warning names
+            // exactly what happened; performPlainDelete stays true.
+            walCleanupWarning = 'preservation cap reached — foreign lines destroyed, not preserved';
+          } else {
+            // 'absent' — the live WAL vanished between the post-claim read and this seal attempt
+            // (e.g. a concurrent purge/reclaim) — nothing left to delete either; residue-not-loss.
+            performPlainDelete = false;
+          }
+        } catch (err) {
+          // A THROW (lock contention, genuine I/O failure) ⇒ warn + SKIP the delete
+          // (residue-not-loss; the fence refuses further appends; purge reaps).
+          performPlainDelete = false;
+          walCleanupWarning = `Failed to seal trace buffer after step failure: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      }
+      if (performPlainDelete) {
+        try {
+          // Delete WAL after run state is written for failure — entries are now in evidence.
+          await options.traceBufferStore?.delete(options.runId, options.command);
+        } catch (walErr) {
+          walCleanupWarning = `Failed to clean up trace buffer after step failure: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
+        }
       }
     }
 
@@ -1961,11 +2134,50 @@ export async function executeStep(
   // settlement already committed and is durably visible, so a cleanup failure here (e.g. lock
   // contention) must degrade to a warning, never surface as though the STEP itself failed (this
   // was previously unwrapped and would have thrown straight out of executeStep).
+  //
+  // issue #197 PR-2 (deliverable 1f): same seal-vs-delete decision as the failure-settle site
+  // above — see its comment for the full outcome table. preserved_foreign === 0 (the common case,
+  // and the ONLY case on a non-seal-declaring store) takes the exact same plain delete() this
+  // always has, byte-identical.
   let successWalCleanupWarning: string | undefined;
-  try {
-    await options.traceBufferStore?.delete(options.runId, options.command);
-  } catch (err) {
-    successWalCleanupWarning = `Failed to clean up trace buffer after step completion: ${err instanceof Error ? err.message : String(err)}`;
+  {
+    let performPlainDelete = true;
+    if (
+      adoptionPartition !== undefined &&
+      adoptionPartition.preserved_foreign > 0 &&
+      options.traceBufferStore !== undefined &&
+      storeDeclaresSeal(options.traceBufferStore)
+    ) {
+      try {
+        const sealResult = await options.traceBufferStore.sealFenced!(
+          options.runId,
+          options.command,
+          buildSettleSealGuard(store, options.runId, options.command),
+        );
+        if (sealResult.sealed) {
+          performPlainDelete = false;
+          successWalCleanupWarning =
+            `${adoptionPartition.preserved_foreign} foreign line(s) preserved (sealed) — ` +
+            'retrieve via `realm run export`';
+        } else if (sealResult.reason === 'capped') {
+          successWalCleanupWarning =
+            'preservation cap reached — foreign lines destroyed, not preserved';
+        } else {
+          // 'absent' — residue-not-loss; nothing left to delete either.
+          performPlainDelete = false;
+        }
+      } catch (err) {
+        performPlainDelete = false;
+        successWalCleanupWarning = `Failed to seal trace buffer after step completion: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    }
+    if (performPlainDelete) {
+      try {
+        await options.traceBufferStore?.delete(options.runId, options.command);
+      } catch (err) {
+        successWalCleanupWarning = `Failed to clean up trace buffer after step completion: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    }
   }
 
   // Step 7: Build and return ResponseEnvelope.
@@ -1988,6 +2200,17 @@ export async function executeStep(
     context_hint: orientation,
     run_phase: savedRun.run_phase,
     next_actions: nextActions,
+    // issue #197 PR-2 (deliverable 2e): additive per-partition counts, SET BY THE ENGINE (never
+    // the MCP tool layer, which strips data/evidence and never sees per-line nonces). Gated on
+    // `carriageActive` (store CAPABILITY), not on whether a nonce happened to be provided this
+    // call — "absent for bare-floor stores" means incapable, not merely unused-this-time.
+    ...(carriageActive && adoptionPartition !== undefined
+      ? {
+          adopted_own: adoptionPartition.adopted_own,
+          adopted_anonymous: adoptionPartition.adopted_anonymous,
+          preserved_foreign: adoptionPartition.preserved_foreign,
+        }
+      : {}),
   };
 }
 
@@ -2459,6 +2682,18 @@ async function executeChainInternal(
     branched_via?: string;
     warnings?: string[];
   }>,
+  /**
+   * issue #197 PR-2 (chain-replacement disposition, accepted): a settled DEPTH-0 step (typically
+   * an agent step — never itself recorded in `chainedSteps`, which is auto-steps-only, feeding
+   * the VISIBLE `chained_auto_steps` list) whose own envelope is about to be discarded in favor
+   * of a deeper auto step's envelope would otherwise silently lose its OWN warnings (seal
+   * outcome / half-minted / missing-carriage-leg advisories) — this separate accumulator exists
+   * ONLY to carry those forward; it never touches `chainedSteps`'/`chained_auto_steps`'s shape.
+   * The three NEW adoption counts on that depth-0 envelope are NOT similarly rescued — they
+   * persist authoritatively in the settled step's own `trace_summary` regardless (see
+   * `ResponseEnvelope.adopted_own`'s own doc) — only the warnings are a load-bearing rescue.
+   */
+  depth0Warnings: string[],
 ): Promise<ResponseEnvelope> {
   if (depth > MAX_CHAIN_DEPTH) {
     return {
@@ -2619,12 +2854,29 @@ async function executeChainInternal(
     return result;
   }
 
+  // issue #197 PR-2 (chain-replacement disposition): THIS step's own result is about to be
+  // discarded in favor of the recursive call's — capture its warnings now, before that happens.
+  // Every step past depth 0 in this recursion is guaranteed 'auto' (nextAutoStep's own filter),
+  // so depth === 0 is the ONLY case where a non-auto (agent) step's warnings would otherwise be
+  // lost here (an 'auto' depth-0 step's warnings are already captured above via `chainedSteps`,
+  // so this would double them — the `depth === 0` guard is exact, not merely conservative:
+  // `chainedSteps` only records 'auto' steps, so a depth-0 'auto' step's warnings are recorded
+  // there, never here, avoiding any double-count).
+  if (
+    depth === 0 &&
+    definition.steps[options.command]?.execution !== 'auto' &&
+    result.warnings.length > 0
+  ) {
+    depth0Warnings.push(...result.warnings);
+  }
+
   return executeChainInternal(
     store,
     definition,
     { ...options, command: nextAutoStep, input: {} },
     depth + 1,
     chainedSteps,
+    depth0Warnings,
   );
 }
 
@@ -2686,8 +2938,18 @@ export async function executeChain(
     branched_via?: string;
     warnings?: string[];
   }> = [];
-  const result = await executeChainInternal(store, definition, effectiveOptions, 0, chained);
-  const chainWarnings = chained.flatMap((s) => s.warnings ?? []);
+  // issue #197 PR-2 (chain-replacement disposition) — see executeChainInternal's own doc on this
+  // parameter for the full contract.
+  const depth0Warnings: string[] = [];
+  const result = await executeChainInternal(
+    store,
+    definition,
+    effectiveOptions,
+    0,
+    chained,
+    depth0Warnings,
+  );
+  const chainWarnings = [...depth0Warnings, ...chained.flatMap((s) => s.warnings ?? [])];
   const envelope = {
     ...result,
     command: options.command,

--- a/packages/core/src/engine/reclaim-step.test.ts
+++ b/packages/core/src/engine/reclaim-step.test.ts
@@ -472,7 +472,7 @@ describe('reclaimStep — fenced pre-update clear (issue #207 PR-2)', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it('call-order recorder: deleteFenced fires BEFORE the update on BOTH the primary and the CAS-retry path (forced first-update STATE_SNAPSHOT_MISMATCH), and warns with the destroyed count', async () => {
+  it('call-order recorder: sealFenced fires BEFORE the update on BOTH the primary and the CAS-retry path (forced first-update STATE_SNAPSHOT_MISMATCH), and warns with the seal outcome (issue #197 PR-2: InMemoryTraceBufferStore now declares seal, so reclaim PRESERVES rather than destroys — see the sibling non-seal-fallback test below for the deleteFenced-drain path this test exercised before #197 PR-1 shipped seal capability)', async () => {
     const { run } = await store.create({
       workflowId: 'reclaim-agent-wf',
       workflowVersion: 1,
@@ -501,6 +501,71 @@ describe('reclaimStep — fenced pre-update clear (issue #207 PR-2)', () => {
       calls.push(`update#${updateCallNum}`);
       return originalUpdate(rec);
     });
+    const originalSealFenced = traceBufferStore.sealFenced!.bind(traceBufferStore);
+    vi.spyOn(traceBufferStore, 'sealFenced').mockImplementation(async (...args) => {
+      calls.push('sealFenced');
+      return originalSealFenced(...args);
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await reclaimStep(store, run.id, 'step-agent', { traceBufferStore });
+      expect(result.outcome).toBe('reclaimed');
+      // Strict seal-before-update ordering, independently on EACH attempt.
+      expect(calls).toEqual(['sealFenced', 'update#1(forced-reject)', 'sealFenced', 'update#2']);
+      // The live WAL is gone — sealed on the FIRST call (before the forced-reject update); the
+      // second call's own attempt finds the live WAL already absent (nothing left to re-seal).
+      expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
+      const sealedArtifacts = await traceBufferStore.listSealedForRun!(run.id);
+      expect(sealedArtifacts).toHaveLength(1);
+      expect(sealedArtifacts[0]?.lines.flatMap((l) => l.entries.map((e) => e.event))).toEqual([
+        'dead_attempt_line',
+      ]);
+      // Seal-outcome warn (issue #197 PR-2: NO fabricated entry count — contents unparsed).
+      expect(
+        warnSpy.mock.calls.some(([msg]) =>
+          String(msg).includes('stale WAL sealed (contents unparsed)'),
+        ),
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('non-seal fallback stays byte-frozen: a store declaring the fenced trio WITHOUT seal still drains via deleteFenced exactly as before #197 PR-1 shipped seal capability', async () => {
+    const { run } = await store.create({
+      workflowId: 'reclaim-agent-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    const claimed = await store.claimStep(run.id, 'step-agent', agentReclaimWf);
+    await store.update({ ...claimed, claims: { 'step-agent': { deadline: pastIso() } } });
+
+    // Trio-only stub — deliberately WITHOUT sealFenced/listSealedForRun/traceCapabilities, so
+    // storeDeclaresSeal is false and reclaim must keep taking the deleteFenced drain path.
+    const buffers = new Map<string, { event: string }[]>();
+    const key = `${run.id}:step-agent`;
+    buffers.set(key, [{ event: 'dead_attempt_line' }]);
+    const traceBufferStore: TraceBufferStore = {
+      append: async () => {
+        throw new Error('not used');
+      },
+      read: async () => [],
+      delete: async () => {
+        throw new Error('not used — this store declares the trio');
+      },
+      deleteAllForRun: async () => {},
+      readAllForRun: async () => ({}),
+      deleteFenced: async (_runId, _stepId, guard) => {
+        await guard();
+        const existing = buffers.get(key) ?? [];
+        buffers.delete(key);
+        return existing.length;
+      },
+    };
+
+    const calls: string[] = [];
     const originalDeleteFenced = traceBufferStore.deleteFenced!.bind(traceBufferStore);
     vi.spyOn(traceBufferStore, 'deleteFenced').mockImplementation(async (...args) => {
       calls.push('deleteFenced');
@@ -511,17 +576,8 @@ describe('reclaimStep — fenced pre-update clear (issue #207 PR-2)', () => {
     try {
       const result = await reclaimStep(store, run.id, 'step-agent', { traceBufferStore });
       expect(result.outcome).toBe('reclaimed');
-      // Strict clear-before-update ordering, independently on EACH attempt.
-      expect(calls).toEqual([
-        'deleteFenced',
-        'update#1(forced-reject)',
-        'deleteFenced',
-        'update#2',
-      ]);
-      // The buffer was actually cleared (first deleteFenced call, before the forced-reject
-      // update, already drained it) — the second call is an idempotent no-op (already absent).
-      expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(0);
-      // Drain-warn with count (the #198 delta): warns with the destroyed entry count > 0.
+      expect(calls).toEqual(['deleteFenced']);
+      expect(buffers.has(key)).toBe(false);
       expect(
         warnSpy.mock.calls.some(([msg]) =>
           String(msg).includes('reclaim cleared 1 buffered trace entries'),

--- a/packages/core/src/engine/reclaim-step.ts
+++ b/packages/core/src/engine/reclaim-step.ts
@@ -10,6 +10,7 @@
 import type { RunStore } from '../store/store-interface.js';
 import type { RunRecord } from '../types/run-record.js';
 import type { TraceBufferStore } from '../store/trace-buffer-store.js';
+import { storeDeclaresSeal } from '../store/trace-buffer-store.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import { captureEvidence } from '../evidence/snapshot.js';
 import { classifyClaim, omitClaim, type ClaimState } from './claim-liveness.js';
@@ -77,19 +78,22 @@ function applyReclaim(run: RunRecord, stepName: string, now: Date): RunRecord {
  * that cannot fence the clear at all.
  *
  * Honest disposition (issue #207 PR-2 — this doc previously overclaimed a stronger guarantee than
- * is actually true). It used to read: "nothing is being discarded that any consumer has seen or
- * could ever see" — that is FALSE as of #207 PR-2's persist-gated failure-settle delete
- * (execution-loop.ts: the WAL delete there now only fires once `store.update` has already
- * SUCCEEDED). When that persist instead FAILS, the step is left in_progress with its trace
- * ALREADY READ INTO an evidence write that never landed anywhere durable — reclaim is exactly the
- * recovery path for that wedge, and this clear (fenced or not) destroys that adopted-but-
+ * is actually true; issue #197 PR-2 narrows the claim further, now that preservation has
+ * shipped). It used to read: "nothing is being discarded that any consumer has seen or could ever
+ * see" — that is FALSE as of #207 PR-2's persist-gated failure-settle delete (execution-loop.ts:
+ * the WAL delete there now only fires once `store.update` has already SUCCEEDED). When that
+ * persist instead FAILS, the step is left in_progress with its trace ALREADY READ INTO an
+ * evidence write that never landed anywhere durable — reclaim is exactly the recovery path for
+ * that wedge, and THIS function (the non-declaring-store / non-seal fallback ONLY, as of #197
+ * PR-2 — see `sealStaleWalFenced` below for the seal-capable path) destroys that adopted-but-
  * unpersisted content too, same as it always destroyed pre-claim, never-adopted content. This is
  * a DELIBERATE, WARNED policy (the #198 delta: reclaim always warns with the count it destroys),
  * not a silent loss, and it is bounded: the destroyed content was never durable anywhere a future
  * reader could find it (the failed `store.update` never committed), so this never destroys any
  * consumer's already-durable view — only a write attempt that never took effect. Full
- * preservation (a sidecar copy taken before this destructive clear) is #197's filed follow-up,
- * not this function's job.
+ * preservation (seal-by-rename, not a sidecar copy) SHIPPED in #197 PR-2: sealed on any
+ * seal-declaring store — this function remains only the byte-frozen fallback for a store that
+ * cannot seal at all.
  *
  * Best-effort and non-blocking by design: a failed clear must never fail the reclaim itself (the
  * claim recovery is the important, safety-gated act; WAL hygiene is secondary) — but per the
@@ -199,6 +203,91 @@ function warnFencedClearOutcome(runId: string, stepName: string, result: FencedC
   }
 }
 
+/** Outcome of `sealStaleWalFenced` (issue #197 PR-2) — what `reclaimStep` needs to decide what to
+ *  log; never surfaced to reclaim's own caller beyond the console.warn it drives. */
+interface FencedSealResult {
+  /** `true` iff the version fence refused (the seal attempt was skipped, buffer left intact). */
+  skipped: boolean;
+  /** `true` iff the buffer was actually sealed. */
+  sealed: boolean;
+  /** Set (to the destroyed entry count) iff the per-key seal budget was reached and this call
+   *  fell back to the existing destructive drain (`deleteFenced`) instead. */
+  cappedFallbackCount?: number;
+}
+
+/**
+ * Fenced pre-update SEAL (issue #197 PR-2, deliverable 1g): reclaim ALWAYS preserves ALL of a
+ * stale step's WAL (no partitioning — zero-cooperation preservation, design §3: "reclaim/settle
+ * preservation ⇔ trio ∧ seal, no carriage needed") on any store declaring `seal`, via the exact
+ * SAME version-fence guard `clearStaleWalFenced` uses above (re-verified against
+ * `expectedVersion`, captured at THIS call's own reclaim-decision read — never a fresh get taken
+ * here). `{sealed:false, reason:'capped'}` falls back to the existing destructive drain
+ * (`deleteFenced`, reusing the SAME guard closure — a second, independent version-fence
+ * re-verification, cheap and safe even if slightly redundant) rather than silently evicting an
+ * already-sealed artifact to make room. `{sealed:false, reason:'absent'}` (no live WAL at all) is
+ * a no-op — nothing to preserve or destroy. Any OTHER thrown error (lock contention, genuine I/O
+ * failure) propagates UNCHANGED, exactly like `clearStaleWalFenced`'s own contract.
+ */
+async function sealStaleWalFenced(
+  store: RunStore,
+  traceBufferStore: TraceBufferStore,
+  runId: string,
+  stepName: string,
+  expectedVersion: number,
+): Promise<FencedSealResult> {
+  const guard = async (): Promise<void> => {
+    const fresh = await store.get(runId);
+    if (fresh.version !== expectedVersion) {
+      throw new ReclaimVersionChanged(
+        `reclaim's version fence refused: run '${runId}' changed since the reclaim decision ` +
+          `(expected version ${expectedVersion}, observed ${fresh.version})`,
+      );
+    }
+  };
+  try {
+    const result = await traceBufferStore.sealFenced!(runId, stepName, guard);
+    if (result.sealed) {
+      return { skipped: false, sealed: true };
+    }
+    if (result.reason === 'capped') {
+      const count = await traceBufferStore.deleteFenced!(runId, stepName, guard);
+      return { skipped: false, sealed: false, cappedFallbackCount: count };
+    }
+    // reason === 'absent' — nothing to seal or drain.
+    return { skipped: false, sealed: false };
+  } catch (err) {
+    if (err instanceof ReclaimVersionChanged) {
+      return { skipped: true, sealed: false };
+    }
+    throw err;
+  }
+}
+
+/** Logs the fenced seal's decision-table outcome (issue #197 PR-2) — the sole place this
+ *  console.warn is emitted, called from both reclaimStep call sites. NO fabricated entry counts
+ *  on a successful seal — the sealed artifact's contents are unparsed at reclaim time (design
+ *  §7: "sealed, contents unparsed"); only the capped-fallback drain has an honest count to report,
+ *  exactly as `warnFencedClearOutcome` already does for the non-seal path. */
+function warnFencedSealOutcome(runId: string, stepName: string, result: FencedSealResult): void {
+  if (result.skipped) {
+    console.warn(
+      `⚠ realm: skipped sealing the trace buffer for run '${runId}' step '${stepName}' during ` +
+        'reclaim — the run changed since the reclaim decision (version fence refused); the ' +
+        'buffer is left intact.',
+    );
+  } else if (result.sealed) {
+    console.warn(
+      `stale WAL sealed (contents unparsed) — retrievable via realm run export for run '${runId}' ` +
+        `step '${stepName}'.`,
+    );
+  } else if (result.cappedFallbackCount !== undefined && result.cappedFallbackCount > 0) {
+    console.warn(
+      `reclaim cleared ${result.cappedFallbackCount} buffered trace entries for run '${runId}' ` +
+        `step '${stepName}' (seal budget reached — fell back to the destructive drain).`,
+    );
+  }
+}
+
 /**
  * Reclaims a single in-progress claim on a run. Guards (in order): store capability → terminal
  * run → the open-gate step → membership. Returns idempotent success when the step is already
@@ -274,15 +363,30 @@ export async function reclaimStep(
   // falls back to the byte-frozen legacy order (after the update, best-effort). `fenced` decides
   // which branch each call site below takes; a `deleteFenced`/lock/I-O throw from the fenced path
   // propagates BEFORE any update runs (claim intact, reclaim aborts loudly, retryable).
+  //
+  // issue #197 PR-2 (deliverable 1g): `sealCapable` is checked FIRST — a seal-declaring store
+  // preserves ALL of a stale step's WAL (zero-cooperation, no partitioning) instead of destroying
+  // it; a fenced-trio-only (non-seal) store keeps the #207 destructive drain unchanged; a
+  // non-declaring store keeps the byte-frozen legacy fallback unchanged.
   const traceBufferStore = options?.traceBufferStore;
   const fenced =
     traceBufferStore !== undefined && typeof traceBufferStore.deleteFenced === 'function';
+  const sealCapable = fenced && storeDeclaresSeal(traceBufferStore!);
 
   try {
-    if (fenced) {
+    if (sealCapable) {
+      const sealResult = await sealStaleWalFenced(
+        store,
+        traceBufferStore!,
+        runId,
+        stepName,
+        run.version,
+      );
+      warnFencedSealOutcome(runId, stepName, sealResult);
+    } else if (fenced) {
       const clearResult = await clearStaleWalFenced(
         store,
-        traceBufferStore,
+        traceBufferStore!,
         runId,
         stepName,
         run.version,
@@ -319,12 +423,22 @@ export async function reclaimStep(
     }
     // Still a stale / unknown-age wedge after the concurrent write → re-apply ONCE on the fresh
     // record. A second mismatch propagates (reclaim loses, abandon-style — no retry loop).
-    // issue #207 PR-2: same fenced-clear-before-update shape as the primary path above, but
-    // version-fenced against THIS path's own decision read (`reloaded.version`) — never `run`'s.
-    if (fenced) {
+    // issue #207 PR-2 / #197 PR-2: same seal-or-clear-before-update shape as the primary path
+    // above, but version-fenced against THIS path's own decision read (`reloaded.version`) —
+    // never `run`'s.
+    if (sealCapable) {
+      const sealResult = await sealStaleWalFenced(
+        store,
+        traceBufferStore!,
+        runId,
+        stepName,
+        reloaded.version,
+      );
+      warnFencedSealOutcome(runId, stepName, sealResult);
+    } else if (fenced) {
       const clearResult = await clearStaleWalFenced(
         store,
-        traceBufferStore,
+        traceBufferStore!,
         runId,
         stepName,
         reloaded.version,

--- a/packages/core/src/engine/trace-adoption.ts
+++ b/packages/core/src/engine/trace-adoption.ts
@@ -1,0 +1,102 @@
+// trace-adoption.ts — the unified writer partition (issue #197 PR-2, design record §2 —
+// `plans/issue-197-design.md`, NORMATIVE).
+//
+// One exported predicate drives adoption, the pre-claim enforce-gate filter, and (at the store
+// layer, issue #197 PR-1) per-writer budget partitioning. Congruence is mandatory: every call
+// site that decides "is this line mine" — the pre-claim `trace_schema` enforce-gate, the
+// post-claim adoption split, and the settle-time seal-vs-delete decision — MUST route through
+// the SAME rule below, never an ad-hoc reimplementation.
+//
+//   adopted(line) ⇔ line.nonce ≡ claimant.nonce, with absent ≡ absent (⊥ = the bare/anonymous
+//   writer class).
+//
+// - Bare claimant + bare lines → adopted (today's behavior, existing caveat).
+// - Nonce claimant + own lines → adopted, NO caveat.
+// - ANY claimant + foreign-nonced lines → preserved, NOT adopted — including the bare claimant
+//   (Option A's ratified scope amendment: the dominant recovery flow is a nonced streamer
+//   crashing and a bare CLI re-driving; adopting those lines would be exactly the false
+//   attribution #197 removes).
+// - NO same-attempt rescue heuristics, ever — server-side authorship inference was the rejected
+//   #185 epoch design's sin; this predicate never guesses at provenance it cannot verify.
+import type { BufferedEntry } from '../store/trace-buffer-store.js';
+
+/**
+ * The ONE authoritative adoption predicate (design §2). `undefined` on either side denotes ⊥
+ * (the bare/anonymous writer class) — `undefined === undefined` is `true` in JS, so
+ * `(lineNonce ?? undefined) === (claimantNonce ?? undefined)` already implements "absent ≡
+ * absent" with no special-casing required.
+ */
+export function adoptsLine(
+  claimantNonce: string | undefined,
+  lineNonce: string | undefined,
+): boolean {
+  return (lineNonce ?? undefined) === (claimantNonce ?? undefined);
+}
+
+/** Result of partitioning a buffer/WAL read against one claimant nonce (issue #197 PR-2). */
+export interface BufferedEntryPartition {
+  /** Entries this claimant adopts — the ONLY entries that may flow into canonical evidence
+   *  (`buildPriorityMergedTrace`) or gate the pre-claim `trace_schema` enforce check. */
+  adopted: BufferedEntry[];
+  /** Entries preserved but NOT adopted — belonging to a different writer. Never merged into
+   *  canonical evidence and never allowed to gate the claimant; sealed (not deleted) at
+   *  settle-time on a store that supports it (issue #197 PR-2, deliverable 1f). */
+  foreign: BufferedEntry[];
+  /**
+   * Count of `adopted` entries that carry a nonce — own-writer adoption, NO caveat (design §6:
+   * "writer continuity verified (same nonce as presented at claim); strength conditional on
+   * nonce secrecy"). Non-zero ONLY for a nonced claimant — a ⊥ claimant's adopted set is, by
+   * the predicate above, exclusively bare entries, so this is always `0` for it.
+   */
+  adopted_own: number;
+  /**
+   * Count of `adopted` entries that are bare — ⊥-writer adoption, the existing #185 caveat
+   * (`buffered_lines_adopted`). Non-zero ONLY for a ⊥ (bare) claimant — a nonced claimant's
+   * adopted set is exclusively its own nonce, never bare, so this is always `0` for it.
+   */
+  adopted_anonymous: number;
+  /** Count of `foreign` entries — preserved, not adopted, from a different writer. */
+  preserved_foreign: number;
+}
+
+/**
+ * Partitions `entries` (a buffer/WAL read) against `claimantNonce` via `adoptsLine` — the ONE
+ * partition every adoption-relevant call site (pre-claim enforce-gate, post-claim adoption,
+ * settle-time seal-vs-delete decision) must use.
+ *
+ * `claimantNonce` should already be ACTIVATION-GATED by the caller (`undefined` when the
+ * configured store doesn't declare `writer_nonce_carriage` — see `execution-loop.ts`'s own
+ * activation-gate comment for why: a non-carriage store's WAL entries are bare too, so honoring
+ * a real nonce there would self-demote the claimant's own bare evidence to "foreign"). This
+ * function itself is unconditional and has no opinion on WHETHER a nonce should be honored —
+ * only on what follows once the caller has already decided that.
+ *
+ * A ⊥ claimant (`claimantNonce === undefined`) can only ever produce `adopted_own === 0` — its
+ * own adopted entries are, by definition, bare — with `adopted_anonymous` carrying the count
+ * instead. A nonced claimant is the mirror image: `adopted_anonymous === 0`, `adopted_own`
+ * carries the count. This is an invariant of the predicate above, not independently computed —
+ * see each field's own doc on `BufferedEntryPartition`.
+ */
+export function partitionBufferedEntries(
+  entries: readonly BufferedEntry[],
+  claimantNonce: string | undefined,
+): BufferedEntryPartition {
+  const adopted: BufferedEntry[] = [];
+  const foreign: BufferedEntry[] = [];
+  for (const entry of entries) {
+    if (adoptsLine(claimantNonce, entry._nonce)) {
+      adopted.push(entry);
+    } else {
+      foreign.push(entry);
+    }
+  }
+  const adopted_own = claimantNonce !== undefined ? adopted.length : 0;
+  const adopted_anonymous = claimantNonce === undefined ? adopted.length : 0;
+  return {
+    adopted,
+    foreign,
+    adopted_own,
+    adopted_anonymous,
+    preserved_foreign: foreign.length,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,10 @@ export {
   propagateSkips,
   isStepSettledOrInFlight,
 } from './engine/eligibility.js';
+// The unified writer partition (issue #197 PR-2) — the ONE authoritative adoption predicate;
+// see trace-adoption.ts's own module doc for the full contract.
+export { adoptsLine, partitionBufferedEntries } from './engine/trace-adoption.js';
+export type { BufferedEntryPartition } from './engine/trace-adoption.js';
 export {
   TERMINAL_PHASES,
   RESUMABLE_PHASES,

--- a/packages/core/src/types/response-envelope.ts
+++ b/packages/core/src/types/response-envelope.ts
@@ -105,4 +105,24 @@ export interface ResponseEnvelope {
    * after start_run or after an agent step that triggers subsequent auto steps.
    */
   chained_auto_steps?: Array<{ step: string; run_phase: string; branched_via?: string }>;
+  /**
+   * Per-partition adoption counts (issue #197 PR-2, design §6) — mirrors the settled step's own
+   * `trace_summary.attributed_lines_adopted` / `buffered_lines_adopted` / `foreign_lines_preserved`
+   * (see run-record.ts) at the moment the adoption partition actually ran. SET BY THE ENGINE at
+   * envelope build (the MCP tool layer strips `data`/`evidence` before returning and never itself
+   * sees per-line nonces). Present ONLY when the adoption partition ran for the step this envelope
+   * settles — absent for a bare-floor store (no `writer_nonce_carriage`), a non-agent step, or an
+   * error/blocked envelope. **Chain-replacement disposition (issue #197 PR-2):** when a settled
+   * agent step's `executeChain` call continues into a subsequently-eligible auto step, the
+   * RETURNED envelope is that deeper step's own — these three counts may be ABSENT there (they
+   * persist authoritatively in the settled step's own `trace_summary` regardless of what this
+   * envelope reports); the accompanying warnings (seal outcome / half-minted advisory / missing
+   * carriage leg) are re-surfaced into the returned envelope's `warnings` via the existing
+   * chain-wide warning re-accumulation even when these counts are not.
+   */
+  adopted_own?: number;
+  /** @see adopted_own — the ⊥ (bare) counterpart; mirrors `trace_summary.buffered_lines_adopted`. */
+  adopted_anonymous?: number;
+  /** @see adopted_own — mirrors `trace_summary.foreign_lines_preserved`. */
+  preserved_foreign?: number;
 }

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -40,18 +40,41 @@ export interface TraceNormalizationSummary {
   /** Number of Ajv validation errors found. Zero means schema-conformant. Present when schema_applied is true. */
   validation_errors?: number;
   /**
-   * Issue #185 (honest seal): the count of buffer/WAL lines adopted into this canonical trace.
-   * Present ONLY when > 0 — i.e., only when this execution's canonical trace includes lines it
-   * cannot itself attribute: the agent trace buffer is not owned by any one writer, so an
-   * adopted line may have been appended by a PRIOR execution attempt (e.g. a crashed run this
-   * one resumed) or by a CONCURRENT one racing on the same (run, step). The engine records this
-   * as an honest fact rather than silently asserting single authorship over content it cannot
-   * verify the provenance of. Absent (never `0` or `false`) when canonical trace was built
-   * entirely from this execution's own `execute_step` submission — no caveat is warranted there.
-   * Faithful per-writer separation (a client-supplied nonce distinguishing writers) is tracked as
-   * a follow-up; this field is deliberately just an honest count, not an attribution mechanism.
+   * Issue #185 (honest seal); issue #197 PR-2 (narrowed): the count of buffer/WAL lines adopted
+   * into this canonical trace THAT CANNOT BE ATTRIBUTED to this claimant — i.e., adopted under
+   * the ⊥ (bare/anonymous) writer class. Present ONLY when > 0. The agent trace buffer is not
+   * owned by any one writer, so a bare-adopted line may have been appended by a PRIOR execution
+   * attempt (e.g. a crashed run this one resumed) or by a CONCURRENT one racing on the same
+   * (run, step). The engine records this as an honest fact rather than silently asserting single
+   * authorship over content it cannot verify the provenance of. Absent (never `0` or `false`)
+   * when canonical trace was built entirely from this execution's own `execute_step` submission,
+   * or entirely from own-nonce-attributed lines (see `attributed_lines_adopted` below) — no
+   * caveat is warranted there. For all-bare traffic (no client ever mints a `writer_nonce`) this
+   * field is numerically IDENTICAL to its pre-#197 meaning — every buffered line was, and still
+   * is, bare-adopted. Faithful per-writer separation shipped in #197: see
+   * `attributed_lines_adopted` (own-nonce adoption, no caveat) and `foreign_lines_preserved`
+   * (a different writer's lines, preserved not adopted) below.
    */
   buffered_lines_adopted?: number;
+  /**
+   * Issue #197 PR-2 (design §2/§6): count of buffer/WAL lines adopted under the SAME nonce this
+   * claimant presented at claim time. Present ONLY when > 0. Unlike `buffered_lines_adopted`,
+   * this carries NO caveat — wording (verbatim, never varied): "writer continuity verified (same
+   * nonce as presented at claim); strength conditional on nonce secrecy." NEVER worded as
+   * "attribution is faithful" — a leaked/guessed nonce lets a different writer's lines pass this
+   * same check, so the guarantee is conditional on the nonce actually staying secret to its
+   * minter, not an unconditional identity proof.
+   */
+  attributed_lines_adopted?: number;
+  /**
+   * Issue #197 PR-2 (design §2/§4): count of buffer/WAL lines found at this claimant's read that
+   * belong to a DIFFERENT writer (nonce mismatch, including a bare claimant seeing nonced lines
+   * or vice versa) — PRESERVED (sealed, on a store that supports it), never adopted into
+   * canonical evidence, never merged, never gating this claimant's `trace_schema` enforce check.
+   * Present ONLY when > 0. Retrieve the preserved content via `realm run export`. Foreign nonce
+   * VALUES never appear anywhere in this record or any envelope — only this count.
+   */
+  foreign_lines_preserved?: number;
 }
 
 /** Diagnostic metadata captured during step execution. Written once; read by inspect. */

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import {
   FailedAttemptStore,
   WorkflowError,
   createDefaultRegistry,
+  validateTraceCapabilities,
   type RunStore,
   type TraceBufferStore,
 } from '@sensigo/realm';
@@ -163,6 +164,15 @@ export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer
       },
     );
   }
+
+  // issue #197 PR-2 (deliverable 2g): validate the store's capability declaration is internally
+  // consistent AT CONSTRUCTION — covers BOTH the derived-local default and the injected path
+  // above (this runs after `traceBufferStore` is finalized regardless of which branch produced
+  // it). A declared-but-inconsistent rung (e.g. `seal` claimed without the fenced trio +
+  // sealFenced + listSealedForRun all actually present) is a construction-time wiring defect —
+  // typed fail-loud here, never a runtime condition discovered later. Undeclared (the honest
+  // floor — trio-alone, or no capabilities at all) is always silent success, never an error.
+  validateTraceCapabilities(traceBufferStore);
 
   registerListWorkflows(server, effectiveOptions);
   registerGetWorkflowProtocol(server, effectiveOptions);

--- a/packages/mcp-server/src/tools/append-trace.ts
+++ b/packages/mcp-server/src/tools/append-trace.ts
@@ -7,6 +7,7 @@ import {
   WorkflowError,
   buildPreExecutionErrorEnvelope,
   isTerminalPhase,
+  storeDeclaresNonceCarriage,
   type AppendResult,
   type TraceBufferStore,
   type AgentTraceEntry,
@@ -14,7 +15,12 @@ import {
   type RunStore,
   type RunRecord,
 } from '@sensigo/realm';
-import { traceEntrySchema } from './execute-step.js';
+import {
+  traceEntrySchema,
+  validateWriterNonceShape,
+  isWriterNonceRequired,
+  writerNonceRequiredError,
+} from './execute-step.js';
 import { sseJsonStringify } from '../sse-json.js';
 
 export interface HandleAppendTraceStores {
@@ -27,12 +33,22 @@ export interface HandleAppendTraceStores {
 export type AppendTraceOkResult = { status: 'ok' } & AppendResult & {
     /**
      * Advisory only, never a gate (#119). May carry the unfenced-store caveat (issue #207 PR-2,
-     * present only when the configured `traceBufferStore` does NOT declare the fenced trio) and/or
-     * the capacity early-warning (issue #208, present once the post-append fill ratio crosses
-     * `CAPACITY_WARNING_THRESHOLD` — see `capacityWarning`, below). Absent entirely (`undefined`,
-     * never `[]`) when neither applies.
+     * present only when the configured `traceBufferStore` does NOT declare the fenced trio),
+     * the not-persisted caveat (issue #197 PR-2, present only when a `writer_nonce` was supplied
+     * but the store doesn't declare `writer_nonce_carriage`), and/or the capacity early-warning
+     * (issue #208, present once the post-append fill ratio crosses `CAPACITY_WARNING_THRESHOLD`
+     * — see `capacityWarning`, below). Absent entirely (`undefined`, never `[]`) when none apply.
      */
     warnings?: string[];
+    /**
+     * Downgrade detector (issue #197 PR-2, design §6, RFC 7507-shaped): `true` iff a
+     * `writer_nonce` was BOTH supplied on this call AND actually carried by the configured store.
+     * Absent (never `false`) when no nonce was supplied, OR when one was supplied but the store
+     * silently cannot carry it (see the not-persisted warning above instead) — an old client that
+     * never looks at this field is unaffected either way; a minting client can detect the silent
+     * demotion by its absence.
+     */
+    writer_nonce_applied?: true;
   };
 
 /**
@@ -46,26 +62,65 @@ export type AppendTraceOkResult = { status: 'ok' } & AppendResult & {
 const CAPACITY_WARNING_THRESHOLD = 0.8;
 
 /**
- * Pure, store-agnostic capacity-warning helper (issue #208, AC 1/3/4) — every `AppendResult`
- * already carries `buffer_count`/`limit_count`/`buffer_bytes`/`limit_bytes` regardless of which
- * `TraceBufferStore` implementation produced it, so this needs no store-specific knowledge at all
- * (the fix genuinely lives at the tool layer, not in any store). Returns `undefined` strictly
- * below `CAPACITY_WARNING_THRESHOLD`; AT OR ABOVE it (`>=`, deliberately not `>` — hitting the
- * threshold exactly still warns) returns ONE deterministic message naming whichever dimension
- * (entries or bytes) is closer to its own ceiling, the actual numbers and percentage, and the
+ * Pure, store-agnostic capacity-warning helper (issue #208, AC 1/3/4; re-homed on both bounds by
+ * issue #197 PR-2) — every `AppendResult` already carries `buffer_count`/`limit_count`/
+ * `buffer_bytes`/`limit_bytes` (WRITER scope) regardless of which `TraceBufferStore`
+ * implementation produced it, so this needs no store-specific knowledge at all. When a carriage
+ * store ALSO returns the additive `file_*` fields (whole-FILE scope, all writers combined —
+ * `BUFFER_BACKSTOP_*`, 2× the per-writer ceiling), this checks that bound too — naive porting
+ * would arithmetically lose a tier (0.8×400 > 200, so a single writer could never trip the file
+ * bound before its own writer bound already fired, silently making the file check dead code for
+ * exactly the common case it must still cover for multi-writer traffic).
+ *
+ * Returns `undefined` strictly below `CAPACITY_WARNING_THRESHOLD` on EITHER bound; AT OR ABOVE it
+ * on the MORE PRESSING one (`>=`, deliberately not `>` — hitting the threshold exactly still
+ * warns) returns ONE deterministic message naming that scope, whichever dimension (entries or
+ * bytes) within it is closer to its own ceiling, the actual numbers and percentage, and the
  * issue's own actionable guidance.
+ *
+ * Byte-identity note (issue #197 PR-2): for a SINGLE writer (all-bare traffic, or any carriage
+ * store with only one active writer on this key), the file-scope ratio is ALWAYS EXACTLY HALF the
+ * writer-scope ratio (file limit = 2× writer limit, same numerator) — so the writer-scope branch
+ * below is provably always the one that fires, reproducing the EXACT pre-#197 message text. The
+ * shipped #208 tests (which drive `InMemoryTraceBufferStore` — ALWAYS `file_*`-present since
+ * PR-1) exercise precisely this provably-writer-scope-wins path; this claim is verified by running
+ * those tests, not merely by this proof (see the PR-2 report's mutation-probe (f) transcript).
  */
 function capacityWarning(result: AppendResult): string | undefined {
-  const countRatio = result.buffer_count / result.limit_count;
-  const bytesRatio = result.buffer_bytes / result.limit_bytes;
-  const ratio = Math.max(countRatio, bytesRatio);
+  const writerCountRatio = result.buffer_count / result.limit_count;
+  const writerBytesRatio = result.buffer_bytes / result.limit_bytes;
+  const writerRatio = Math.max(writerCountRatio, writerBytesRatio);
+
+  const hasFileScope =
+    result.file_count !== undefined &&
+    result.file_limit_count !== undefined &&
+    result.file_bytes !== undefined &&
+    result.file_limit_bytes !== undefined;
+  const fileCountRatio = hasFileScope ? result.file_count! / result.file_limit_count! : 0;
+  const fileBytesRatio = hasFileScope ? result.file_bytes! / result.file_limit_bytes! : 0;
+  const fileRatio = hasFileScope ? Math.max(fileCountRatio, fileBytesRatio) : 0;
+
+  const ratio = Math.max(writerRatio, fileRatio);
   if (ratio < CAPACITY_WARNING_THRESHOLD) return undefined;
 
-  const binding = countRatio >= bytesRatio ? 'entries' : 'bytes';
+  if (hasFileScope && fileRatio >= writerRatio) {
+    const binding = fileCountRatio >= fileBytesRatio ? 'entries' : 'bytes';
+    const detail =
+      binding === 'entries'
+        ? `${result.file_count}/${result.file_limit_count} entries (${Math.round(fileCountRatio * 100)}%)`
+        : `${result.file_bytes}/${result.file_limit_bytes} bytes (${Math.round(fileBytesRatio * 100)}%)`;
+    return (
+      `trace buffer for this step (whole-file, all writers combined) is at ${detail} of ` +
+      'capacity, approaching the limit — reduce tracing verbosity or call execute_step to ' +
+      'finalize the step before further appends are refused with BUFFER_FULL'
+    );
+  }
+
+  const binding = writerCountRatio >= writerBytesRatio ? 'entries' : 'bytes';
   const detail =
     binding === 'entries'
-      ? `${result.buffer_count}/${result.limit_count} entries (${Math.round(countRatio * 100)}%)`
-      : `${result.buffer_bytes}/${result.limit_bytes} bytes (${Math.round(bytesRatio * 100)}%)`;
+      ? `${result.buffer_count}/${result.limit_count} entries (${Math.round(writerCountRatio * 100)}%)`
+      : `${result.buffer_bytes}/${result.limit_bytes} bytes (${Math.round(writerBytesRatio * 100)}%)`;
 
   return (
     `trace buffer for this step is at ${detail} of capacity, approaching the limit — reduce ` +
@@ -141,6 +196,33 @@ export function resetUnfencedTraceStoreWarnings(): void {
 }
 
 /**
+ * Builds the ok envelope's warnings + `writer_nonce_applied` marker (issue #197 PR-2) — shared by
+ * all three append call sites (empty-probe, fenced, unfenced) so this logic lives in exactly one
+ * place. `extraWarnings` carries whatever warnings that SPECIFIC call site already has (e.g. the
+ * unfenced-store caveat) — capacity and not-persisted are always appended AFTER, matching each
+ * call site's own pre-existing ordering convention.
+ */
+function buildAppendOkResult(
+  result: AppendResult,
+  writerNonce: string | undefined,
+  carriageActive: boolean,
+  extraWarnings: string[],
+): AppendTraceOkResult {
+  const warnings = [...extraWarnings];
+  const capacity = capacityWarning(result);
+  if (capacity !== undefined) warnings.push(capacity);
+  if (writerNonce !== undefined && !carriageActive) {
+    warnings.push('writer_nonce not persisted: attribution unavailable on this store');
+  }
+  return {
+    status: 'ok',
+    ...result,
+    ...(warnings.length > 0 ? { warnings } : {}),
+    ...(writerNonce !== undefined && carriageActive ? { writer_nonce_applied: true as const } : {}),
+  };
+}
+
+/**
  * Business logic for the append_trace tool.
  * Buffers trace entries to the WAL for (runId, stepId). Entries are merged with
  * any entries submitted at execute_step finalization.
@@ -153,6 +235,7 @@ export async function handleAppendTrace(
     run_id: string;
     step_id: string;
     entries: AgentTraceEntry[];
+    writer_nonce?: string | undefined;
   },
   stores?: HandleAppendTraceStores,
 ): Promise<AppendTraceOkResult> {
@@ -237,20 +320,37 @@ export async function handleAppendTrace(
     });
   }
 
+  // issue #197 PR-2 (design §6): shape-validate BEFORE anything else touches the store — routes
+  // every violation through ONE typed refusal, never a bare zod/SDK error.
+  if (args.writer_nonce !== undefined) {
+    validateWriterNonceShape(args.writer_nonce);
+  }
+
+  // issue #197 PR-2 (design §6, dormant strict posture — default off, zero behavior change):
+  // non-agent steps already refused above (step 4), before this check ever runs.
+  if (isWriterNonceRequired() && args.writer_nonce === undefined) {
+    throw writerNonceRequiredError(args.step_id, run.version);
+  }
+
+  // issue #197 PR-2 (FLAG_GATING, design §3 activation gate): a nonce is carried ONLY when this
+  // store genuinely declares writer_nonce_carriage — a non-declaring store must NEVER receive the
+  // nonce argument at all (never merely ignore it silently inside the store call).
+  const carriageActive = storeDeclaresNonceCarriage(traceBufferStore);
+  const nonceOptions =
+    args.writer_nonce !== undefined && carriageActive
+      ? { writerNonce: args.writer_nonce }
+      : undefined;
+
   // 6. Empty entries — return current buffer state without writing. Stays on the raw unlocked
   // path UNCONDITIONALLY (issue #207 PR-2, D3 §2) — writes nothing, so there is no settlement
   // race to fence against and no unfenced-store advisory to add here, regardless of what the
   // store declares. The CAPACITY warning (issue #208) still applies: this is the natural
   // read-your-capacity call — an agent probing at 85% full should see it just as a real append
-  // would show it.
+  // would show it. issue #197 PR-2: the probe passes the nonce too (writer-scope numbers for the
+  // probing writer specifically, not the whole file).
   if (args.entries.length === 0) {
-    const result = await traceBufferStore.append(args.run_id, args.step_id, []);
-    const capacity = capacityWarning(result);
-    return {
-      status: 'ok',
-      ...result,
-      ...(capacity !== undefined ? { warnings: [capacity] } : {}),
-    };
+    const result = await traceBufferStore.append(args.run_id, args.step_id, [], nonceOptions);
+    return buildAppendOkResult(result, args.writer_nonce, carriageActive, []);
   }
 
   // 7. Append entries to the buffer.
@@ -284,13 +384,8 @@ export async function handleAppendTrace(
         throw stepNotEligibleError(args.step_id, freshRun.version, freshState);
       }
     };
-    const result = await appendFenced(args.run_id, args.step_id, args.entries, guard);
-    const capacity = capacityWarning(result);
-    return {
-      status: 'ok',
-      ...result,
-      ...(capacity !== undefined ? { warnings: [capacity] } : {}),
-    };
+    const result = await appendFenced(args.run_id, args.step_id, args.entries, guard, nonceOptions);
+    return buildAppendOkResult(result, args.writer_nonce, carriageActive, []);
   }
 
   // Capability absent (issue #207 PR-2): legacy unfenced append() — Window A stays open for this
@@ -307,19 +402,21 @@ export async function handleAppendTrace(
         'same caveat on every affected call.',
     );
   }
-  const result = await traceBufferStore.append(args.run_id, args.step_id, args.entries);
-  const capacity = capacityWarning(result);
-  return {
-    status: 'ok',
-    ...result,
-    // issue #208: capacity SECOND, after the pre-existing unfenced-store advisory — both may be
-    // present at once (the store's fenced-ness and its fill level are independent facts).
-    warnings: [
-      'this store does not fence trace appends against concurrent settlement; entries ' +
-        'acknowledged here may not be adopted',
-      ...(capacity !== undefined ? [capacity] : []),
-    ],
-  };
+  // issue #197 PR-2: an unfenced store can never satisfy the ladder (carriage requires seal
+  // requires the fenced trio) — carriageActive is always false on this branch, so nonceOptions is
+  // always undefined here and the not-persisted warning fires whenever a nonce was supplied.
+  const result = await traceBufferStore.append(
+    args.run_id,
+    args.step_id,
+    args.entries,
+    nonceOptions,
+  );
+  // issue #208: capacity SECOND, after the pre-existing unfenced-store advisory — both (and the
+  // #197 not-persisted caveat) may be present at once; each is an independent fact.
+  return buildAppendOkResult(result, args.writer_nonce, carriageActive, [
+    'this store does not fence trace appends against concurrent settlement; entries ' +
+      'acknowledged here may not be adopted',
+  ]);
 }
 
 /** Registers the append_trace MCP tool on the server. */
@@ -331,11 +428,21 @@ export function registerAppendTrace(server: McpServer, opts?: HandleAppendTraceS
       'Entries are buffered and merged with any entries submitted at execute_step finalization.',
       'Delivery is best-effort: entries are durable after this call returns but are not canonical until execute_step completes.',
       'Only valid for agent steps that have not yet been claimed (before execute_step is called).',
+      'Optional: writer_nonce — mint a fresh UUIDv4 per step-attempt (the SAME value on every',
+      "append_trace call for this attempt, a NEW one next attempt) to get this attempt's own",
+      'lines faithfully attributed instead of the honest-but-unattributed floor. Mint on BOTH',
+      'append_trace and execute_step for this attempt, or neither — a guessable or reused nonce',
+      'is worse than omitting one (it lets residue be adopted with no caveat, or silently folds a',
+      'crashed attempt into this one).',
     ].join(' '),
     {
       run_id: z.string(),
       step_id: z.string(),
       entries: z.array(traceEntrySchema),
+      // issue #197 PR-2 (design §6): UNBOUNDED at the zod layer — every shape violation
+      // (empty/whitespace/too-long) routes through validateWriterNonceShape to ONE typed realm
+      // envelope refusal, never a bare zod/SDK error.
+      writer_nonce: z.string().optional(),
     },
     async (args) => {
       try {

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -16,6 +16,64 @@ import {
 import type { HandleRunStores, FailedAttemptStoreLike } from './start-run.js';
 import { sseJsonStringify } from '../sse-json.js';
 
+/** Maximum `writer_nonce` length (issue #197 PR-2, design §6). */
+const WRITER_NONCE_MAX_LENGTH = 128;
+
+/** Actionable guidance appended to every writer_nonce-related refusal (issue #197 PR-2). */
+export const WRITER_NONCE_GUIDANCE =
+  'writer_nonce must be a non-empty string, ≤128 chars, no leading/trailing whitespace; ' +
+  'recommended: a fresh UUIDv4 per step-attempt.';
+
+/**
+ * Validates a caller-submitted `writer_nonce`'s SHAPE (issue #197 PR-2, design §6) — throws a
+ * typed `WorkflowError` on any violation, never a bare zod/SDK error (the zod schema itself
+ * accepts any string, deliberately UNBOUNDED, so every shape violation routes through this ONE
+ * check). Shared by `append_trace` and `execute_step` — the shape rule lives in exactly one
+ * place; each tool's OWN refusal taxonomy is otherwise free to differ.
+ */
+export function validateWriterNonceShape(nonce: string): void {
+  let reason: string | undefined;
+  if (nonce.length === 0) {
+    reason = 'must not be empty';
+  } else if (nonce !== nonce.trim()) {
+    reason = 'must not have leading or trailing whitespace';
+  } else if (nonce.length > WRITER_NONCE_MAX_LENGTH) {
+    reason = `must be ≤${WRITER_NONCE_MAX_LENGTH} characters`;
+  }
+  if (reason === undefined) return;
+  throw new WorkflowError(`Invalid writer_nonce: ${reason}. ${WRITER_NONCE_GUIDANCE}`, {
+    code: 'VALIDATION_EMPTY_VALUE',
+    category: 'VALIDATION',
+    agentAction: 'provide_input',
+    retryable: false,
+  });
+}
+
+/**
+ * Dormant strict posture (issue #197 PR-2, design §6 — the #169→#170 template): read PER CALL,
+ * NEVER cached at module load (a test flips the env var mid-process). "on" = set to any
+ * non-empty value other than `'0'`/`'false'`. Default (unset) ⇒ zero behavior change anywhere.
+ */
+export function isWriterNonceRequired(): boolean {
+  const v = process.env['REALM_REQUIRE_WRITER_NONCE'];
+  return v !== undefined && v !== '' && v !== '0' && v !== 'false';
+}
+
+/** Refusal for `isWriterNonceRequired()` ⇒ true and a bare (agent-step) call (issue #197 PR-2). */
+export function writerNonceRequiredError(stepId: string, runVersion: number): WorkflowError {
+  return new WorkflowError(
+    'This deployment requires writer_nonce for agent steps (REALM_REQUIRE_WRITER_NONCE is set) ' +
+      `— step '${stepId}' was called without one. ${WRITER_NONCE_GUIDANCE}`,
+    {
+      code: 'VALIDATION_EMPTY_VALUE',
+      category: 'VALIDATION',
+      agentAction: 'provide_input',
+      retryable: false,
+      details: { step_id: stepId, run_version: runVersion },
+    },
+  );
+}
+
 /**
  * Pre-claim validation rejections carry one of these error codes (claimStep runs strictly after all
  * three schema gates, so they never reach failed_steps[] / never bump version — a write-free path).
@@ -115,6 +173,7 @@ export async function handleExecuteStep(
     command: string;
     params?: Record<string, unknown>;
     trace?: AgentTraceEntry[] | undefined;
+    writer_nonce?: string | undefined;
   },
   stores?: HandleRunStores,
 ): Promise<ResponseEnvelope> {
@@ -123,6 +182,42 @@ export async function handleExecuteStep(
   const run = await runStore.get(args.run_id);
   const definition = await workflowStore.get(run.workflow_id);
   const params = args.params ?? {};
+  const stepDef = definition.steps[args.command];
+
+  // issue #197 PR-2 (design §6): shape-validate BEFORE anything else — routes every violation
+  // through ONE typed refusal, never a bare zod/SDK error.
+  if (args.writer_nonce !== undefined) {
+    validateWriterNonceShape(args.writer_nonce);
+  }
+
+  // A writer_nonce PRESENT on a non-agent step is refused (design §6) — mirrors append_trace's
+  // own non-agent taxonomy (STATE_STEP_NOT_ELIGIBLE + step_type detail). A BARE execute_step call
+  // on a non-agent step stays byte-identical — auto/handler steps legally execute through this
+  // tool, and this check only fires when a nonce was actually supplied.
+  if (args.writer_nonce !== undefined && stepDef !== undefined && stepDef.execution !== 'agent') {
+    throw new WorkflowError(
+      `Step '${args.command}' is not an agent step (execution: '${stepDef.execution}') — ` +
+        'writer_nonce is only meaningful on agent steps.',
+      {
+        code: 'STATE_STEP_NOT_ELIGIBLE',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+        details: { step_id: args.command, step_type: stepDef.execution, run_version: run.version },
+      },
+    );
+  }
+
+  // issue #197 PR-2 (design §6, dormant strict posture — default off, zero behavior change):
+  // agent steps only — an auto/handler step's execute_step call never carries a caller-chosen
+  // writer_nonce in the first place.
+  if (
+    isWriterNonceRequired() &&
+    stepDef?.execution === 'agent' &&
+    args.writer_nonce === undefined
+  ) {
+    throw writerNonceRequiredError(args.command, run.version);
+  }
 
   // Per-definition registry (project extensions) — awaited before execution; a throwing
   // provider fails the tool call before any step is claimed. Provider wins over `registry`.
@@ -143,6 +238,7 @@ export async function handleExecuteStep(
     ...(stores?.traceBufferStore !== undefined
       ? { traceBufferStore: stores.traceBufferStore }
       : {}),
+    ...(args.writer_nonce !== undefined ? { writerNonce: args.writer_nonce } : {}),
   });
 
   // P2/P3 observability: on a pre-claim validation rejection, fan a metadata-only record out to the
@@ -164,6 +260,7 @@ export async function handleExecuteStepTool(
     command: string;
     params?: Record<string, unknown>;
     trace?: AgentTraceEntry[] | undefined;
+    writer_nonce?: string | undefined;
   },
   stores?: HandleRunStores,
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
@@ -215,12 +312,24 @@ export async function handleExecuteStepTool(
 export function registerExecuteStep(server: McpServer, opts?: HandleRunStores): void {
   server.tool(
     'execute_step',
-    'Execute a workflow step. For agent steps, pass your output in params.',
+    [
+      'Execute a workflow step. For agent steps, pass your output in params.',
+      'Optional: writer_nonce — mint a fresh UUIDv4 per step-attempt (same value on every',
+      "append_trace call for this attempt, a NEW one next attempt) to get this step's own",
+      'buffered trace lines faithfully attributed instead of the honest-but-unattributed floor.',
+      'Mint on BOTH append_trace and execute_step for this attempt, or neither — a guessable or',
+      'reused nonce is worse than omitting one (it lets residue be adopted with no caveat, or',
+      'silently folds a crashed attempt into this one).',
+    ].join(' '),
     {
       run_id: z.string(),
       command: z.string(),
       params: z.record(z.unknown()).optional().default({}),
       trace: z.array(traceEntrySchema).optional(),
+      // issue #197 PR-2 (design §6): UNBOUNDED at the zod layer — every shape violation
+      // (empty/whitespace/too-long) routes through validateWriterNonceShape to ONE typed realm
+      // envelope refusal, never a bare zod/SDK error.
+      writer_nonce: z.string().optional(),
     },
     async (args) => {
       return handleExecuteStepTool(args, opts);

--- a/packages/mcp-server/src/tools/get-workflow-protocol.ts
+++ b/packages/mcp-server/src/tools/get-workflow-protocol.ts
@@ -7,6 +7,19 @@ import { generateProtocol, type WorkflowProtocol } from '../protocol/generator.j
 import type { HandleStores } from './list-workflows.js';
 
 /**
+ * Issue #197 PR-2 (design §6): one brief affordance line teaching cooperating agents to mint
+ * `writer_nonce` — consistent with `append_trace`'s own opt-in posture (an affordance, never a
+ * requirement). Appended to `rules` here (in the TOOL layer) rather than in
+ * `protocol/generator.ts` itself, since that module is off this PR's touch list — this keeps the
+ * generator's own output byte-identical for any OTHER consumer that calls it directly.
+ */
+const WRITER_NONCE_PROTOCOL_RULE =
+  'Optional: mint a fresh UUIDv4 writer_nonce per step-attempt (the same value on every ' +
+  'append_trace call for that attempt, a new one next attempt, on BOTH append_trace and ' +
+  'execute_step or neither) to get your own buffered trace lines faithfully attributed instead ' +
+  'of the honest-but-unattributed floor.';
+
+/**
  * Business logic for the get_workflow_protocol tool.
  * Returns the full agent protocol for the specified workflow.
  */
@@ -16,7 +29,8 @@ export async function handleGetWorkflowProtocol(
 ): Promise<WorkflowProtocol> {
   const store = stores?.workflowStore ?? new JsonWorkflowStore();
   const definition = await store.get(args.workflow_id);
-  return generateProtocol(definition);
+  const protocol = generateProtocol(definition);
+  return { ...protocol, rules: [...protocol.rules, WRITER_NONCE_PROTOCOL_RULE] };
 }
 
 /** Registers the get_workflow_protocol MCP tool on the server. */

--- a/packages/mcp-server/src/tools/writer-nonce.test.ts
+++ b/packages/mcp-server/src/tools/writer-nonce.test.ts
@@ -1,0 +1,502 @@
+// Tests for the writer_nonce protocol surface (issue #197 PR-2, design record
+// `plans/issue-197-design.md` §6): shape validation, non-agent refusals, carriage gating
+// (FLAG_GATING), the applied-nonce marker, the dormant REALM_REQUIRE_WRITER_NONCE strict posture,
+// non-disclosure pins (get_run_state / append_trace never leak buffered-line content or nonce
+// values), and the #208 capacityWarning re-home onto the whole-file scope.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  InMemoryTraceBufferStore,
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+} from '@sensigo/realm';
+import type { WorkflowDefinition, TraceBufferStore } from '@sensigo/realm';
+import { handleAppendTrace } from './append-trace.js';
+import { handleExecuteStep } from './execute-step.js';
+import { handleGetRunState } from './get-run-state.js';
+
+function makeWorkflowDef(): WorkflowDefinition {
+  return {
+    id: 'writer-nonce-wf',
+    name: 'Writer Nonce Test Workflow',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    steps: {
+      'step-auto': { description: 'Auto step', execution: 'auto', depends_on: [] },
+      'step-agent': { description: 'Agent step', execution: 'agent', depends_on: [] },
+    },
+  };
+}
+
+describe('writer_nonce protocol surface (issue #197 PR-2)', () => {
+  let runDir: string;
+  let workflowDir: string;
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+  let traceBufferStore: InMemoryTraceBufferStore;
+
+  beforeEach(async () => {
+    runDir = await mkdtemp(join(tmpdir(), 'realm-writer-nonce-runs-'));
+    workflowDir = await mkdtemp(join(tmpdir(), 'realm-writer-nonce-wf-'));
+    runStore = new JsonFileStore(runDir);
+    workflowStore = new JsonWorkflowStore(workflowDir);
+    traceBufferStore = new InMemoryTraceBufferStore();
+
+    const def = makeWorkflowDef();
+    await writeFile(join(workflowDir, `${def.id}.json`), JSON.stringify(def, null, 2), 'utf8');
+  });
+
+  afterEach(() => {
+    delete process.env['REALM_REQUIRE_WRITER_NONCE'];
+  });
+
+  describe('shape validation (both tools)', () => {
+    it.each([
+      ['empty string', ''],
+      ['whitespace-only', '   '],
+      ['leading whitespace', ' abc'],
+      ['trailing whitespace', 'abc '],
+      ['too long (129 chars)', 'a'.repeat(129)],
+    ])('append_trace refuses a malformed writer_nonce (%s)', async (_label, nonce) => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleAppendTrace(
+          { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'e' }], writer_nonce: nonce },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({ code: 'VALIDATION_EMPTY_VALUE', agentAction: 'provide_input' });
+    });
+
+    it.each([
+      ['empty string', ''],
+      ['whitespace-only', '   '],
+      ['too long (129 chars)', 'a'.repeat(129)],
+    ])('execute_step refuses a malformed writer_nonce (%s)', async (_label, nonce) => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleExecuteStep(
+          { run_id: run.id, command: 'step-agent', params: {}, writer_nonce: nonce },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({ code: 'VALIDATION_EMPTY_VALUE', agentAction: 'provide_input' });
+    });
+
+    it('a valid nonce (fresh UUIDv4-shaped) is accepted by both tools', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: [{ event: 'e' }],
+          writer_nonce: 'a-perfectly-valid-nonce-value',
+        },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(result.status).toBe('ok');
+    });
+  });
+
+  describe('non-agent refusals', () => {
+    it('append_trace: the EXISTING non-agent refusal fires BEFORE any nonce validation (a malformed nonce on a non-agent step still surfaces the non-agent error, not the shape error)', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleAppendTrace(
+          {
+            run_id: run.id,
+            step_id: 'step-auto',
+            entries: [{ event: 'e' }],
+            writer_nonce: '', // malformed — would trip shape validation if reached
+          },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({
+        code: 'STATE_STEP_NOT_ELIGIBLE',
+        details: { step_type: 'auto' },
+      });
+    });
+
+    it('execute_step: a writer_nonce PRESENT on a non-agent step is refused (STATE_STEP_NOT_ELIGIBLE + step_type detail)', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleExecuteStep(
+          {
+            run_id: run.id,
+            command: 'step-auto',
+            params: {},
+            writer_nonce: 'some-valid-nonce',
+          },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({
+        code: 'STATE_STEP_NOT_ELIGIBLE',
+        details: { step_type: 'auto' },
+      });
+    });
+
+    it('execute_step: a BARE call on a non-agent step stays byte-identical (auto steps still execute normally)', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await handleExecuteStep(
+        { run_id: run.id, command: 'step-auto', params: {} },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(result.status).toBe('ok');
+    });
+  });
+
+  describe('carriage gating (FLAG_GATING, issue #197 PR-2)', () => {
+    it('a non-declaring store NEVER receives the nonce argument, even when writer_nonce was supplied — plus the not-persisted warning fires', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      // A store with the fenced trio but NO traceCapabilities at all (no carriage).
+      const inner = new InMemoryTraceBufferStore();
+      const nonCarryingStore: TraceBufferStore = {
+        append: (runId, stepId, entries) => inner.append(runId, stepId, entries),
+        read: (runId, stepId) => inner.read(runId, stepId),
+        delete: (runId, stepId) => inner.delete(runId, stepId),
+        deleteAllForRun: (runId, dirEntries) => inner.deleteAllForRun(runId, dirEntries),
+        readAllForRun: (runId) => inner.readAllForRun(runId),
+      };
+      const appendSpy = vi.spyOn(nonCarryingStore, 'append');
+
+      const result = await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: [{ event: 'e' }],
+          writer_nonce: 'a-real-nonce-value',
+        },
+        { runStore, workflowStore, traceBufferStore: nonCarryingStore },
+      );
+
+      expect(result.status).toBe('ok');
+      // The nonce argument was never forwarded — the store call's 4th arg is undefined.
+      expect(appendSpy).toHaveBeenCalledWith(run.id, 'step-agent', [{ event: 'e' }], undefined);
+      expect(result.warnings).toContain(
+        'writer_nonce not persisted: attribution unavailable on this store',
+      );
+      expect(result.writer_nonce_applied).toBeUndefined();
+    });
+
+    it('a declaring store DOES receive the nonce argument, and the not-persisted warning is absent', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      // InMemoryTraceBufferStore declares the fenced trio too, so append_trace prefers
+      // appendFenced over the plain append() — spy on the one actually called.
+      const appendFencedSpy = vi.spyOn(traceBufferStore, 'appendFenced');
+
+      const result = await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: [{ event: 'e' }],
+          writer_nonce: 'a-real-nonce-value',
+        },
+        { runStore, workflowStore, traceBufferStore },
+      );
+
+      expect(result.status).toBe('ok');
+      expect(appendFencedSpy).toHaveBeenCalledTimes(1);
+      const call = appendFencedSpy.mock.calls[0]!;
+      expect(call[0]).toBe(run.id);
+      expect(call[1]).toBe('step-agent');
+      expect(call[2]).toEqual([{ event: 'e' }]);
+      expect(call[4]).toEqual({ writerNonce: 'a-real-nonce-value' }); // trailing options arg
+      expect(result.warnings ?? []).not.toContain(
+        'writer_nonce not persisted: attribution unavailable on this store',
+      );
+    });
+  });
+
+  describe('applied-nonce marker (issue #197 PR-2, design §6)', () => {
+    it('writer_nonce_applied: true when a nonce was BOTH supplied AND carried', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: [{ event: 'e' }],
+          writer_nonce: 'a-real-nonce-value',
+        },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(result.writer_nonce_applied).toBe(true);
+    });
+
+    it('writer_nonce_applied is ABSENT (never false) when no nonce was supplied at all', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'e' }] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(result.writer_nonce_applied).toBeUndefined();
+    });
+  });
+
+  describe('dormant strict posture — REALM_REQUIRE_WRITER_NONCE (issue #197 PR-2, design §6)', () => {
+    it('default (unset): zero behavior change — a bare agent-step call still succeeds on both tools', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const appendResult = await handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'e' }] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(appendResult.status).toBe('ok');
+
+      const { run: run2 } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const execResult = await handleExecuteStep(
+        { run_id: run2.id, command: 'step-agent', params: {} },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(execResult.status).toBe('ok');
+    });
+
+    it('set (any non-empty value other than 0/false): refuses a bare agent-step call on both tools', async () => {
+      process.env['REALM_REQUIRE_WRITER_NONCE'] = '1';
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleAppendTrace(
+          { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'e' }] },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({ code: 'VALIDATION_EMPTY_VALUE' });
+
+      const { run: run2 } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleExecuteStep(
+          { run_id: run2.id, command: 'step-agent', params: {} },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({ code: 'VALIDATION_EMPTY_VALUE' });
+    });
+
+    it('"0" and "false" are treated as OFF, not on', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      process.env['REALM_REQUIRE_WRITER_NONCE'] = '0';
+      const r1 = await handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'e' }] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(r1.status).toBe('ok');
+
+      const { run: run2 } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      process.env['REALM_REQUIRE_WRITER_NONCE'] = 'false';
+      const r2 = await handleExecuteStep(
+        { run_id: run2.id, command: 'step-agent', params: {} },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(r2.status).toBe('ok');
+    });
+
+    it('read PER CALL, never cached — flipping the env mid-process takes effect on the very next call', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const before = await handleAppendTrace(
+        { run_id: run.id, step_id: 'step-agent', entries: [{ event: 'e' }] },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(before.status).toBe('ok');
+
+      process.env['REALM_REQUIRE_WRITER_NONCE'] = '1';
+      const { run: run2 } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await expect(
+        handleAppendTrace(
+          { run_id: run2.id, step_id: 'step-agent', entries: [{ event: 'e' }] },
+          { runStore, workflowStore, traceBufferStore },
+        ),
+      ).rejects.toMatchObject({ code: 'VALIDATION_EMPTY_VALUE' });
+    });
+
+    it('execute_step: a non-agent step is unaffected by the strict posture (never requires a nonce it cannot use)', async () => {
+      process.env['REALM_REQUIRE_WRITER_NONCE'] = '1';
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const result = await handleExecuteStep(
+        { run_id: run.id, command: 'step-auto', params: {} },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      expect(result.status).toBe('ok');
+    });
+  });
+
+  describe('non-disclosure pins (issue #197 PR-2, design §6 — status quo before adoption lands)', () => {
+    it('append_trace envelopes never contain buffered-line content or a foreign nonce value', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await traceBufferStore.append(
+        run.id,
+        'step-agent',
+        [{ event: 'pre-existing-secret-event' }],
+        {
+          writerNonce: 'PRE-EXISTING-FOREIGN-NONCE',
+        },
+      );
+
+      const result = await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: [{ event: 'new' }],
+          writer_nonce: 'MY-OWN-NONCE',
+        },
+        { runStore, workflowStore, traceBufferStore },
+      );
+
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('pre-existing-secret-event');
+      expect(serialized).not.toContain('PRE-EXISTING-FOREIGN-NONCE');
+      // Its OWN nonce is never echoed back either — only the boolean applied-marker.
+      expect(serialized).not.toContain('MY-OWN-NONCE');
+    });
+
+    it('get_run_state envelopes never contain buffered-line content or any nonce value, even after a mixed-adoption settle', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await traceBufferStore.append(run.id, 'step-agent', [{ event: 'own-event' }], {
+        writerNonce: 'my-nonce',
+      });
+      await traceBufferStore.append(run.id, 'step-agent', [{ event: 'foreign-secret-event' }], {
+        writerNonce: 'FOREIGN-NONCE-VALUE',
+      });
+      await handleExecuteStep(
+        { run_id: run.id, command: 'step-agent', params: {}, writer_nonce: 'my-nonce' },
+        { runStore, workflowStore, traceBufferStore },
+      );
+
+      const state = await handleGetRunState({ run_id: run.id }, { runStore });
+
+      const serialized = JSON.stringify(state);
+      expect(serialized).not.toContain('foreign-secret-event');
+      expect(serialized).not.toContain('own-event');
+      expect(serialized).not.toContain('FOREIGN-NONCE-VALUE');
+      expect(serialized).not.toContain('my-nonce');
+      // evidence is never embedded in get_run_state — only a count.
+      expect(state).not.toHaveProperty('evidence');
+      expect(typeof state.evidence_count).toBe('number');
+    });
+  });
+
+  describe('#208 capacityWarning re-home (issue #197 PR-2, deliverable 2d)', () => {
+    it('the whole-file (backstop) scope can warn even when the appending writer is NOT individually near its own ceiling', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'writer-nonce-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const bigBatch = (label: string, n: number) =>
+        Array.from({ length: n }, (_, i) => ({ event: `${label}-${i}` }));
+
+      // Writer A fills its own ceiling exactly (200/200 = 100% for ITS OWN append — a separate
+      // fact from what this test asserts). Writer B then appends 150 (150/200 = 75% — below the
+      // 80% threshold for its OWN writer scope), but the file total (200+150=350)/400 = 87.5% —
+      // ABOVE threshold — so the warning on B's OWN result must be the FILE-scope one.
+      await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: bigBatch('a', 200),
+          writer_nonce: 'writer-a',
+        },
+        { runStore, workflowStore, traceBufferStore },
+      );
+      const result = await handleAppendTrace(
+        {
+          run_id: run.id,
+          step_id: 'step-agent',
+          entries: bigBatch('b', 150),
+          writer_nonce: 'writer-b',
+        },
+        { runStore, workflowStore, traceBufferStore },
+      );
+
+      expect(result.status).toBe('ok');
+      expect(result.buffer_count).toBe(150); // writer B's OWN share — well under its own ceiling
+      const capacityWarn = (result.warnings ?? []).find((w) => w.includes('approaching the limit'));
+      expect(capacityWarn).toBeDefined();
+      expect(capacityWarn).toContain('whole-file, all writers combined');
+      expect(capacityWarn).toContain('350/400 entries');
+      // Never introduces a <n>/<m> substring for the OTHER dimension that would trip a
+      // not-the-other-dimension style assertion elsewhere — only ONE binding dimension reported.
+      expect(capacityWarn).toMatch(/\d+\/\d+ (entries|bytes)/);
+    });
+  });
+});


### PR DESCRIPTION
## Context

Issue #197 — the deferred completion of the #185 trace-buffer arc. PR-1 (#212) shipped the store layer (capability ladder, `sealFenced`/`listSealedForRun`, nonce carriage, per-writer budgets), behaviorally inert. This PR-2 wires it into every real call site. Full design record local (`plans/issue-197-design.md`), converged via a 2-round peer exploration, 3-round design review, and a 14-agent prior-art sweep; Option A (unified partition) user-ratified 2026-07-18.

## Motivation

The trace WAL had no writer identity: a crashed prior attempt's buffered lines were folded into the next driver's canonical evidence (false attribution — honest-labeled since #185, destroyed-with-warning at reclaim since #207, never attributed, never preserved). This PR delivers attributed adoption with evidence-class preservation, with correctness never depending on client cooperation.

## Changes

- **Unified writer partition** (`trace-adoption.ts`): `adopted(line) ⇔ line.nonce ≡ claimant.nonce`, absent ≡ absent (⊥ class). One exported predicate drives the pre-claim `trace_schema` enforce-gate (foreign garbage can never gate a claimant), post-claim adoption, and the settle seal-vs-delete decision. Activation-gated on `storeDeclaresNonceCarriage` (floor + loud missing-leg advisory otherwise). No same-attempt rescue heuristics.
- **Settle-time preservation**: `preserved_foreign > 0` ⇒ `sealFenced` (after `store.update`, guard re-verifies settlement) instead of delete; seal-throw ⇒ skip delete (residue-not-loss); cap ⇒ delete + loud warning; `preserved_foreign === 0` ⇒ plain delete, byte-identical. Run record carries detection counts only — never seal outcome.
- **Reclaim preserves instead of destroying** on seal-declaring stores: `sealFenced` (preserve-ALL, zero-cooperation) before the un-claiming update, version-fenced; cap falls back to the #207 drain; non-seal/non-declaring paths byte-frozen.
- **Protocol surface**: optional `writer_nonce` on `append_trace` + `execute_step` (shape-validated to realm envelopes; strict carriage gating — a non-declaring store never receives the nonce; `writer_nonce_applied` downgrade-detector marker; nonce-conditional non-agent refusal on `execute_step`). #208 `capacityWarning` re-homed onto both per-writer and file-backstop bounds (shipped boundary tests green unmodified).
- **Evidence three-way split** (`trace_summary`, additive): `buffered_lines_adopted` (bare-adopted, existing caveat), `attributed_lines_adopted` ("writer continuity verified; strength conditional on nonce secrecy"), `foreign_lines_preserved` + export pointer. Envelope adoption counts + engine-side half-minted advisory (neutral phrasing; foreign nonce values never echoed anywhere).
- **CLI**: `--mint-writer-nonce` (fresh UUIDv4 per step-attempt; no caller-fixed values). Dormant `REALM_REQUIRE_WRITER_NONCE` strict posture (off by default, documented).
- **Export v3**: additive `sealed` field (`null` = incapability, `{}` = none) with #186 degradation; non-terminal exports redact live-step nonce values (`[redacted-live-claim]`); terminal verbatim. purge/gc needed zero changes (verified by test, not assumed).
- **`server.ts`** invokes `validateTraceCapabilities` at the co-location seam (declared-but-inconsistent fails loud at construction).
- Correction commit: 4 tests pinning the half-minted advisory heuristics (found unpinned by an architect-side mutation probe).

## Verification

```bash
npx turbo run build test lint --force   # core 1734 / mcp 252 / cli 764 / testing 81 — all green
npm run check:versions                  # all 0.26.0
```

Mutation probes (all red→restore→green; independently reproduced in review): enforce-gate predicate bypass ⇒ congruence red; delete-then-seal reorder ⇒ ordering red; seal-throw-still-deletes ⇒ residue-not-loss red; reclaim seal-after-update ⇒ 4 tests red; nonce force-passed to non-declaring store ⇒ spy red; file-ratio dropped from capacityWarning ⇒ new test red while shipped #208 tests stay green; seal-outcome leaked into run record ⇒ attestation red; redaction disabled ⇒ 2 tests red; both half-minted branches killed ⇒ exactly the 2 new advisory tests red.

## Rollback

```bash
git revert 91e280e 89e8102
```

No data migrations. Sealed artifacts already written are ignored by reverted readers (unknown-file tolerant); WAL `nonce` fields are ignored by reverted engines (adopt-all floor).

## Related

Closes #197 (PR-2 of 2 — PR-1 was #212). Builds on #207/#183/#185/#208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
