### PR TITLE
chore(release): v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.27.0] — 2026-07-18
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.26.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.27.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,7 +100,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.26.0';
+export const VERSION = '0.27.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.26.0';
+export const VERSION = '0.27.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.26.0',
+    version: '0.27.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -57,4 +57,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.26.0';
+export const VERSION = '0.27.0';


### PR DESCRIPTION
## Context

Release v0.27.0 (minor) — the trace-buffer integrity release. `[Unreleased]` accumulated the complete #207 fenced-trio program (PRs #209/#210), the #208 capacity early-warning (PR #211), and the complete #197 attributed-adoption program (PRs #212/#213). All milestone PRs are merged; issues #207, #208, #197, #185, #198 are closed.

## Motivation

Standard two-part release process (pre-publication instructions, Part B): changelog cut + atomic four-package version bump + tag on a release branch; publishing happens via `publish.yml` OIDC on the tag push after this PR merges.

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `[0.27.0] — 2026-07-18` (Added: fenced trio + TCK; #208 capacity warning; #197 capability ladder/sealed-WAL/nonce carriage/per-writer budgets; attributed adoption + writer_nonce protocol surface + export v3. Changed/Fixed entries per section.)
- `chore: release v0.27.0` — bumps all four `package.json` files + five `VERSION` constants to 0.27.0, tags `v0.27.0`.

## Verification

```bash
npm run check:versions          # all 0.27.0
npx turbo run build test lint --force   # 4/4 green (core 1734 / mcp 252 / cli 764 / testing 81)
npm audit --omit=dev --audit-level=high # 0 vulnerabilities
```

## Rollback

Do not revert; if the publish fails mid-way, follow the pre-publication rollback note (re-push the tag; EPUBLISHCONFLICT skips already-published packages). A broken published artifact ⇒ patch release.

## Related

Releases #207 (PRs #209/#210), #208 (PR #211), #197 (PRs #212/#213).

**MERGE WITH A MERGE COMMIT (`gh pr merge --merge`)** — the tag points at the release commit; rebase/squash would strand it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
