### PR TITLE
feat(loader): warn on inert retry sub-keys on non-auto steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- **`RETRY_INERT_NON_AUTO` loader advisory for bare `retry:` sub-keys on a non-auto step (issue
+  #218).** Extends #140's W5 (`TOTAL_TIMEOUT_NON_AUTO`, cap-only) family: a `retry:` block with no
+  `total_timeout_seconds` on an `agent`/`guard` step now also draws a warning — the built-in
+  dispatch path never throws for these steps, so `max_attempts`/`backoff`/`base_delay_ms` are
+  otherwise silent dead config. Mutually exclusive with W5 by construction (exactly one of the two
+  fires for any non-auto retry block that loads). Advisory only (#119) — `create_workflow` stays
+  lenient; `validate --strict`/`register --strict` fail on it via the existing #169 accumulators.
+
 - **In-drive schema-feedback repair loop for `realm agent` (issue #217).** When an `execution:
 'agent'` step's output is rejected by `output_schema`/`input_schema` validation
   (`VALIDATION_OUTPUT_SCHEMA`/`VALIDATION_INPUT_SCHEMA`), the drive now re-prompts the SAME step

--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -677,6 +677,10 @@ fetch_document:
 > unrecognized retry sub-keys and are silently ignored, so a declared cap goes unenforced — this
 > fails safe: retry semantics are otherwise unchanged, only the bound is missing.
 
+> **Non-auto steps (issue #218):** any `retry:` sub-key on an `agent`/`guard` step draws an
+> advisory (`RETRY_INERT_NON_AUTO`), since the built-in dispatch path never throws for those steps
+> and so never consumes the block.
+
 ---
 
 ## Services

--- a/packages/cli/src/commands/validate-retry-timeout-advisory.test.ts
+++ b/packages/cli/src/commands/validate-retry-timeout-advisory.test.ts
@@ -77,7 +77,7 @@ steps:
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('does NOT warn on a step with retry but execution: agent (enforcement never applies)', async () => {
+  it('does NOT warn with the A3 text on a step with retry but execution: agent (A3 enforcement never applies there) — issue #218 correction: this exact fixture now legitimately draws the UNRELATED RETRY_INERT_NON_AUTO advisory instead, so the negative assertion is narrowed to the A3-specific text rather than "no warnSpy calls at all"', async () => {
     const wfPath = join(dir, 'workflow.yaml');
     writeFileSync(
       wfPath,
@@ -100,7 +100,12 @@ steps:
 
     await validateCommand.parseAsync([wfPath], { from: 'user' });
 
-    expect(warnSpy).not.toHaveBeenCalled();
+    const warned = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warned).not.toContain("declares 'retry' but no 'timeout_seconds'");
+    // issue #218: the new advisory legitimately fires on this exact fixture (bare retry on a
+    // non-auto step) — pinned here so this test keeps testing what it always tested (A3's
+    // absence) without silently going vacuous now that warnSpy IS called for an unrelated reason.
+    expect(warned).toContain("'retry' is inert on execution: 'agent' steps");
   });
 
   it('does NOT warn on an auto step with no retry at all', async () => {

--- a/packages/core/src/workflow/diagnostics.ts
+++ b/packages/core/src/workflow/diagnostics.ts
@@ -23,7 +23,10 @@ export type WarningCode =
   | 'UNKNOWN_RETRY_KEY'
   | 'ON_TIMEOUT_SINGLE_ATTEMPT'
   | 'TOTAL_TIMEOUT_BELOW_ATTEMPT'
-  | 'TOTAL_TIMEOUT_NON_AUTO';
+  | 'TOTAL_TIMEOUT_NON_AUTO'
+  // issue #218 (extends the #140 W5 family: bare retry sub-keys, not just the cap, on a
+  // non-auto step):
+  | 'RETRY_INERT_NON_AUTO';
 
 /**
  * A single structured diagnostic. `message` is the full human-readable text (matching, for the
@@ -62,6 +65,7 @@ export const DEFAULT_POLICY: Record<WarningCode, 'warn' | 'error'> = {
   ON_TIMEOUT_SINGLE_ATTEMPT: 'warn',
   TOTAL_TIMEOUT_BELOW_ATTEMPT: 'warn',
   TOTAL_TIMEOUT_NON_AUTO: 'warn',
+  RETRY_INERT_NON_AUTO: 'warn',
 };
 
 /**
@@ -198,8 +202,9 @@ const UNKNOWN_KEY_CODES = new Set<WarningCode>([
  * byte-identical to the pre-#169 console.warn text (UNKNOWN_RETRY_KEY, issue #140, follows the
  * same rendering exactly, just with a 'retry' noun instead of 'step'/'workflow'). Every other code
  * (IDEMPOTENT_INERT_IN_FINALIZER, DUAL_SCHEMA_DECLARED, RETRY_NO_TIMEOUT, EXTENSION_SENTINEL,
- * ON_TIMEOUT_SINGLE_ATTEMPT, TOTAL_TIMEOUT_BELOW_ATTEMPT, TOTAL_TIMEOUT_NON_AUTO) returns
- * `message` verbatim: these are free-text warnings whose exact current prefix (or lack of one) is
+ * ON_TIMEOUT_SINGLE_ATTEMPT, TOTAL_TIMEOUT_BELOW_ATTEMPT, TOTAL_TIMEOUT_NON_AUTO,
+ * RETRY_INERT_NON_AUTO) returns `message` verbatim: these are free-text warnings whose exact
+ * current prefix (or lack of one) is
  * preserved byte-for-byte by whatever constructed them, not re-derived here.
  */
 export function renderLoaderWarning(w: LoaderWarning): string {

--- a/packages/core/src/workflow/retryable-timeout-loader.test.ts
+++ b/packages/core/src/workflow/retryable-timeout-loader.test.ts
@@ -4,7 +4,13 @@
 import { describe, it, expect } from 'vitest';
 import { loadWorkflowFromString, loadWorkflowFromStringWithDiagnostics } from './yaml-loader.js';
 import { WorkflowError } from '../types/workflow-error.js';
-import { DEFAULT_POLICY, type WarningCode } from './diagnostics.js';
+import {
+  DEFAULT_POLICY,
+  resolveSeverity,
+  renderLoaderWarning,
+  type WarningCode,
+  type LoaderWarning,
+} from './diagnostics.js';
 
 function expectThrows(yaml: string, substring: string): void {
   expect(() => loadWorkflowFromString(yaml)).toThrow(WorkflowError);
@@ -526,5 +532,172 @@ steps:
       const neverReintroduced: _Check = true;
       expect(neverReintroduced).toBe(true);
     });
+  });
+});
+
+describe('yaml-loader — issue #218 RETRY_INERT_NON_AUTO (bare retry sub-keys on a non-auto step)', () => {
+  it('1. agent step, bare retry ⇒ advisory fires, message contains --schema-retries AND the embedder caveat', () => {
+    const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: retry-inert-agent-wf
+name: Retry Inert Agent
+version: 1
+steps:
+  work:
+    description: Work
+    execution: agent
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`);
+    const w = warnings.find((warning) => warning.code === 'RETRY_INERT_NON_AUTO');
+    expect(w).toBeDefined();
+    expect(w?.message).toContain("execution: 'agent'");
+    expect(w?.message).toContain('--schema-retries');
+    expect(w?.message).toContain('embedder-supplied throwing dispatcher');
+  });
+
+  it('2. guard step, same block ⇒ fires, message does NOT contain --schema-retries', () => {
+    const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: retry-inert-guard-wf
+name: Retry Inert Guard
+version: 1
+steps:
+  work:
+    description: Work
+    execution: guard
+    abort_unless: ["work.ok == true"]
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`);
+    const w = warnings.find((warning) => warning.code === 'RETRY_INERT_NON_AUTO');
+    expect(w).toBeDefined();
+    expect(w?.message).toContain("execution: 'guard'");
+    expect(w?.message).not.toContain('--schema-retries');
+    expect(w?.message).toContain('embedder-supplied throwing dispatcher');
+  });
+
+  it("3. finalizer step, same block ⇒ load HARD-ERRORS with \"'retry' is not valid on execution: finalizer steps\" and no advisory is observable (composition pin; mirrors finalizer-loader.test.ts:99-106) — the issue's AC2 finalizer clause is satisfied by this PRE-EXISTING STRONGER rejection, not by the new advisory", () => {
+    expectThrows(
+      `
+id: retry-inert-finalizer-wf
+name: Retry Inert Finalizer
+version: 1
+steps:
+  work:
+    description: Work
+    execution: auto
+    handler: h
+  cleanup:
+    description: Cleanup finalizer
+    execution: finalizer
+    on_outcome: always
+    handler: do_cleanup
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`,
+      "'retry' is not valid on execution: finalizer steps",
+    );
+  });
+
+  it('4. auto step, same block ⇒ NO RETRY_INERT_NON_AUTO (and no W5)', () => {
+    const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: retry-inert-auto-wf
+name: Retry Inert Auto
+version: 1
+steps:
+  work:
+    description: Work
+    execution: auto
+    handler: h
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`);
+    expect(warnings.find((w) => w.code === 'RETRY_INERT_NON_AUTO')).toBeUndefined();
+    expect(warnings.find((w) => w.code === 'TOTAL_TIMEOUT_NON_AUTO')).toBeUndefined();
+  });
+
+  describe('5. mutual-exclusivity pin, both directions', () => {
+    it('non-auto + explicit cap ⇒ W5 fires AND RETRY_INERT_NON_AUTO does NOT', () => {
+      const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: mutex-cap-wf
+name: Mutex Cap
+version: 1
+steps:
+  work:
+    description: Work
+    execution: agent
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+      total_timeout_seconds: 60
+`);
+      expect(warnings.find((w) => w.code === 'TOTAL_TIMEOUT_NON_AUTO')).toBeDefined();
+      expect(warnings.find((w) => w.code === 'RETRY_INERT_NON_AUTO')).toBeUndefined();
+    });
+
+    it('non-auto + bare keys ⇒ RETRY_INERT_NON_AUTO fires AND W5 does NOT', () => {
+      const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: mutex-bare-wf
+name: Mutex Bare
+version: 1
+steps:
+  work:
+    description: Work
+    execution: agent
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`);
+      expect(warnings.find((w) => w.code === 'RETRY_INERT_NON_AUTO')).toBeDefined();
+      expect(warnings.find((w) => w.code === 'TOTAL_TIMEOUT_NON_AUTO')).toBeUndefined();
+    });
+  });
+
+  it('6. strict-severity proof at the LOADER level: the code appears in warnings[] and resolveSeverity honors a policy override to error (the same array + policy mechanism validate/register --strict count on, already pinned code-agnostically by cli/src/commands/validate-strict.test.ts — no new CLI test added here)', () => {
+    const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: strict-wf
+name: Strict
+version: 1
+steps:
+  work:
+    description: Work
+    execution: agent
+    retry:
+      max_attempts: 3
+      backoff: fixed
+      base_delay_ms: 10
+`);
+    const w = warnings.find((warning) => warning.code === 'RETRY_INERT_NON_AUTO');
+    expect(w).toBeDefined();
+    expect(w?.severity).toBe('warn');
+    const strictPolicy: Record<WarningCode, 'warn' | 'error'> = {
+      ...DEFAULT_POLICY,
+      RETRY_INERT_NON_AUTO: 'error',
+    };
+    expect(resolveSeverity('RETRY_INERT_NON_AUTO', strictPolicy)).toBe('error');
+    // create_workflow: NO test possible and none required — create_workflow never runs the YAML
+    // loader at all (its envelope is findUnknownKeys-only; its stepSchema has no `retry` field, so
+    // `retry` is dropped as UNKNOWN_CREATE_WORKFLOW_KEY before this code could ever run) — the
+    // issue's AC3 "create_workflow stays lenient" holds BY CONSTRUCTION. See the report.
+  });
+
+  it('7. renderer golden test: RETRY_INERT_NON_AUTO renders message verbatim (the #169 renderLoaderWarning family pattern — no ⚠ prefix added, byte-identical to whatever constructed it)', () => {
+    const warning: LoaderWarning = {
+      code: 'RETRY_INERT_NON_AUTO',
+      severity: 'warn',
+      scope: 'step',
+      step: 'work',
+      message: "Step 'work': 'retry' is inert on execution: 'agent' steps.",
+    };
+    expect(renderLoaderWarning(warning)).toBe(warning.message);
   });
 });

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -953,6 +953,36 @@ function parseWorkflowString(
           });
         }
 
+        // issue #218 (extends the W5 family): the BARE-KEYS advisory — no explicit
+        // total_timeout_seconds (that shape is W5's, above), but retry: is present on a step the
+        // built-in dispatch path never wraps in a throwing retry loop at all. Complementary to
+        // W5's own `!== undefined` conjunct on the SAME `execution !== 'auto'` gate, so for any
+        // non-auto retry block that reaches this point (finalizer+retry and invalid-cap shapes
+        // already hard-errored above; on_timeout: true already hard-errored via E1 unless
+        // idempotent is also declared, which is itself rejected by the pre-existing
+        // idempotent-non-auto check) exactly ONE of {W5, RETRY_INERT_NON_AUTO} ever fires — never
+        // both, never neither.
+        if (step['execution'] !== 'auto' && retry['total_timeout_seconds'] === undefined) {
+          const isAgent = step['execution'] === 'agent';
+          const message = isAgent
+            ? `Step '${stepName}': 'retry' is inert on execution: 'agent' steps — the built-in ` +
+              `dispatch path never throws for agent steps, so this block can never mint a second ` +
+              `attempt here (for schema-repair budgets, use the CLI drive's '--schema-retries' ` +
+              `flag instead). An embedder-supplied throwing dispatcher may still consume this ` +
+              `config — a deliberate public-API capability, not an invalid one.`
+            : `Step '${stepName}': 'retry' is inert on execution: '${String(step['execution'])}' ` +
+              `steps — the built-in dispatch path never throws for these steps, so this block can ` +
+              `never mint a second attempt here. An embedder-supplied throwing dispatcher may ` +
+              `still consume this config — a deliberate public-API capability, not an invalid one.`;
+          warnings.push({
+            code: 'RETRY_INERT_NON_AUTO',
+            severity: resolveSeverity('RETRY_INERT_NON_AUTO'),
+            scope: 'step',
+            step: stepName,
+            message,
+          });
+        }
+
         // W1: on_timeout with an effective max_attempts of 1 (explicit OR absent, since the
         // loader admits an absent max_attempts and the engine then defaults it to 1) — there is
         // no second attempt for the opt-in to retry into.


### PR DESCRIPTION
## Context

Issue #218 (from the verified CS1 suggestion doc, R-5's surviving half): a bare `retry:` block
(`max_attempts`/`backoff`/`base_delay_ms`/`max_delay_ms`) on a non-auto step parses and warns
about nothing — dead config with zero signal. #140's W5 covered only the explicit-cap shape.

## Motivation

The loader's warn-don't-reject posture is binding (#144/#169/#170), and the reject option was
declined on record — the engine deliberately honors retry+backoff for embedder-supplied throwing
dispatchers (public API, test-pinned). What was missing is the signal: an author writing
`retry: {max_attempts: 5}` on an agent step expecting five schema repairs gets the built-in
drive's `--schema-retries` default instead, silently.

## Changes

- New `RETRY_INERT_NON_AUTO` WarningCode (#169 machinery: compiler-forced `DEFAULT_POLICY`
  entry, generic renderer, automatic `validate/register --strict` propagation).
- Emission on the existing retry-block walk, **mutually exclusive with W5 by construction** —
  the exact logical complement on the same gate, so for any non-auto retry block that loads,
  exactly one of the two fires (hard-error shapes — finalizer+retry, invalid cap, on_timeout
  without idempotent — never surface warnings at all).
- Variant-aware message (C5 precedent): the agent variant points at `--schema-retries` (the
  #217 cross-comment's mandate) and both variants carry the embedder caveat — the config is
  inert under built-in dispatch, never invalid.
- One sanctioned pre-existing-test change: the A3 advisory test's zero-warnings assertion
  narrowed to A3-text-absence + a positive pin of the new advisory (this exact fixture now
  legitimately warns).
- AC note: the issue's finalizer clause is satisfied by the PRE-EXISTING stronger rejection
  (`retry` is a prohibited field on finalizer steps — hard error), pinned by a composition test.

## Verification

```bash
npm test -- --force   # 173 files / 2970 tests, 4 packages, all green (core 1832)
npm run lint          # clean
cd packages/core && npx vitest run src/workflow/retryable-timeout-loader.test.ts  # 33/33
```

4 mutation probes, every predicted signal reproduced (probe (c) exceeded prediction in the
strengthening direction, with the renderer test's non-vacuity confirmed); probe (a)
independently re-verified by the architect.

## Rollback

```bash
git revert 2e886eb
```

Advisory-only (#119) — no refusal anywhere; removing it restores silent inertness only.

## Related

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
