### PR TITLE
feat(cli): in-drive schema-feedback repair loop for realm agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **In-drive schema-feedback repair loop for `realm agent` (issue #217).** When an `execution:
+'agent'` step's output is rejected by `output_schema`/`input_schema` validation
+  (`VALIDATION_OUTPUT_SCHEMA`/`VALIDATION_INPUT_SCHEMA`), the drive now re-prompts the SAME step
+  with the validator's errors appended — a PRISTINE copy of the original prompt plus the LATEST
+  rejection's whitelisted summary only (never accumulated, never the raw Ajv error array, which
+  can carry schema-declared values like `enum.allowedValues`). New `--schema-retries <n>` flag on
+  `realm agent` (default `2`, non-negative integer, `0` disables and reproduces today's
+  single-attempt behavior byte-for-byte); one stderr line is printed per repair attempt, and the
+  eventual failure message gains an "after N schema-repair attempts" suffix once at least one
+  repair ran. Applies to both the plain `callStep` path and the MCP tools path (tools-path repair
+  is scoped to a ZERO-toolCall attempt only — a repair after a tool actually ran is out of scope
+  for this pass; see the `ToolCapableLlmProvider.callStepWithTools` JSDoc for the provider
+  contract this relies on). Auto steps and the MCP protocol path are entirely unaffected — zero
+  engine change. New core export-adjacent addition: `summarizeAjvErrors` (in
+  `buildFailedAttemptRecord`'s `validation_error_summary`) now carries two additional
+  keyword-conditional, key-name-only fields, `additional_property`/`missing_property`, feeding the
+  repair prompt's summary without ever leaking a submitted or schema-declared value. Semver:
+  minor-additive.
+
+---
+
 ## [0.28.0] — 2026-07-19
 
 ### Added

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -229,16 +229,17 @@ realm agent \
   --params '{"key":"value"}'
 ```
 
-| Option                     | Default          | Description                                                                                                                                            |
-| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--workflow <path>`        | (required)       | Path to `workflow.yaml` or its containing directory                                                                                                    |
-| `--params <json>`          | `{}`             | Run params as a JSON string                                                                                                                            |
-| `--provider <name>`        | auto             | LLM provider. Values: `openai`, `anthropic`. Auto-detected from whichever API key is set.                                                              |
-| `--model <name>`           | provider default | Model name override. Default: `gpt-4o` for OpenAI, `claude-sonnet-4-5` for Anthropic.                                                                  |
-| `--base-url <url>`         | —                | Base URL for OpenAI-compatible endpoints (DeepSeek, Qwen, Groq, etc.). Only valid with `--provider openai` or when `OPENAI_API_KEY` is set.            |
-| `--provider-module <path>` | —                | Path to a custom provider module. Cannot be combined with `--provider`, `--model`, or `--base-url`. See [Custom providers](#custom-providers) below.   |
-| `--register`               | off              | Persist the workflow to `~/.realm/workflows/` so `realm run inspect` resolves it by ID                                                                 |
-| `--run-id <id>`            | —                | Attach to an existing run instead of creating a new one. Mutually exclusive with `--workflow`. The run must exist and must not be in a terminal state. |
+| Option                     | Default          | Description                                                                                                                                                                                               |
+| -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--workflow <path>`        | (required)       | Path to `workflow.yaml` or its containing directory                                                                                                                                                       |
+| `--params <json>`          | `{}`             | Run params as a JSON string                                                                                                                                                                               |
+| `--provider <name>`        | auto             | LLM provider. Values: `openai`, `anthropic`. Auto-detected from whichever API key is set.                                                                                                                 |
+| `--model <name>`           | provider default | Model name override. Default: `gpt-4o` for OpenAI, `claude-sonnet-4-5` for Anthropic.                                                                                                                     |
+| `--base-url <url>`         | —                | Base URL for OpenAI-compatible endpoints (DeepSeek, Qwen, Groq, etc.). Only valid with `--provider openai` or when `OPENAI_API_KEY` is set.                                                               |
+| `--provider-module <path>` | —                | Path to a custom provider module. Cannot be combined with `--provider`, `--model`, or `--base-url`. See [Custom providers](#custom-providers) below.                                                      |
+| `--register`               | off              | Persist the workflow to `~/.realm/workflows/` so `realm run inspect` resolves it by ID                                                                                                                    |
+| `--run-id <id>`            | —                | Attach to an existing run instead of creating a new one. Mutually exclusive with `--workflow`. The run must exist and must not be in a terminal state.                                                    |
+| `--schema-retries <n>`     | `2`              | In-drive repair attempts when an agent step's output/input is rejected by schema validation (issue #217) — the drive re-prompts with the validator's errors appended. Non-negative integer; `0` disables. |
 
 **LLM key:** set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` in your shell or `.env` file. The
 CLI loads `.env` automatically on startup.

--- a/packages/cli/src/agent/providers/llm-provider.ts
+++ b/packages/cli/src/agent/providers/llm-provider.ts
@@ -38,6 +38,14 @@ export abstract class LlmProvider {
  * Extend this class if your provider can drive tool-enabled workflow steps.
  */
 export abstract class ToolCapableLlmProvider extends LlmProvider {
+  /**
+   * issue #217 provider contract: every executor invocation MUST produce an entry in
+   * `toolCalls`, including failed/timed-out calls — the drive's schema-repair gate relies on
+   * `toolCalls.length === 0 ⇒ executor never invoked`. A custom `--provider-module` that violates
+   * this (e.g. swallows a failed call without recording it) is a trusted-injector residual — the
+   * repair gate would then wrongly treat a tool-using attempt as tool-free and repair it (cross-
+   * ref #224).
+   */
   abstract callStepWithTools(
     prompt: string,
     tools: ToolDefinition[],

--- a/packages/cli/src/agent/run-agent.test.ts
+++ b/packages/cli/src/agent/run-agent.test.ts
@@ -1,8 +1,9 @@
 // run-agent.test.ts — Tests for runAgent() and MCP tool dispatch.
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { InvalidArgumentError } from 'commander';
 import { runAgent } from './run-agent.js';
 import type { AgentDeps } from './run-agent.js';
-import type { WorkflowDefinition, ToolCallRecord } from '@sensigo/realm';
+import type { WorkflowDefinition, ToolCallRecord, TraceBufferStore } from '@sensigo/realm';
 import {
   CURRENT_WORKFLOW_SCHEMA_VERSION,
   createDefaultRegistry,
@@ -11,6 +12,7 @@ import {
 import { InMemoryStore } from '@sensigo/realm-testing';
 import { LlmProvider, ToolCapableLlmProvider } from './providers/llm-provider.js';
 import type { McpClient, McpTool } from './mcp/mcp-extensions.js';
+import { agentCommand } from '../commands/agent.js';
 
 // ---------------------------------------------------------------------------
 // MCP tools integration tests
@@ -682,5 +684,445 @@ describe('runAgent — effective output schema routing (#robust-anthropic-provid
     const optsArg = provider.callStepWithTools.mock.calls[0]?.[3] as { inputSchema?: unknown };
     // output_schema wins over input_schema — the effective schema fed to the provider.
     expect(optsArg.inputSchema).toEqual(outputSchema);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #217 — in-drive schema-feedback repair loop
+// ---------------------------------------------------------------------------
+
+/** A single agent step, `execution: 'agent'`, description 'Draft' — schema declared via override. */
+function agentWorkflow(
+  overrides: Partial<WorkflowDefinition['steps'][string]> = {},
+): WorkflowDefinition {
+  return {
+    id: 'repair-wf',
+    name: 'Repair WF',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    steps: {
+      draft: {
+        description: 'Draft',
+        execution: 'agent',
+        ...overrides,
+      },
+    },
+  };
+}
+
+/** A single tools-path agent step declaring both input_schema (loader-required alongside `tools`)
+ *  and output_schema (the schema actually exercised by these tests). */
+function toolsWorkflow(): WorkflowDefinition {
+  return {
+    id: 'tools-repair-wf',
+    name: 'Tools Repair WF',
+    version: 1,
+    schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    mcp_servers: [{ id: 'github', command: 'npx', args: ['-y', 'mcp-github'] }],
+    steps: {
+      draft: {
+        description: 'Draft',
+        execution: 'agent',
+        tools: ['github:get_pull_request'],
+        input_schema: { type: 'object', properties: { note: { type: 'string' } } },
+        output_schema: {
+          type: 'object',
+          properties: { category: { type: 'string', enum: ['ok'] } },
+          required: ['category'],
+        },
+      },
+    },
+  };
+}
+
+/**
+ * A trace-buffer store whose `read()` always throws a generic (non-WorkflowError) — reproduces a
+ * genuinely PRE-claim, non-validation ENGINE_STORE_FAILED envelope (test 7). execution-loop.ts
+ * reads the WAL before claimStep for an agent step, so this failure occurs before any run-record
+ * version bump — cleanly isolating conjunct (ii) from the run_version-based conjunct (vi): a
+ * POST-claim non-validation failure (e.g. a settle-time `store.update()` throw) would ALSO
+ * independently fail (vi) (its envelope's run_version differs from the pre-claim baseline,
+ * confirmed empirically), which would mask conjunct (ii) in probe (a).
+ */
+const throwingTraceBufferStore = {
+  read: async () => {
+    throw new Error('simulated trace-buffer read failure');
+  },
+} as unknown as TraceBufferStore;
+
+describe('runAgent — schema-feedback repair loop (issue #217)', () => {
+  it('test 1: repair-success — 2 provider calls; attempt-2 prompt carries the summary, never the raw AJV leak (enum.allowedValues)', async () => {
+    const def = agentWorkflow({
+      output_schema: {
+        type: 'object',
+        properties: { status: { type: 'string', enum: ['SENTINEL_ALLOWED_ZZZ'] } },
+        required: ['status'],
+      },
+    });
+    const provider = new (class extends LlmProvider {
+      callStep = vi
+        .fn()
+        .mockResolvedValueOnce({ status: 'WRONG_VALUE_MARKER_XYZ' })
+        .mockResolvedValueOnce({ status: 'SENTINEL_ALLOWED_ZZZ' });
+    })();
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('completed');
+    expect(provider.callStep).toHaveBeenCalledTimes(2);
+    const secondPrompt = provider.callStep.mock.calls[1]?.[0] as string;
+    // (i) carries the enum failure message.
+    expect(secondPrompt).toContain('must be equal to one of the allowed values');
+    // (ii) never leaks the allowed value — the raw AJV array would via params.allowedValues.
+    expect(secondPrompt).not.toContain('SENTINEL_ALLOWED_ZZZ');
+    // (iii) never leaks a sentinel from a VALUE position of the invalid output either (future-
+    // proofing — non-verbose Ajv never echoes data values, so (ii) is the real discriminator).
+    expect(secondPrompt).not.toContain('WRONG_VALUE_MARKER_XYZ');
+  });
+
+  it('test 2: LATEST-only feedback — attempt-3 prompt carries ONLY rejection-2, never rejection-1, and exactly one feedback-block header', async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' }, beta: { type: 'number' } },
+      required: ['alpha', 'beta'],
+    };
+    const def = agentWorkflow({ output_schema: schema });
+    const provider = new (class extends LlmProvider {
+      callStep = vi
+        .fn()
+        .mockResolvedValueOnce({ beta: 5 }) // rejection 1: required-miss on 'alpha'
+        .mockResolvedValueOnce({ alpha: 'x', beta: 'not-a-number' }) // rejection 2: type-miss at /beta
+        .mockResolvedValueOnce({ alpha: 'x', beta: 5 }); // valid
+    })();
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('completed');
+    expect(provider.callStep).toHaveBeenCalledTimes(3);
+    const thirdPrompt = provider.callStep.mock.calls[2]?.[0] as string;
+    expect(thirdPrompt).toContain('/beta'); // rejection-2-unique marker present
+    expect(thirdPrompt).not.toContain("'alpha'"); // rejection-1-unique marker absent
+    const headerMatches = thirdPrompt.match(/rejected by the output schema validator:/g) ?? [];
+    expect(headerMatches).toHaveLength(1); // exactly one feedback-block header
+  });
+
+  it("test 3: exhaustion — N+1 provider calls, 'failed', message notes the repair count; run stays non-terminal + step still eligible (today's engine posture — #220 will terminalize persistent rejection; delete this pin when it ships)", async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' } },
+      required: ['alpha'],
+    };
+    const def = agentWorkflow({ output_schema: schema });
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({}); // always invalid — missing 'alpha' every time
+    })();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = new InMemoryStore();
+    const { run } = await store.create({
+      workflowId: def.id,
+      workflowVersion: def.version,
+      params: {},
+    });
+
+    const result = await runAgent(
+      { store, workflowStore: makeWorkflowStore(def), provider, registry: createDefaultRegistry() },
+      { existingRunId: run.id, definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    expect(provider.callStep).toHaveBeenCalledTimes(3); // 1 + 2 repairs (default schemaRetries=2)
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).toContain('after 2 schema-repair attempts');
+
+    // #220 will terminalize persistent rejection — delete this pin when it ships
+    const after = await store.get(run.id);
+    expect(after.terminal_state).toBe(false);
+    expect(after.completed_steps).not.toContain('draft');
+    expect(after.in_progress_steps).not.toContain('draft');
+    expect(after.failed_steps).not.toContain('draft');
+    errorSpy.mockRestore();
+  });
+
+  it('test 4: VALIDATION_INPUT_SCHEMA variant — repair fires for an agent step declaring only input_schema', async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' } },
+      required: ['alpha'],
+    };
+    const def = agentWorkflow({ input_schema: schema });
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValueOnce({}).mockResolvedValueOnce({ alpha: 'x' });
+    })();
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('completed');
+    expect(provider.callStep).toHaveBeenCalledTimes(2);
+    const secondPrompt = provider.callStep.mock.calls[1]?.[0] as string;
+    expect(secondPrompt).toContain('rejected by the input schema validator');
+  });
+
+  it('test 5: auto-step never repairs — exactly one executeChain submission (one auto-banner print), no repair message', async () => {
+    const def: WorkflowDefinition = {
+      id: 'auto-repair-wf',
+      name: 'Auto Repair WF',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      steps: {
+        finalize: {
+          description: 'Finalize',
+          execution: 'auto',
+          input_schema: {
+            type: 'object',
+            properties: { alpha: { type: 'string' } },
+            required: ['alpha'],
+          },
+        },
+      },
+    };
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn();
+    })();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    expect(provider.callStep).not.toHaveBeenCalled();
+    const autoLines = logSpy.mock.calls
+      .flat()
+      .filter((l) => typeof l === 'string' && l.includes('→ [auto] finalize'));
+    expect(autoLines).toHaveLength(1);
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).not.toContain('repairing');
+    expect(printed).not.toContain('schema-repair');
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('test 6a: --schema-retries 0 — exactly 1 provider call, byte-identical today-behavior (no repair)', async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' } },
+      required: ['alpha'],
+    };
+    const def = agentWorkflow({ output_schema: schema });
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({}); // always invalid
+    })();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+        schemaRetries: 0,
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    expect(provider.callStep).toHaveBeenCalledTimes(1);
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).not.toContain('schema-repair');
+    errorSpy.mockRestore();
+  });
+
+  describe('test 6b: --schema-retries argParser', () => {
+    beforeEach(() => {
+      vi.spyOn(process, 'exit').mockImplementation((() => {}) as () => never);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("rejects a non-numeric value loudly ('abc')", async () => {
+      await agentCommand
+        .parseAsync(['node', 'realm', '--workflow', 'x', '--schema-retries', 'abc'])
+        .catch(() => {});
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("rejects a negative value loudly ('-1')", async () => {
+      await agentCommand
+        .parseAsync(['node', 'realm', '--workflow', 'x', '--schema-retries', '-1'])
+        .catch(() => {});
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('the parseArg itself throws InvalidArgumentError for non-numeric/negative input, and defaults to the numeric 2', () => {
+      const opt = agentCommand.options.find((o) => o.long === '--schema-retries')!;
+      expect(() => opt.parseArg('abc', undefined)).toThrow(InvalidArgumentError);
+      expect(() => opt.parseArg('-1', undefined)).toThrow(InvalidArgumentError);
+      expect(opt.parseArg('5', undefined)).toBe(5);
+      expect(agentCommand.opts()['schemaRetries']).toBe(2);
+    });
+  });
+
+  it('test 7: non-validation error on an agent step ⇒ no repair (exactly 1 provider call)', async () => {
+    const def = agentWorkflow(); // no schema at all — any output would settle
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({ anything: true });
+    })();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+        traceBufferStore: throwingTraceBufferStore,
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    expect(provider.callStep).toHaveBeenCalledTimes(1);
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).not.toContain('repairing');
+    expect(printed).not.toContain('schema-repair');
+    errorSpy.mockRestore();
+  });
+
+  it('test 8a: tools path, zero toolCalls on the invalid attempt ⇒ repair fires and succeeds', async () => {
+    const def = toolsWorkflow();
+    const provider = new (class extends ToolCapableLlmProvider {
+      callStepWithTools = vi
+        .fn()
+        .mockResolvedValueOnce({ output: { category: 'WRONG' }, toolCalls: [] })
+        .mockResolvedValueOnce({ output: { category: 'ok' }, toolCalls: [] });
+    })();
+    const mockClient = makeMockMcpClient();
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+        mcpClientFactory: () => mockClient,
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('completed');
+    expect(provider.callStepWithTools).toHaveBeenCalledTimes(2);
+  });
+
+  it("test 8b: tools path, toolCalls>0 on the invalid attempt ⇒ NO repair (today's failure path)", async () => {
+    const def = toolsWorkflow();
+    const toolCalls: ToolCallRecord[] = [
+      {
+        tool: 'get_pull_request',
+        server_id: 'github',
+        args: {},
+        result: 'x',
+        duration_ms: 1,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    const provider = new (class extends ToolCapableLlmProvider {
+      callStepWithTools = vi.fn().mockResolvedValue({ output: { category: 'WRONG' }, toolCalls });
+    })();
+    const mockClient = makeMockMcpClient();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+        mcpClientFactory: () => mockClient,
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    expect(provider.callStepWithTools).toHaveBeenCalledTimes(1);
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).not.toContain('schema-repair');
+    errorSpy.mockRestore();
+  });
+
+  it('test 10: chained-auto no-false-repair — an agent step chaining into an auto step with a required-prop input_schema does not falsely repair the already-settled agent step', async () => {
+    const def: WorkflowDefinition = {
+      id: 'chained-auto-wf',
+      name: 'Chained Auto WF',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      steps: {
+        draft: { description: 'Draft', execution: 'agent' },
+        finalize: {
+          description: 'Finalize',
+          execution: 'auto',
+          depends_on: ['draft'],
+          input_schema: {
+            type: 'object',
+            properties: { alpha: { type: 'string' } },
+            required: ['alpha'],
+          },
+        },
+      },
+    };
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({ ok: true });
+    })();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    expect(provider.callStep).toHaveBeenCalledTimes(1);
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).not.toContain('repairing');
+    expect(printed).not.toContain('schema-repair');
+    errorSpy.mockRestore();
   });
 });

--- a/packages/cli/src/agent/run-agent.test.ts
+++ b/packages/cli/src/agent/run-agent.test.ts
@@ -3,11 +3,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InvalidArgumentError } from 'commander';
 import { runAgent } from './run-agent.js';
 import type { AgentDeps } from './run-agent.js';
-import type { WorkflowDefinition, ToolCallRecord, TraceBufferStore } from '@sensigo/realm';
+import type {
+  WorkflowDefinition,
+  ToolCallRecord,
+  TraceBufferStore,
+  RunRecord,
+} from '@sensigo/realm';
 import {
   CURRENT_WORKFLOW_SCHEMA_VERSION,
   createDefaultRegistry,
   ExtensionRegistry,
+  findEligibleSteps,
 } from '@sensigo/realm';
 import { InMemoryStore } from '@sensigo/realm-testing';
 import { LlmProvider, ToolCapableLlmProvider } from './providers/llm-provider.js';
@@ -750,6 +756,30 @@ const throwingTraceBufferStore = {
   },
 } as unknown as TraceBufferStore;
 
+/**
+ * issue #217 correction, deliverable 3a — concurrency witness store. Simulates a concurrent
+ * EXTERNAL writer (a second drive, a gate `respond`, a parallel-step settle) bumping the run's
+ * version WHILE a repair attempt is in flight. `armed` is flipped externally by the test's
+ * console.error spy the instant the FIRST 'repairing' line prints. The very NEXT `get(runId)`
+ * call — from ANY caller sharing this store instance (the drive's own per-attempt baseline read
+ * under the fix, or the engine's internal pre-claim read either way) — performs exactly ONE
+ * `super.update({...await super.get(runId)})` (a genuine version bump, no other field touched)
+ * BEFORE returning the (now-bumped) record, modeling a real external write racing in. Bumps only
+ * once (`bumped` latches), so later `get()` calls just pass through.
+ */
+class ConcurrentWriterStore extends InMemoryStore {
+  armed = false;
+  private bumped = false;
+  override async get(runId: string): Promise<RunRecord> {
+    if (this.armed && !this.bumped) {
+      this.bumped = true;
+      const current = await super.get(runId);
+      await super.update({ ...current });
+    }
+    return super.get(runId);
+  }
+}
+
 describe('runAgent — schema-feedback repair loop (issue #217)', () => {
   it('test 1: repair-success — 2 provider calls; attempt-2 prompt carries the summary, never the raw AJV leak (enum.allowedValues)', async () => {
     const def = agentWorkflow({
@@ -786,6 +816,42 @@ describe('runAgent — schema-feedback repair loop (issue #217)', () => {
     // (iii) never leaks a sentinel from a VALUE position of the invalid output either (future-
     // proofing — non-verbose Ajv never echoes data values, so (ii) is the real discriminator).
     expect(secondPrompt).not.toContain('WRONG_VALUE_MARKER_XYZ');
+  });
+
+  it('test 1b: positive visibility witness — the per-repair stderr line is actually emitted (every existing assertion up to now only checked its ABSENCE on non-repair paths)', async () => {
+    const def = agentWorkflow({
+      output_schema: {
+        type: 'object',
+        properties: { status: { type: 'string', enum: ['SENTINEL_ALLOWED_ZZZ'] } },
+        required: ['status'],
+      },
+    });
+    const provider = new (class extends LlmProvider {
+      callStep = vi
+        .fn()
+        .mockResolvedValueOnce({ status: 'WRONG_VALUE_MARKER_XYZ' })
+        .mockResolvedValueOnce({ status: 'SENTINEL_ALLOWED_ZZZ' });
+    })();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+      },
+      { definition: def, params: {} },
+    );
+
+    expect(result).toBe('completed');
+    // Exactly one repair happens (1 rejection, then valid) — exactly one console.error call on
+    // this clean success path (no other error branch is reachable here).
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain(
+      '⚠ output rejected (VALIDATION_OUTPUT_SCHEMA); repairing (attempt 1/2)',
+    );
+    errorSpy.mockRestore();
   });
 
   it('test 2: LATEST-only feedback — attempt-3 prompt carries ONLY rejection-2, never rejection-1, and exactly one feedback-block header', async () => {
@@ -856,6 +922,45 @@ describe('runAgent — schema-feedback repair loop (issue #217)', () => {
     expect(after.completed_steps).not.toContain('draft');
     expect(after.in_progress_steps).not.toContain('draft');
     expect(after.failed_steps).not.toContain('draft');
+    // Pins the actual re-drivability contract (not its structural shadow via the three fields
+    // above): the step is genuinely eligible again, so `realm agent --run-id` can re-drive it.
+    expect(findEligibleSteps(def, after)).toContain('draft');
+    errorSpy.mockRestore();
+  });
+
+  it('test 3a: concurrent-writer repair-survival — a run-version bump from an external writer landing mid-attempt does not silently forfeit a legitimate repair (per-attempt baseline)', async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' } },
+      required: ['alpha'],
+    };
+    const def = agentWorkflow({ output_schema: schema });
+    const store = new ConcurrentWriterStore();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const line = typeof args[0] === 'string' ? args[0] : '';
+      if (line.includes('repairing')) {
+        store.armed = true;
+      }
+    });
+    const provider = new (class extends LlmProvider {
+      callStep = vi
+        .fn()
+        .mockResolvedValueOnce({}) // rejection 1: missing 'alpha'
+        .mockResolvedValueOnce({}) // rejection 2: still missing 'alpha' (post-bump attempt)
+        .mockResolvedValueOnce({ alpha: 'x' }); // valid
+    })();
+
+    const result = await runAgent(
+      { store, workflowStore: makeWorkflowStore(def), provider, registry: createDefaultRegistry() },
+      { definition: def, params: {} },
+    );
+
+    // Under the shipped per-STEP capture this survives only 2 calls (repair 2 is falsely
+    // forfeited — see the report's red-on-shipped transcript). Under the per-ATTEMPT fix, the
+    // attempt-2 loop-top baseline get absorbs the external bump, so repair 2 fires and the drive
+    // completes.
+    expect(result).toBe('completed');
+    expect(provider.callStep).toHaveBeenCalledTimes(3);
     errorSpy.mockRestore();
   });
 
@@ -992,7 +1097,11 @@ describe('runAgent — schema-feedback repair loop (issue #217)', () => {
       expect(() => opt.parseArg('abc', undefined)).toThrow(InvalidArgumentError);
       expect(() => opt.parseArg('-1', undefined)).toThrow(InvalidArgumentError);
       expect(opt.parseArg('5', undefined)).toBe(5);
-      expect(agentCommand.opts()['schemaRetries']).toBe(2);
+      // issue #217 correction: `agentCommand.opts()` reads the SHARED singleton's last-parsed
+      // state, which the two parseAsync sub-tests above already mutated (order-coupled) — read
+      // the Option's own static `defaultValue` instead, which is set once at Command construction
+      // and never mutated by parsing.
+      expect(opt.defaultValue).toBe(2);
     });
   });
 

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -374,10 +374,6 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
 
       const stepName = eligible[0]!;
       const stepDef: StepDefinition = definition.steps[stepName]!;
-      // issue #217 conjunct (vi) ground truth — captured ONCE per step, before any attempt.
-      // See the repair-gate comment below for why this (not `result.command`) is the correct
-      // discriminator for "did a DEEPER chained step actually produce this error?".
-      const versionBeforeStep = currentRun.version;
 
       // issue #217: the in-drive schema-feedback repair loop. `stepInput`/`toolCallsForMeta`/
       // `result` are re-assigned on every attempt inside the `for` loop below; `repairsUsed`/
@@ -395,6 +391,13 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
 
       for (;;) {
         toolCallsForMeta = undefined;
+        // issue #217 conjunct (vi) ground truth — captured FRESH at the top of EVERY attempt
+        // (including the first), never once per step: a per-step capture is stale across the
+        // whole provider LLM call, so any concurrent writer (a second drive, a gate `respond`, a
+        // parallel-step settle) landing during that call would silently forfeit a legitimate
+        // repair. See the repair-gate comment below for the full discriminator rationale. Cost:
+        // one extra store read per attempt — accepted.
+        const versionBeforeAttempt = (await deps.store.get(runId)).version;
 
         if (stepDef.execution === 'agent') {
           // Resolve template-expanded prompt via buildNextActions so {{ context.resources.* }}
@@ -626,12 +629,15 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         // The corrected, structurally-sound discriminator: a pre-claim validation rejection is
         // write-free (no run-record version bump — see execute-step.ts:77-80 / execution-loop.ts's
         // Step 2b/2c, both before claimStep). So if `result.run_version` has advanced past
-        // `versionBeforeStep` (captured before this step's first attempt), something committed to
-        // the run BEFORE this error occurred — i.e. THIS step's own claim+settle, followed by a
-        // DEEPER chained step's pre-claim rejection — so the error cannot be this step's own output/
-        // input. `result.run_version === versionBeforeStep` preserves the exact same protective
-        // intent as the record's conjunct (vi): never repair a step whose own attempt didn't
-        // actually produce the error. See run-agent.test.ts's "chained-auto no-false-repair" test.
+        // `versionBeforeAttempt` (captured fresh at the top of each repair attempt), something
+        // committed to the run BEFORE this error occurred — e.g. THIS step's own claim+settle,
+        // followed by a DEEPER chained step's pre-claim rejection — so the error cannot be this
+        // step's own output/input. A concurrent external writer bumping the run mid-attempt also
+        // lands here — the gate then fails CLOSED (repair forfeited, today's failure path). See
+        // run-agent.test.ts's "chained-auto no-false-repair" and concurrent-writer tests.
+        //
+        // #220 must keep rejected attempts write-free w.r.t. the run record (or report the
+        // pre-write version in the envelope), else repairs 2..N silently vanish — see test 3's pin.
         if (
           result.status === 'error' &&
           (result.error_code === 'VALIDATION_OUTPUT_SCHEMA' ||
@@ -639,7 +645,7 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
           stepDef.execution === 'agent' &&
           (toolCallsForMeta === undefined || toolCallsForMeta.length === 0) &&
           repairsUsed < schemaRetries &&
-          result.run_version === versionBeforeStep
+          result.run_version === versionBeforeAttempt
         ) {
           repairsUsed++;
           const record = buildFailedAttemptRecord({

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -11,6 +11,7 @@ import {
   findCapabilityBlockedSteps,
   unmetCapabilities,
   capabilityWarning,
+  buildFailedAttemptRecord,
   WorkflowError,
   type RunStore,
   type WorkflowDefinition,
@@ -20,6 +21,7 @@ import {
   type McpServerConfig,
   type ToolCallRecord,
   type TraceBufferStore,
+  type ValidationErrorSummaryEntry,
 } from '@sensigo/realm';
 import type { WorkflowRegistrar } from '@sensigo/realm';
 import type { LlmProvider } from './providers/llm-provider.js';
@@ -69,6 +71,16 @@ export interface AgentDeps {
    * `crypto.randomUUID()` is minted independently for EVERY step-attempt in the loop below.
    */
   mintWriterNonce?: boolean;
+  /**
+   * Budget for issue #217's in-drive schema-feedback repair loop: how many times the drive
+   * re-prompts an `execution: 'agent'` step after its output/input is rejected by
+   * output_schema/input_schema validation, appending the validator's errors to the prompt.
+   * Threaded exactly like `mintWriterNonce` above (agent.ts's `--schema-retries` flag → both
+   * runAgent call sites → this field). Default `2` when omitted (mirrors the CLI flag's own
+   * default) — `0` disables the loop entirely, reproducing today's single-attempt behavior
+   * byte-for-byte.
+   */
+  schemaRetries?: number;
 }
 
 /**
@@ -178,6 +190,25 @@ async function pollUntilGateResolved(
 }
 
 /**
+ * Renders one whitelisted Ajv-error summary entry (issue #217, core's
+ * `buildFailedAttemptRecord(...).validation_error_summary`) as a single human-readable line for
+ * the schema-repair prompt trailer. Key NAMES only — the summary entry already strips value
+ * echoes (see failed-attempt-record.ts's `summarizeAjvErrors`), so nothing rendered here can leak
+ * a submitted or schema-declared VALUE (e.g. `enum.allowedValues`).
+ */
+function renderValidationSummaryEntry(entry: ValidationErrorSummaryEntry): string {
+  const path = entry.instancePath !== '' ? entry.instancePath : '(root)';
+  let line = `- ${path}: ${entry.message} [${entry.keyword}]`;
+  if (entry.additional_property !== undefined) {
+    line += ` (additional property: '${entry.additional_property}')`;
+  }
+  if (entry.missing_property !== undefined) {
+    line += ` (missing property: '${entry.missing_property}')`;
+  }
+  return line;
+}
+
+/**
  * Runs a workflow to completion using the provided dependencies.
  * Returns 'completed' when the run finishes normally; 'failed' otherwise.
  * Throws on setup failures (e.g. workflow file not found, provider error).
@@ -191,6 +222,10 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
   // tool-execution errors serialized by the provider loop get these values masked
   // alongside process.env values.
   setAdditionalRedactionValues(deps.redactionValues ?? []);
+
+  // issue #217: resolved once per run (not per call, unlike shouldMintWriterNonce — there is no
+  // env-var strict-flip counterpart here). `0` disables the repair loop entirely.
+  const schemaRetries = deps.schemaRetries ?? 2;
 
   // Load or use provided definition.
   const definition: WorkflowDefinition =
@@ -339,199 +374,296 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
 
       const stepName = eligible[0]!;
       const stepDef: StepDefinition = definition.steps[stepName]!;
+      // issue #217 conjunct (vi) ground truth — captured ONCE per step, before any attempt.
+      // See the repair-gate comment below for why this (not `result.command`) is the correct
+      // discriminator for "did a DEEPER chained step actually produce this error?".
+      const versionBeforeStep = currentRun.version;
 
-      let stepInput: Record<string, unknown>;
+      // issue #217: the in-drive schema-feedback repair loop. `stepInput`/`toolCallsForMeta`/
+      // `result` are re-assigned on every attempt inside the `for` loop below; `repairsUsed`/
+      // `lastRejection` persist ACROSS attempts within this one step, and are fresh (0/undefined)
+      // for every new step. The loop body is exactly the former single-pass step-execution region
+      // (the agent/auto branch bodies + the executeChain call) — an auto step's
+      // `execution !== 'agent'` means the repair gate's conjunct (iii) can never hold for it, so
+      // it structurally can never iterate more than once: the loop is a no-op wrapper for every
+      // pre-existing (non-repair) case.
+      let stepInput: Record<string, unknown> = {};
       let toolCallsForMeta: ToolCallRecord[] | undefined;
+      let result: Awaited<ReturnType<typeof executeChain>>;
+      let repairsUsed = 0;
+      let lastRejection: { kind: 'output' | 'input'; summary: string } | undefined;
 
-      if (stepDef.execution === 'agent') {
-        // Resolve template-expanded prompt via buildNextActions so {{ context.resources.* }}
-        // references are substituted before the LLM call.
-        const nextActions = buildNextActions(definition, currentRun);
-        const nextAction =
-          nextActions.find(
-            (a) =>
-              a.instruction !== null &&
-              (a.instruction.call_with['command'] as string | undefined) === stepName,
-          ) ?? nextActions[0];
+      for (;;) {
+        toolCallsForMeta = undefined;
 
-        const prompt = nextAction?.prompt ?? stepDef.description;
-        // #robust-anthropic-provider Part 1: route the schema the ENGINE validates output against
-        // (output_schema, execution-loop.ts validateOutputSchema) ahead of the execute_step-param
-        // schema (input_schema / nextAction.input_schema) the provider was fed until now. Both-
-        // declared-and-divergent degrades to a clean recoverable VALIDATION_*_SCHEMA error downstream,
-        // not a parse-strand — see the Part 6 loader warning for the authoring-time signal.
-        const inputSchema =
-          (stepDef.output_schema as Record<string, unknown> | undefined) ??
-          (nextAction?.input_schema as Record<string, unknown> | undefined) ??
-          (stepDef.input_schema as Record<string, unknown> | undefined);
-        const agentProfileInstructions =
-          stepDef.agent_profile !== undefined
-            ? definition.resolved_profiles?.[stepDef.agent_profile]?.content
-            : undefined;
+        if (stepDef.execution === 'agent') {
+          // Resolve template-expanded prompt via buildNextActions so {{ context.resources.* }}
+          // references are substituted before the LLM call. Pure w.r.t. `definition`/`currentRun`,
+          // both unchanged across repair attempts (pre-claim validation is write-free — nothing is
+          // ever persisted on a rejected attempt, per execute-step.ts) — safe to recompute per
+          // iteration.
+          const nextActions = buildNextActions(definition, currentRun);
+          const nextAction =
+            nextActions.find(
+              (a) =>
+                a.instruction !== null &&
+                (a.instruction.call_with['command'] as string | undefined) === stepName,
+            ) ?? nextActions[0];
 
-        const descPreview = stepDef.description.slice(0, 80);
-        console.log(`\n→ [agent] ${stepName}`);
-        console.log(`  ${descPreview}${stepDef.description.length > 80 ? '…' : ''}`);
+          // PRISTINE original prompt — never mutated across repair attempts. The prompt actually
+          // sent to the provider (`promptForAttempt` below) is always derived FRESH from this,
+          // plus at most the LATEST rejection's feedback — never accumulated, never stale.
+          const prompt = nextAction?.prompt ?? stepDef.description;
+          const promptForAttempt =
+            lastRejection !== undefined
+              ? `${prompt}\n\nYour previous output was rejected by the ${lastRejection.kind} schema validator:\n${lastRejection.summary}\nEmit corrected JSON only, matching the schema exactly.`
+              : prompt;
+          // #robust-anthropic-provider Part 1: route the schema the ENGINE validates output against
+          // (output_schema, execution-loop.ts validateOutputSchema) ahead of the execute_step-param
+          // schema (input_schema / nextAction.input_schema) the provider was fed until now. Both-
+          // declared-and-divergent degrades to a clean recoverable VALIDATION_*_SCHEMA error downstream,
+          // not a parse-strand — see the Part 6 loader warning for the authoring-time signal.
+          const inputSchema =
+            (stepDef.output_schema as Record<string, unknown> | undefined) ??
+            (nextAction?.input_schema as Record<string, unknown> | undefined) ??
+            (stepDef.input_schema as Record<string, unknown> | undefined);
+          const agentProfileInstructions =
+            stepDef.agent_profile !== undefined
+              ? definition.resolved_profiles?.[stepDef.agent_profile]?.content
+              : undefined;
 
-        if (stepDef.tools && stepDef.tools.length > 0 && mcpClient) {
-          // Tools path: build tool definitions, call callStepWithTools.
-          const byServer = new Map<string, string[]>();
-          for (const entry of stepDef.tools) {
-            const [serverId, toolName] = entry.split(':') as [string, string];
-            if (!byServer.has(serverId)) byServer.set(serverId, []);
-            byServer.get(serverId)!.push(toolName);
+          if (repairsUsed === 0) {
+            const descPreview = stepDef.description.slice(0, 80);
+            console.log(`\n→ [agent] ${stepName}`);
+            console.log(`  ${descPreview}${stepDef.description.length > 80 ? '…' : ''}`);
           }
 
-          let toolsResult;
-          try {
-            const toolDefs: ToolDefinition[] = [];
-            const barenameOwner = new Map<string, string>(); // bareName → serverId of first registration
-            for (const [serverId, allowList] of byServer) {
-              const mcpTools = await mcpClient.getTools(serverId, allowList);
-
-              const returnedNames = new Set(mcpTools.map((t) => t.name));
-              for (const name of allowList) {
-                if (!returnedNames.has(name)) {
-                  throw new WorkflowError(
-                    `Step '${stepName}' declares tool '${serverId}:${name}' which is not exposed by MCP server '${serverId}'. ` +
-                      `Check the tool name against the server's published tool list.`,
-                    {
-                      code: 'MCP_TOOL_NOT_FOUND',
-                      category: 'ENGINE',
-                      agentAction: 'stop',
-                      retryable: false,
-                    },
-                  );
-                }
-              }
-
-              for (const mcpTool of mcpTools) {
-                const firstOwner = barenameOwner.get(mcpTool.name);
-                if (firstOwner !== undefined) {
-                  throw new WorkflowError(
-                    `Tool name collision in step '${stepName}': '${mcpTool.name}' is exposed by both '${firstOwner}' and '${serverId}'. ` +
-                      `Tool names must be unique across all connected servers within a step.`,
-                    {
-                      code: 'MCP_TOOL_NAME_COLLISION',
-                      category: 'ENGINE',
-                      agentAction: 'stop',
-                      retryable: false,
-                    },
-                  );
-                }
-                barenameOwner.set(mcpTool.name, serverId);
-                toolDefs.push({
-                  id: `${serverId}:${mcpTool.name}`,
-                  serverId,
-                  name: mcpTool.name,
-                  description: mcpTool.description,
-                  inputSchema: mcpTool.inputSchema,
-                });
-              }
+          if (stepDef.tools && stepDef.tools.length > 0 && mcpClient) {
+            // Tools path: build tool definitions, call callStepWithTools. Rebuilt every attempt
+            // (issue #217) — safe: repair only ever follows a ZERO-toolCall attempt, so no budget
+            // was spent and nothing can duplicate.
+            const byServer = new Map<string, string[]>();
+            for (const entry of stepDef.tools) {
+              const [serverId, toolName] = entry.split(':') as [string, string];
+              if (!byServer.has(serverId)) byServer.set(serverId, []);
+              byServer.get(serverId)!.push(toolName);
             }
 
-            const baseExecutor: ToolExecutor = async (namespacedName, args) => {
-              const [serverId, toolName] = namespacedName.split(':') as [string, string];
-              return mcpClient!.call(serverId, toolName, args);
-            };
-
-            // Wrap the executor to enforce max_fan_out when set.
-            // Counts calls to start_run and start_run_batch (regardless of server prefix).
-            let fanOutCallCount = 0;
-            const maxFanOut = stepDef.max_fan_out;
-            const executor: ToolExecutor = async (namespacedName, args) => {
-              const toolName = namespacedName.includes(':')
-                ? namespacedName.split(':')[1]!
-                : namespacedName;
-              if (toolName === 'start_run' || toolName === 'start_run_batch') {
-                fanOutCallCount += 1;
-                if (maxFanOut !== undefined && fanOutCallCount > maxFanOut) {
-                  throw new WorkflowError(
-                    `max_fan_out of ${maxFanOut} reached for step '${stepName}'. ` +
-                      `No further start_run or start_run_batch calls are permitted in this step.`,
-                    {
-                      code: 'VALIDATION_BATCH_TOO_LARGE',
-                      category: 'VALIDATION',
-                      agentAction: 'provide_input',
-                      retryable: false,
-                    },
-                  );
-                }
-              }
-              return baseExecutor(namespacedName, args);
-            };
-
-            if (!isToolCapable(deps.provider)) {
-              throw new Error(
-                'invariant: provider lost tool capability between startup and step execution',
-              );
-            }
-            // #robust-anthropic-provider Part 1: same output-over-input precedence as the callStep
-            // path above.
-            const toolsEffectiveOutputSchema =
-              (stepDef.output_schema as Record<string, unknown> | undefined) ??
-              (stepDef.input_schema as Record<string, unknown> | undefined);
-            toolsResult = await deps.provider.callStepWithTools(prompt, toolDefs, executor, {
-              ...(toolsEffectiveOutputSchema !== undefined
-                ? { inputSchema: toolsEffectiveOutputSchema }
-                : {}),
-              maxToolCalls: stepDef.max_tool_calls ?? 20,
-              ...(stepDef.max_fan_out !== undefined ? { maxFanOut: stepDef.max_fan_out } : {}),
-              toolTimeoutMs: (stepDef.tool_timeout ?? 30) * 1000,
-              ...(agentProfileInstructions !== undefined ? { agentProfileInstructions } : {}),
-            });
-          } catch (err) {
-            console.error(
-              `\n✗ Step '${stepName}' (tools) failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-            return 'failed';
-          }
-          stepInput = toolsResult.output;
-          toolCallsForMeta = toolsResult.toolCalls;
-        } else {
-          // Retry the LLM call once on failure before giving up.
-          let callError: unknown;
-          stepInput = {};
-          for (let attempt = 0; attempt < 2; attempt++) {
+            let toolsResult;
             try {
-              stepInput = await deps.provider.callStep(
-                prompt,
-                inputSchema,
-                agentProfileInstructions,
+              const toolDefs: ToolDefinition[] = [];
+              const barenameOwner = new Map<string, string>(); // bareName → serverId of first registration
+              for (const [serverId, allowList] of byServer) {
+                const mcpTools = await mcpClient.getTools(serverId, allowList);
+
+                const returnedNames = new Set(mcpTools.map((t) => t.name));
+                for (const name of allowList) {
+                  if (!returnedNames.has(name)) {
+                    throw new WorkflowError(
+                      `Step '${stepName}' declares tool '${serverId}:${name}' which is not exposed by MCP server '${serverId}'. ` +
+                        `Check the tool name against the server's published tool list.`,
+                      {
+                        code: 'MCP_TOOL_NOT_FOUND',
+                        category: 'ENGINE',
+                        agentAction: 'stop',
+                        retryable: false,
+                      },
+                    );
+                  }
+                }
+
+                for (const mcpTool of mcpTools) {
+                  const firstOwner = barenameOwner.get(mcpTool.name);
+                  if (firstOwner !== undefined) {
+                    throw new WorkflowError(
+                      `Tool name collision in step '${stepName}': '${mcpTool.name}' is exposed by both '${firstOwner}' and '${serverId}'. ` +
+                        `Tool names must be unique across all connected servers within a step.`,
+                      {
+                        code: 'MCP_TOOL_NAME_COLLISION',
+                        category: 'ENGINE',
+                        agentAction: 'stop',
+                        retryable: false,
+                      },
+                    );
+                  }
+                  barenameOwner.set(mcpTool.name, serverId);
+                  toolDefs.push({
+                    id: `${serverId}:${mcpTool.name}`,
+                    serverId,
+                    name: mcpTool.name,
+                    description: mcpTool.description,
+                    inputSchema: mcpTool.inputSchema,
+                  });
+                }
+              }
+
+              const baseExecutor: ToolExecutor = async (namespacedName, args) => {
+                const [serverId, toolName] = namespacedName.split(':') as [string, string];
+                return mcpClient!.call(serverId, toolName, args);
+              };
+
+              // Wrap the executor to enforce max_fan_out when set.
+              // Counts calls to start_run and start_run_batch (regardless of server prefix).
+              let fanOutCallCount = 0;
+              const maxFanOut = stepDef.max_fan_out;
+              const executor: ToolExecutor = async (namespacedName, args) => {
+                const toolName = namespacedName.includes(':')
+                  ? namespacedName.split(':')[1]!
+                  : namespacedName;
+                if (toolName === 'start_run' || toolName === 'start_run_batch') {
+                  fanOutCallCount += 1;
+                  if (maxFanOut !== undefined && fanOutCallCount > maxFanOut) {
+                    throw new WorkflowError(
+                      `max_fan_out of ${maxFanOut} reached for step '${stepName}'. ` +
+                        `No further start_run or start_run_batch calls are permitted in this step.`,
+                      {
+                        code: 'VALIDATION_BATCH_TOO_LARGE',
+                        category: 'VALIDATION',
+                        agentAction: 'provide_input',
+                        retryable: false,
+                      },
+                    );
+                  }
+                }
+                return baseExecutor(namespacedName, args);
+              };
+
+              if (!isToolCapable(deps.provider)) {
+                throw new Error(
+                  'invariant: provider lost tool capability between startup and step execution',
+                );
+              }
+              // #robust-anthropic-provider Part 1: same output-over-input precedence as the callStep
+              // path above.
+              const toolsEffectiveOutputSchema =
+                (stepDef.output_schema as Record<string, unknown> | undefined) ??
+                (stepDef.input_schema as Record<string, unknown> | undefined);
+              toolsResult = await deps.provider.callStepWithTools(
+                promptForAttempt,
+                toolDefs,
+                executor,
+                {
+                  ...(toolsEffectiveOutputSchema !== undefined
+                    ? { inputSchema: toolsEffectiveOutputSchema }
+                    : {}),
+                  maxToolCalls: stepDef.max_tool_calls ?? 20,
+                  ...(stepDef.max_fan_out !== undefined ? { maxFanOut: stepDef.max_fan_out } : {}),
+                  toolTimeoutMs: (stepDef.tool_timeout ?? 30) * 1000,
+                  ...(agentProfileInstructions !== undefined ? { agentProfileInstructions } : {}),
+                },
               );
-              callError = undefined;
-              break;
             } catch (err) {
-              callError = err;
-              console.warn(
-                `  ⚠  LLM call attempt ${attempt + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+              console.error(
+                `\n✗ Step '${stepName}' (tools) failed: ${err instanceof Error ? err.message : String(err)}`,
               );
+              return 'failed';
+            }
+            stepInput = toolsResult.output;
+            toolCallsForMeta = toolsResult.toolCalls;
+          } else {
+            // Retry the LLM call once on failure before giving up.
+            let callError: unknown;
+            stepInput = {};
+            for (let attempt = 0; attempt < 2; attempt++) {
+              try {
+                stepInput = await deps.provider.callStep(
+                  promptForAttempt,
+                  inputSchema,
+                  agentProfileInstructions,
+                );
+                callError = undefined;
+                break;
+              } catch (err) {
+                callError = err;
+                console.warn(
+                  `  ⚠  LLM call attempt ${attempt + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
+            }
+            if (callError !== undefined) {
+              console.error(`\n✗ Step '${stepName}' LLM call failed after 2 attempts`);
+              return 'failed';
             }
           }
-          if (callError !== undefined) {
-            console.error(`\n✗ Step '${stepName}' LLM call failed after 2 attempts`);
-            return 'failed';
-          }
+        } else {
+          // Auto step — the engine dispatches to the service adapter directly.
+          console.log(`→ [auto] ${stepName}`);
+          stepInput = {};
         }
-      } else {
-        // Auto step — the engine dispatches to the service adapter directly.
-        console.log(`→ [auto] ${stepName}`);
-        stepInput = {};
-      }
 
-      const result = await executeChain(deps.store, definition, {
-        runId,
-        command: stepName,
-        input: stepInput,
-        dispatcher: async () => stepInput,
-        registry: deps.registry,
-        ...(deps.traceBufferStore !== undefined ? { traceBufferStore: deps.traceBufferStore } : {}),
-        ...(toolCallsForMeta !== undefined ? { stepMeta: { toolCalls: toolCallsForMeta } } : {}),
-        // issue #197 PR-2: a FRESH nonce per step-attempt — resolved per call, never cached, so
-        // the strict-flip (checked inside shouldMintWriterNonce) is honored even if the env var
-        // changes mid-process (tests flip it).
-        ...(shouldMintWriterNonce(deps) ? { writerNonce: crypto.randomUUID() } : {}),
-      });
+        result = await executeChain(deps.store, definition, {
+          runId,
+          command: stepName,
+          input: stepInput,
+          dispatcher: async () => stepInput,
+          registry: deps.registry,
+          ...(deps.traceBufferStore !== undefined
+            ? { traceBufferStore: deps.traceBufferStore }
+            : {}),
+          ...(toolCallsForMeta !== undefined ? { stepMeta: { toolCalls: toolCallsForMeta } } : {}),
+          // issue #197 PR-2: a FRESH nonce per step-attempt — resolved per call, never cached, so
+          // the strict-flip (checked inside shouldMintWriterNonce) is honored even if the env var
+          // changes mid-process (tests flip it). Also fresh per issue #217 repair attempt, since
+          // this call sits inside the repair loop.
+          ...(shouldMintWriterNonce(deps) ? { writerNonce: crypto.randomUUID() } : {}),
+        });
+
+        // issue #217: the in-drive schema-feedback repair gate. Fires ONLY when ALL SIX conjuncts
+        // hold — see plans/issue-217/design-v2.md §Mechanism for the rationale on (i)-(v).
+        //
+        // Conjunct (vi) — CORRECTED from the design record's literal `result.command === stepName`
+        // (flagged as a divergence in the implementation report): the record's premise was that
+        // executeChain "returns the DEEPER step's own envelope" on a chain-replacement error,
+        // citing execution-loop.ts:2855-2859/:3015 (executeChainInternal's recursive early-return,
+        // which DOES set `command` to the deeper step). But run-agent.ts calls the PUBLIC
+        // `executeChain` wrapper, not executeChainInternal directly — and that wrapper
+        // unconditionally overwrites the returned envelope's `command` back to the TOP-LEVEL
+        // requested command on every call (execution-loop.ts:3094, `command: options.command`),
+        // confirmed empirically against the built engine. So `result.command` always equals
+        // `stepName` here and can never discriminate a deeper chained step's error from this step's
+        // own — the literal conjunct is vacuously true and provides zero protection.
+        //
+        // The corrected, structurally-sound discriminator: a pre-claim validation rejection is
+        // write-free (no run-record version bump — see execute-step.ts:77-80 / execution-loop.ts's
+        // Step 2b/2c, both before claimStep). So if `result.run_version` has advanced past
+        // `versionBeforeStep` (captured before this step's first attempt), something committed to
+        // the run BEFORE this error occurred — i.e. THIS step's own claim+settle, followed by a
+        // DEEPER chained step's pre-claim rejection — so the error cannot be this step's own output/
+        // input. `result.run_version === versionBeforeStep` preserves the exact same protective
+        // intent as the record's conjunct (vi): never repair a step whose own attempt didn't
+        // actually produce the error. See run-agent.test.ts's "chained-auto no-false-repair" test.
+        if (
+          result.status === 'error' &&
+          (result.error_code === 'VALIDATION_OUTPUT_SCHEMA' ||
+            result.error_code === 'VALIDATION_INPUT_SCHEMA') &&
+          stepDef.execution === 'agent' &&
+          (toolCallsForMeta === undefined || toolCallsForMeta.length === 0) &&
+          repairsUsed < schemaRetries &&
+          result.run_version === versionBeforeStep
+        ) {
+          repairsUsed++;
+          const record = buildFailedAttemptRecord({
+            run_id: runId,
+            workflow_id: definition.id,
+            step_id: stepName,
+            ts: new Date().toISOString(),
+            error_code: result.error_code,
+            ajv_errors: (result.error_details?.['errors'] as unknown[]) ?? [],
+            params: stepInput,
+            trace_entry_count: 0,
+          });
+          lastRejection = {
+            kind: result.error_code === 'VALIDATION_OUTPUT_SCHEMA' ? 'output' : 'input',
+            summary: record.validation_error_summary.map(renderValidationSummaryEntry).join('\n'),
+          };
+          console.error(
+            `  ⚠ output rejected (${result.error_code}); repairing (attempt ${repairsUsed}/${schemaRetries})`,
+          );
+          continue;
+        }
+
+        break;
+      }
 
       if (result.status === 'error') {
         // #134: a NOT-REGISTERED handler/adapter settles RECOVERABLY — the run is NOT failed, the step
@@ -541,6 +673,9 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         const isCapabilityBlock =
           result.error_code === 'ENGINE_HANDLER_NOT_REGISTERED' ||
           result.error_code === 'ENGINE_ADAPTER_NOT_REGISTERED';
+        // issue #217: append the repair count ONLY when at least one repair actually ran — never
+        // "after 0 schema-repair attempts".
+        const repairSuffix = repairsUsed > 0 ? ` after ${repairsUsed} schema-repair attempts` : '';
         if (isCapabilityBlock) {
           currentRun = await deps.store.get(runId);
           const block = findCapabilityBlockedSteps(currentRun).find((b) => b.step === stepName);
@@ -555,7 +690,9 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
               `The run is NOT failed — add ${need} and re-attach (\`realm agent --run-id ${runId}\`).`,
           );
         } else {
-          console.error(`\n✗ Step '${stepName}' failed: ${result.errors.join(', ')}`);
+          console.error(
+            `\n✗ Step '${stepName}' failed: ${result.errors.join(', ')}${repairSuffix}`,
+          );
         }
         return 'failed';
       }

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -5,7 +5,7 @@
 // adapters are constructed from the deployment manifest (realm.yaml); the loader registry
 // (with its drift identity attached) flows directly into the run. Gate-notifier config is
 // sourced from `manifest.notifiers.slack_gate` (the nine SLACK_* env reads are deleted).
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { loadWorkflowFromFile, JsonFileStore, JsonWorkflowStore } from '@sensigo/realm';
@@ -59,6 +59,21 @@ export function buildManifestGateHandler(
   return createSlackGateHandler(config);
 }
 
+/**
+ * Commander argParser for `--schema-retries` (issue #217). Commander does NOT run the argParser
+ * on the option's own default value — only on a user-supplied string — so an out-of-range default
+ * can never reach here; this only guards user input. Rejects loudly (InvalidArgumentError, commander
+ * ^14 idiom) on anything that isn't a non-negative integer — do NOT copy listen.ts's silent
+ * `parseInt` (which truncates '3abc' to 3 instead of rejecting it).
+ */
+function parseSchemaRetries(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new InvalidArgumentError('--schema-retries must be a non-negative integer.');
+  }
+  return n;
+}
+
 export const agentCommand = new Command('agent')
   .description('Run a workflow autonomously using an LLM provider')
   .option('--workflow <path>', 'Path to workflow directory or workflow.yaml file')
@@ -92,6 +107,14 @@ export const agentCommand = new Command('agent')
       "#197) — opt-in; default OFF (today's behavior). No caller-supplied value is accepted.",
     false,
   )
+  .option(
+    '--schema-retries <n>',
+    "Number of in-drive repair attempts when an agent step's output is rejected by " +
+      'output_schema/input_schema validation (issue #217) — the drive re-prompts the same step ' +
+      "with the validator's errors appended. 0 disables (today's behavior).",
+    parseSchemaRetries,
+    2,
+  )
   .action(
     async (opts: {
       workflow?: string;
@@ -105,6 +128,7 @@ export const agentCommand = new Command('agent')
       extensionsModule?: string;
       project?: string;
       mintWriterNonce?: boolean;
+      schemaRetries: number;
     }) => {
       if (!opts.workflow && !opts.runId) {
         console.error('Error: one of --workflow or --run-id is required');
@@ -202,6 +226,9 @@ export const agentCommand = new Command('agent')
               // issue #197 PR-2: default OFF; the strict-flip (REALM_REQUIRE_WRITER_NONCE) force-
               // enables minting even without the flag — resolved once in run-agent.ts's loop.
               mintWriterNonce: opts.mintWriterNonce === true,
+              // issue #217: default 2, threaded exactly like mintWriterNonce above. Commander
+              // always supplies a value (the option's own default), so this is never undefined.
+              schemaRetries: opts.schemaRetries,
               ...(gateHandler ? { gateHandler } : {}),
               ...(loaded.secretValues !== undefined
                 ? { redactionValues: loaded.secretValues }
@@ -245,6 +272,9 @@ export const agentCommand = new Command('agent')
               // issue #197 PR-2: default OFF; the strict-flip (REALM_REQUIRE_WRITER_NONCE) force-
               // enables minting even without the flag — resolved once in run-agent.ts's loop.
               mintWriterNonce: opts.mintWriterNonce === true,
+              // issue #217: default 2, threaded exactly like mintWriterNonce above. Commander
+              // always supplies a value (the option's own default), so this is never undefined.
+              schemaRetries: opts.schemaRetries,
               ...(gateHandler ? { gateHandler } : {}),
               ...(loaded.secretValues !== undefined
                 ? { redactionValues: loaded.secretValues }

--- a/packages/core/src/observability/failed-attempt-record.test.ts
+++ b/packages/core/src/observability/failed-attempt-record.test.ts
@@ -119,6 +119,76 @@ describe('buildFailedAttemptRecord', () => {
     expect(rec.submitted_keys).toEqual(['ticket_body']);
   });
 
+  // issue #217: keyword-conditional key-name-only fields feeding the CLI schema-repair prompt.
+  it('populates additional_property for an additionalProperties error, missing_property for a required error, and neither for other keywords', () => {
+    const rec = buildFailedAttemptRecord(
+      baseInput({
+        ajv_errors: [
+          {
+            instancePath: '',
+            schemaPath: '#/additionalProperties',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: { additionalProperty: 'extra_field' },
+          },
+          {
+            instancePath: '',
+            schemaPath: '#/required',
+            keyword: 'required',
+            message: "must have required property 'status'",
+            params: { missingProperty: 'status' },
+          },
+          {
+            instancePath: '/status',
+            schemaPath: '#/properties/status/enum',
+            keyword: 'enum',
+            message: 'must be equal to one of the allowed values',
+            params: { allowedValues: ['open', 'closed'] },
+          },
+        ],
+      }),
+    );
+    expect(rec.validation_error_summary[0]).toMatchObject({
+      keyword: 'additionalProperties',
+      additional_property: 'extra_field',
+    });
+    expect(rec.validation_error_summary[0]!.missing_property).toBeUndefined();
+    expect(rec.validation_error_summary[1]).toMatchObject({
+      keyword: 'required',
+      missing_property: 'status',
+    });
+    expect(rec.validation_error_summary[1]!.additional_property).toBeUndefined();
+    // enum entry gets neither new field — no key present at all (exactOptionalPropertyTypes).
+    expect('additional_property' in rec.validation_error_summary[2]!).toBe(false);
+    expect('missing_property' in rec.validation_error_summary[2]!).toBe(false);
+  });
+
+  it('truncates additional_property/missing_property at MAX_FIELD_CHARS (200)', () => {
+    const longKey = 'k'.repeat(500);
+    const rec = buildFailedAttemptRecord(
+      baseInput({
+        ajv_errors: [
+          {
+            instancePath: '',
+            schemaPath: '#/additionalProperties',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: { additionalProperty: longKey },
+          },
+          {
+            instancePath: '',
+            schemaPath: '#/required',
+            keyword: 'required',
+            message: 'must have required property',
+            params: { missingProperty: longKey },
+          },
+        ],
+      }),
+    );
+    expect(rec.validation_error_summary[0]!.additional_property).toHaveLength(200);
+    expect(rec.validation_error_summary[1]!.missing_property).toHaveLength(200);
+  });
+
   it('is defensive: non-array ajv_errors yields an empty summary, no throw', () => {
     expect(() =>
       buildFailedAttemptRecord(baseInput({ ajv_errors: 'not-an-array' as unknown as unknown[] })),

--- a/packages/core/src/observability/failed-attempt-record.ts
+++ b/packages/core/src/observability/failed-attempt-record.ts
@@ -34,6 +34,18 @@ export interface ValidationErrorSummaryEntry {
   schemaPath: string;
   keyword: string;
   message: string;
+  /**
+   * issue #217: present ONLY for `additionalProperties` keyword errors — the offending key NAME
+   * from `params.additionalProperty` (never a value). Truncated to MAX_FIELD_CHARS like every
+   * other field here.
+   */
+  additional_property?: string;
+  /**
+   * issue #217: present ONLY for `required` keyword errors — the missing key NAME (schema-
+   * derived, from `params.missingProperty`; never a submitted value). Truncated to
+   * MAX_FIELD_CHARS like every other field here.
+   */
+  missing_property?: string;
 }
 
 /** Metadata-only record describing a failed agent-step validation attempt. */
@@ -85,9 +97,13 @@ function safeStringify(value: unknown): string {
 }
 
 /**
- * Map raw Ajv errors to the whitelisted summary. Drops `params`/`data` (Ajv embeds offending VALUES
- * there — a leak vector). Skips non-object entries, caps at the first 10, truncates path/message
- * fields to 200 chars. Never throws.
+ * Map raw Ajv errors to the whitelisted summary. Drops `params`/`data` WHOLESALE (Ajv embeds
+ * offending/schema VALUES there — a leak vector, e.g. `enum.allowedValues`) EXCEPT for two
+ * keyword-conditional KEY-NAME-ONLY fields (issue #217) that carry no value: `additional_property`
+ * (from `params.additionalProperty` on an `additionalProperties` error) and `missing_property`
+ * (from `params.missingProperty` on a `required` error) — both gated on keyword AND a string-typed
+ * params field, so no other keyword's `params` is ever touched. Skips non-object entries, caps at
+ * the first 10, truncates path/message/the two new fields to 200 chars. Never throws.
  */
 function summarizeAjvErrors(ajvErrors: unknown[]): ValidationErrorSummaryEntry[] {
   if (!Array.isArray(ajvErrors)) return [];
@@ -96,11 +112,30 @@ function summarizeAjvErrors(ajvErrors: unknown[]): ValidationErrorSummaryEntry[]
     if (out.length >= MAX_SUMMARY_ENTRIES) break;
     if (entry === null || typeof entry !== 'object') continue;
     const e = entry as Record<string, unknown>;
+    const keyword = truncate(asString(e['keyword']), MAX_FIELD_CHARS);
+    const params =
+      e['params'] !== null && typeof e['params'] === 'object'
+        ? (e['params'] as Record<string, unknown>)
+        : undefined;
+    const additionalProperty =
+      keyword === 'additionalProperties' && typeof params?.['additionalProperty'] === 'string'
+        ? params['additionalProperty']
+        : undefined;
+    const missingProperty =
+      keyword === 'required' && typeof params?.['missingProperty'] === 'string'
+        ? params['missingProperty']
+        : undefined;
     out.push({
       instancePath: truncate(asString(e['instancePath']), MAX_FIELD_CHARS),
       schemaPath: truncate(asString(e['schemaPath']), MAX_FIELD_CHARS),
-      keyword: truncate(asString(e['keyword']), MAX_FIELD_CHARS),
+      keyword,
       message: truncate(asString(e['message']), MAX_FIELD_CHARS),
+      ...(additionalProperty !== undefined
+        ? { additional_property: truncate(additionalProperty, MAX_FIELD_CHARS) }
+        : {}),
+      ...(missingProperty !== undefined
+        ? { missing_property: truncate(missingProperty, MAX_FIELD_CHARS) }
+        : {}),
     });
   }
   return out;


### PR DESCRIPTION
## Context

Issue #217 — filed from the verified CS1 suggestion doc (R-1, the highest-value item): a
schema-rejected agent step in a CLI drive exited on the first rejection without ever showing the
model the validation errors, even though the full AJV list already travels on the envelope. The
origin FR's P0 explicitly requested this repair loop; it fell through the #136 Group A/B scope
split — deferred, never rejected, never filed until now.

## Motivation

The standard structured-output repair loop, at the only seam where the ENGINE's AJV verdict can
feed back: on `VALIDATION_OUTPUT_SCHEMA`/`VALIDATION_INPUT_SCHEMA`, re-prompt the same step
(default 2, `--schema-retries <n>`) appending a whitelisted error summary — never the raw AJV
array (its `params` carries schema-side values like `enum.allowedValues`). Expected effect:
near-elimination of the wedge class (#220's population) for schemas a model can satisfy.

## Changes

- **Repair loop** (`run-agent.ts`): one inner loop around {provider call → executeChain}, gated
  on SIX conjuncts — error status ∧ validation-code set ∧ `execution: 'agent'` ∧ zero tool calls
  (a tools-path re-call would fabricate evidence or duplicate side effects — excluded v1,
  in-conversation mechanism filed as #224) ∧ retry budget ∧ a **per-attempt fresh
  `run_version` baseline** (excludes chained-step errors and any concurrent-writer interleaving;
  fails closed). Fresh writer nonce per attempt; pristine-prompt + latest-rejection-only
  feedback; one stderr line per repair; exhaustion behaves exactly as today.
- **Flag**: `--schema-retries <n>` (default 2, `InvalidArgumentError` on bad input, 0 disables).
- **Provider contract clause** (JSDoc): `callStepWithTools` must record every executor
  invocation — the gate's zero-toolCalls proof depends on it (trusted-injector residual, #224).
- **Core summarizer extension** (additive): `additional_property`/`missing_property` key-name-only
  fields (truncated; names never values) so repairs can name the offending key.
- **Docs/CHANGELOG**: `[Unreleased]` Added entry; CLI reference row.
- Two commits: base (`595af74`) + review correction (`7e5a096` — per-attempt baseline upgrade,
  positive visibility witness, eligibility-contract pin, report errata).

## Verification

```bash
npm test -- --force     # 171 files / 2897 tests, 4 packages, all green
npm run lint            # clean
cd packages/cli && npx vitest run src/agent/run-agent.test.ts   # 30/30 incl. the new describe
```

12 mutation probes across both rounds (9 + 3), every predicted signal reproduced and
independently re-verified by the architect (3 spot-reproductions round 1, 1 round 2); plus a
red-on-shipped proof for the concurrency witness. Design record: `plans/issue-217/design-v2.md`
(local) — 2 review rounds + 2 prompt audits + implementation review.

## Rollback

```bash
git revert 7e5a096 595af74
```

CLI-drive-only behavior (engine untouched except an additive observability field); MCP path
unchanged; `--schema-retries 0` restores byte-identical pre-#217 behavior at runtime.

## Related

Closes #217

Cross-refs: #224 (tools-path in-conversation repair), #220 (write-free constraint posted),
#218 (advisory wording follow-up), #219 (CLI-drive telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
