### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.29.0] — 2026-07-20
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.28.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.29.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,7 +104,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.28.0';
+export const VERSION = '0.29.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.28.0';
+export const VERSION = '0.29.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.28.0',
+    version: '0.29.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -57,4 +57,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.28.0';
+export const VERSION = '0.29.0';


### PR DESCRIPTION
## Context

Release v0.29.0 (minor) — the agent-robustness release: ships the three arcs from the verified
CS1 suggestion-doc sweep (#217 PR #225, #221 PR #226, #218 PR #227), all merged and
architect-verified by value.

## Motivation

`[Unreleased]` carries three Added + two Changed entries; per release policy it must not
accumulate. Minor bump: new backwards-compatible capabilities (schema-repair loop +
`--schema-retries`, `classifyRunHealth`/`run_health`/`--older-than`, the inert-retry advisory)
plus two disclosed behavior changes (reclaim's honest `no_active_claim` outcome split;
`list --stuck` age-gating).

## Changes

- CHANGELOG: `[Unreleased]` → `[0.29.0] — 2026-07-20`
- `chore: release v0.29.0` (`scripts/release.mjs`): four `package.json` + five `VERSION`
  constants bumped; tag `v0.29.0` on the release commit

## Verification

```bash
npm test -- --force     # 2970 tests / 4 packages green at the head this releases
npm run check:versions  # all four packages + five VERSION constants at 0.29.0
npm audit --audit-level=high --omit=dev   # 0 vulnerabilities
```

Post-merge, the tag push triggers `publish.yml` (OIDC); the artifact will be verified by
clean-install ESM `import { VERSION }` + published-CLI `--version` + a live `classifyRunHealth`
check.

## Rollback

Before the tag push: revert the merge and delete the tag. After: npm versions are immutable —
publish a follow-up patch instead.

## Related

Releases #217 / #221 / #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
