### PR TITLE
feat(engine): bounded validation-rejection exhaustion (issue #220, PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Bounded validation-rejection exhaustion, PR-1 (issue #220).** A persistently schema-rejected
+  `execution: 'agent'` step is no longer an unbounded wedge: `RunRecord.validation_rejections?:
+Record<string, number>` (additive, joins the #188 `LoadBearingRunRecordField` closed set) counts
+  the two model-attributable rejection codes (`VALIDATION_INPUT_SCHEMA`/`VALIDATION_OUTPUT_SCHEMA`)
+  per step, pooled across writers, never reset. `countRejection` (the engine's single counting
+  chokepoint) persists the count via a bump-and-report CAS write — the rejection's own envelope
+  keeps reporting the pre-write version, so the #217 in-drive repair gate's `run_version`
+  comparison stays sound across repeated repairs. At `count ≥ threshold`
+  (`DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD = 6`, exported; per-step override via
+  `validation_exhaustion: { threshold }`, integer ≥ 1) the engine mints a NEW `VALIDATION_EXHAUSTED`
+  error and falls through to a REAL step failure — claims, fails, drains `on_outcome: fail`
+  finalizers when the run completes, seals, exactly like any other dispatch failure. On a later
+  SUCCESS settle with an accrued count > 0, the settle evidence is stamped
+  `diagnostics.validation_rejections: N` ("succeeded after N rejections"). `VALIDATION_EXHAUSTED`
+  joins the MCP `execute_step` telemetry set (its `ajv_errors` sourced from
+  `error_details.last_ajv_errors`). `realm agent` warns once per step, at drive time, when
+  `--schema-retries`'s own repair budget exceeds the step's effective exhaustion threshold
+  (operator intent would otherwise be silently truncated mid-loop). Advisory-only elsewhere (#119):
+  a store not declaring `validation_rejections` draws a softened durability caveat on every counted
+  rejection; `create_workflow` draws a targeted "register-time only" warning for a submitted
+  `validation_exhaustion` key (dynamic workflows are still auto-enrolled at the default posture).
+  `$settlement` is reserved as a step name NOW (both the YAML loader and `create_workflow`) ahead
+  of a later PR's namespace mint — the PR-ordering interlock that prevents an inter-PR gap from
+  registering a step name that would become load-refused the instant the mint ships. PR-2
+  (fail-open `mode`/`default_output`) and PR-3 (the `$settlement` mint) are separate, later
+  changes — this PR is counting + terminalization only.
+
+### Changed
+
+- **AUTO-ENROLLMENT (issue #220): every `execution: 'agent'` step with a countable schema now
+  terminalizes after 6 persistent rejections by default — there is no reachable per-step opt-out
+  in PR-1.** This is deliberate: an unbounded, silently-write-free rejection wedge is strictly
+  worse than an honest, finalizer-visible failure (the #138/#140 precedent). Override the default
+  via `validation_exhaustion: { threshold: N }` (`N ≥ 1`; `1` disables in-drive schema-repair,
+  since the very first rejection already meets it).
+- **`create_workflow`'s step-id reservation gains a pre-existing gap fix (issue #220): `run` and
+  `context` are now refused as step ids, mirroring the YAML loader's own long-standing reservation
+  (`create_workflow` never enforced either before this change).** `$settlement` joins both
+  reservations as a new refusal on a name that was previously loader-legal (see the PR-ordering
+  interlock note above).
+
+---
+
 ## [0.29.0] — 2026-07-20
 
 ### Added

--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -343,7 +343,7 @@ steps:
 
 Start a shadow run with `params: { mode: "shadow" }`. Steps annotated with `when: "run.params.mode == 'live'"` are skipped. The run reaches terminal state cleanly — `propagateSkips` handles skip propagation once their dependencies settle.
 
-**Limitations:** `when:` supports a single expression only. A step that needs both a shadow guard and a data condition cannot express both in one `when:` clause — use `depends_on` with `trigger_rule` or a preceding guard step instead. The step name `run` is reserved and cannot be used as a step identifier.
+**Limitations:** `when:` supports a single expression only. A step that needs both a shadow guard and a data condition cannot express both in one `when:` clause — use `depends_on` with `trigger_rule` or a preceding guard step instead. The step names `run`, `context`, and `$settlement` are reserved and cannot be used as step identifiers (`$settlement` reserved as of issue #220, ahead of a future namespace mint under that name — reserving it now closes the gap where an inter-release workflow could register a step that would become load-refused the instant the mint ships).
 
 ---
 
@@ -680,6 +680,48 @@ fetch_document:
 > **Non-auto steps (issue #218):** any `retry:` sub-key on an `agent`/`guard` step draws an
 > advisory (`RETRY_INERT_NON_AUTO`), since the built-in dispatch path never throws for those steps
 > and so never consumes the block.
+
+---
+
+## `validation_exhaustion` (bounded schema-rejection exhaustion)
+
+```yaml
+draft:
+  execution: agent
+  output_schema: { type: object, required: [category], properties: { category: { type: string } } }
+  validation_exhaustion:
+    threshold: 3
+```
+
+Every `execution: 'agent'` step whose submitted output/input is rejected against `output_schema`/
+`input_schema` (`VALIDATION_OUTPUT_SCHEMA`/`VALIDATION_INPUT_SCHEMA`) accrues a persistent,
+per-step rejection count on the run record (`RunRecord.validation_rejections`, pooled across
+concurrent writers, never reset). Once the count reaches a threshold — `6` by default
+(`DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD`, exported), or the value declared here — the step
+terminalizes with a real `VALIDATION_EXHAUSTED` failure: it claims, fails, drains `on_outcome:
+fail` finalizers when the run completes, and seals exactly like any other dispatch failure. This
+is deliberate (issue #220): a persistently-rejected agent step is otherwise an unbounded,
+write-free wedge — `run_phase` never reaches `failed` and finalizer machinery never fires. **Every
+countable agent step is auto-enrolled at the default threshold — there is no way to disable
+exhaustion in PR-1**, only to retune it.
+
+| Field       | Type    | Description                                                                                                                                                                                                                           |
+| ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `threshold` | integer | Overrides the default threshold (6) for this step. Must be a positive integer. `1` is legal and documented as disabling in-drive schema-repair (`realm agent`'s `--schema-retries`), since the very first rejection already meets it. |
+
+Only valid on `execution: 'agent'` steps — the countable rejection classes are agent-only by
+construction. `mode`/`default_output` sub-keys are **not yet supported** (a later PR's surface);
+declaring them today draws an unknown-key warning, never a rejection.
+
+> **`realm agent` coherence warning:** when `--schema-retries`'s own in-drive repair budget
+> (`schemaRetries + 1` attempts) exceeds a step's effective exhaustion threshold, the drive prints
+> one warning at that step's first attempt — the repair loop would otherwise keep retrying past
+> the point the engine has already terminalized the step.
+
+> **`create_workflow` (dynamic workflows):** `validation_exhaustion` is register-time only — a
+> dynamically-created workflow cannot declare it, and draws a targeted warning naming the
+> disposition if submitted. Every dynamic agent step with a countable schema is still auto-enrolled
+> at the default threshold; there is no reachable override or opt-out for a dynamic workflow.
 
 ---
 

--- a/packages/cli/src/agent/run-agent.test.ts
+++ b/packages/cli/src/agent/run-agent.test.ts
@@ -888,13 +888,13 @@ describe('runAgent — schema-feedback repair loop (issue #217)', () => {
     expect(headerMatches).toHaveLength(1); // exactly one feedback-block header
   });
 
-  it("test 3: exhaustion — N+1 provider calls, 'failed', message notes the repair count; run stays non-terminal + step still eligible (today's engine posture — #220 will terminalize persistent rejection; delete this pin when it ships)", async () => {
+  it('test 3 REPLACEMENT (issue #220 SHIPPED): persistent rejection across TWO FULL default drives (3 attempts/drive × 2 = 6 = the default exhaustion threshold) terminalizes with VALIDATION_EXHAUSTED — the fixture declares NO validation_exhaustion key at all, pinning AUTO-ENROLLMENT at the default threshold (a default-mode-off mutant reds; deleted-and-replaced per the design record, not reddened — the original #220-pending pin predicted exactly this break)', async () => {
     const schema = {
       type: 'object',
       properties: { alpha: { type: 'string' } },
       required: ['alpha'],
     };
-    const def = agentWorkflow({ output_schema: schema });
+    const def = agentWorkflow({ output_schema: schema }); // NO validation_exhaustion key
     const provider = new (class extends LlmProvider {
       callStep = vi.fn().mockResolvedValue({}); // always invalid — missing 'alpha' every time
     })();
@@ -906,25 +906,115 @@ describe('runAgent — schema-feedback repair loop (issue #217)', () => {
       params: {},
     });
 
-    const result = await runAgent(
+    // Drive 1: 1 + 2 repairs = 3 attempts (rejections 1-3 of the default threshold of 6).
+    const result1 = await runAgent(
       { store, workflowStore: makeWorkflowStore(def), provider, registry: createDefaultRegistry() },
       { existingRunId: run.id, definition: def, params: {} },
     );
+    expect(result1).toBe('failed');
+    const afterDrive1 = await store.get(run.id);
+    expect(afterDrive1.terminal_state).toBe(false); // 3 < 6 — not yet at threshold
+    expect(afterDrive1.validation_rejections?.['draft']).toBe(3);
+    expect(findEligibleSteps(def, afterDrive1)).toContain('draft'); // still re-drivable
+
+    // Drive 2: 3 MORE attempts (rejections 4-6) — the 6th reaches the default threshold and
+    // terminalizes the step with VALIDATION_EXHAUSTED instead of returning control at attempt 3.
+    const result2 = await runAgent(
+      { store, workflowStore: makeWorkflowStore(def), provider, registry: createDefaultRegistry() },
+      { existingRunId: run.id, definition: def, params: {} },
+    );
+    expect(result2).toBe('failed');
+    expect(provider.callStep).toHaveBeenCalledTimes(6);
+
+    const after = await store.get(run.id);
+    expect(after.terminal_state).toBe(true);
+    expect(after.run_phase).toBe('failed');
+    expect(after.failed_steps).toContain('draft');
+    expect(after.validation_rejections?.['draft']).toBe(6);
+    errorSpy.mockRestore();
+  });
+
+  it("issue #220 deliverable 7 — coherence warn (pin (i)): schemaRetries exceeding the effective exhaustion threshold prints one stderr warning at the step's first attempt; the defaults (schemaRetries=2, threshold=6) print none", async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' } },
+      required: ['alpha'],
+    };
+
+    // Case 1: schemaRetries 7 (budget 8 attempts) vs a per-step threshold of 6 ⇒ warns.
+    const defLowThreshold = agentWorkflow({
+      output_schema: schema,
+      validation_exhaustion: { threshold: 6 },
+    });
+    const providerAlwaysValid = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({ alpha: 'x' });
+    })();
+    const errorSpyWarn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(defLowThreshold),
+        provider: providerAlwaysValid,
+        registry: createDefaultRegistry(),
+        schemaRetries: 7,
+      },
+      { definition: defLowThreshold, params: {} },
+    );
+    const printedWarn = errorSpyWarn.mock.calls.flat().join('\n');
+    expect(printedWarn).toContain('--schema-retries');
+    expect(printedWarn).toContain('validation-exhaustion threshold');
+    errorSpyWarn.mockRestore();
+
+    // Case 2: defaults (schemaRetries=2, threshold=6 via DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD)
+    // ⇒ no warning (2 + 1 = 3 ≤ 6).
+    const defDefault = agentWorkflow({ output_schema: schema });
+    const errorSpyNoWarn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await runAgent(
+      {
+        store: new InMemoryStore(),
+        workflowStore: makeWorkflowStore(defDefault),
+        provider: providerAlwaysValid,
+        registry: createDefaultRegistry(),
+      },
+      { definition: defDefault, params: {} },
+    );
+    const printedNoWarn = errorSpyNoWarn.mock.calls.flat().join('\n');
+    expect(printedNoWarn).not.toContain('validation-exhaustion threshold');
+    errorSpyNoWarn.mockRestore();
+  });
+
+  it('issue #220 pin (h) — mid-loop truncation fails closed: a per-step threshold of 2 with the default schemaRetries (2) terminalizes at attempt 2 with the DISTINCT VALIDATION_EXHAUSTED code, and the repair loop breaks there — no repair is attempted on it', async () => {
+    const schema = {
+      type: 'object',
+      properties: { alpha: { type: 'string' } },
+      required: ['alpha'],
+    };
+    const def = agentWorkflow({
+      output_schema: schema,
+      validation_exhaustion: { threshold: 2 },
+    });
+    const provider = new (class extends LlmProvider {
+      callStep = vi.fn().mockResolvedValue({}); // always invalid — missing 'alpha' every time
+    })();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = new InMemoryStore();
+
+    const result = await runAgent(
+      { store, workflowStore: makeWorkflowStore(def), provider, registry: createDefaultRegistry() },
+      { definition: def, params: {} },
+    );
 
     expect(result).toBe('failed');
-    expect(provider.callStep).toHaveBeenCalledTimes(3); // 1 + 2 repairs (default schemaRetries=2)
+    // Attempt 1 rejects at count 1 (< threshold 2) — an ORDINARY repairable VALIDATION_OUTPUT_SCHEMA,
+    // so the gate legitimately repairs once. Attempt 2 rejects at count 2 (=== threshold) —
+    // terminalizes as VALIDATION_EXHAUSTED, a DISTINCT code the repair gate's own conjunct
+    // (error_code ∈ {VALIDATION_OUTPUT_SCHEMA, VALIDATION_INPUT_SCHEMA}) never matches, so the
+    // loop breaks THERE instead of attempting a 3rd repair on an already-terminalized step. Only
+    // 2 provider calls total — NOT schemaRetries+1 (3) — and only ONE "repairing" line, not two.
+    expect(provider.callStep).toHaveBeenCalledTimes(2);
     const printed = errorSpy.mock.calls.flat().join('\n');
-    expect(printed).toContain('after 2 schema-repair attempts');
-
-    // #220 will terminalize persistent rejection — delete this pin when it ships
-    const after = await store.get(run.id);
-    expect(after.terminal_state).toBe(false);
-    expect(after.completed_steps).not.toContain('draft');
-    expect(after.in_progress_steps).not.toContain('draft');
-    expect(after.failed_steps).not.toContain('draft');
-    // Pins the actual re-drivability contract (not its structural shadow via the three fields
-    // above): the step is genuinely eligible again, so `realm agent --run-id` can re-drive it.
-    expect(findEligibleSteps(def, after)).toContain('draft');
+    expect(printed.match(/repairing/g) ?? []).toHaveLength(1); // exactly one repair, not a second
+    expect(printed).toContain('after 1 schema-repair attempts'); // never "after 2"
     errorSpy.mockRestore();
   });
 

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -664,7 +664,7 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         // PRE-write version (the Step-1 `run`), so `result.run_version` still equals
         // `versionBeforeAttempt` here across repairs 2..N. Pin (a) (bump-and-report) guards this
         // invariant — see execution-loop.ts's countRejection for the mechanism, and
-        // run-agent.test.ts's "test (a)" for the pin.
+        // packages/core/src/engine/validation-exhaustion.test.ts's pin (a) for the pin.
         if (
           result.status === 'error' &&
           (result.error_code === 'VALIDATION_OUTPUT_SCHEMA' ||

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -13,6 +13,7 @@ import {
   capabilityWarning,
   buildFailedAttemptRecord,
   WorkflowError,
+  DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
   type RunStore,
   type WorkflowDefinition,
   type StepDefinition,
@@ -402,9 +403,13 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         if (stepDef.execution === 'agent') {
           // Resolve template-expanded prompt via buildNextActions so {{ context.resources.* }}
           // references are substituted before the LLM call. Pure w.r.t. `definition`/`currentRun`,
-          // both unchanged across repair attempts (pre-claim validation is write-free — nothing is
-          // ever persisted on a rejected attempt, per execute-step.ts) — safe to recompute per
-          // iteration.
+          // both unchanged across repair attempts — a rejected attempt no longer leaves
+          // `currentRun` itself stale relative to what's persisted (issue #220: countRejection DOES
+          // persist a bounded rejection counter on a counted rejection — "nothing is ever
+          // persisted on a rejected attempt" is FALSE as of #220), but `currentRun`/`definition`
+          // are still safe to recompute per iteration here regardless, since neither is read from
+          // again until the NEXT step (this step's own next_actions/prompt derivation never
+          // consults `validation_rejections`).
           const nextActions = buildNextActions(definition, currentRun);
           const nextAction =
             nextActions.find(
@@ -439,6 +444,22 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
             const descPreview = stepDef.description.slice(0, 80);
             console.log(`\n→ [agent] ${stepName}`);
             console.log(`  ${descPreview}${stepDef.description.length > 80 ? '…' : ''}`);
+
+            // issue #220 deliverable 7 — drive-time coherence warn: once per step (gated on the
+            // same `repairsUsed === 0` this banner uses), warn when the repair budget itself
+            // (schemaRetries + 1 attempts) exceeds the engine's own exhaustion threshold for this
+            // step — operator intent would be silently truncated mid-loop (the drive keeps
+            // repairing past the point the engine terminalizes the step with VALIDATION_EXHAUSTED).
+            const exhaustionThreshold =
+              stepDef.validation_exhaustion?.threshold ?? DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD;
+            if (schemaRetries + 1 > exhaustionThreshold) {
+              console.error(
+                `  ⚠ --schema-retries ${schemaRetries} (repair budget ${schemaRetries + 1} attempts) ` +
+                  `exceeds step '${stepName}''s validation-exhaustion threshold ` +
+                  `(${exhaustionThreshold}) — the engine will terminalize this step before the ` +
+                  `repair loop's own budget is exhausted.`,
+              );
+            }
           }
 
           if (stepDef.tools && stepDef.tools.length > 0 && mcpClient) {
@@ -636,8 +657,14 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
         // lands here — the gate then fails CLOSED (repair forfeited, today's failure path). See
         // run-agent.test.ts's "chained-auto no-false-repair" and concurrent-writer tests.
         //
-        // #220 must keep rejected attempts write-free w.r.t. the run record (or report the
-        // pre-write version in the envelope), else repairs 2..N silently vanish — see test 3's pin.
+        // issue #220 (SHIPPED): countRejection now persists a bounded rejection counter via a
+        // real CAS write on a counted rejection — rejected attempts are NO LONGER write-free w.r.t.
+        // the run record. What keeps this conjunct sound anyway is bump-and-report: the write's
+        // return value is discarded, and the rejection's own ENVELOPE keeps reporting the
+        // PRE-write version (the Step-1 `run`), so `result.run_version` still equals
+        // `versionBeforeAttempt` here across repairs 2..N. Pin (a) (bump-and-report) guards this
+        // invariant — see execution-loop.ts's countRejection for the mechanism, and
+        // run-agent.test.ts's "test (a)" for the pin.
         if (
           result.status === 'error' &&
           (result.error_code === 'VALIDATION_OUTPUT_SCHEMA' ||

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -80,7 +80,14 @@ describe('buildExportBundle', () => {
   it('terminal run, full artifacts: bundle matches run/attempts/WAL exactly, across multiple WAL steps', async () => {
     const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
     try {
-      const run = makeRun({ run_phase: 'abandoned', terminal_state: true });
+      const run = makeRun({
+        run_phase: 'abandoned',
+        terminal_state: true,
+        // issue #220 (R-EXTRAS): the counter rides the run record verbatim — no export-side
+        // handling needed. Included here so the round-trip is proven explicitly, not just
+        // implied by the whole-record `toEqual` below.
+        validation_rejections: { 'step-a': 3 },
+      });
       await injectRun(dir, run);
       await appendSidecarLine(failedAttemptStore, run.id);
       await traceBufferStore.append(run.id, 'step-a', [{ event: 'orphaned-a' }]);
@@ -97,6 +104,8 @@ describe('buildExportBundle', () => {
       expect(bundle.realm_export_version).toBe(3);
       expect(bundle.exported_at).toBe(now.toISOString());
       expect(bundle.run).toEqual(run);
+      // issue #220 (R-EXTRAS): the export bundle round-trips validation_rejections.
+      expect(bundle.run.validation_rejections).toEqual({ 'step-a': 3 });
       expect(bundle.attempts).toHaveLength(1);
       expect(bundle.attempts[0]?.step_id).toBe('classify');
       expect(Object.keys(bundle.wal).sort()).toEqual(['step-a', 'step-b']);

--- a/packages/cli/src/store-contracts/run-store-fidelity.contract.test.ts
+++ b/packages/cli/src/store-contracts/run-store-fidelity.contract.test.ts
@@ -33,6 +33,7 @@ describe('JsonFileStore — RunStore fidelity TCK conformance (issue #188)', () 
       expect(store.persistedRunRecordFields?.has('capability_blocks')).toBe(true);
       expect(store.persistedRunRecordFields?.has('workflow_context_snapshots')).toBe(true);
       expect(store.persistedRunRecordFields?.has('extension_identity')).toBe(true);
+      expect(store.persistedRunRecordFields?.has('validation_rejections')).toBe(true);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -326,7 +326,11 @@ describe('executeStep', () => {
     expect(dispatchCalled).not.toHaveBeenCalled();
     expect(envelope.agent_action).toBe('provide_input');
     // The step was never claimed — it is still eligible and appears in next_actions
-    // so the agent can immediately correct and re-submit it.
+    // so the agent can immediately correct and re-submit it. issue #220: true while this step's
+    // accrued rejection count stays below its exhaustion threshold (default 6) — this single
+    // rejection is call 1 of 6 by default, so this premise holds here; it stops holding once the
+    // count reaches the threshold, at which point the step terminalizes instead (see
+    // validation-exhaustion.test.ts).
     expect(envelope.next_actions).toHaveLength(1);
 
     const runAfter = await store.get(run.id);
@@ -423,7 +427,8 @@ describe('executeStep', () => {
       params: {},
     });
 
-    // First call with invalid input — should fail
+    // First call with invalid input — should fail. issue #220: this is rejection 1 of a default
+    // threshold of 6 — well under exhaustion, so today's re-submittable behavior below holds.
     const first = await executeStep(store, schemaDefinition, {
       runId: run.id,
       command: 'step-one',
@@ -432,7 +437,9 @@ describe('executeStep', () => {
     });
     expect(first.status).toBe('error');
 
-    // Second call with valid input — step was never claimed, so it can be re-submitted
+    // Second call with valid input — step was never claimed, so it can be re-submitted (true
+    // while under the exhaustion threshold — issue #220; see validation-exhaustion.test.ts for
+    // the terminalizing case once the threshold is reached).
     const second = await executeStep(store, schemaDefinition, {
       runId: run.id,
       command: 'step-one',

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -193,6 +193,17 @@ function withTimeout<T>(
 const MAX_INPUT_MAP_DEPTH = 10;
 
 /**
+ * Issue #220: default per-step threshold for bounded validation-rejection exhaustion — the
+ * multiple-of-(schemaRetries+1) alignment formula at k=2 (two full default `realm agent` repair
+ * drives, schemaRetries defaulting to 2 ⇒ 3 attempts/drive ⇒ termination lands at drive
+ * boundaries at defaults). Exported so `realm agent`'s drive-time coherence warn (run-agent.ts)
+ * and a per-step `validation_exhaustion.threshold` override (yaml-loader.ts) share ONE source of
+ * truth. Every countable agent step (see `countRejection` below) is auto-enrolled at this
+ * threshold — there is no reachable default-off posture in PR-1.
+ */
+export const DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD = 6;
+
+/**
  * Resolves an input_map declaration into a concrete params object.
  * Falls back to options.input when input_map is absent.
  */
@@ -969,24 +980,167 @@ export async function executeStep(
 
   let inputTokenEstimate = Math.ceil(JSON.stringify(effectiveInput).length / 4);
 
+  // issue #220: bounded validation-rejection exhaustion — locals shared by countRejection below
+  // and by both its call sites (Step 2b/2c) and the trace enforce-gate further down. `exhaustion`
+  // stays null unless/until a counted rejection's JUST-persisted count reaches its threshold;
+  // once armed, EVERY subsequent validation return in this call YIELDS instead of returning.
+  let exhaustion: WorkflowError | null = null;
+  let counted = false; // at-most-once arm per invocation
+  let persisted: number | undefined; // the count actually PERSISTED this invocation, if any
+  const countWarnings: string[] = [];
+
+  /**
+   * issue #220 (design record §2) — the single chokepoint every counted rejection passes through.
+   * Counts ONLY `{VALIDATION_INPUT_SCHEMA, VALIDATION_OUTPUT_SCHEMA}` on `execution: 'agent'`
+   * steps (CLOSED set: for agent steps, Step 2b/2c validates `options.input`, which is
+   * model-authored by construction — every counted rejection is model-attributable bytes.
+   * `VALIDATION_TRACE_SCHEMA` is EXCLUDED v1 — a WAL-merged trace may carry preserved foreign
+   * lines (#185/#197), so counting it would poison a step on someone else's bytes; the
+   * nonce-refusal class is pre-engine today [structurally thrown in the MCP wrapper before this
+   * function ever runs] — re-adjudicate this exclusion if that gate ever moves into core).
+   * Read-modify-write from the Step-1 `run` through `store.update()`'s CAS, with the write's
+   * return value DISCARDED — the envelope keeps building from the stale Step-1 `run`
+   * (bump-and-report; this is the #217 repair-gate contract's own ordering guarantee — see
+   * run-agent.ts's cross-ref comment at the repair gate). CAS failure retries ONCE on a fresh
+   * `get()` (the extension-identity precedent above), re-checking countability on the FRESH
+   * record [P-B1]: an unguarded retry could write onto a terminal/claimed/gate-waiting record,
+   * worst case CAS-failing a concurrent VALID submission's settle into a human-judged claim
+   * wedge. Any further failure — or a failed countability re-check — drops and swallows
+   * (undercount-safe); envelope delivery is unconditional regardless of what this function does.
+   */
+  async function countRejection(err: WorkflowError): Promise<void> {
+    if (counted) return; // at-most-once per invocation
+    if (stepDef?.execution !== 'agent') return; // non-agent steps are never counted
+    if (err.code !== 'VALIDATION_INPUT_SCHEMA' && err.code !== 'VALIDATION_OUTPUT_SCHEMA') return;
+    counted = true;
+
+    const threshold =
+      stepDef.validation_exhaustion?.threshold ?? DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD;
+    const attempted = (run.validation_rejections?.[options.command] ?? 0) + 1;
+
+    try {
+      // FIRST CAS — expected version = the Step-1 read. Return value DISCARDED: the envelope
+      // built at the call site keeps using the stale `run`, never this write's result.
+      await store.update({
+        ...run,
+        validation_rejections: {
+          ...(run.validation_rejections ?? {}),
+          [options.command]: attempted,
+        },
+      });
+      persisted = attempted;
+    } catch {
+      // CAS loser — retry ONCE on fresh state, WITH a countability re-check on the fresh record.
+      try {
+        const fresh = await store.get(options.runId);
+        if (
+          !fresh.terminal_state &&
+          fresh.pending_gate === undefined &&
+          findEligibleSteps(definition, fresh).includes(options.command)
+        ) {
+          const freshN = (fresh.validation_rejections?.[options.command] ?? 0) + 1;
+          // CAS on fresh.version closes the re-check's own TOCTOU: a claim landing after the
+          // re-check above but before this write fails THIS write too (caught below).
+          await store.update({
+            ...fresh,
+            validation_rejections: {
+              ...(fresh.validation_rejections ?? {}),
+              [options.command]: freshN,
+            },
+          });
+          persisted = freshN;
+        } else {
+          persisted = undefined; // drop-and-swallow (undercount-safe)
+        }
+      } catch {
+        persisted = undefined; // double-CAS-failure swallow
+      }
+    }
+
+    // [design record §2, P-S4] fires on the drop path AND the double-failure path alike — nothing
+    // was persisted THIS invocation either way.
+    if (persisted === undefined) {
+      countWarnings.push(`rejection count not persisted — record remains at ${attempted - 1}`);
+    }
+    // [design record §1, softened per the final gate] a store round-tripping everything but not
+    // declaring this field yet is not called broken definitively — "MAY be unavailable", not "is".
+    if (!persistsField(store, 'validation_rejections')) {
+      countWarnings.push(
+        'rejection counting not declared durable on this store — exhaustion terminalization MAY ' +
+          'be unavailable',
+      );
+    }
+    // Countdown observable (Temporal-style) — `rejections` is the JUST-PERSISTED count when one
+    // exists, else the attempted (unpersisted) value, so a caller always sees SOME number.
+    err.details['rejections'] = persisted ?? attempted;
+    err.details['threshold'] = threshold;
+
+    if (persisted !== undefined && persisted >= threshold) {
+      exhaustion = new WorkflowError(
+        `Step '${options.command}' exhausted its validation-rejection budget (${persisted}/${threshold})`,
+        {
+          code: 'VALIDATION_EXHAUSTED',
+          category: 'VALIDATION',
+          agentAction: 'stop',
+          retryable: false,
+          details: {
+            step_id: options.command,
+            rejections: persisted,
+            threshold,
+            last_error: err.message,
+            last_ajv_errors: err.details['errors'],
+          },
+        },
+      );
+    }
+  }
+
   // Step 2b: Validate input schema.
   if (stepDef?.input_schema !== undefined) {
     try {
       validateInputSchema(effectiveInput, stepDef.input_schema, options.command);
     } catch (err) {
-      return makeErrorEnvelope(options, run, err as WorkflowError, definition);
+      await countRejection(err as WorkflowError);
+      if (exhaustion === null) {
+        return makeErrorEnvelope(
+          options,
+          run,
+          err as WorkflowError,
+          definition,
+          countWarnings.length > 0 ? countWarnings : undefined,
+        );
+      }
+      // FALL THROUGH — exhaustion armed; Step 2c below is gated on `exhaustion === null` (skipped
+      // whole), and every downstream gate yields toward terminalization instead of returning.
     }
   }
 
-  // Step 2c: Validate output schema (agent steps only).
+  // Step 2c: Validate output schema (agent steps only). issue #220: the WHOLE block is gated on
+  // `exhaustion === null` — once armed by Step 2b above, 2c does not run at all (no validation,
+  // no catch), matching W5's own conjunct set exactly [P-S1]: a both-schemas step must never
+  // double-count or report the wrong last_error.
   // For agent steps dispatch is a pass-through, so options.input IS the agent's
   // submitted output. Validating here (pre-claim) is equivalent to
   // "post-generation, pre-commit" — the standard output guardrail position.
-  if (stepDef?.execution === 'agent' && stepDef.output_schema !== undefined) {
+  if (
+    exhaustion === null &&
+    stepDef?.execution === 'agent' &&
+    stepDef.output_schema !== undefined
+  ) {
     try {
       validateOutputSchema(effectiveInput, stepDef.output_schema, options.command);
     } catch (err) {
-      return makeErrorEnvelope(options, run, err as WorkflowError, definition);
+      await countRejection(err as WorkflowError);
+      if (exhaustion === null) {
+        return makeErrorEnvelope(
+          options,
+          run,
+          err as WorkflowError,
+          definition,
+          countWarnings.length > 0 ? countWarnings : undefined,
+        );
+      }
+      // FALL THROUGH — exhaustion armed.
     }
   }
 
@@ -998,6 +1152,12 @@ export async function executeStep(
   // never be adopted, then be silently destroyed when the WAL is deleted at settlement (issue
   // #185 Finding 2). A rare line landing in exactly that window bypasses THIS enforce check —
   // documented, accepted (see the post-claim block).
+  //
+  // issue #220 carve-out: the ABOVE "stays pre-claim so an invalid trace doesn't consume a claim"
+  // guarantee is for the COMMON case only — when validation exhaustion is already armed by an
+  // earlier Step 2b/2c rejection, the enforce-gate below deliberately YIELDS its return instead
+  // (still never deletes/consumes the WAL) so a persistently-invalid-trace agent under `enforce`
+  // can be terminalized rather than wedging forever purely on this unrelated gate.
   //
   // walEntries is declared at this outer scope because it is REASSIGNED to the post-claim read
   // below and referenced at the captureEvidence call site further down this function.
@@ -1094,7 +1254,29 @@ export async function executeStep(
             };
           } catch (err) {
             // On enforce rejection: do NOT delete the WAL — agent retries with WAL preserved.
-            return makeErrorEnvelope(options, run, err as WorkflowError, definition);
+            if (exhaustion === null) {
+              return makeErrorEnvelope(options, run, err as WorkflowError, definition);
+            }
+            // issue #220: exhaustion is already armed by an earlier Step 2b/2c rejection — the
+            // enforce-gate YIELDS its return (rather than returning) so a persistently-invalid
+            // trace under `enforce` can still be terminalized instead of wedging forever on this
+            // unrelated gate (the exact class #220 exists to kill). Re-run the WARN-shape pass
+            // (never enforce) purely so `preClaimSchemaResult`/the summary still reflect what
+            // actually happened to the trace; `validateTraceSchema('warn', ...)` never throws.
+            const warnResult = validateTraceSchema(
+              preClaimNormalized.entries,
+              stepDef.trace_schema,
+              options.command,
+              'warn',
+            );
+            preClaimSchemaResult = {
+              schema_applied: true,
+              validation_mode: 'warn',
+              validation_errors: warnResult.errorCount,
+            };
+            if (warnResult.errorCount > 0) {
+              traceWarnings.push(warnResult.warning);
+            }
           }
         } else {
           const result = validateTraceSchema(
@@ -1459,278 +1641,337 @@ export async function executeStep(
   const allEvidence: EvidenceSnapshot[] = [];
   let currentWarn: string | undefined;
 
-  for (let attemptNum = 1; attemptNum <= maxAttempts; attemptNum++) {
-    // SITE (a) — issue #140, loop-top, BEFORE attemptsUsed is assigned: attempt 1 ALWAYS
-    // proceeds regardless of capMs (the `attemptNum > 1` conjunct) — this guard exists solely for
-    // the clock-anomaly window between `capStart` above and here (a suspend/resume or NTP forward
-    // jump), never to gate the very first attempt.
-    if (capMs !== undefined && attemptNum > 1 && remainingMs() <= 0) {
-      capExhausted = true;
-      break;
-    }
-    attemptsUsed = attemptNum;
-    const startedAt = new Date();
-    let attemptOutput: Record<string, unknown> = {};
-    let attemptError: WorkflowError | null = null;
-    let resolvedParams: Record<string, unknown> | undefined;
+  // issue #220: once exhaustion is armed by an earlier Step 2b/2c/enforce-gate rejection, bypass
+  // the ENTIRE dispatch loop below AND the retry-wrap block that follows it — claimStep's own
+  // under-lock re-check (STATE_STEP_NOT_ELIGIBLE) is the safety net that cleanly aborts
+  // terminalization if a concurrent valid submission or abandon beat this invocation to the claim
+  // (see the claim's own catch above). Without this bypass, a hand-built max_attempts:0 definition
+  // would wrap VALIDATION_EXHAUSTED into STEP_RETRY_EXHAUSTED, destroying the discriminator.
+  const bypassDispatch = exhaustion !== null;
 
-    // Per-attempt effective timeout (issue #140): uniform full-clip to whatever cap budget
-    // remains. Clip floor `max(0, remainingMs())` ensures a clock anomaly (see SITE (a) above)
-    // never passes a negative ms to withTimeout. capMs undefined ⇒ effectiveMs === timeoutMs,
-    // byte-identical to pre-#140 behavior (every non-retry-configured, or unopted-uncapped-by-
-    // total_timeout_seconds-being-absent-pre-amendment, auto step). `clippedToMs` records the
-    // per-attempt evidence value ONLY when the cap actually reduced the bound below the step's
-    // own declared/default timeout — never on an uncapped or not-yet-biting attempt.
-    const effectiveMs =
-      timeoutMs !== undefined
-        ? capMs !== undefined
-          ? Math.min(timeoutMs, Math.max(0, remainingMs()))
-          : timeoutMs
-        : undefined;
-    const clippedToMs =
-      capMs !== undefined && effectiveMs !== undefined && effectiveMs < timeoutMs!
-        ? effectiveMs
-        : undefined;
+  if (!bypassDispatch) {
+    for (let attemptNum = 1; attemptNum <= maxAttempts; attemptNum++) {
+      // SITE (a) — issue #140, loop-top, BEFORE attemptsUsed is assigned: attempt 1 ALWAYS
+      // proceeds regardless of capMs (the `attemptNum > 1` conjunct) — this guard exists solely for
+      // the clock-anomaly window between `capStart` above and here (a suspend/resume or NTP forward
+      // jump), never to gate the very first attempt.
+      if (capMs !== undefined && attemptNum > 1 && remainingMs() <= 0) {
+        capExhausted = true;
+        break;
+      }
+      attemptsUsed = attemptNum;
+      const startedAt = new Date();
+      let attemptOutput: Record<string, unknown> = {};
+      let attemptError: WorkflowError | null = null;
+      let resolvedParams: Record<string, unknown> | undefined;
 
-    try {
-      const makeCall = (
-        signal?: AbortSignal,
-      ): Promise<{
-        output: Record<string, unknown>;
-        resolvedParams: Record<string, unknown> | undefined;
-        handlerAbort?: { message: string };
-        handlerWarn?: string;
-      }> => {
-        if (stepDef?.execution === 'auto' && stepDef.uses_service !== undefined) {
-          return callAdapter(
-            stepDef,
-            definition,
-            effectiveOptions,
-            pendingRun,
-            rateLimiterRegistry,
-            signal,
-          );
-        } else if (stepDef?.execution === 'auto' && stepDef.handler !== undefined) {
-          return callHandler(stepDef, effectiveOptions, pendingRun, evidenceByStep, signal).then(
-            (result) => {
-              if (result.kind === 'abort') {
-                return {
-                  output: {},
-                  resolvedParams: undefined,
-                  handlerAbort: { message: result.message },
-                };
-              }
-              if (result.kind === 'warn') {
-                return {
-                  output: result.output,
-                  resolvedParams: result.resolvedParams,
-                  handlerWarn: result.message,
-                };
-              }
-              return { output: result.output, resolvedParams: result.resolvedParams };
+      // Per-attempt effective timeout (issue #140): uniform full-clip to whatever cap budget
+      // remains. Clip floor `max(0, remainingMs())` ensures a clock anomaly (see SITE (a) above)
+      // never passes a negative ms to withTimeout. capMs undefined ⇒ effectiveMs === timeoutMs,
+      // byte-identical to pre-#140 behavior (every non-retry-configured, or unopted-uncapped-by-
+      // total_timeout_seconds-being-absent-pre-amendment, auto step). `clippedToMs` records the
+      // per-attempt evidence value ONLY when the cap actually reduced the bound below the step's
+      // own declared/default timeout — never on an uncapped or not-yet-biting attempt.
+      const effectiveMs =
+        timeoutMs !== undefined
+          ? capMs !== undefined
+            ? Math.min(timeoutMs, Math.max(0, remainingMs()))
+            : timeoutMs
+          : undefined;
+      const clippedToMs =
+        capMs !== undefined && effectiveMs !== undefined && effectiveMs < timeoutMs!
+          ? effectiveMs
+          : undefined;
+
+      try {
+        const makeCall = (
+          signal?: AbortSignal,
+        ): Promise<{
+          output: Record<string, unknown>;
+          resolvedParams: Record<string, unknown> | undefined;
+          handlerAbort?: { message: string };
+          handlerWarn?: string;
+        }> => {
+          if (stepDef?.execution === 'auto' && stepDef.uses_service !== undefined) {
+            return callAdapter(
+              stepDef,
+              definition,
+              effectiveOptions,
+              pendingRun,
+              rateLimiterRegistry,
+              signal,
+            );
+          } else if (stepDef?.execution === 'auto' && stepDef.handler !== undefined) {
+            return callHandler(stepDef, effectiveOptions, pendingRun, evidenceByStep, signal).then(
+              (result) => {
+                if (result.kind === 'abort') {
+                  return {
+                    output: {},
+                    resolvedParams: undefined,
+                    handlerAbort: { message: result.message },
+                  };
+                }
+                if (result.kind === 'warn') {
+                  return {
+                    output: result.output,
+                    resolvedParams: result.resolvedParams,
+                    handlerWarn: result.message,
+                  };
+                }
+                return { output: result.output, resolvedParams: result.resolvedParams };
+              },
+            );
+          } else {
+            return options
+              .dispatcher(options.command, effectiveInput, pendingRun, signal)
+              .then((result) => ({ output: result, resolvedParams: undefined }));
+          }
+        };
+        const callResult =
+          effectiveMs !== undefined
+            ? await withTimeout((signal) => makeCall(signal), effectiveMs, options.command)
+            : await makeCall();
+
+        // Handle graceful abort from a handler returning { abort: { message } }.
+        if (callResult.handlerAbort !== undefined) {
+          const abortMessage = callResult.handlerAbort.message;
+          const now = new Date();
+          const abortEvidence: EvidenceSnapshot = {
+            ...captureEvidence({
+              stepId: options.command,
+              startedAt: now,
+              completedAt: now,
+              input: effectiveInput,
+              output: { aborted: true, abort_message: abortMessage },
+              error: abortMessage,
+              ...(debugOutput !== undefined ? { debugOutput } : {}),
+            }),
+            status: 'skipped',
+          };
+          const withHandlerSkipped: RunRecord = {
+            ...pendingRun,
+            in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
+            // Delete the claim clock in the SAME mutation that removes the step (issue #101).
+            claims: omitClaim(pendingRun.claims, options.command),
+            evidence: [...pendingRun.evidence, abortEvidence],
+            skipped_steps: [...pendingRun.skipped_steps, options.command],
+          };
+          // #111: merge is load-bearing — it preserves any cascade details propagateSkips derives
+          // for OTHER now-unreachable steps alongside this step's own handler_abort tag.
+          const handlerAbortPropagated = propagateSkips(withHandlerSkipped, definition);
+          const withAllSkipped: RunRecord = {
+            ...withHandlerSkipped,
+            skipped_steps: handlerAbortPropagated.skipped,
+            skip_details: {
+              ...handlerAbortPropagated.details,
+              [options.command]: { kind: 'handler_abort' },
             },
+          };
+          const abortDraft: RunRecord = {
+            ...withAllSkipped,
+            terminal_state: true,
+            terminal_reason: `Handler '${options.command}' aborted the run: ${abortMessage}`,
+            aborted_at: {
+              step_id: options.command,
+              abort_message: abortMessage,
+            },
+          };
+          // NEW: a handler-abort now drains the abort/always finalizers before sealing
+          // (previously it sealed-and-returned immediately). Single seal write below.
+          const abortedRun = await buildFinalizedSeal(
+            definition,
+            abortDraft,
+            'abort',
+            options.registry,
           );
+          let persistedAbortRun: RunRecord | undefined;
+          try {
+            persistedAbortRun = await store.update(abortedRun);
+          } catch {
+            // Persist failed — return the in-memory run version.
+          }
+          return {
+            command: options.command,
+            run_id: options.runId,
+            run_version: (persistedAbortRun ?? abortedRun).version,
+            status: 'ok',
+            data: {},
+            evidence: [abortEvidence],
+            // Issue #140: was hardcoded `[]` — now threads traceWarnings (e.g. the programmatic
+            // on_timeout/idempotent gate advisory above) so it survives this settle path too.
+            warnings: mergeWarnings(traceWarnings),
+            errors: [],
+            context_hint: `Handler step '${options.command}' aborted the run: ${abortMessage}`,
+            run_phase: (persistedAbortRun ?? abortedRun).run_phase,
+            next_actions: [],
+          };
+        }
+
+        attemptOutput = callResult.output;
+        resolvedParams = callResult.resolvedParams;
+        currentWarn = callResult.handlerWarn;
+        if (resolvedParams !== undefined) {
+          inputTokenEstimate = Math.ceil(JSON.stringify(resolvedParams).length / 4);
+        }
+      } catch (err) {
+        if (err instanceof WorkflowError) {
+          attemptError = err;
         } else {
-          return options
-            .dispatcher(options.command, effectiveInput, pendingRun, signal)
-            .then((result) => ({ output: result, resolvedParams: undefined }));
-        }
-      };
-      const callResult =
-        effectiveMs !== undefined
-          ? await withTimeout((signal) => makeCall(signal), effectiveMs, options.command)
-          : await makeCall();
-
-      // Handle graceful abort from a handler returning { abort: { message } }.
-      if (callResult.handlerAbort !== undefined) {
-        const abortMessage = callResult.handlerAbort.message;
-        const now = new Date();
-        const abortEvidence: EvidenceSnapshot = {
-          ...captureEvidence({
+          const message = err instanceof Error ? err.message : String(err);
+          attemptError = new WorkflowError(`Dispatcher failed: ${message}`, {
+            code: 'ENGINE_INTERNAL',
+            category: 'ENGINE',
+            agentAction: 'stop',
+            retryable: false,
             stepId: options.command,
-            startedAt: now,
-            completedAt: now,
-            input: effectiveInput,
-            output: { aborted: true, abort_message: abortMessage },
-            error: abortMessage,
-            ...(debugOutput !== undefined ? { debugOutput } : {}),
-          }),
-          status: 'skipped',
-        };
-        const withHandlerSkipped: RunRecord = {
-          ...pendingRun,
-          in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
-          // Delete the claim clock in the SAME mutation that removes the step (issue #101).
-          claims: omitClaim(pendingRun.claims, options.command),
-          evidence: [...pendingRun.evidence, abortEvidence],
-          skipped_steps: [...pendingRun.skipped_steps, options.command],
-        };
-        // #111: merge is load-bearing — it preserves any cascade details propagateSkips derives
-        // for OTHER now-unreachable steps alongside this step's own handler_abort tag.
-        const handlerAbortPropagated = propagateSkips(withHandlerSkipped, definition);
-        const withAllSkipped: RunRecord = {
-          ...withHandlerSkipped,
-          skipped_steps: handlerAbortPropagated.skipped,
-          skip_details: {
-            ...handlerAbortPropagated.details,
-            [options.command]: { kind: 'handler_abort' },
-          },
-        };
-        const abortDraft: RunRecord = {
-          ...withAllSkipped,
-          terminal_state: true,
-          terminal_reason: `Handler '${options.command}' aborted the run: ${abortMessage}`,
-          aborted_at: {
-            step_id: options.command,
-            abort_message: abortMessage,
-          },
-        };
-        // NEW: a handler-abort now drains the abort/always finalizers before sealing
-        // (previously it sealed-and-returned immediately). Single seal write below.
-        const abortedRun = await buildFinalizedSeal(
-          definition,
-          abortDraft,
-          'abort',
-          options.registry,
-        );
-        let persistedAbortRun: RunRecord | undefined;
-        try {
-          persistedAbortRun = await store.update(abortedRun);
-        } catch {
-          // Persist failed — return the in-memory run version.
+          });
         }
-        return {
-          command: options.command,
-          run_id: options.runId,
-          run_version: (persistedAbortRun ?? abortedRun).version,
-          status: 'ok',
-          data: {},
-          evidence: [abortEvidence],
-          // Issue #140: was hardcoded `[]` — now threads traceWarnings (e.g. the programmatic
-          // on_timeout/idempotent gate advisory above) so it survives this settle path too.
-          warnings: mergeWarnings(traceWarnings),
-          errors: [],
-          context_hint: `Handler step '${options.command}' aborted the run: ${abortMessage}`,
-          run_phase: (persistedAbortRun ?? abortedRun).run_phase,
-          next_actions: [],
-        };
       }
 
-      attemptOutput = callResult.output;
-      resolvedParams = callResult.resolvedParams;
-      currentWarn = callResult.handlerWarn;
-      if (resolvedParams !== undefined) {
-        inputTokenEstimate = Math.ceil(JSON.stringify(resolvedParams).length / 4);
+      const completedAt = new Date();
+      const profile = stepDef?.agent_profile;
+      const profileData =
+        profile !== undefined ? definition.resolved_profiles?.[profile] : undefined;
+      const baseSnap = captureEvidence({
+        stepId: options.command,
+        startedAt,
+        completedAt,
+        input: effectiveInput,
+        output: attemptOutput,
+        ...(attemptError !== null ? { error: attemptError.message } : {}),
+        diagnostics: {
+          input_token_estimate: inputTokenEstimate,
+          precondition_trace: preconditionTrace,
+          // issue #220: success-settle stamp — a free diagnostic proving this step needed N prior
+          // rejections before finally succeeding ("succeeded after N rejections"). Only stamped on
+          // a SUCCESS settle. `run` here is the Step-1 read, so this reflects rejections accrued
+          // in PRIOR invocations only — a rejection in THIS invocation never reaches this call site
+          // (countRejection only runs from the Step 2b/2c catch, which always either returns or
+          // falls through toward terminalization, never toward dispatch).
+          ...(attemptError === null && (run.validation_rejections?.[options.command] ?? 0) > 0
+            ? { validation_rejections: run.validation_rejections![options.command] }
+            : {}),
+        },
+        ...(profileData !== undefined
+          ? { agentProfile: profile!, agentProfileHash: profileData.content_hash }
+          : {}),
+        ...(resolvedParams !== undefined ? { resolvedParams } : {}),
+        ...(currentWarn !== undefined ? { warn: currentWarn } : {}),
+        ...(debugOutput !== undefined ? { debugOutput } : {}),
+        ...(options.stepMeta?.toolCalls !== undefined
+          ? { toolCalls: options.stepMeta.toolCalls }
+          : {}),
+        // issue #140: PER-ATTEMPT value (may be smaller than the outer effectiveTimeoutSeconds once
+        // the cap starts clipping) — byte-identical to the pre-#140 outer value whenever capMs is
+        // undefined or hasn't bitten yet.
+        ...(effectiveMs !== undefined ? { effectiveTimeoutSeconds: effectiveMs / 1000 } : {}),
+        ...(clippedToMs !== undefined ? { clippedToMs } : {}),
+        // Gate trace to agent steps only — drop silently for auto/adapter/handler steps.
+        // When pre-normalized (WAL merge + schema validation ran), pass the pre-normalized
+        // result to avoid double normalization. Also handle WAL-only case (options.trace may
+        // be undefined while walEntries contributed entries via preNormalizedTrace).
+        ...(stepDef?.execution === 'agent' && (options.trace !== undefined || walEntries.length > 0)
+          ? preNormalizedTrace !== undefined
+            ? { normalizedTrace: preNormalizedTrace }
+            : { trace: options.trace ?? [] }
+          : {}),
+      });
+      const snap: EvidenceSnapshot =
+        retryConfig !== undefined ? { ...baseSnap, attempt: attemptNum } : baseSnap;
+      allEvidence.push(snap);
+
+      if (attemptError === null) {
+        output = attemptOutput;
+        dispatchError = null;
+        break;
       }
-    } catch (err) {
-      if (err instanceof WorkflowError) {
-        attemptError = err;
+
+      dispatchError = attemptError;
+      // SITE (b) — issue #140, post-attempt, AFTER dispatchError is set, BEFORE willRetry: the
+      // primary capExhausted setter (site (a) above only catches the loop-top clock-anomaly window;
+      // site (c) below re-checks once more right before an actual sleep). Fires on ANY dispatch
+      // error once the cap is spent, not just STEP_TIMEOUT — the cap bounds the step's total
+      // budget, regardless of which error exhausted it.
+      if (capMs !== undefined && remainingMs() <= 0) {
+        capExhausted = true;
+      }
+      const willRetry =
+        (retryConfig !== undefined && attemptError.retryable && attemptNum < maxAttempts) ||
+        // issue #140 (AMENDED): a STEP_TIMEOUT may ALSO retry in place when the step opted in via
+        // `retry.on_timeout: true` AND attested `idempotent: true` (the concurrency-safety gate).
+        // ALL SIX conjuncts are required; `capMs !== undefined` enforces opted⇒capped
+        // structurally — this disjunct is inert off the enforced auto class even for a hand-built
+        // definition bypassing the loader's E1 gate on a non-auto step, since capMs is undefined
+        // there (shouldEnforceTimeout false ⇒ enforceTimeout false ⇒ capMs undefined) — see R11 in
+        // the design record.
+        (attemptError.code === 'STEP_TIMEOUT' &&
+          capMs !== undefined &&
+          retryConfig?.on_timeout === true &&
+          stepDef!.idempotent === true &&
+          !capExhausted &&
+          attemptNum < maxAttempts);
+      if (willRetry) {
+        const baseBackoff = computeBackoff(retryConfig!, attemptNum);
+        const retryAfterMs =
+          attemptError instanceof WorkflowError && attemptError.retry_after !== undefined
+            ? attemptError.retry_after * 1000
+            : 0;
+        const waitMs = Math.max(baseBackoff, retryAfterMs);
+        // SITE (c) — issue #140, sleep guard, BEFORE every backoff/retry_after sleep (`>=`: an
+        // exact-fit sleep is doomed too — never sleep into a wall). dispatchError already holds the
+        // ACTUAL last error (e.g. a 429 with retry_after in its details); the post-loop wrap gate
+        // below decides whether/how to wrap it — this site only decides whether to sleep at all.
+        if (capMs !== undefined && sleepWouldExceedCap(Date.now() - capStart, waitMs, capMs)) {
+          capExhausted = true;
+          break;
+        }
+        await delayMs(waitMs);
       } else {
-        const message = err instanceof Error ? err.message : String(err);
-        attemptError = new WorkflowError(`Dispatcher failed: ${message}`, {
-          code: 'ENGINE_INTERNAL',
-          category: 'ENGINE',
-          agentAction: 'stop',
-          retryable: false,
-          stepId: options.command,
-        });
+        break;
       }
     }
+  } // end issue #220 `if (!bypassDispatch)` — the dispatch loop
 
-    const completedAt = new Date();
-    const profile = stepDef?.agent_profile;
-    const profileData = profile !== undefined ? definition.resolved_profiles?.[profile] : undefined;
-    const baseSnap = captureEvidence({
+  if (bypassDispatch) {
+    // issue #220: terminalize. `dispatchError` is PRE-SET to the minted VALIDATION_EXHAUSTED error
+    // HERE, BEFORE the retry-wrap block below — that block's own `!bypassDispatch` guard is what
+    // then keeps it from being wrapped: without dispatchError being non-null at this exact point,
+    // a hand-built `max_attempts: 0` definition's retry-wrap condition
+    // (`attemptsUsed(0) === maxAttempts(0)`) would trivially hold and wrap the terminal code into
+    // STEP_RETRY_EXHAUSTED, robbing Step 5 of the discriminator it needs. ONE synthesized evidence
+    // snapshot mirrors the real dispatch-loop capture at its own `captureEvidence` call site
+    // VERBATIM — including the normalizedTrace/trace spread — so the WAL delete at Step 5 never
+    // destroys adopted post-claim lines unrecorded (issue #185 Finding 2 would otherwise be
+    // reintroduced inside this feature).
+    dispatchError = exhaustion;
+    const exhaustedAt = new Date();
+    const exhaustedSnap: EvidenceSnapshot = captureEvidence({
       stepId: options.command,
-      startedAt,
-      completedAt,
+      startedAt: exhaustedAt,
+      completedAt: exhaustedAt,
       input: effectiveInput,
-      output: attemptOutput,
-      ...(attemptError !== null ? { error: attemptError.message } : {}),
+      output: {},
+      error: exhaustion!.message,
       diagnostics: {
         input_token_estimate: inputTokenEstimate,
         precondition_trace: preconditionTrace,
+        validation_rejections: exhaustion!.details['rejections'] as number,
       },
-      ...(profileData !== undefined
-        ? { agentProfile: profile!, agentProfileHash: profileData.content_hash }
-        : {}),
-      ...(resolvedParams !== undefined ? { resolvedParams } : {}),
-      ...(currentWarn !== undefined ? { warn: currentWarn } : {}),
       ...(debugOutput !== undefined ? { debugOutput } : {}),
-      ...(options.stepMeta?.toolCalls !== undefined
-        ? { toolCalls: options.stepMeta.toolCalls }
-        : {}),
-      // issue #140: PER-ATTEMPT value (may be smaller than the outer effectiveTimeoutSeconds once
-      // the cap starts clipping) — byte-identical to the pre-#140 outer value whenever capMs is
-      // undefined or hasn't bitten yet.
-      ...(effectiveMs !== undefined ? { effectiveTimeoutSeconds: effectiveMs / 1000 } : {}),
-      ...(clippedToMs !== undefined ? { clippedToMs } : {}),
-      // Gate trace to agent steps only — drop silently for auto/adapter/handler steps.
-      // When pre-normalized (WAL merge + schema validation ran), pass the pre-normalized
-      // result to avoid double normalization. Also handle WAL-only case (options.trace may
-      // be undefined while walEntries contributed entries via preNormalizedTrace).
+      // Gate trace to agent steps only — drop silently for auto/adapter/handler steps. Mirrors
+      // the real dispatch-loop capture's own trace-spread conjunct exactly (execution-loop.ts's
+      // per-attempt captureEvidence call, further above).
       ...(stepDef?.execution === 'agent' && (options.trace !== undefined || walEntries.length > 0)
         ? preNormalizedTrace !== undefined
           ? { normalizedTrace: preNormalizedTrace }
           : { trace: options.trace ?? [] }
         : {}),
     });
-    const snap: EvidenceSnapshot =
-      retryConfig !== undefined ? { ...baseSnap, attempt: attemptNum } : baseSnap;
-    allEvidence.push(snap);
-
-    if (attemptError === null) {
-      output = attemptOutput;
-      dispatchError = null;
-      break;
-    }
-
-    dispatchError = attemptError;
-    // SITE (b) — issue #140, post-attempt, AFTER dispatchError is set, BEFORE willRetry: the
-    // primary capExhausted setter (site (a) above only catches the loop-top clock-anomaly window;
-    // site (c) below re-checks once more right before an actual sleep). Fires on ANY dispatch
-    // error once the cap is spent, not just STEP_TIMEOUT — the cap bounds the step's total
-    // budget, regardless of which error exhausted it.
-    if (capMs !== undefined && remainingMs() <= 0) {
-      capExhausted = true;
-    }
-    const willRetry =
-      (retryConfig !== undefined && attemptError.retryable && attemptNum < maxAttempts) ||
-      // issue #140 (AMENDED): a STEP_TIMEOUT may ALSO retry in place when the step opted in via
-      // `retry.on_timeout: true` AND attested `idempotent: true` (the concurrency-safety gate).
-      // ALL SIX conjuncts are required; `capMs !== undefined` enforces opted⇒capped
-      // structurally — this disjunct is inert off the enforced auto class even for a hand-built
-      // definition bypassing the loader's E1 gate on a non-auto step, since capMs is undefined
-      // there (shouldEnforceTimeout false ⇒ enforceTimeout false ⇒ capMs undefined) — see R11 in
-      // the design record.
-      (attemptError.code === 'STEP_TIMEOUT' &&
-        capMs !== undefined &&
-        retryConfig?.on_timeout === true &&
-        stepDef!.idempotent === true &&
-        !capExhausted &&
-        attemptNum < maxAttempts);
-    if (willRetry) {
-      const baseBackoff = computeBackoff(retryConfig!, attemptNum);
-      const retryAfterMs =
-        attemptError instanceof WorkflowError && attemptError.retry_after !== undefined
-          ? attemptError.retry_after * 1000
-          : 0;
-      const waitMs = Math.max(baseBackoff, retryAfterMs);
-      // SITE (c) — issue #140, sleep guard, BEFORE every backoff/retry_after sleep (`>=`: an
-      // exact-fit sleep is doomed too — never sleep into a wall). dispatchError already holds the
-      // ACTUAL last error (e.g. a 429 with retry_after in its details); the post-loop wrap gate
-      // below decides whether/how to wrap it — this site only decides whether to sleep at all.
-      if (capMs !== undefined && sleepWouldExceedCap(Date.now() - capStart, waitMs, capMs)) {
-        capExhausted = true;
-        break;
-      }
-      await delayMs(waitMs);
-    } else {
-      break;
-    }
+    allEvidence.push(exhaustedSnap);
   }
 
   if (
+    !bypassDispatch &&
     dispatchError !== null &&
     retryConfig !== undefined &&
     (attemptsUsed === maxAttempts || capExhausted)

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -1081,6 +1081,8 @@ export async function executeStep(
         {
           code: 'VALIDATION_EXHAUSTED',
           category: 'VALIDATION',
+          // observationally inert on this path (Step-5 terminal translation supplies 'stop');
+          // kept for error-catalog coherence
           agentAction: 'stop',
           retryable: false,
           details: {
@@ -1945,6 +1947,13 @@ export async function executeStep(
     // reintroduced inside this feature).
     dispatchError = exhaustion;
     const exhaustedAt = new Date();
+    // issue #220 correction (deliverable 1 — snapshot completeness): these two derivation lines
+    // replicate the dispatch-loop's own `profile`/`profileData` consts VERBATIM (that block's
+    // own locals are out of scope here, but `stepDef`/`definition` — the two inputs they're
+    // derived from — are both still in scope at this bypass block).
+    const exhaustedProfile = stepDef?.agent_profile;
+    const exhaustedProfileData =
+      exhaustedProfile !== undefined ? definition.resolved_profiles?.[exhaustedProfile] : undefined;
     const exhaustedSnap: EvidenceSnapshot = captureEvidence({
       stepId: options.command,
       startedAt: exhaustedAt,
@@ -1957,6 +1966,12 @@ export async function executeStep(
         precondition_trace: preconditionTrace,
         validation_rejections: exhaustion!.details['rejections'] as number,
       },
+      ...(exhaustedProfileData !== undefined
+        ? { agentProfile: exhaustedProfile!, agentProfileHash: exhaustedProfileData.content_hash }
+        : {}),
+      ...(options.stepMeta?.toolCalls !== undefined
+        ? { toolCalls: options.stepMeta.toolCalls }
+        : {}),
       ...(debugOutput !== undefined ? { debugOutput } : {}),
       // Gate trace to agent steps only — drop silently for auto/adapter/handler steps. Mirrors
       // the real dispatch-loop capture's own trace-spread conjunct exactly (execution-loop.ts's

--- a/packages/core/src/engine/run-health.ts
+++ b/packages/core/src/engine/run-health.ts
@@ -42,9 +42,13 @@
 //      caller still classifies correctly on age alone.
 //
 // Honest-admission rule (Celery-corrected, record §1): `never_claimed_idle`'s reason text NEVER
-// claims rejection — "parked with no claimed step, idle", never "rejected" or "stuck". A rejection
-// COUNT would require sidecar evidence this function structurally cannot see (classification here
-// is write-free by construction) — that is #219's future enrichment slot, not this one's.
+// claims rejection — "parked with no claimed step, idle", never "rejected" or "stuck". Rescoped
+// (issue #220): the two COUNTED validation-rejection codes (VALIDATION_INPUT_SCHEMA/
+// VALIDATION_OUTPUT_SCHEMA) are now record-carried since #220 (`RunRecord.validation_rejections`)
+// — but this function still does not render that count; surfacing it is #219's future enrichment
+// slot, not this one's. A TRACE-rejection count (VALIDATION_TRACE_SCHEMA, uncounted v1 — see
+// execution-loop.ts's countRejection doc) still requires sidecar evidence this function
+// structurally cannot see (classification here is write-free by construction).
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import { classifyInProgressClaims } from './claim-liveness.js';

--- a/packages/core/src/engine/validation-exhaustion.test.ts
+++ b/packages/core/src/engine/validation-exhaustion.test.ts
@@ -1,0 +1,761 @@
+// Tests for issue #220 PR-1 — bounded validation-rejection exhaustion (countRejection +
+// VALIDATION_EXHAUSTED terminalization). Letter labels match the implementation prompt's pin
+// set / design record §5 letter map exactly, for mechanical diffing against mutation probes.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeStep, DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD } from './execution-loop.js';
+import type { StepDispatcher } from './execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { InMemoryTraceBufferStore } from '../store/trace-buffer-store.js';
+import { WorkflowError } from '../types/workflow-error.js';
+import type { WorkflowDefinition, StepDefinition } from '../types/workflow-definition.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { RunStore, LoadBearingRunRecordField } from '../store/store-interface.js';
+
+const echoDispatcher: StepDispatcher = async (_step, input) => ({ ...input });
+
+/** Single-step agent workflow, output_schema requiring `category`. */
+function makeDef(
+  stepOverrides: Partial<StepDefinition> = {},
+  extraSteps: Record<string, StepDefinition> = {},
+): WorkflowDefinition {
+  return {
+    id: 'vx-wf',
+    name: 'VX WF',
+    version: 1,
+    steps: {
+      draft: {
+        description: 'Draft',
+        execution: 'agent',
+        output_schema: {
+          type: 'object',
+          required: ['category'],
+          properties: { category: { type: 'string' } },
+        },
+        ...stepOverrides,
+      },
+      ...extraSteps,
+    },
+  };
+}
+
+const INVALID_OUTPUT = {}; // missing 'category' — fails output_schema
+const VALID_OUTPUT = { category: 'ok' };
+
+describe('issue #220 PR-1 — bounded validation-rejection exhaustion', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-vx-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  it('(a) bump-and-report: a counted, non-terminal rejection reports the PRE-write version, and the count IS persisted', async () => {
+    const def = makeDef();
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    const versionBefore = run.version;
+
+    const envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('VALIDATION_OUTPUT_SCHEMA');
+    expect(envelope.run_version).toBe(versionBefore); // bump-and-report
+
+    const after = await store.get(run.id);
+    expect(after.version).toBe(versionBefore + 1); // the CAS write DID actually happen
+    expect(after.validation_rejections?.['draft']).toBe(1);
+    expect(after.terminal_state).toBe(false);
+  });
+
+  it('(b) valid-always-wins: persisted count already AT threshold, then a VALID submission ⇒ success settle, never exhaustion', async () => {
+    const def = makeDef();
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD },
+    });
+
+    const envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: VALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('ok');
+    const after = await store.get(run.id);
+    expect(after.completed_steps).toContain('draft');
+    expect(after.terminal_state).toBe(true); // single-step workflow
+    expect(after.failed_steps).not.toContain('draft');
+  });
+
+  it("(c) exactly-one-terminalizer: the winner terminalizes with VALIDATION_EXHAUSTED; a concurrent loser's retry lands after the winner's count-write and before its claim ⇒ the loser gets the ALREADY_CLAIMED-class blocked envelope, never a second terminal settle", async () => {
+    // --- winner: a real, straightforward invocation reaching threshold ---
+    const def = makeDef();
+    const { run: winnerRun } = await store.create({
+      workflowId: def.id,
+      workflowVersion: 1,
+      params: {},
+    });
+    await store.update({
+      ...winnerRun,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+    const winnerEnvelope = await executeStep(store, def, {
+      runId: winnerRun.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    expect(winnerEnvelope.status).toBe('error');
+    expect(winnerEnvelope.error_code).toBe('VALIDATION_EXHAUSTED');
+    const winnerAfter = await store.get(winnerRun.id);
+    expect(winnerAfter.terminal_state).toBe(true);
+    expect(winnerAfter.failed_steps).toContain('draft');
+
+    // --- loser: a scripted store reproducing the EXACT race (reclaim-step.test.ts precedent) ---
+    // getIdx 0 → Step 1's read (STALE: count = threshold-1, unclaimed).
+    // update 0 → the FIRST CAS (keyed on the stale snapshot) → MISMATCH (winner already wrote).
+    // getIdx 1 → the retry's read: lands AFTER the winner's count-write, BEFORE the winner's claim
+    //            (count = threshold, still unclaimed, not terminal, no pending_gate).
+    // update 1 → the retry's OWN CAS → succeeds (this is the loser's own re-increment).
+    // getIdx 2 → the claim-catch's own fresh re-read (after claimStep throws) — reuses the last
+    //            scripted record (array exhausted, held at its last entry).
+    // claimStep → throws STATE_STEP_ALREADY_CLAIMED (the winner claimed first).
+    const base: RunRecord = {
+      id: 'loser-run',
+      workflow_id: def.id,
+      workflow_version: 1,
+      completed_steps: [],
+      in_progress_steps: [],
+      failed_steps: [],
+      skipped_steps: [],
+      run_phase: 'running',
+      version: 10,
+      params: {},
+      evidence: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      terminal_state: false,
+    };
+    const staleSnapshot: RunRecord = {
+      ...base,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    };
+    const midSnapshot: RunRecord = {
+      ...base,
+      version: 11,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD },
+    };
+    let getIdx = 0;
+    let updateIdx = 0;
+    const records = [staleSnapshot, midSnapshot];
+    const loserStore = {
+      get: async () => records[Math.min(getIdx++, records.length - 1)]!,
+      update: async (rec: RunRecord) => {
+        const idx = updateIdx++;
+        if (idx === 0) {
+          throw new WorkflowError('Version conflict', {
+            code: 'STATE_SNAPSHOT_MISMATCH',
+            category: 'STATE',
+            agentAction: 'report_to_user',
+            retryable: true,
+          });
+        }
+        return { ...rec, version: rec.version + 1 };
+      },
+      claimStep: async (runId: string, stepName: string) => {
+        throw new WorkflowError(`Step '${stepName}' is already claimed`, {
+          code: 'STATE_STEP_ALREADY_CLAIMED',
+          category: 'STATE',
+          agentAction: 'resolve_precondition',
+          retryable: false,
+          details: { runId, stepName },
+        });
+      },
+    } as unknown as RunStore;
+
+    const loserEnvelope = await executeStep(loserStore, def, {
+      runId: 'loser-run',
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(loserEnvelope.status).toBe('blocked');
+    expect(loserEnvelope.context_hint).toContain('already claimed');
+    expect(updateIdx).toBe(2); // first CAS (mismatch) + retry CAS (succeeded) — never a third write
+  });
+
+  it("(d) enforce-gate yield: an exhausting call under trace_validation_mode enforce with an invalid trace terminalizes (no pre-claim VALIDATION_TRACE_SCHEMA return); a non-exhausting invalid-trace call still returns today's VALIDATION_TRACE_SCHEMA rejection", async () => {
+    const def = makeDef({
+      trace_schema: {
+        type: 'array',
+        items: { type: 'object', properties: { event: { enum: ['required_event_name'] } } },
+      },
+      trace_validation_mode: 'enforce',
+    });
+    const invalidTrace = [{ event: 'thinking' }]; // violates the `event` enum above
+
+    // Non-exhausting: valid output, but the enforce-mode trace schema check fails.
+    const { run: freshRun } = await store.create({
+      workflowId: def.id,
+      workflowVersion: 1,
+      params: {},
+    });
+    const nonExhausting = await executeStep(store, def, {
+      runId: freshRun.id,
+      command: 'draft',
+      input: VALID_OUTPUT,
+      trace: invalidTrace,
+      dispatcher: echoDispatcher,
+    });
+    expect(nonExhausting.status).toBe('error');
+    expect(nonExhausting.error_code).toBe('VALIDATION_TRACE_SCHEMA');
+    const afterNonExhausting = await store.get(freshRun.id);
+    expect(afterNonExhausting.in_progress_steps).not.toContain('draft'); // never claimed
+
+    // Exhausting: count at threshold-1, invalid OUTPUT (arms exhaustion via 2c) AND an invalid
+    // trace (would fail the enforce gate on its own) — the enforce-gate must YIELD, not return.
+    const { run: hotRun } = await store.create({
+      workflowId: def.id,
+      workflowVersion: 1,
+      params: {},
+    });
+    await store.update({
+      ...hotRun,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+    const exhausting = await executeStep(store, def, {
+      runId: hotRun.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      trace: invalidTrace,
+      dispatcher: echoDispatcher,
+    });
+    expect(exhausting.status).toBe('error');
+    expect(exhausting.error_code).toBe('VALIDATION_EXHAUSTED');
+    const afterExhausting = await store.get(hotRun.id);
+    expect(afterExhausting.terminal_state).toBe(true);
+    expect(afterExhausting.failed_steps).toContain('draft');
+  });
+
+  it('(e) synthesized-snapshot trace carriage: an exhausting call with a submitted trace carries the normalized trace on the failure evidence', async () => {
+    const def = makeDef();
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+
+    const envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      trace: [{ event: 'thinking', data: { note: 'considering' } }],
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('VALIDATION_EXHAUSTED');
+    const after = await store.get(run.id);
+    const exhaustedEvidence = after.evidence.find(
+      (e) => e.step_id === 'draft' && e.status === 'error',
+    );
+    expect(exhaustedEvidence).toBeDefined();
+    expect(exhaustedEvidence?.trace).toBeDefined();
+    expect(exhaustedEvidence?.trace?.length).toBe(1);
+    expect(exhaustedEvidence?.trace?.[0]?.event).toBe('thinking');
+    expect(exhaustedEvidence?.diagnostics?.validation_rejections).toBe(
+      DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
+    );
+  });
+
+  it('(f) wrap-block guard: a hand-built max_attempts:0 definition (bypassing the loader) still terminalizes as VALIDATION_EXHAUSTED, never wrapped into STEP_RETRY_EXHAUSTED', async () => {
+    const def = makeDef({
+      retry: { max_attempts: 0, backoff: 'fixed', base_delay_ms: 0 },
+    });
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+
+    const envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('VALIDATION_EXHAUSTED');
+    expect(envelope.error_code).not.toBe('STEP_RETRY_EXHAUSTED');
+  });
+
+  it('(j) success-settle stamp: reject twice then succeed ⇒ the settle evidence carries diagnostics.validation_rejections === 2', async () => {
+    const def = makeDef();
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    const success = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: VALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(success.status).toBe('ok');
+    const after = await store.get(run.id);
+    const settleEvidence = after.evidence.find(
+      (e) => e.step_id === 'draft' && e.status === 'success',
+    );
+    expect(settleEvidence?.diagnostics?.validation_rejections).toBe(2);
+    expect(after.validation_rejections?.['draft']).toBe(2); // count itself is NEVER reset
+  });
+
+  it("(k) store honesty advisory: a store not declaring 'validation_rejections' draws the softened durability warning on a counted rejection", async () => {
+    class UndeclaredFieldStore extends JsonFileStore {
+      override readonly persistedRunRecordFields: ReadonlySet<LoadBearingRunRecordField> = new Set([
+        'capability_blocks',
+        'workflow_context_snapshots',
+        'extension_identity',
+      ]); // deliberately mirrors the pre-#220 3-member set — validation_rejections NOT declared
+    }
+    const undeclaredStore = new UndeclaredFieldStore(dir);
+    const def = makeDef();
+    const { run } = await undeclaredStore.create({
+      workflowId: def.id,
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(undeclaredStore, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.warnings?.join(' ')).toContain(
+      'rejection counting not declared durable on this store',
+    );
+  });
+
+  it('(l) countdown with a PER-STEP THRESHOLD OVERRIDE: rejections 1, 2 with threshold: 2 ⇒ the SECOND rejection terminalizes at the OVERRIDE value, not the hardcoded default', async () => {
+    const def = makeDef({ validation_exhaustion: { threshold: 2 } });
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+    const first = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    expect(first.status).toBe('error');
+    expect(first.error_code).toBe('VALIDATION_OUTPUT_SCHEMA');
+    expect(first.error_details?.['rejections']).toBe(1);
+    expect(first.error_details?.['threshold']).toBe(2);
+
+    const second = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    expect(second.status).toBe('error');
+    expect(second.error_code).toBe('VALIDATION_EXHAUSTED');
+    expect(second.error_details?.['rejections']).toBe(2);
+    expect(second.error_details?.['threshold']).toBe(2);
+  });
+
+  it('(m) CAS-swallow: a forced double-CAS-failure produces the not-persisted warning, still delivers the envelope, and the FOLLOWING rejection re-converges the persisted count', async () => {
+    // A wrapper whose get() bumps the real store on EVERY call as a side effect (but returns the
+    // pre-bump snapshot) — this forces BOTH the first CAS (keyed on Step 1's snapshot) AND the
+    // retry's own CAS (keyed on the retry's own snapshot) to lose to a "concurrent" writer.
+    class DoubleFailureStore extends JsonFileStore {
+      override async get(runId: string): Promise<RunRecord> {
+        const rec = await super.get(runId);
+        await super.update({ ...rec });
+        return rec;
+      }
+    }
+    const doubleFailureStore = new DoubleFailureStore(dir);
+    const def = makeDef();
+    const { run } = await doubleFailureStore.create({
+      workflowId: def.id,
+      workflowVersion: 1,
+      params: {},
+    });
+
+    const envelope = await executeStep(doubleFailureStore, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('VALIDATION_OUTPUT_SCHEMA'); // never exhausted — nothing persisted
+    expect(envelope.warnings?.join(' ')).toContain('rejection count not persisted');
+
+    // The double-failure attempt left the real stored count untouched (both its writes lost).
+    const afterDoubleFailure = await store.get(run.id);
+    expect(afterDoubleFailure.validation_rejections?.['draft'] ?? 0).toBe(0);
+
+    // The FOLLOWING rejection, against a plain (non-double-failing) store, re-converges: it
+    // starts counting from the REAL stored value (0), not from the swallowed attempt's "1".
+    const following = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    expect(following.error_details?.['rejections']).toBe(1);
+    const afterFollowing = await store.get(run.id);
+    expect(afterFollowing.validation_rejections?.['draft']).toBe(1);
+  });
+
+  it("(n) never-reset across steps: A rejects 3× → B settles → A rejects 3× more ⇒ VALIDATION_EXHAUSTED on A's 6th rejection (settled steps simply leave the eligible set — they never reset another step's counter)", async () => {
+    const def: WorkflowDefinition = {
+      id: 'vx-two-step-wf',
+      name: 'VX Two Step',
+      version: 1,
+      steps: {
+        A: {
+          description: 'A',
+          execution: 'agent',
+          output_schema: {
+            type: 'object',
+            required: ['category'],
+            properties: { category: { type: 'string' } },
+          },
+        },
+        B: { description: 'B', execution: 'auto' },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+    for (let i = 0; i < 3; i++) {
+      const r = await executeStep(store, def, {
+        runId: run.id,
+        command: 'A',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+      expect(r.status).toBe('error');
+      expect(r.error_code).toBe('VALIDATION_OUTPUT_SCHEMA');
+    }
+
+    const bResult = await executeStep(store, def, {
+      runId: run.id,
+      command: 'B',
+      input: {},
+      dispatcher: echoDispatcher,
+    });
+    expect(bResult.status).toBe('ok');
+    const afterB = await store.get(run.id);
+    expect(afterB.completed_steps).toContain('B');
+    expect(afterB.validation_rejections?.['A']).toBe(3); // B settling never touched A's counter
+
+    let last;
+    for (let i = 0; i < 3; i++) {
+      last = await executeStep(store, def, {
+        runId: run.id,
+        command: 'A',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+    }
+    expect(last?.status).toBe('error');
+    expect(last?.error_code).toBe('VALIDATION_EXHAUSTED');
+    const final = await store.get(run.id);
+    expect(final.validation_rejections?.['A']).toBe(6);
+    expect(final.terminal_state).toBe(true);
+  });
+
+  it('(o) pooled-across-writers: two distinct writer nonces alternate rejections ⇒ terminalizes at the pooled threshold (never per-nonce-partitioned)', async () => {
+    const def = makeDef();
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    // Declares writer_nonce_carriage so effectiveClaimantNonce genuinely differs between the two
+    // nonces at the adoption layer — countRejection itself never reads nonce at all, but wiring
+    // real nonce differentiation is what makes a per-nonce-keying mutant visible (undefined≡
+    // undefined would otherwise mask it).
+    const traceBufferStore = new InMemoryTraceBufferStore();
+
+    let last;
+    for (let i = 0; i < DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD; i++) {
+      last = await executeStep(store, def, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+        traceBufferStore,
+        writerNonce: i % 2 === 0 ? 'nonce-A' : 'nonce-B',
+      });
+    }
+
+    expect(last?.status).toBe('error');
+    expect(last?.error_code).toBe('VALIDATION_EXHAUSTED');
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['draft']).toBe(DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD);
+  });
+
+  it('(p) both-schemas single increment: input+output schemas both declared, an input-invalid threshold call increments EXACTLY once and details.last_error carries the 2b (input-schema) code', async () => {
+    const def = makeDef({
+      input_schema: {
+        type: 'object',
+        required: ['x'],
+        properties: { x: { type: 'string' } },
+      },
+      // output_schema (required: category) inherited from makeDef's base
+    });
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+
+    // Missing BOTH 'x' (input_schema) and 'category' (output_schema) — 2b fails first.
+    const envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: {},
+      dispatcher: echoDispatcher,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('VALIDATION_EXHAUSTED');
+    const lastAjvErrors = envelope.error_details?.['last_ajv_errors'] as
+      | Array<{ instancePath?: string }>
+      | undefined;
+    // The 2b (input-schema) ajv error set is about the MISSING 'x' — never mentions 'category'.
+    expect(JSON.stringify(lastAjvErrors)).not.toContain('category');
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['draft']).toBe(DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD); // exactly ONE increment, not two
+  });
+
+  describe('(q) retry-countability, TWO-WITNESS', () => {
+    it('(q1) abandon-mid-count ⇒ NO post-terminal write (the CAS-failure retry drops and swallows once the fresh record is terminal)', async () => {
+      const def = makeDef();
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      class AbandonMidCountStore extends JsonFileStore {
+        private triggered = false;
+        override async get(runId: string): Promise<RunRecord> {
+          const rec = await super.get(runId);
+          if (!this.triggered) {
+            this.triggered = true;
+            // Simulate a concurrent abandon landing between Step 1's read and countRejection's
+            // first CAS — the CAS below will be keyed on this STALE (pre-abandon) snapshot.
+            await super.update({
+              ...rec,
+              terminal_state: true,
+              terminal_reason: 'abandoned mid-count (test)',
+            });
+          }
+          return rec;
+        }
+      }
+      const abandonStore = new AbandonMidCountStore(dir);
+
+      const envelope = await executeStep(abandonStore, def, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      expect(envelope.status).toBe('error');
+      expect(envelope.error_code).toBe('VALIDATION_OUTPUT_SCHEMA'); // never exhausted — dropped
+      const after = await store.get(run.id);
+      expect(after.terminal_state).toBe(true); // the abandon itself persisted
+      expect(after.validation_rejections?.['draft'] ?? 0).toBe(0); // NO post-terminal count write
+    });
+
+    it('(q2) a concurrent VALID claim landing between the first-CAS-failure and the retry ⇒ the retry performs NO write, and the valid settle SUCCEEDS untouched', async () => {
+      // TWO-STEP workflow (deliberate — discriminates the ELIGIBILITY conjunct from the
+      // terminal_state conjunct): 'other' has no dependency on 'draft' and stays pending after
+      // 'draft' settles, so the RUN itself never goes terminal — only 'draft' itself becomes
+      // ineligible (already settled). A single-step fixture would make BOTH conjuncts trip
+      // together (the lone step settling always terminates a single-step run), masking whichever
+      // one a mutant dropped.
+      const def = makeDef({}, { other: { description: 'Other', execution: 'auto' } });
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      let validSettleEnvelope: Awaited<ReturnType<typeof executeStep>> | undefined;
+      class ConcurrentValidSettleStore extends JsonFileStore {
+        private triggered = false;
+        constructor(
+          runsDir: string,
+          private def: WorkflowDefinition,
+        ) {
+          super(runsDir);
+        }
+        override async get(runId: string): Promise<RunRecord> {
+          const rec = await super.get(runId);
+          if (!this.triggered) {
+            this.triggered = true;
+            // A genuinely CONCURRENT valid submission settles the step for real, between THIS
+            // read (Step 1's snapshot) and countRejection's first CAS — which will therefore be
+            // keyed on a now-stale version and fail.
+            validSettleEnvelope = await executeStep(this, this.def, {
+              runId,
+              command: 'draft',
+              input: VALID_OUTPUT,
+              dispatcher: echoDispatcher,
+            });
+          }
+          return rec;
+        }
+      }
+      const concurrentStore = new ConcurrentValidSettleStore(dir, def);
+
+      const rejectingEnvelope = await executeStep(concurrentStore, def, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      expect(validSettleEnvelope?.status).toBe('ok');
+      expect(rejectingEnvelope.status).toBe('error');
+      expect(rejectingEnvelope.error_code).toBe('VALIDATION_OUTPUT_SCHEMA'); // never exhausted
+      const after = await store.get(run.id);
+      expect(after.completed_steps).toContain('draft'); // the valid settle's own success
+      expect(after.validation_rejections?.['draft'] ?? 0).toBe(0); // retry performed NO write
+    });
+  });
+
+  it('(u) trace-exclusion negative: threshold+1 enforce-mode TRACE rejections never count, and the step stays claimable', async () => {
+    const def = makeDef({
+      trace_schema: {
+        type: 'array',
+        items: { type: 'object', properties: { event: { enum: ['required_event_name'] } } },
+      },
+      trace_validation_mode: 'enforce',
+    });
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    const invalidTrace = [{ event: 'thinking' }];
+
+    for (let i = 0; i < DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD + 1; i++) {
+      const r = await executeStep(store, def, {
+        runId: run.id,
+        command: 'draft',
+        input: VALID_OUTPUT,
+        trace: invalidTrace,
+        dispatcher: echoDispatcher,
+      });
+      expect(r.status).toBe('error');
+      expect(r.error_code).toBe('VALIDATION_TRACE_SCHEMA');
+    }
+
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['draft']).toBeUndefined(); // never counted
+    expect(after.in_progress_steps).not.toContain('draft'); // still claimable
+
+    // Prove it's still genuinely claimable: a valid submission (with a schema-conformant trace)
+    // succeeds outright — never exhausted, confirming the prior threshold+1 rejections left
+    // zero durable trace.
+    const success = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: VALID_OUTPUT,
+      trace: [{ event: 'required_event_name' }],
+      dispatcher: echoDispatcher,
+    });
+    expect(success.status).toBe('ok');
+  });
+
+  it('(v) auto-step-exclusion negative: an auto step with repeated INPUT_SCHEMA rejections is never counted', async () => {
+    const def: WorkflowDefinition = {
+      id: 'vx-auto-wf',
+      name: 'VX Auto',
+      version: 1,
+      steps: {
+        work: {
+          description: 'Work',
+          execution: 'auto',
+          handler: 'noop',
+          input_schema: {
+            type: 'object',
+            required: ['x'],
+            properties: { x: { type: 'string' } },
+          },
+        },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+    for (let i = 0; i < DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD + 1; i++) {
+      const r = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: echoDispatcher,
+      });
+      expect(r.status).toBe('error');
+      expect(r.error_code).toBe('VALIDATION_INPUT_SCHEMA');
+    }
+
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['work']).toBeUndefined();
+    expect(after.in_progress_steps).not.toContain('work');
+  });
+
+  it('(w) INPUT_SCHEMA-only exhaustion positive: an agent step with ONLY input_schema (no output_schema) still terminalizes on repeated input rejections', async () => {
+    const def: WorkflowDefinition = {
+      id: 'vx-input-only-wf',
+      name: 'VX Input Only',
+      version: 1,
+      steps: {
+        draft: {
+          description: 'Draft',
+          execution: 'agent',
+          input_schema: {
+            type: 'object',
+            required: ['x'],
+            properties: { x: { type: 'string' } },
+          },
+        },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+    let last;
+    for (let i = 0; i < DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD; i++) {
+      last = await executeStep(store, def, {
+        runId: run.id,
+        command: 'draft',
+        input: {},
+        dispatcher: echoDispatcher,
+      });
+    }
+
+    expect(last?.status).toBe('error');
+    expect(last?.error_code).toBe('VALIDATION_EXHAUSTED');
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['draft']).toBe(DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD);
+    expect(after.terminal_state).toBe(true);
+  });
+});

--- a/packages/core/src/engine/validation-exhaustion.test.ts
+++ b/packages/core/src/engine/validation-exhaustion.test.ts
@@ -249,7 +249,12 @@ describe('issue #220 PR-1 — bounded validation-rejection exhaustion', () => {
   });
 
   it('(e) synthesized-snapshot trace carriage: an exhausting call with a submitted trace carries the normalized trace on the failure evidence', async () => {
-    const def = makeDef();
+    const def = {
+      ...makeDef({ agent_profile: 'reviewer' }),
+      resolved_profiles: {
+        reviewer: { content: 'You are a reviewer.', content_hash: 'sha256:test-hash' },
+      },
+    };
     const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
     await store.update({
       ...run,
@@ -291,6 +296,10 @@ describe('issue #220 PR-1 — bounded validation-rejection exhaustion', () => {
     // exhausted step must not silently drop agent-supplied toolCalls.
     expect(exhaustedEvidence?.tool_calls).toHaveLength(1);
     expect(exhaustedEvidence?.tool_calls?.[0]?.tool).toBe('get_pull_request');
+    // issue #220 correction 2 — the profile spread was UNPINNED (deleting it left all tests
+    // green): an exhausted step must not silently drop agent-profile attribution either.
+    expect(exhaustedEvidence?.agent_profile).toBe('reviewer');
+    expect(exhaustedEvidence?.agent_profile_hash).toBe('sha256:test-hash');
   });
 
   it('(e) correction — WAL-variant: an exhausting call with a BARE WAL line (no options.trace at all) still carries the WAL-originated line on the failure evidence — the discriminating witness a submitted-trace-only fixture cannot provide', async () => {

--- a/packages/core/src/engine/validation-exhaustion.test.ts
+++ b/packages/core/src/engine/validation-exhaustion.test.ts
@@ -256,12 +256,22 @@ describe('issue #220 PR-1 — bounded validation-rejection exhaustion', () => {
       validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
     });
 
+    const toolCalls = [
+      {
+        server_id: 'github',
+        tool: 'get_pull_request',
+        args: { pr: 1 },
+        result: 'PR data',
+        duration_ms: 50,
+      },
+    ];
     const envelope = await executeStep(store, def, {
       runId: run.id,
       command: 'draft',
       input: INVALID_OUTPUT,
       trace: [{ event: 'thinking', data: { note: 'considering' } }],
       dispatcher: echoDispatcher,
+      stepMeta: { toolCalls },
     });
 
     expect(envelope.status).toBe('error');
@@ -277,6 +287,48 @@ describe('issue #220 PR-1 — bounded validation-rejection exhaustion', () => {
     expect(exhaustedEvidence?.diagnostics?.validation_rejections).toBe(
       DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
     );
+    // issue #220 correction, deliverable 1/verification (d) — snapshot completeness: an
+    // exhausted step must not silently drop agent-supplied toolCalls.
+    expect(exhaustedEvidence?.tool_calls).toHaveLength(1);
+    expect(exhaustedEvidence?.tool_calls?.[0]?.tool).toBe('get_pull_request');
+  });
+
+  it('(e) correction — WAL-variant: an exhausting call with a BARE WAL line (no options.trace at all) still carries the WAL-originated line on the failure evidence — the discriminating witness a submitted-trace-only fixture cannot provide', async () => {
+    const def = makeDef();
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+    // The test-(o) store wiring (declares writer_nonce_carriage), but appended BARE (no nonce
+    // option) and called with NO writerNonce — a nonced/mismatched config would instead route
+    // the line to preserved-foreign/attributed, not bare-adoption, which is what this test needs
+    // to discriminate (see deliverable 2's own note on this).
+    const traceBufferStore = new InMemoryTraceBufferStore();
+    await traceBufferStore.append(run.id, 'draft', [{ event: 'wal-thinking' }]);
+
+    const envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'draft',
+      input: INVALID_OUTPUT,
+      // Deliberately NO `trace:` — the WAL line is the ONLY source of trace content here.
+      dispatcher: echoDispatcher,
+      traceBufferStore,
+    });
+
+    expect(envelope.status).toBe('error');
+    expect(envelope.error_code).toBe('VALIDATION_EXHAUSTED');
+    const after = await store.get(run.id);
+    const exhaustedEvidence = after.evidence.find(
+      (e) => e.step_id === 'draft' && e.status === 'error',
+    );
+    expect(exhaustedEvidence).toBeDefined();
+    expect(exhaustedEvidence?.trace).toBeDefined();
+    expect(exhaustedEvidence?.trace?.length).toBe(1);
+    expect(exhaustedEvidence?.trace?.[0]?.event).toBe('wal-thinking');
+    // Set only on the bare-adoption path (#185/#197) — a second, independent witness of the
+    // same fact.
+    expect(exhaustedEvidence?.trace_summary?.buffered_lines_adopted).toBeGreaterThanOrEqual(1);
   });
 
   it('(f) wrap-block guard: a hand-built max_attempts:0 definition (bypassing the loader) still terminalizes as VALIDATION_EXHAUSTED, never wrapped into STEP_RETRY_EXHAUSTED', async () => {
@@ -299,6 +351,15 @@ describe('issue #220 PR-1 — bounded validation-rejection exhaustion', () => {
     expect(envelope.status).toBe('error');
     expect(envelope.error_code).toBe('VALIDATION_EXHAUSTED');
     expect(envelope.error_code).not.toBe('STEP_RETRY_EXHAUSTED');
+    // issue #220 correction, deliverable 3 — agent_action honesty pin: this run is
+    // single-step-terminal, so Step 5's `resolvePostDispatchAgentAction(dispatchError, true)`
+    // returns 'stop' UNCONDITIONALLY (error-resolution.ts:31 — the terminal branch never even
+    // reads `dispatchError.agentAction`). This pin guards that TERMINAL-TRANSLATION behavior (an
+    // exhausted run correctly tells the agent to stop) — NOT the mint's own `agentAction: 'stop'`
+    // field, which is observationally inert on this specific path (see the mint-site comment in
+    // execution-loop.ts). A mint-site mutant will NOT redden this assertion; only a mutation to
+    // the terminal-branch translation itself will.
+    expect(envelope.agent_action).toBe('stop');
   });
 
   it('(j) success-settle stamp: reject twice then succeed ⇒ the settle evidence carries diagnostics.validation_rejections === 2', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export {
   executeChain,
   buildNextActions,
   buildPreExecutionErrorEnvelope,
+  DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
 } from './engine/execution-loop.js';
 export type { SubmitGateOptions, ExecuteChainOptions } from './engine/execution-loop.js';
 export {

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -119,6 +119,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     'capability_blocks',
     'workflow_context_snapshots',
     'extension_identity',
+    'validation_rejections',
   ]);
 
   constructor(runsDir?: string) {

--- a/packages/core/src/store/store-interface.ts
+++ b/packages/core/src/store/store-interface.ts
@@ -17,11 +17,17 @@ import type { WorkflowDefinition } from '../types/workflow-definition.js';
  *  - `extension_identity` — read by the execution loop's drift-evidence append (issue #119) and
  *    `realm inspect --check-drift`; a store that drops it resets the drift baseline every
  *    execution, so drift can never accumulate or be detected.
+ *  - `validation_rejections` — read by `countRejection`'s exhaustion-threshold gate (issue #220,
+ *    execution-loop.ts) on every counted rejection; a store that drops it resets the count to
+ *    zero every write, so a persistently-invalid agent step never reaches the threshold and the
+ *    exhaustion terminalization this field exists for silently never fires (the wedge #220 kills
+ *    quietly resurrects on such a store).
  */
 export type LoadBearingRunRecordField =
   | 'capability_blocks'
   | 'workflow_context_snapshots'
-  | 'extension_identity';
+  | 'extension_identity'
+  | 'validation_rejections';
 
 export interface CreateRunOptions {
   workflowId: string;

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -87,6 +87,15 @@ export interface StepDiagnostics {
     passed: boolean;
     resolved_value: unknown;
   }>;
+  /**
+   * Issue #220: stamped on a SUCCESS settle evidence snapshot when the step's accrued
+   * `RunRecord.validation_rejections` count was > 0 at settle time ("succeeded after N
+   * rejections") — free diagnostic, never gates anything. Also present on the synthesized
+   * evidence snapshot a `VALIDATION_EXHAUSTED` terminalization mints (the just-persisted count).
+   * Optional-additive: absent on every pre-#220 snapshot and on any snapshot for a step that was
+   * never rejected.
+   */
+  validation_rejections?: number;
 }
 
 export interface EvidenceSnapshot {
@@ -402,4 +411,17 @@ export interface RunRecord {
    * derived phase regardless of `failed_steps` / `terminal_reason` (mirrors `aborted_at`).
    */
   abandoned_at?: string;
+  /**
+   * Issue #220 (bounded validation exhaustion): per-step count of COUNTED validation rejections
+   * — the closed set `{VALIDATION_INPUT_SCHEMA, VALIDATION_OUTPUT_SCHEMA}` on `execution: 'agent'`
+   * steps only (`VALIDATION_TRACE_SCHEMA` and any non-agent rejection are never counted here; see
+   * `countRejection` in execution-loop.ts for the full mechanism). Keyed by step name, POOLED
+   * across concurrent writers/nonces (deliberate — the wedge-cure goal is run-level, not
+   * per-writer fairness). NEVER reset: a settled step's count is a permanent, structurally-costless
+   * fact about this run (settled steps simply leave the eligible set — see the #221 derivation
+   * note, TD-R12, for the reader-side "meaningful only against unsettled state" caveat).
+   * Additive-optional (the `claims`/`capability_blocks` precedent): absent on legacy records and
+   * on any run with zero counted rejections so far.
+   */
+  validation_rejections?: Record<string, number>;
 }

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -292,6 +292,17 @@ export interface StepDefinition {
   trust?: TrustLevel;
   timeout_seconds?: number;
   retry?: RetryConfig;
+  /**
+   * Issue #220 (PR-1 subset — `mode`/`default_output` are NOT yet supported; a future PR extends
+   * this shape): bounds the run of persistent schema-rejections on this step. Only valid on
+   * `execution: 'agent'` steps (the countable set — VALIDATION_INPUT_SCHEMA/
+   * VALIDATION_OUTPUT_SCHEMA — is agent-only). `threshold` overrides
+   * `DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD` (6) for THIS step; must be a positive integer
+   * (`1` is legal and documented as disabling in-drive schema-repair, since the very first
+   * rejection then already meets the threshold). Absent ⇒ every countable agent step is
+   * auto-enrolled at the default threshold — there is no reachable per-step opt-out in PR-1.
+   */
+  validation_exhaustion?: { threshold?: number };
   /** Plain-English instructions for the agent at this step. */
   instructions?: string;
   /**
@@ -402,6 +413,7 @@ export const KNOWN_STEP_KEYS = [
   'trust',
   'timeout_seconds',
   'retry',
+  'validation_exhaustion',
   'instructions',
   'prompt',
   'display',

--- a/packages/core/src/types/workflow-error.ts
+++ b/packages/core/src/types/workflow-error.ts
@@ -55,6 +55,10 @@ export type ErrorCode =
   | 'VALIDATION_INPUT_SCHEMA'
   | 'VALIDATION_OUTPUT_SCHEMA'
   | 'VALIDATION_TRACE_SCHEMA'
+  // issue #220: a persistently-rejected agent step's bounded rejection count reached its
+  // threshold — a REAL terminal step failure (kept separate from #140's `exhausted_by` taxonomy:
+  // disjoint lifecycles — this is a validation-rejection count, not a retry/timeout budget).
+  | 'VALIDATION_EXHAUSTED'
   | 'VALIDATION_WORKFLOW_SCHEMA'
   | 'VALIDATION_HASH_MISMATCH'
   | 'VALIDATION_QUOTE_NOT_FOUND'

--- a/packages/core/src/workflow/validation-exhaustion-loader.test.ts
+++ b/packages/core/src/workflow/validation-exhaustion-loader.test.ts
@@ -1,0 +1,203 @@
+// Loader validation for issue #220 PR-1: the `validation_exhaustion` step key (agent-only,
+// `{ threshold? }` only) and the `$settlement` reserved-name legislation.
+import { describe, it, expect } from 'vitest';
+import { loadWorkflowFromString, loadWorkflowFromStringWithDiagnostics } from './yaml-loader.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+function expectThrows(yaml: string, substring: string): void {
+  expect(() => loadWorkflowFromString(yaml)).toThrow(WorkflowError);
+  try {
+    loadWorkflowFromString(yaml);
+    throw new Error('expected loadWorkflowFromString to throw');
+  } catch (err) {
+    expect((err as WorkflowError).message).toContain(substring);
+  }
+}
+
+describe('yaml-loader — issue #220 PR-1 validation_exhaustion', () => {
+  describe('(y) loader rows', () => {
+    it('agent-only refusal: validation_exhaustion on an auto step is a hard error', () => {
+      expectThrows(
+        `
+id: vx-auto-wf
+name: VX Auto
+version: 1
+steps:
+  work:
+    description: Work
+    execution: auto
+    handler: h
+    validation_exhaustion:
+      threshold: 3
+`,
+        "'validation_exhaustion' is only valid on execution: agent steps",
+      );
+    });
+
+    it('agent-only refusal: validation_exhaustion on a guard step is a hard error', () => {
+      expectThrows(
+        `
+id: vx-guard-wf
+name: VX Guard
+version: 1
+steps:
+  work:
+    description: Work
+    execution: guard
+    abort_unless: ["work.ok == true"]
+    validation_exhaustion:
+      threshold: 3
+`,
+        "'validation_exhaustion' is only valid on execution: agent steps",
+      );
+    });
+
+    it('threshold range refusal: 0 is rejected', () => {
+      expectThrows(
+        `
+id: vx-zero-wf
+name: VX Zero
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      threshold: 0
+`,
+        "'validation_exhaustion.threshold' must be a positive integer",
+      );
+    });
+
+    it('threshold range refusal: a negative value is rejected', () => {
+      expectThrows(
+        `
+id: vx-neg-wf
+name: VX Negative
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      threshold: -1
+`,
+        "'validation_exhaustion.threshold' must be a positive integer",
+      );
+    });
+
+    it('threshold range refusal: a non-integer (1.5) value is rejected', () => {
+      expectThrows(
+        `
+id: vx-frac-wf
+name: VX Fractional
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      threshold: 1.5
+`,
+        "'validation_exhaustion.threshold' must be a positive integer",
+      );
+    });
+
+    it('threshold: 1 is accepted (documented as disabling in-drive schema-repair)', () => {
+      const def = loadWorkflowFromString(`
+id: vx-one-wf
+name: VX One
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      threshold: 1
+`);
+      expect(def.steps['draft']?.validation_exhaustion).toEqual({ threshold: 1 });
+    });
+
+    it('unknown sub-key warning: mode is not yet supported in PR-1 and draws a warning, never a rejection', () => {
+      const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: vx-mode-wf
+name: VX Mode
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      mode: fail
+`);
+      const w = warnings.find((warning) => warning.key === 'mode');
+      expect(w).toBeDefined();
+      expect(w?.message).toContain('validation_exhaustion');
+    });
+
+    it('unknown sub-key warning: default_output is not yet supported in PR-1 and draws a warning, never a rejection', () => {
+      const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: vx-default-output-wf
+name: VX Default Output
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      default_output: { category: 'x' }
+`);
+      const w = warnings.find((warning) => warning.key === 'default_output');
+      expect(w).toBeDefined();
+      expect(w?.message).toContain('validation_exhaustion');
+    });
+
+    it('a bare validation_exhaustion: {} (no threshold) is legal — the default applies', () => {
+      const def = loadWorkflowFromString(`
+id: vx-bare-wf
+name: VX Bare
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion: {}
+`);
+      expect(def.steps['draft']?.validation_exhaustion).toEqual({});
+    });
+  });
+
+  describe('(cc) reserved-name refusal — the loader half', () => {
+    it('$settlement is refused as a step id', () => {
+      expectThrows(
+        `
+id: settlement-name-wf
+name: Settlement Name
+version: 1
+steps:
+  $settlement:
+    description: Work
+    execution: auto
+    handler: h
+`,
+        "Step name '$settlement' is reserved",
+      );
+    });
+
+    it('run and context remain refused as step ids (pre-existing, unaffected by this change)', () => {
+      expectThrows(
+        `
+id: run-name-wf
+name: Run Name
+version: 1
+steps:
+  run:
+    description: Work
+    execution: auto
+    handler: h
+`,
+        "Step name 'run' is reserved",
+      );
+    });
+  });
+});

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -138,6 +138,9 @@ const SERVICE_ENTRY_JSON_SCHEMA = {
 
 const VALID_EXECUTIONS = new Set(['auto', 'agent', 'guard', 'finalizer']);
 const VALID_FINALIZER_TRIGGERS = new Set(['complete', 'fail', 'abort', 'always']);
+// issue #220 (PR-1 subset): the ONLY validation_exhaustion sub-key this PR recognizes. `mode`/
+// `default_output` are a future PR's surface — declaring them now warns as unknown, never rejects.
+const KNOWN_VALIDATION_EXHAUSTION_KEYS = ['threshold'];
 const VALID_SERVICE_METHODS = new Set(['fetch', 'create', 'update', 'delete']);
 const VALID_TRIGGER_RULES = new Set<TriggerRule>([
   'all_success',
@@ -635,7 +638,10 @@ function parseWorkflowString(
       }),
     );
 
-    if (stepName === 'run' || stepName === 'context') {
+    // issue #220 §4c PR ordering interlock: `$settlement` is reserved NOW (PR-1) even though the
+    // namespace it names is not minted until a later PR — else the inter-PR gap could register a
+    // `$settlement`-named step that becomes a load-refused fossil the instant the mint ships.
+    if (stepName === 'run' || stepName === 'context' || stepName === '$settlement') {
       errors.push(`Step name '${stepName}' is reserved and cannot be used as a step identifier`);
     }
 
@@ -799,6 +805,50 @@ function parseWorkflowString(
     // output_schema is only valid on execution: agent steps.
     if (step['output_schema'] !== undefined && step['execution'] !== 'agent') {
       errors.push(`Step '${stepName}': 'output_schema' is only valid on execution: agent steps`);
+    }
+
+    // issue #220 (PR-1 subset): validation_exhaustion is only valid on execution: agent steps —
+    // the countable rejection set (VALIDATION_INPUT_SCHEMA/VALIDATION_OUTPUT_SCHEMA) is agent-only
+    // by construction (execution-loop.ts's countRejection). PR-1 supports ONLY `{ threshold? }` —
+    // `mode`/`default_output` are a future PR's surface; declaring them here WARNS (never
+    // rejects) as an unknown sub-key, the loader's warn-don't-reject posture (#144/#169/#170).
+    if (step['validation_exhaustion'] !== undefined) {
+      if (step['execution'] !== 'agent') {
+        errors.push(
+          `Step '${stepName}': 'validation_exhaustion' is only valid on execution: agent steps`,
+        );
+      } else if (
+        typeof step['validation_exhaustion'] !== 'object' ||
+        step['validation_exhaustion'] === null
+      ) {
+        errors.push(`Step '${stepName}': 'validation_exhaustion' must be an object`);
+      } else {
+        const exhaustionBlock = step['validation_exhaustion'] as Record<string, unknown>;
+
+        // WARN (do not reject) on an unknown validation_exhaustion sub-key — the retry-block-style
+        // pattern (issue #140's UNKNOWN_RETRY_KEY), reusing the existing UNKNOWN_STEP_KEY code
+        // with the noun overridden (PR-1 mints no new WarningCode for this nested block).
+        warnings.push(
+          ...findUnknownKeys(exhaustionBlock, KNOWN_VALIDATION_EXHAUSTION_KEYS, {
+            scope: 'step',
+            code: 'UNKNOWN_STEP_KEY',
+            step: stepName,
+            noun: 'validation_exhaustion',
+          }),
+        );
+
+        if (
+          'threshold' in exhaustionBlock &&
+          (!Number.isInteger(exhaustionBlock['threshold']) ||
+            (exhaustionBlock['threshold'] as number) < 1)
+        ) {
+          errors.push(
+            `Step '${stepName}': 'validation_exhaustion.threshold' must be a positive integer ` +
+              `(1 is legal — it disables in-drive schema-repair, since the first rejection ` +
+              `already meets it)`,
+          );
+        }
+      }
     }
 
     // WARN (do not reject): an agent step declaring BOTH input_schema and output_schema has its

--- a/packages/mcp-server/src/tools/create-workflow.test.ts
+++ b/packages/mcp-server/src/tools/create-workflow.test.ts
@@ -133,6 +133,57 @@ describe('handleCreateWorkflow', () => {
     expect(result.errors.some((e) => e.includes('invalid'))).toBe(true);
   });
 
+  describe('issue #220 §4c — reserved step ids (the create_workflow half of pin (cc))', () => {
+    it("'run' is refused as a step id (the pre-existing gap fix — create_workflow never enforced this before)", async () => {
+      const result = await handleCreateWorkflow(
+        { steps: [{ id: 'run', description: 'Bad step' }] },
+        stores,
+      );
+      expect(result.status).toBe('error');
+      expect(result.errors.some((e) => e.includes("Step id 'run' is reserved"))).toBe(true);
+    });
+
+    it("'context' is refused as a step id (the pre-existing gap fix)", async () => {
+      const result = await handleCreateWorkflow(
+        { steps: [{ id: 'context', description: 'Bad step' }] },
+        stores,
+      );
+      expect(result.status).toBe('error');
+      expect(result.errors.some((e) => e.includes("Step id 'context' is reserved"))).toBe(true);
+    });
+
+    it("'$settlement' is refused as a step id (the PR-ordering interlock — reserved ahead of its later mint)", async () => {
+      const result = await handleCreateWorkflow(
+        { steps: [{ id: '$settlement', description: 'Bad step' }] },
+        stores,
+      );
+      expect(result.status).toBe('error');
+      expect(result.errors.some((e) => e.includes("Step id '$settlement' is reserved"))).toBe(true);
+    });
+  });
+
+  it('issue #220 §3b [P-S6] — a submitted validation_exhaustion key draws the TARGETED register-time-only message, not the generic unknown-key text (pin (s))', async () => {
+    const result = await handleCreateWorkflow(
+      {
+        steps: [
+          {
+            id: 'step-a',
+            description: 'A step',
+            validation_exhaustion: { threshold: 3 },
+          } as unknown as import('./create-workflow.js').CreateWorkflowStep,
+        ],
+      },
+      stores,
+    );
+    expect(result.status).toBe('ok'); // advisory only — never rejects
+    const warning = result.warnings.find((w) => w.includes('validation_exhaustion'));
+    expect(warning).toBeDefined();
+    expect(warning).toContain('register-time only');
+    expect(warning).toContain('dynamic workflows use the default exhaustion posture');
+    // Never the generic "not a recognized field" phrasing other unknown keys get.
+    expect(warning).not.toContain('not a recognized');
+  });
+
   it('validation — depends_on with multiple predecessors returns error', async () => {
     const result = await handleCreateWorkflow(
       {

--- a/packages/mcp-server/src/tools/create-workflow.ts
+++ b/packages/mcp-server/src/tools/create-workflow.ts
@@ -130,6 +130,17 @@ function validateArgs(args: CreateWorkflowArgs): string[] {
     }
   }
 
+  // Rule 3b (issue #220 §4c): reserved step ids — a PRE-EXISTING GAP fixed in the same edit that
+  // reserves `$settlement` (the PR ordering interlock: the namespace ships in a later PR, but the
+  // reservation must ship NOW, else the inter-PR gap can register a `$settlement`-named step that
+  // becomes load-refused the instant the mint ships). `run`/`context` mirror the YAML loader's own
+  // reservation (yaml-loader.ts) — create_workflow never enforced these two at all before this fix.
+  for (const step of args.steps) {
+    if (step.id === 'run' || step.id === 'context' || step.id === '$settlement') {
+      errors.push(`Step id '${step.id}' is reserved and cannot be used as a step identifier`);
+    }
+  }
+
   // Rule 4: descriptions must be non-empty.
   for (const step of args.steps) {
     if (step.description.trim() === '') {
@@ -282,13 +293,26 @@ export async function handleCreateWorkflow(
   // the single source of truth, no hand-maintained list). Distinct code (UNKNOWN_CREATE_WORKFLOW_KEY)
   // from the loader's UNKNOWN_STEP_KEY — #170 never flips it, so create_workflow stays lenient for
   // agents forever. The workflow is still created either way; this only ever warns, never rejects.
-  const stepDiagnostics: LoaderWarning[] = args.steps.flatMap((step) =>
-    findUnknownKeys(step as unknown as Record<string, unknown>, Object.keys(stepSchema.shape), {
-      scope: 'step',
-      code: 'UNKNOWN_CREATE_WORKFLOW_KEY',
-      step: step.id,
-    }),
-  );
+  const stepDiagnostics: LoaderWarning[] = args.steps
+    .flatMap((step) =>
+      findUnknownKeys(step as unknown as Record<string, unknown>, Object.keys(stepSchema.shape), {
+        scope: 'step',
+        code: 'UNKNOWN_CREATE_WORKFLOW_KEY',
+        step: step.id,
+      }),
+    )
+    // issue #220 §3b [P-S6]: `validation_exhaustion` gets its OWN targeted message — the generic
+    // "not a recognized field" text doesn't teach the actual disposition (register-time-only; a
+    // dynamic workflow is auto-enrolled at the default fail-at-6 posture with no reachable
+    // override). Every other unknown key keeps the generic message unchanged.
+    .map((w) =>
+      w.key === 'validation_exhaustion'
+        ? {
+            ...w,
+            message: `Step '${w.step}': 'validation_exhaustion' is register-time only — dynamic workflows use the default exhaustion posture.`,
+          }
+        : w,
+    );
 
   const result = await handleStartRun(
     { workflow_id: workflowId, params: {} },

--- a/packages/mcp-server/src/tools/execute-step.ts
+++ b/packages/mcp-server/src/tools/execute-step.ts
@@ -75,14 +75,25 @@ export function writerNonceRequiredError(stepId: string, runVersion: number): Wo
 }
 
 /**
- * Pre-claim validation rejections carry one of these error codes (claimStep runs strictly after all
- * three schema gates, so they never reach failed_steps[] / never bump version — a write-free path).
+ * Pre-claim validation rejections carry one of these error codes. Historical framing (pre-#220):
+ * claimStep runs strictly after all three schema gates, so a rejection never reached
+ * failed_steps[] / never bumped the run version — a write-free path. **Issue #220 changes this
+ * for the two COUNTED codes**: `VALIDATION_INPUT_SCHEMA`/`VALIDATION_OUTPUT_SCHEMA` on an agent
+ * step now persist a bounded rejection counter via a real CAS write (`countRejection` in
+ * execution-loop.ts) — the rejection's own ENVELOPE still reports the PRE-write version
+ * (bump-and-report), so callers observing only the envelope see no behavior change, but the run
+ * record itself is no longer untouched. `VALIDATION_TRACE_SCHEMA` remains genuinely write-free (an
+ * uncounted v1 residual — see execution-loop.ts's countRejection doc). `VALIDATION_EXHAUSTED`
+ * (issue #220) is the terminal rejection itself — a real step failure that claims, fails, and
+ * bumps the version exactly like any other dispatch failure; it is included here because it is
+ * the single most diagnostic sidecar record a persistently-invalid agent step can produce.
  * Failed agent attempts on these codes are surfaced as stderr telemetry below.
  */
 const VALIDATION_TELEMETRY_CODES = new Set([
   'VALIDATION_INPUT_SCHEMA',
   'VALIDATION_OUTPUT_SCHEMA',
   'VALIDATION_TRACE_SCHEMA',
+  'VALIDATION_EXHAUSTED',
 ]);
 
 /**
@@ -109,7 +120,13 @@ async function emitFailedAttemptTelemetry(
     if (result.status !== 'error') return;
     const code = result.error_code;
     if (code === undefined || !VALIDATION_TELEMETRY_CODES.has(code)) return;
-    const ajvErrors = result.error_details?.['errors'];
+    // issue #220: VALIDATION_EXHAUSTED carries its ajv errors under `last_ajv_errors` (the last
+    // counted rejection's own errors, threaded through by countRejection) — every other code here
+    // carries them under the pre-existing `errors` key.
+    const ajvErrors =
+      code === 'VALIDATION_EXHAUSTED'
+        ? result.error_details?.['last_ajv_errors']
+        : result.error_details?.['errors'];
     record = buildFailedAttemptRecord({
       run_id: args.run_id,
       workflow_id: workflowId,

--- a/packages/mcp-server/src/tools/failed-attempt-telemetry.test.ts
+++ b/packages/mcp-server/src/tools/failed-attempt-telemetry.test.ts
@@ -9,6 +9,7 @@ import {
   JsonWorkflowStore,
   FailedAttemptStore,
   CURRENT_WORKFLOW_SCHEMA_VERSION,
+  DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
 } from '@sensigo/realm';
 import type { WorkflowDefinition } from '@sensigo/realm';
 import { handleExecuteStep, handleExecuteStepTool } from './execute-step.js';
@@ -190,9 +191,13 @@ describe('execute_step failed-attempt sidecar (P3 durable sink)', () => {
     // Metadata-only: no raw PII value persisted.
     expect(JSON.stringify(records[0])).not.toContain('jane@example.com');
 
-    // Pure side-channel: the run record is untouched (pre-claim, write-free).
+    // issue #220 blast radius (sanctioned, record P-M3): this rejection is now COUNTED — a
+    // persisted CAS write bumps validation_rejections (and the version), even though the
+    // rejection's own ENVELOPE still reports the pre-write version (bump-and-report, pin (a)).
+    // The side-channel INTENT this test guards survives unchanged: the run's DAG state
+    // (failed_steps) is still untouched — only the new counter moved.
     const after = await runStore.get(run.id);
-    expect(after.version).toBe(versionBefore);
+    expect(after.version).toBe(versionBefore + 1);
     expect(after.failed_steps).not.toContain('classify');
     // stderr sink still fired too (both sinks independent).
     expect(errSpy).toHaveBeenCalled();
@@ -232,5 +237,52 @@ describe('execute_step failed-attempt sidecar (P3 durable sink)', () => {
       .map((c) => String(c[0]))
       .filter((s) => s.includes('agent_step_attempt_failed'));
     expect(emitted.length).toBeGreaterThan(0);
+  });
+});
+
+describe('execute_step failed-attempt telemetry — VALIDATION_EXHAUSTED (issue #220, pin (t))', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+  let failedAttemptStore: FailedAttemptStore;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    const runsDir = await mkdtemp(join(tmpdir(), 'fat4-run-'));
+    runStore = new JsonFileStore(runsDir);
+    workflowStore = new JsonWorkflowStore(await mkdtemp(join(tmpdir(), 'fat4-wf-')));
+    failedAttemptStore = new FailedAttemptStore(runsDir);
+    await workflowStore.register(wf);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it('the terminalizing call reaches the failed-attempt sidecar with ajv_errors sourced from last_ajv_errors', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'classify-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await runStore.update({
+      ...run,
+      validation_rejections: { classify: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+
+    const result = await handleExecuteStep(
+      { run_id: run.id, command: 'classify', params: { ticket_body: 'jane@example.com' } },
+      { runStore, workflowStore, failedAttemptStore },
+    );
+    expect(result.status).toBe('error');
+    expect(result.error_code).toBe('VALIDATION_EXHAUSTED');
+
+    const { records } = await failedAttemptStore.read(run.id);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.step_id).toBe('classify');
+    expect(records[0]!.error_code).toBe('VALIDATION_EXHAUSTED');
+    // last_ajv_errors sourcing: the summary is non-empty (built FROM error_details.last_ajv_errors,
+    // not the — absent on this code — `errors` key).
+    expect(records[0]!.validation_error_summary.length).toBeGreaterThan(0);
   });
 });

--- a/packages/testing/src/store/in-memory-store.test.ts
+++ b/packages/testing/src/store/in-memory-store.test.ts
@@ -58,6 +58,7 @@ const ALL_FIELDS: LoadBearingRunRecordField[] = [
   'capability_blocks',
   'workflow_context_snapshots',
   'extension_identity',
+  'validation_rejections',
 ];
 
 describe('InMemoryStore — RunStore fidelity TCK conformance (issue #188)', () => {

--- a/packages/testing/src/store/in-memory-store.ts
+++ b/packages/testing/src/store/in-memory-store.ts
@@ -28,6 +28,7 @@ export class InMemoryStore implements RunStore {
     'capability_blocks',
     'workflow_context_snapshots',
     'extension_identity',
+    'validation_rejections',
   ]);
 
   async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {

--- a/packages/testing/src/store/run-store-fidelity-contract.ts
+++ b/packages/testing/src/store/run-store-fidelity-contract.ts
@@ -59,6 +59,7 @@ const SAMPLE_VALUES: {
   capability_blocks: Record<string, CapabilityBlock>;
   workflow_context_snapshots: Record<string, WorkflowContextSnapshot>;
   extension_identity: ExtensionIdentityEntry[];
+  validation_rejections: Record<string, number>;
 } = {
   capability_blocks: {
     'tck-step': {
@@ -90,6 +91,7 @@ const SAMPLE_VALUES: {
       coverage: 'dir_tree_v1',
     },
   ],
+  validation_rejections: { 'tck-step': 3 },
 };
 
 /**


### PR DESCRIPTION
## Context

Issue #220 (filed 2026-07-20 from the verified CS1 agent-robustness suggestions, `plans/realm-improvements/DISPOSITION.md` R-2): an agent step that keeps submitting schema-invalid output loops forever — every `VALIDATION_INPUT_SCHEMA`/`VALIDATION_OUTPUT_SCHEMA` rejection returns the same envelope, the run never terminalizes, and the operator sees an eternally "running" run (the wedge class #221's `classifyRunHealth` can only *observe*, not cure). Design converged through the full debate protocol: 4-lane grounding dossier → dual blind derivation → Peer round 2 (91% coverage) → 3-lens REFUTE panel → promoted-refuter re-review → final completeness gate. Design record: `plans/issue-220/design-d3.md` (local). This is **PR-1 of 3** (Option A): counting + fall-through terminalization. PR-2 = declared fail-open (`validation_exhaustion: {mode, default_output}`); PR-3 = the `$settlement` evaluation-root namespace.

## Motivation

Poison-message termination with broker-position counting (SQS `maxReceiveCount` / Temporal server-state attempts / K8s Job `backoffLimit`): the rejection count must live in the authoritative unit-of-work record and termination must be minted by the record's owner — the engine, not the drive. Without it, a schema-wedged agent step burns tokens indefinitely and lies to operators by omission. Run terminality stays DERIVED (a step failure with normal workflow semantics — `failed_steps`, skip propagation, recovery branches all inherited), never asserted.

## Changes

- **`RunRecord.validation_rejections?: Record<stepName, number>`** — per-step, pooled, never reset; joins #188's `LoadBearingRunRecordField` closed set (JsonFileStore + InMemoryStore declare it; TCK FIDELITY_HONESTY descriptors 3→4 per store; runtime honesty advisory when a store doesn't declare it).
- **`countRejection` at the engine chokepoint** (all three validation entry paths): counts only `{VALIDATION_INPUT_SCHEMA, VALIDATION_OUTPUT_SCHEMA}` ∧ `execution === 'agent'`; CAS bump-and-report (envelope reports the PRE-write version — #217's repair gate stays sound); CAS-fail retry ONCE with a countability re-check (`!terminal && no pending_gate && step still eligible`), else drop-and-swallow (undercount-safe); every counted envelope carries `{rejections, threshold}` countdown.
- **`VALIDATION_EXHAUSTED`** (new ErrorCode, category VALIDATION, `agentAction: 'stop'`, non-retryable, details `{step_id, rejections, threshold, last_error, last_ajv_errors}`) minted at `count ≥ threshold` (default `DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD = 6`; per-step `validation_exhaustion.threshold` loader key with name reservations for PR-2's `mode`/`default_output`).
- **Fall-through terminalization**: persist-then-terminalize; a valid submission always wins; trace enforce-gate yields when exhausting (warn-pass still runs for the summary); dispatch loop AND retry-wrap block bypassed (`bypassDispatch`) so a hand-built `max_attempts: 0` def can't wrap the code into `STEP_RETRY_EXHAUSTED`; ONE synthesized evidence snapshot mirroring the real capture site (normalizedTrace/WAL spread — #185-Finding-2 guarded — plus toolCalls + agent-profile attribution); Step 5/5b/6 fully inherited.
- **Drive alignment** (`run-agent.ts`): the #217 repair gate consumes the countdown; success-settle stamps `diagnostics.validation_rejections: N` ("succeeded after N rejections", feeds #219).
- Corrections (commits 2–3): WAL-variant + agent_action + store-declaration + toolCalls/profile-spread pins (review-found unpinned rules), snapshot completeness spreads, cross-ref fix, report errata.

## Verification

```bash
npx turbo run test lint --force   # 12/12 tasks; core 1862 / mcp 265 / testing 81 / cli 799
```

Review trail (all reproduced independently by the architect): 3 rounds; 12 IA mutation probes + 6 architect spot-reproductions + 3 novel probes. Key witnesses: branch-collapse mutant reds ONLY the WAL-variant test; `error-resolution.ts:31` terminal-branch mutant reds the `agent_action` pin; dropping either store's `validation_rejections` declaration reds its TCK/ALL_FIELDS test; eligibility-conjunct removal reds exactly q2; `!bypassDispatch` removal reds exactly (f); reassignment mutant in `countRejection` reds exactly pin (a).

## Rollback

```bash
git revert 1c285b8 5b67630 cf2f4e6
```

No out-of-band mutations. The record field is additive-optional — records written with counts remain readable by pre-#220 code (unknown-field tolerant).

## Related

- Issue #220 (PR 1 of 3 — do NOT auto-close)
- #217 (repair-gate contract preserved), #221 (wedge observation → this cures), #185/#197 (WAL adoption honored), #188 (fidelity contract joined), #140 (exhausted_by taxonomy kept disjoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
