### PR TITLE
feat(engine): declared fail-open for validation-rejection exhaustion (issue #220, PR 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,30 @@ Record<string, number>` (additive, joins the #188 `LoadBearingRunRecordField` cl
   (fail-open `mode`/`default_output`) and PR-3 (the `$settlement` mint) are separate, later
   changes — this PR is counting + terminalization only.
 
+- **Declared fail-open for bounded validation-rejection exhaustion, PR-2 (issue #220).**
+  `validation_exhaustion` gains `mode?: 'fail' | 'default'` and `default_output?: unknown` —
+  **strictly opt-in; every existing workflow keeps PR-1's `mode: 'fail'` behavior byte-for-byte,
+  with zero change to counting, terminalization, or #217's repair gate.** An author opting a step
+  into `mode: 'default'` must also declare `output_schema` and a `default_output` that validates
+  against it — enforced at LOAD TIME by reusing the exact runtime AJV validator
+  (`validateOutputSchema`), so a fallback that would itself fail runtime validation is refused
+  before the workflow ever registers. On exhaustion, the engine SETTLES the step successfully with
+  `default_output` instead of failing the run: the settle evidence is stamped
+  `diagnostics.settled_by_default: true` alongside `diagnostics.validation_rejections: N`; the
+  success `ResponseEnvelope` carries a matching top-level `settled_by_default: true` and a
+  human-readable disclosure line in `warnings` (both survive the MCP tool wrapper's strip). A
+  `human_confirmed`/`human_reviewed` step opens its gate on the `default_output` preview instead
+  (fail-safe — the human sees the substitution before it settles; a `reject` choice still settles
+  the step with that output — a rejecting human does not "un-default"). `RunRecord` gains an
+  additive-optional `defaulted_steps?: string[]` — a run-level convenience list of every step that
+  settled via its declared default in this run, stamped onto the sealed record ONLY on the
+  `'complete'` terminal transition (a run that later fails after a mid-workflow default-settle
+  does not carry this field on its `'fail'`-sealed record; the per-step evidence stamp is the
+  durable per-step truth regardless). `defaulted_steps` joins the #188
+  `LoadBearingRunRecordField` closed set under a new membership class (a write-site
+  disclosure-integrity advisory, alongside the existing read-site-consumer class) — a store that
+  doesn't declare it durable draws an explicit warning rather than silently losing the marker.
+
 ### Changed
 
 - **AUTO-ENROLLMENT (issue #220): every `execution: 'agent'` step with a countable schema now
@@ -48,6 +72,18 @@ Record<string, number>` (additive, joins the #188 `LoadBearingRunRecordField` cl
   (`create_workflow` never enforced either before this change).** `$settlement` joins both
   reservations as a new refusal on a name that was previously loader-legal (see the PR-ordering
   interlock note above).
+- **Two new loader `WarningCode`s for `validation_exhaustion`, PR-2 (issue #220):
+  `UNKNOWN_VALIDATION_EXHAUSTION_KEY` replaces PR-1's reuse of `UNKNOWN_STEP_KEY` for an
+  unrecognized sub-key (closes an incoherence against the structurally identical retry-key
+  family, which stays `warn`); `DEAD_VALIDATION_EXHAUSTION_CONFIG` warns when `default_output` is
+  declared without `mode: 'default'` (inert, not an error).** Both default to `warn` — no existing
+  workflow's load behavior changes.
+- **`ResponseEnvelope` gains two additive-optional top-level fields (issue #220 PR-2):
+  `settled_by_default?: boolean` (set only on the success envelope of a step that just settled via
+  its declared default, never on a gate-open or human-response envelope) and `defaulted_steps?:
+string[]` (mirrors `RunRecord.defaulted_steps` on a terminal `complete` envelope).** Both are
+  absent on every envelope for a workflow that doesn't use `mode: 'default'` — no observable change
+  for existing consumers.
 
 ---
 

--- a/packages/cli/src/store-contracts/run-store-fidelity.contract.test.ts
+++ b/packages/cli/src/store-contracts/run-store-fidelity.contract.test.ts
@@ -34,6 +34,7 @@ describe('JsonFileStore — RunStore fidelity TCK conformance (issue #188)', () 
       expect(store.persistedRunRecordFields?.has('workflow_context_snapshots')).toBe(true);
       expect(store.persistedRunRecordFields?.has('extension_identity')).toBe(true);
       expect(store.persistedRunRecordFields?.has('validation_rejections')).toBe(true);
+      expect(store.persistedRunRecordFields?.has('defaulted_steps')).toBe(true);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -628,6 +628,34 @@ function mergeWarnings(
 }
 
 /**
+ * Pure helper (issue #220 PR-2, D6): scans `sealDraft`'s evidence for entries stamped
+ * `diagnostics.settled_by_default === true` and, if any exist, returns the record with
+ * `defaulted_steps` set to their distinct step names (declaration order of first occurrence) —
+ * else returns the SAME record reference unchanged, so a run with no default-settle anywhere is
+ * byte-identical to pre-PR-2 behavior (the damage-rail this preserves). Pure, no I/O.
+ *
+ * Applied by WRAPPING the `buildFinalizedSeal` call inside the TERMINAL branch of each seal
+ * ternary — `buildFinalizedSeal` itself stays byte-untouched (a chokepoint insertion was
+ * considered and rejected in the design record: it reaches fail/abort seals too and would be a
+ * fragile two-touch above the damage-rail fast-path). Callers must pass ONLY a sealed record from
+ * the `'complete'` branch — never a non-terminal draft, and never a fail/abort seal — so
+ * `defaulted_steps` never leaks onto a persisted non-terminal record that a later FAIL seal
+ * inherits (the FM-5 residual this guards).
+ */
+function stampDefaultedSteps(sealDraft: RunRecord): RunRecord {
+  const steps: string[] = [];
+  const seen = new Set<string>();
+  for (const snap of sealDraft.evidence) {
+    if (snap.diagnostics?.settled_by_default === true && !seen.has(snap.step_id)) {
+      seen.add(snap.step_id);
+      steps.push(snap.step_id);
+    }
+  }
+  if (steps.length === 0) return sealDraft;
+  return { ...sealDraft, defaulted_steps: steps };
+}
+
+/**
  * Compensating un-claim (issue #207 PR-2, D3 §5): built from `pendingRun` — the record OUR OWN
  * `claimStep` call returned, never a fresh get — removing the step from `in_progress_steps` AND
  * `claims[step]` in the SAME mutation (the settle-site invariant every other settle path in this
@@ -1639,6 +1667,12 @@ export async function executeStep(
 
   let output: Record<string, unknown> = {};
   let dispatchError: WorkflowError | null = null;
+  // issue #220 PR-2: true iff THIS invocation settles the step via its declared default_output
+  // substitution (exhaustion armed above AND the step opted into mode: 'default') — computed once,
+  // function-scoped (not inside the `if (bypassDispatch)` block below, which closes long before
+  // D5's Step-6 envelope build reads this local) so it survives to every downstream read site.
+  const settledByDefault =
+    exhaustion !== null && stepDef?.validation_exhaustion?.mode === 'default';
   let attemptsUsed = 0;
   const allEvidence: EvidenceSnapshot[] = [];
   let currentWarn: string | undefined;
@@ -1934,7 +1968,66 @@ export async function executeStep(
     }
   } // end issue #220 `if (!bypassDispatch)` — the dispatch loop
 
-  if (bypassDispatch) {
+  if (bypassDispatch && settledByDefault) {
+    // issue #220 PR-2 (D4): declared fail-open. The step opted into `validation_exhaustion.mode:
+    // 'default'` and its schema-rejection budget is exhausted — SETTLE the step SUCCESSFULLY with
+    // the declared `default_output` instead of terminalizing. `dispatchError` stays `null` here
+    // (deliberately NOT set) so every existing downstream success path runs UNMODIFIED: Step 5
+    // (dispatch-failure handling) is skipped, Step 5b's gate fires for `human_confirmed` steps on
+    // the default_output preview (pin z falls out of this structurally — D7), and Step 6's
+    // complete-settle records the step in `completed_steps`. Step 6 does NOT read the `output`
+    // local at all — the step's durable output travels via the EVIDENCE SNAPSHOT's
+    // `output_summary` (what `buildEvidenceByStep`/eligibility read for downstream steps) — so
+    // this branch does exactly two things and no more: (1) set `output` for the envelope/gate
+    // preview; (2) push ONE synthesized SUCCESS evidence snapshot mirroring the dispatch-loop's
+    // own success `captureEvidence` call (the same one PR-1's FAILURE snapshot above was modeled
+    // on, for the success shape instead).
+    const defaultOutput = stepDef!.validation_exhaustion!.default_output as Record<string, unknown>;
+    output = defaultOutput;
+    const settledAt = new Date();
+    const defaultProfile = stepDef?.agent_profile;
+    const defaultProfileData =
+      defaultProfile !== undefined ? definition.resolved_profiles?.[defaultProfile] : undefined;
+    const defaultSnap: EvidenceSnapshot = captureEvidence({
+      stepId: options.command,
+      startedAt: settledAt,
+      completedAt: settledAt,
+      input: effectiveInput,
+      output: defaultOutput,
+      diagnostics: {
+        input_token_estimate: inputTokenEstimate,
+        precondition_trace: preconditionTrace,
+        settled_by_default: true,
+        validation_rejections: exhaustion!.details['rejections'] as number,
+      },
+      ...(defaultProfileData !== undefined
+        ? { agentProfile: defaultProfile!, agentProfileHash: defaultProfileData.content_hash }
+        : {}),
+      ...(options.stepMeta?.toolCalls !== undefined
+        ? { toolCalls: options.stepMeta.toolCalls }
+        : {}),
+      ...(debugOutput !== undefined ? { debugOutput } : {}),
+      // Gate trace to agent steps only — drop silently for auto/adapter/handler steps. Mirrors
+      // the real dispatch-loop capture's own trace-spread conjunct exactly.
+      ...(stepDef?.execution === 'agent' && (options.trace !== undefined || walEntries.length > 0)
+        ? preNormalizedTrace !== undefined
+          ? { normalizedTrace: preNormalizedTrace }
+          : { trace: options.trace ?? [] }
+        : {}),
+    });
+    allEvidence.push(defaultSnap);
+    // Human-readable disclosure (record §4 — the fourth default-settle disclosure element the
+    // record enumerates) + the store-honesty advisory (§5c nuance 1: `countWarnings` are normally
+    // delivered ONLY on counted-rejection RETURN envelopes and DROPPED on the fall-through
+    // terminalization path — deliberately re-threaded here, for the default-settle success
+    // envelope only, so an undeclared-but-persisting store's advisory is not silently lost).
+    traceWarnings.push(
+      `Step '${options.command}' settled with its declared default_output after ` +
+        `${exhaustion!.details['rejections'] as number} schema rejection(s) ` +
+        `(validation_exhaustion.mode: 'default')`,
+    );
+    traceWarnings.push(...countWarnings);
+  } else if (bypassDispatch) {
     // issue #220: terminalize. `dispatchError` is PRE-SET to the minted VALIDATION_EXHAUSTED error
     // HERE, BEFORE the retry-wrap block below — that block's own `!bypassDispatch` guard is what
     // then keeps it from being wrapped: without dispatchError being non-null at this exact point,
@@ -2492,9 +2585,23 @@ export async function executeStep(
     ...(isComplete ? { terminal_reason: `Workflow completed.` } : {}),
   };
   // On the terminal transition, drain the complete/always finalizers before the single seal.
+  // issue #220 PR-2 (D6): stamp defaulted_steps onto the SEALED terminal record only — the
+  // non-terminal branch (`completeDraft`) is never stamped (FM-5 guard: it must never leak onto a
+  // record a later FAIL seal inherits).
   const finalRun: RunRecord = isComplete
-    ? await buildFinalizedSeal(definition, completeDraft, 'complete', options.registry)
+    ? stampDefaultedSteps(
+        await buildFinalizedSeal(definition, completeDraft, 'complete', options.registry),
+      )
     : completeDraft;
+  // issue #220 PR-2 (D6 write-site consumer): when the stamped seal record's defaulted_steps is
+  // non-empty but this store doesn't declare it durable, disclose the gap explicitly rather than
+  // silently losing the run-level marker on round-trip.
+  const defaultedStepsDurabilityWarning =
+    finalRun.defaulted_steps !== undefined &&
+    finalRun.defaulted_steps.length > 0 &&
+    !persistsField(store, 'defaulted_steps')
+      ? 'run-level defaultedness marker (defaulted_steps) not durable on this store'
+      : undefined;
 
   let savedRun: RunRecord;
   try {
@@ -2590,7 +2697,12 @@ export async function executeStep(
     status: 'ok',
     data: output,
     evidence: allEvidence,
-    warnings: mergeWarnings(traceWarnings, currentWarn, successWalCleanupWarning),
+    warnings: mergeWarnings(
+      traceWarnings,
+      currentWarn,
+      successWalCleanupWarning,
+      defaultedStepsDurabilityWarning,
+    ),
     errors: [],
     context_hint: orientation,
     run_phase: savedRun.run_phase,
@@ -2606,6 +2718,13 @@ export async function executeStep(
           preserved_foreign: adoptionPartition.preserved_foreign,
         }
       : {}),
+    // issue #220 PR-2 (D5/D6): settled_by_default set true on EXACTLY this success envelope, when
+    // THIS invocation settled via the declared default_output substitution. defaulted_steps read
+    // off `finalRun` — the STAMPED PRE-PERSIST seal record — never off the round-tripped
+    // `savedRun`, since a non-persisting store would silently drop the field from that round-trip
+    // and the qualifier must state the run's TRUE defaultedness.
+    ...(settledByDefault ? { settled_by_default: true } : {}),
+    ...(finalRun.defaulted_steps?.length ? { defaulted_steps: finalRun.defaulted_steps } : {}),
   };
 }
 
@@ -2751,9 +2870,20 @@ export async function submitHumanResponse(
     ...(isComplete ? { terminal_reason: `Workflow completed.` } : {}),
   };
   // On the gate-completion terminal transition, drain complete/always finalizers before seal.
+  // issue #220 PR-2 (D6): stamp defaulted_steps onto the SEALED terminal record only (never the
+  // non-terminal `gateDraft` — the FM-5 guard).
   const finalRun: RunRecord = isComplete
-    ? await buildFinalizedSeal(definition, gateDraft, 'complete', options.registry)
+    ? stampDefaultedSteps(
+        await buildFinalizedSeal(definition, gateDraft, 'complete', options.registry),
+      )
     : gateDraft;
+  // issue #220 PR-2 (D6 write-site consumer): see the Step-6 twin above.
+  const defaultedStepsDurabilityWarning =
+    finalRun.defaulted_steps !== undefined &&
+    finalRun.defaulted_steps.length > 0 &&
+    !persistsField(store, 'defaulted_steps')
+      ? 'run-level defaultedness marker (defaulted_steps) not durable on this store'
+      : undefined;
 
   let savedRun: RunRecord;
   try {
@@ -2792,11 +2922,17 @@ export async function submitHumanResponse(
     status: 'ok',
     data,
     evidence: [],
-    warnings: [],
+    // issue #220 PR-2 (D5): submitHumanResponse is a SEPARATE function with no D4
+    // `settledByDefault` local in scope — it does NOT set the per-settle `settled_by_default`
+    // envelope flag (do NOT add an evidence scan to recompute it). Its disclosure surface is the
+    // run-level `defaulted_steps` marker below, plus whatever the gate-open envelope already
+    // warned the human with.
+    warnings: mergeWarnings([], defaultedStepsDurabilityWarning),
     errors: [],
     context_hint: orientation,
     run_phase: savedRun.run_phase,
     next_actions: nextActions,
+    ...(finalRun.defaulted_steps?.length ? { defaulted_steps: finalRun.defaulted_steps } : {}),
   };
 }
 
@@ -3164,10 +3300,24 @@ async function executeChainInternal(
           ? 'complete'
           : 'fail'
       : undefined;
+    // issue #220 PR-2 (D6): stamp defaulted_steps ONLY on the 'complete' seal — a guard that FAILS
+    // or ABORTS the run does not get the qualifier (the FM-5 guard: never on a non-complete
+    // terminal, and never on the non-terminal `guardResult` passthrough).
     const guardSealed =
-      guardOutcome !== undefined
-        ? await buildFinalizedSeal(definition, guardResult, guardOutcome, options.registry)
-        : guardResult;
+      guardOutcome === 'complete'
+        ? stampDefaultedSteps(
+            await buildFinalizedSeal(definition, guardResult, guardOutcome, options.registry),
+          )
+        : guardOutcome !== undefined
+          ? await buildFinalizedSeal(definition, guardResult, guardOutcome, options.registry)
+          : guardResult;
+    // issue #220 PR-2 (D6 write-site consumer): see the Step-6 twin above.
+    const guardDefaultedStepsDurabilityWarning =
+      guardSealed.defaulted_steps !== undefined &&
+      guardSealed.defaulted_steps.length > 0 &&
+      !persistsField(store, 'defaulted_steps')
+        ? 'run-level defaultedness marker (defaulted_steps) not durable on this store'
+        : undefined;
 
     // Persist the guard step result.
     let persistedGuardRun: RunRecord;
@@ -3212,11 +3362,16 @@ async function executeChainInternal(
         data: {},
         // The guard's own evidence entry, captured before the finalizer drain appended any.
         evidence: guardOwnEvidence,
-        warnings: [],
+        warnings: mergeWarnings([], guardDefaultedStepsDurabilityWarning),
         errors: [],
         context_hint: contextHint,
         run_phase: persistedGuardRun.run_phase,
         next_actions: [],
+        // issue #220 PR-2 (D6): read off `guardSealed` — the stamped PRE-PERSIST record — never
+        // the round-tripped `persistedGuardRun`, so a non-persisting store can't silently drop it.
+        ...(guardSealed.defaulted_steps?.length
+          ? { defaulted_steps: guardSealed.defaulted_steps }
+          : {}),
       };
     }
 

--- a/packages/core/src/engine/validation-exhaustion-default.test.ts
+++ b/packages/core/src/engine/validation-exhaustion-default.test.ts
@@ -1,0 +1,398 @@
+// Tests for issue #220 PR-2 — declared fail-open (`validation_exhaustion.mode: 'default'`).
+// Letter labels match the design record's §5 pin set (g, r, z) for mechanical diffing against
+// mutation probes. PR-1's counting/terminalization tests live in validation-exhaustion.test.ts —
+// this file is scoped to the NEW default-settle mechanism only.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  executeStep,
+  executeChain,
+  submitHumanResponse,
+  DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
+} from './execution-loop.js';
+import type { StepDispatcher } from './execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { WorkflowError } from '../types/workflow-error.js';
+import type { WorkflowDefinition, StepDefinition } from '../types/workflow-definition.js';
+import type { LoadBearingRunRecordField } from '../store/store-interface.js';
+
+const echoDispatcher: StepDispatcher = async (_step, input) => ({ ...input });
+
+const OUTPUT_SCHEMA = {
+  type: 'object',
+  required: ['category'],
+  properties: { category: { type: 'string' } },
+};
+const DEFAULT_OUTPUT = { category: 'fallback' };
+const INVALID_OUTPUT = {}; // missing 'category' — fails output_schema
+const VALID_OUTPUT = { category: 'ok' };
+
+/** Single-step agent workflow, mode: 'default' pre-wired. */
+function makeDefaultDef(
+  stepOverrides: Partial<StepDefinition> = {},
+  extraSteps: Record<string, StepDefinition> = {},
+): WorkflowDefinition {
+  return {
+    id: 'vx-default-wf',
+    name: 'VX Default WF',
+    version: 1,
+    steps: {
+      draft: {
+        description: 'Draft',
+        execution: 'agent',
+        output_schema: OUTPUT_SCHEMA,
+        validation_exhaustion: { mode: 'default', default_output: DEFAULT_OUTPUT },
+        ...stepOverrides,
+      },
+      ...extraSteps,
+    },
+  };
+}
+
+async function driveToExhaustion(
+  store: JsonFileStore,
+  def: WorkflowDefinition,
+  runId: string,
+  command = 'draft',
+): Promise<Awaited<ReturnType<typeof executeStep>>> {
+  const run = await store.get(runId);
+  await store.update({
+    ...run,
+    validation_rejections: { [command]: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+  });
+  return executeStep(store, def, {
+    runId,
+    command,
+    input: INVALID_OUTPUT,
+    dispatcher: echoDispatcher,
+  });
+}
+
+describe('issue #220 PR-2 — declared fail-open (validation_exhaustion.mode: default)', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-vx-default-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  describe('(g) V-D4 end-to-end default-settle', () => {
+    it('(i)-(vi): settles successfully with default_output, terminalizes the run, stamps diagnostics, discloses on the envelope, and threads the store-honesty advisory', async () => {
+      class UndeclaredFieldStore extends JsonFileStore {
+        override readonly persistedRunRecordFields: ReadonlySet<LoadBearingRunRecordField> =
+          new Set([
+            'capability_blocks',
+            'workflow_context_snapshots',
+            'extension_identity',
+            // deliberately omits 'validation_rejections' — mirrors test (k) in
+            // validation-exhaustion.test.ts, to prove the store-honesty advisory rides the
+            // default-settle SUCCESS envelope too (§5c nuance 1).
+          ]);
+      }
+      const undeclaredStore = new UndeclaredFieldStore(dir);
+      const def = makeDefaultDef();
+      const { run } = await undeclaredStore.create({
+        workflowId: def.id,
+        workflowVersion: 1,
+        params: {},
+      });
+      await undeclaredStore.update({
+        ...run,
+        validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+      });
+
+      const envelope = await executeStep(undeclaredStore, def, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      // (i) the step lands in completed_steps with output === default_output.
+      expect(envelope.status).toBe('ok');
+      const after = await undeclaredStore.get(run.id);
+      expect(after.completed_steps).toContain('draft');
+      expect(envelope.data).toEqual(DEFAULT_OUTPUT);
+
+      // (ii) the run reaches terminal complete (single-step workflow).
+      expect(after.terminal_state).toBe(true);
+      expect(after.run_phase).toBe('completed');
+
+      // (iii) the settle evidence carries diagnostics.settled_by_default === true +
+      // validation_rejections === <count>.
+      const settleEvidence = after.evidence.find(
+        (e) => e.step_id === 'draft' && e.status === 'success',
+      );
+      expect(settleEvidence).toBeDefined();
+      expect(settleEvidence?.output_summary).toEqual(DEFAULT_OUTPUT);
+      expect(settleEvidence?.diagnostics?.settled_by_default).toBe(true);
+      expect(settleEvidence?.diagnostics?.validation_rejections).toBe(
+        DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
+      );
+
+      // (iv) the success envelope carries top-level settled_by_default === true.
+      expect(envelope.settled_by_default).toBe(true);
+
+      // (v) the human-readable default-settle line rides the plain success envelope's warnings.
+      expect(envelope.warnings.join(' ')).toContain('settled with its declared default_output');
+      expect(envelope.warnings.join(' ')).toContain(
+        `after ${DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD} schema rejection`,
+      );
+
+      // (vi) the undeclared-but-persisting store's honesty advisory also rides that envelope.
+      expect(envelope.warnings.join(' ')).toContain(
+        'rejection counting not declared durable on this store',
+      );
+    });
+
+    it('never sets settled_by_default on a step that succeeds via its OWN valid submission (no exhaustion)', async () => {
+      const def = makeDefaultDef();
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const envelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'draft',
+        input: VALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      expect(envelope.status).toBe('ok');
+      expect(envelope.data).toEqual(VALID_OUTPUT);
+      expect(envelope.settled_by_default).toBeUndefined();
+      const after = await store.get(run.id);
+      const settleEvidence = after.evidence.find(
+        (e) => e.step_id === 'draft' && e.status === 'success',
+      );
+      expect(settleEvidence?.diagnostics?.settled_by_default).toBeUndefined();
+    });
+
+    it('never sets settled_by_default even after PRIOR rejections, when the FINAL submission is the agent’s own valid output (not exhaustion-driven)', async () => {
+      const def = makeDefaultDef();
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      // One rejection short of the threshold — not yet exhausted.
+      await store.update({
+        ...run,
+        validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 2 },
+      });
+      await executeStep(store, def, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+      const envelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'draft',
+        input: VALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+      expect(envelope.status).toBe('ok');
+      expect(envelope.settled_by_default).toBeUndefined();
+    });
+  });
+
+  describe('(r) V-D6 run-level disclosure: defaulted_steps', () => {
+    it('(a) a mid-workflow default-settled step with a LATER terminal step ⇒ the terminal ok envelope carries defaulted_steps containing that step', async () => {
+      const def = makeDefaultDef({}, { finish: { description: 'Finish', execution: 'auto' } });
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const draftEnvelope = await driveToExhaustion(store, def, run.id);
+      expect(draftEnvelope.status).toBe('ok');
+      // Non-terminal — the qualifier is naturally absent here (§ D6, "on the NON-terminal Step-6
+      // return this is naturally absent").
+      expect(draftEnvelope.defaulted_steps).toBeUndefined();
+
+      const finishEnvelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'finish',
+        input: {},
+        dispatcher: echoDispatcher,
+      });
+
+      expect(finishEnvelope.status).toBe('ok');
+      const after = await store.get(run.id);
+      expect(after.terminal_state).toBe(true);
+      expect(finishEnvelope.defaulted_steps).toEqual(['draft']);
+      expect(after.defaulted_steps).toEqual(['draft']); // JsonFileStore persists it too
+    });
+
+    it('(b) mode: default on a human_confirmed LAST step ⇒ approval via submitHumanResponse settles AND defaulted_steps is stamped', async () => {
+      const def = makeDefaultDef({ trust: 'human_confirmed' });
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const gateEnvelope = await driveToExhaustion(store, def, run.id);
+      expect(gateEnvelope.status).toBe('confirm_required');
+
+      const result = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: gateEnvelope.gate!.gate_id,
+        choice: 'approve',
+      });
+
+      expect(result.status).toBe('ok');
+      const after = await store.get(run.id);
+      expect(after.completed_steps).toContain('draft');
+      expect(after.terminal_state).toBe(true);
+      expect(result.defaulted_steps).toEqual(['draft']);
+      expect(after.defaulted_steps).toEqual(['draft']);
+    });
+
+    it('(c) a guard step that COMPLETES the run after a prior default-settle ⇒ stamped', async () => {
+      const guardCompleteDef: WorkflowDefinition = makeDefaultDef(
+        {},
+        {
+          guard_done: {
+            description: 'Guard that completes the run',
+            execution: 'guard',
+            depends_on: ['draft'],
+            abort_unless: [`draft.category == '${DEFAULT_OUTPUT.category}'`],
+          },
+        },
+      );
+      const { run } = await store.create({
+        workflowId: guardCompleteDef.id,
+        workflowVersion: 1,
+        params: {},
+      });
+      await store.update({
+        ...run,
+        validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+      });
+
+      const envelope = await executeChain(store, guardCompleteDef, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      expect(envelope.status).toBe('ok');
+      expect(envelope.chained_auto_steps?.some((s) => s.step === 'guard_done')).toBe(true);
+      const after = await store.get(run.id);
+      expect(after.terminal_state).toBe(true);
+      expect(after.run_phase).toBe('completed');
+      expect(envelope.defaulted_steps).toEqual(['draft']);
+      expect(after.defaulted_steps).toEqual(['draft']);
+    });
+
+    it('(c) negative: a guard step that ABORTS the run after a prior default-settle does NOT get the qualifier', async () => {
+      const guardAbortDef: WorkflowDefinition = makeDefaultDef(
+        {},
+        {
+          guard_abort: {
+            description: 'Guard that aborts the run',
+            execution: 'guard',
+            depends_on: ['draft'],
+            abort_unless: [`draft.category == 'never-matches'`],
+          },
+        },
+      );
+      const { run } = await store.create({
+        workflowId: guardAbortDef.id,
+        workflowVersion: 1,
+        params: {},
+      });
+      await store.update({
+        ...run,
+        validation_rejections: { draft: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+      });
+
+      const envelope = await executeChain(store, guardAbortDef, {
+        runId: run.id,
+        command: 'draft',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      expect(envelope.status).toBe('ok');
+      const after = await store.get(run.id);
+      expect(after.run_phase).toBe('aborted');
+      expect(after.terminal_state).toBe(true);
+      // The FM-5 guard: an abort seal is never stamped, even though 'draft' genuinely
+      // default-settled earlier in this same run.
+      expect(envelope.defaulted_steps).toBeUndefined();
+      expect(after.defaulted_steps).toBeUndefined();
+    });
+
+    it('(e) NEGATIVE (FM-5 guard): a run that default-settles a mid-workflow step and then FAILS a later step ⇒ the fail-sealed record has NO defaulted_steps', async () => {
+      const throwingDispatcher: StepDispatcher = async () => {
+        throw new WorkflowError('boom', {
+          code: 'ENGINE_HANDLER_FAILED',
+          category: 'ENGINE',
+          agentAction: 'stop',
+          retryable: false,
+        });
+      };
+      const def = makeDefaultDef({}, { finish: { description: 'Finish', execution: 'auto' } });
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const draftEnvelope = await driveToExhaustion(store, def, run.id);
+      expect(draftEnvelope.status).toBe('ok');
+      // The mid-workflow default-settle's OWN non-terminal Step-6 envelope carries no
+      // defaulted_steps qualifier.
+      expect(draftEnvelope.defaulted_steps).toBeUndefined();
+
+      const finishEnvelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'finish',
+        input: {},
+        dispatcher: throwingDispatcher,
+      });
+
+      expect(finishEnvelope.status).toBe('error');
+      const after = await store.get(run.id);
+      expect(after.terminal_state).toBe(true);
+      expect(after.run_phase).toBe('failed');
+      expect(after.failed_steps).toContain('finish');
+      // The 'fail'-sealed record has NO defaulted_steps, even though 'draft' genuinely
+      // default-settled earlier in this same run (a named residual, not a false statement — the
+      // per-step evidence snapshot still carries settled_by_default: true regardless).
+      expect(after.defaulted_steps).toBeUndefined();
+      const draftSettleEvidence = after.evidence.find(
+        (e) => e.step_id === 'draft' && e.status === 'success',
+      );
+      expect(draftSettleEvidence?.diagnostics?.settled_by_default).toBe(true);
+    });
+  });
+
+  describe('(z) V-D7 trust-gate × default', () => {
+    it('human_confirmed + exhaustion + mode: default ⇒ the gate OPENS on the default_output preview with the disclosure in gate warnings; the step is NOT in completed_steps; settled_by_default is ABSENT', async () => {
+      const def = makeDefaultDef({ trust: 'human_confirmed' });
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const gateEnvelope = await driveToExhaustion(store, def, run.id);
+
+      expect(gateEnvelope.status).toBe('confirm_required');
+      expect(gateEnvelope.gate?.preview).toEqual(DEFAULT_OUTPUT);
+      expect(gateEnvelope.data).toEqual(DEFAULT_OUTPUT);
+      expect(gateEnvelope.settled_by_default).toBeUndefined();
+      expect(gateEnvelope.warnings.join(' ')).toContain('settled with its declared default_output');
+
+      const after = await store.get(run.id);
+      expect(after.completed_steps).not.toContain('draft');
+      expect(after.pending_gate).toBeDefined();
+    });
+
+    it('a reject choice STILL settles the step with the default output (a rejecting human does not un-default)', async () => {
+      const def = makeDefaultDef({ trust: 'human_confirmed' });
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const gateEnvelope = await driveToExhaustion(store, def, run.id);
+      const result = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: gateEnvelope.gate!.gate_id,
+        choice: 'reject',
+      });
+
+      expect(result.status).toBe('ok');
+      expect(result.data['choice']).toBe('reject');
+      expect(result.data['category']).toBe(DEFAULT_OUTPUT.category);
+      const after = await store.get(run.id);
+      expect(after.completed_steps).toContain('draft');
+      expect(after.terminal_state).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/validation-exhaustion-default.test.ts
+++ b/packages/core/src/engine/validation-exhaustion-default.test.ts
@@ -195,6 +195,51 @@ describe('issue #220 PR-2 — declared fail-open (validation_exhaustion.mode: de
   });
 
   describe('(r) V-D6 run-level disclosure: defaulted_steps', () => {
+    it("control: a plain successful step with NO default-settled evidence reaches a terminal COMPLETE seal with defaulted_steps ABSENT (undefined), never an empty array — pins stampDefaultedSteps' byte-identity damage-rail (its `if (steps.length === 0) return sealDraft` early-return)", async () => {
+      // Deliberately a workflow with NO `validation_exhaustion` at all — the step submits VALID
+      // output on its first attempt (no exhaustion, no default-settle branch ever runs), so the
+      // evidence set stampDefaultedSteps scans at the Step-6 'complete' seal contains ZERO
+      // `diagnostics.settled_by_default` entries. This is the control the other (r) tests lack:
+      // every existing `defaulted_steps).toBeUndefined()` assertion elsewhere in this file is
+      // either on a FAIL-sealed record (never wrapped by stampDefaultedSteps at all) or a
+      // non-terminal Step-6 envelope (finalRun === the un-stamped completeDraft) — neither one
+      // actually calls stampDefaultedSteps with a zero-settled-by-default evidence set. This test
+      // does: a mutant that deletes stampDefaultedSteps' empty-check (so it unconditionally
+      // returns `{ ...sealDraft, defaulted_steps: steps }` with `steps === []`) would make
+      // `after.defaulted_steps` equal `[]` instead of `undefined` here — a plain `toBeUndefined()`
+      // catches that (`[]` is defined, and `expect([]).toBeUndefined()` fails).
+      const plainDef: WorkflowDefinition = {
+        id: 'vx-plain-wf',
+        name: 'VX Plain WF',
+        version: 1,
+        steps: {
+          draft: {
+            description: 'Draft',
+            execution: 'agent',
+            output_schema: OUTPUT_SCHEMA,
+          },
+        },
+      };
+      const { run } = await store.create({
+        workflowId: plainDef.id,
+        workflowVersion: 1,
+        params: {},
+      });
+
+      const envelope = await executeStep(store, plainDef, {
+        runId: run.id,
+        command: 'draft',
+        input: VALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+
+      expect(envelope.status).toBe('ok');
+      const after = await store.get(run.id);
+      expect(after.terminal_state).toBe(true); // single-step workflow ⇒ Step-6 DOES seal 'complete'
+      expect(envelope.defaulted_steps).toBeUndefined();
+      expect(after.defaulted_steps).toBeUndefined(); // NOT [] — stampDefaultedSteps' early-return
+    });
+
     it('(a) a mid-workflow default-settled step with a LATER terminal step ⇒ the terminal ok envelope carries defaulted_steps containing that step', async () => {
       const def = makeDefaultDef({}, { finish: { description: 'Finish', execution: 'auto' } });
       const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -120,6 +120,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     'workflow_context_snapshots',
     'extension_identity',
     'validation_rejections',
+    'defaulted_steps',
   ]);
 
   constructor(runsDir?: string) {

--- a/packages/core/src/store/store-interface.ts
+++ b/packages/core/src/store/store-interface.ts
@@ -3,11 +3,16 @@ import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 
 /**
- * The load-bearing `RunRecord` fields whose ABSENCE the engine interprets (control flow / the
- * drift-detection pillar) — a store that drops one silently corrupts behavior, so it must
- * DECLARE which it round-trips (issue #188). This is a CLOSED set — only fields with a real,
- * verified read-site consumer (see `RunStore.persistedRunRecordFields`'s own doc for the
- * consumer list), not an open-ended "everything RunRecord might ever carry":
+ * The load-bearing `RunRecord` fields the engine treats specially enough that a store must
+ * DECLARE which it round-trips (issue #188). This is a CLOSED set — a field qualifies via EITHER
+ * (a) a real, verified READ-SITE consumer whose absence corrupts control flow (see
+ * `RunStore.persistedRunRecordFields`'s own doc for the consumer list) — the first four below —
+ * OR (b) a WRITE-SITE disclosure-integrity advisory, whose non-durability is surfaced LOUDLY
+ * (a runtime warning) rather than silently dropped — `defaulted_steps` (issue #220 PR-2), which
+ * has no read-site consumer in-repo today (reading it is PR-3's `$settlement` namespace) but whose
+ * silent loss on a non-declaring store would misrepresent a run's true defaultedness to any
+ * external consumer inspecting the persisted record directly. Not an open-ended "everything
+ * RunRecord might ever carry":
  *  - `capability_blocks` — read by `findCapabilityBlockedSteps` (capability.ts), which returns
  *    `[]` on `undefined`; a store that drops it makes a genuinely-blocked step silently look
  *    unblocked to `get_run_state` / `list` / `run-agent`.
@@ -22,12 +27,18 @@ import type { WorkflowDefinition } from '../types/workflow-definition.js';
  *    zero every write, so a persistently-invalid agent step never reaches the threshold and the
  *    exhaustion terminalization this field exists for silently never fires (the wedge #220 kills
  *    quietly resurrects on such a store).
+ *  - `defaulted_steps` — a run-level convenience aggregate of steps that settled via their
+ *    declared `validation_exhaustion.default_output` (issue #220 PR-2). No read-site consumer
+ *    in-repo (PR-3's `$settlement` namespace reads per-step evidence instead); a store that drops
+ *    it loses only the run-level convenience marker — the per-step evidence truth is unaffected —
+ *    but the engine surfaces that loss as an explicit envelope warning rather than staying silent.
  */
 export type LoadBearingRunRecordField =
   | 'capability_blocks'
   | 'workflow_context_snapshots'
   | 'extension_identity'
-  | 'validation_rejections';
+  | 'validation_rejections'
+  | 'defaulted_steps';
 
 export interface CreateRunOptions {
   workflowId: string;

--- a/packages/core/src/types/response-envelope.ts
+++ b/packages/core/src/types/response-envelope.ts
@@ -125,4 +125,24 @@ export interface ResponseEnvelope {
   adopted_anonymous?: number;
   /** @see adopted_own — mirrors `trace_summary.foreign_lines_preserved`. */
   preserved_foreign?: number;
+  /**
+   * Issue #220 PR-2 (declared fail-open, pin g). `true` ONLY on the terminal success envelope of
+   * the step that just settled via its declared `validation_exhaustion.default_output`
+   * substitution (mirrors the settling evidence snapshot's `diagnostics.settled_by_default`).
+   * SURVIVES the MCP tool wrapper's strip (`execute-step.ts`/`submit-human-response.ts` only strip
+   * `data`+`evidence`, every other top-level field passes through — the #197 partition-fields
+   * precedent). Absent (never `false`) on every other envelope, INCLUDING the `confirm_required`
+   * gate-open envelope for a `human_confirmed` step at exhaustion (the step is not yet settled
+   * there — see the gate's own `warnings` for the disclosure) and `submitHumanResponse`'s envelope
+   * (a separate function with no access to the settling snapshot; see `defaulted_steps` below for
+   * that surface's disclosure instead).
+   */
+  settled_by_default?: boolean;
+  /**
+   * Issue #220 PR-2 (run-level disclosure, pin r). Mirrors `RunRecord.defaulted_steps` — present
+   * only on a TERMINAL `complete` envelope whose sealed run record carries a non-empty
+   * `defaulted_steps` (read off the stamped pre-persist seal record, never the round-tripped
+   * persisted record, so a non-persisting store can't silently drop it from this envelope too).
+   */
+  defaulted_steps?: string[];
 }

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -91,11 +91,20 @@ export interface StepDiagnostics {
    * Issue #220: stamped on a SUCCESS settle evidence snapshot when the step's accrued
    * `RunRecord.validation_rejections` count was > 0 at settle time ("succeeded after N
    * rejections") — free diagnostic, never gates anything. Also present on the synthesized
-   * evidence snapshot a `VALIDATION_EXHAUSTED` terminalization mints (the just-persisted count).
-   * Optional-additive: absent on every pre-#220 snapshot and on any snapshot for a step that was
-   * never rejected.
+   * evidence snapshot a `VALIDATION_EXHAUSTED` terminalization mints (the just-persisted count),
+   * and on the synthesized SUCCESS snapshot a declared default-settle mints (issue #220 PR-2 —
+   * see `settled_by_default` below). Optional-additive: absent on every pre-#220 snapshot and on
+   * any snapshot for a step that was never rejected.
    */
   validation_rejections?: number;
+  /**
+   * Issue #220 PR-2 (declared fail-open): `true` on the ONE synthesized SUCCESS evidence snapshot
+   * minted when a step's exhausted schema-rejection budget is settled via its declared
+   * `validation_exhaustion.default_output` rather than by the agent's own submission. Never present
+   * on any other snapshot (absent, never `false`) — a step that succeeded on its own submission,
+   * even one that previously accrued rejections, carries only `validation_rejections` here.
+   */
+  settled_by_default?: boolean;
 }
 
 export interface EvidenceSnapshot {
@@ -424,4 +433,15 @@ export interface RunRecord {
    * on any run with zero counted rejections so far.
    */
   validation_rejections?: Record<string, number>;
+  /**
+   * Issue #220 PR-2 (run-level disclosure, pin r): names of steps that settled via their declared
+   * `validation_exhaustion.default_output` substitution rather than the agent's own submission —
+   * a run-level convenience aggregate over the per-step `EvidenceSnapshot.diagnostics
+   * .settled_by_default` truth. Present only when non-empty; stamped ONLY on the terminal
+   * `'complete'`-sealed record by `stampDefaultedSteps` (see execution-loop.ts) — a run that later
+   * FAILS after a mid-workflow default-settle does NOT carry this field (the per-step evidence
+   * snapshot remains the durable per-step truth regardless; this is a named residual, not a false
+   * statement — see the design record). Additive-optional (the `validation_rejections` precedent).
+   */
+  defaulted_steps?: string[];
 }

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -293,16 +293,33 @@ export interface StepDefinition {
   timeout_seconds?: number;
   retry?: RetryConfig;
   /**
-   * Issue #220 (PR-1 subset — `mode`/`default_output` are NOT yet supported; a future PR extends
-   * this shape): bounds the run of persistent schema-rejections on this step. Only valid on
-   * `execution: 'agent'` steps (the countable set — VALIDATION_INPUT_SCHEMA/
-   * VALIDATION_OUTPUT_SCHEMA — is agent-only). `threshold` overrides
-   * `DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD` (6) for THIS step; must be a positive integer
-   * (`1` is legal and documented as disabling in-drive schema-repair, since the very first
-   * rejection then already meets the threshold). Absent ⇒ every countable agent step is
-   * auto-enrolled at the default threshold — there is no reachable per-step opt-out in PR-1.
+   * Issue #220 (PR-1 counting/terminalization + PR-2 declared fail-open): bounds the run of
+   * persistent schema-rejections on this step. Only valid on `execution: 'agent'` steps (the
+   * countable set — VALIDATION_INPUT_SCHEMA/VALIDATION_OUTPUT_SCHEMA — is agent-only).
+   * `threshold` overrides `DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD` (6) for THIS step; must be a
+   * positive integer (`1` is legal and documented as disabling in-drive schema-repair, since the
+   * very first rejection then already meets the threshold). Absent ⇒ every countable agent step
+   * is auto-enrolled at the default threshold — there is no reachable per-step opt-out.
+   *
+   * `mode` (PR-2): `'fail'` (default when absent) terminalizes the step with `VALIDATION_EXHAUSTED`
+   * on exhaustion, byte-unchanged from PR-1. `'default'` instead SETTLES the step successfully with
+   * `default_output` once the threshold is reached — bounded, declared, and disclosed (never a
+   * silent fallback): the run proceeds as if the agent had submitted `default_output` itself.
+   *
+   * `default_output` (PR-2): REQUIRED when `mode: 'default'`; ignored (and warned as dead config)
+   * otherwise. Only legal when the step also declares `output_schema` (an undeclared schema makes
+   * the substitute unvalidatable — refused at load) — `default_output` is then AJV-validated
+   * against that `output_schema` AT LOAD TIME, so a fallback that would itself fail runtime
+   * validation is refused before the workflow ever registers. Typed `unknown` here; every runtime
+   * sink narrows it via `default_output as Record<string, unknown>` — provably safe because the
+   * load-time proof already rejected any value that doesn't validate against the (object-typed)
+   * `output_schema`.
    */
-  validation_exhaustion?: { threshold?: number };
+  validation_exhaustion?: {
+    threshold?: number;
+    mode?: 'fail' | 'default';
+    default_output?: unknown;
+  };
   /** Plain-English instructions for the agent at this step. */
   instructions?: string;
   /**

--- a/packages/core/src/workflow/diagnostics.ts
+++ b/packages/core/src/workflow/diagnostics.ts
@@ -26,14 +26,17 @@ export type WarningCode =
   | 'TOTAL_TIMEOUT_NON_AUTO'
   // issue #218 (extends the #140 W5 family: bare retry sub-keys, not just the cap, on a
   // non-auto step):
-  | 'RETRY_INERT_NON_AUTO';
+  | 'RETRY_INERT_NON_AUTO'
+  // issue #220 PR-2 (declared fail-open validation_exhaustion.mode/default_output):
+  | 'UNKNOWN_VALIDATION_EXHAUSTION_KEY'
+  | 'DEAD_VALIDATION_EXHAUSTION_CONFIG';
 
 /**
- * A single structured diagnostic. `message` is the full human-readable text (matching, for the
- * three unknown-key codes, exactly what `renderLoaderWarning` would independently reconstruct
- * from the structured fields — kept in sync by construction, not by convention: see
- * `findUnknownKeys` below). `scope`/`id`/`step`/`key`/`did_you_mean` are populated only by the
- * unknown-key family; other codes carry just `code`/`severity`/`message`.
+ * A single structured diagnostic. `message` is the full human-readable text (matching, for every
+ * unknown-key code, exactly what `renderLoaderWarning` would independently reconstruct from the
+ * structured fields — kept in sync by construction, not by convention: see `findUnknownKeys`
+ * below). `scope`/`id`/`step`/`key`/`did_you_mean` are populated only by the unknown-key family;
+ * other codes carry just `code`/`severity`/`message`.
  */
 export interface LoaderWarning {
   code: WarningCode;
@@ -66,6 +69,8 @@ export const DEFAULT_POLICY: Record<WarningCode, 'warn' | 'error'> = {
   TOTAL_TIMEOUT_BELOW_ATTEMPT: 'warn',
   TOTAL_TIMEOUT_NON_AUTO: 'warn',
   RETRY_INERT_NON_AUTO: 'warn',
+  UNKNOWN_VALIDATION_EXHAUSTION_KEY: 'warn',
+  DEAD_VALIDATION_EXHAUSTION_CONFIG: 'warn',
 };
 
 /**
@@ -190,6 +195,7 @@ const UNKNOWN_KEY_CODES = new Set<WarningCode>([
   'UNKNOWN_STEP_KEY',
   'UNKNOWN_CREATE_WORKFLOW_KEY',
   'UNKNOWN_RETRY_KEY',
+  'UNKNOWN_VALIDATION_EXHAUSTION_KEY',
 ]);
 
 /**
@@ -197,15 +203,16 @@ const UNKNOWN_KEY_CODES = new Set<WarningCode>([
  * yaml-loader.ts, and the CLI's `printLoaderWarnings` helper) renders through this, never by
  * hand-rolling a `⚠ ` string itself.
  *
- * The four unknown-key codes are templated fresh from the structured fields (so the
- * `did_you_mean` suggestion is appended only when present) and always carry the `⚠ ` prefix —
- * byte-identical to the pre-#169 console.warn text (UNKNOWN_RETRY_KEY, issue #140, follows the
- * same rendering exactly, just with a 'retry' noun instead of 'step'/'workflow'). Every other code
+ * Every code in `UNKNOWN_KEY_CODES` is templated fresh from the structured fields (so the
+ * `did_you_mean` suggestion is appended only when present) and always carries the `⚠ ` prefix —
+ * byte-identical to the pre-#169 console.warn text (UNKNOWN_RETRY_KEY, issue #140, and
+ * UNKNOWN_VALIDATION_EXHAUSTION_KEY, issue #220, both follow the same rendering exactly, just with
+ * a different noun instead of 'step'/'workflow'). Every other code
  * (IDEMPOTENT_INERT_IN_FINALIZER, DUAL_SCHEMA_DECLARED, RETRY_NO_TIMEOUT, EXTENSION_SENTINEL,
  * ON_TIMEOUT_SINGLE_ATTEMPT, TOTAL_TIMEOUT_BELOW_ATTEMPT, TOTAL_TIMEOUT_NON_AUTO,
- * RETRY_INERT_NON_AUTO) returns `message` verbatim: these are free-text warnings whose exact
- * current prefix (or lack of one) is
- * preserved byte-for-byte by whatever constructed them, not re-derived here.
+ * RETRY_INERT_NON_AUTO, DEAD_VALIDATION_EXHAUSTION_CONFIG) returns `message` verbatim: these are
+ * free-text warnings whose exact current prefix (or lack of one) is preserved byte-for-byte by
+ * whatever constructed them, not re-derived here.
  */
 export function renderLoaderWarning(w: LoaderWarning): string {
   if (UNKNOWN_KEY_CODES.has(w.code)) {

--- a/packages/core/src/workflow/validation-exhaustion-loader.test.ts
+++ b/packages/core/src/workflow/validation-exhaustion-loader.test.ts
@@ -1,8 +1,12 @@
-// Loader validation for issue #220 PR-1: the `validation_exhaustion` step key (agent-only,
-// `{ threshold? }` only) and the `$settlement` reserved-name legislation.
+// Loader validation for issue #220: the `validation_exhaustion` step key (agent-only) and the
+// `$settlement` reserved-name legislation. PR-1 shipped `{ threshold? }`; PR-2 (this file's
+// (y)/(z) additions) extends the rule table with `mode`/`default_output` — the declared,
+// load-time-proven fail-open surface.
 import { describe, it, expect } from 'vitest';
 import { loadWorkflowFromString, loadWorkflowFromStringWithDiagnostics } from './yaml-loader.js';
 import { WorkflowError } from '../types/workflow-error.js';
+import { validateOutputSchema } from '../validation/input-schema.js';
+import { renderLoaderWarning } from './diagnostics.js';
 
 function expectThrows(yaml: string, substring: string): void {
   expect(() => loadWorkflowFromString(yaml)).toThrow(WorkflowError);
@@ -118,8 +122,8 @@ steps:
       expect(def.steps['draft']?.validation_exhaustion).toEqual({ threshold: 1 });
     });
 
-    it('unknown sub-key warning: mode is not yet supported in PR-1 and draws a warning, never a rejection', () => {
-      const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+    it('mode: fail is a fully-supported value — registers clean, no warning (issue #220 PR-2)', () => {
+      const { definition, warnings } = loadWorkflowFromStringWithDiagnostics(`
 id: vx-mode-wf
 name: VX Mode
 version: 1
@@ -130,26 +134,29 @@ steps:
     validation_exhaustion:
       mode: fail
 `);
-      const w = warnings.find((warning) => warning.key === 'mode');
-      expect(w).toBeDefined();
-      expect(w?.message).toContain('validation_exhaustion');
+      expect(warnings).toEqual([]);
+      expect(definition.steps['draft']?.validation_exhaustion).toEqual({ mode: 'fail' });
     });
 
-    it('unknown sub-key warning: default_output is not yet supported in PR-1 and draws a warning, never a rejection', () => {
+    it('an unrecognized validation_exhaustion sub-key still warns UNKNOWN_VALIDATION_EXHAUSTION_KEY (issue #220 PR-2 — replaces the PR-1 mode/default_output reuse)', () => {
       const { warnings } = loadWorkflowFromStringWithDiagnostics(`
-id: vx-default-output-wf
-name: VX Default Output
+id: vx-unknown-key-wf
+name: VX Unknown Key
 version: 1
 steps:
   draft:
     description: Draft
     execution: agent
     validation_exhaustion:
-      default_output: { category: 'x' }
+      bogus_key: 1
 `);
-      const w = warnings.find((warning) => warning.key === 'default_output');
+      const w = warnings.find((warning) => warning.key === 'bogus_key');
       expect(w).toBeDefined();
+      expect(w?.code).toBe('UNKNOWN_VALIDATION_EXHAUSTION_KEY');
+      expect(w?.severity).toBe('warn');
       expect(w?.message).toContain('validation_exhaustion');
+      // (y)/(z): joins UNKNOWN_KEY_CODES — always carries the ⚠ prefix.
+      expect(renderLoaderWarning(w!)).toMatch(/^⚠ /);
     });
 
     it('a bare validation_exhaustion: {} (no threshold) is legal — the default applies', () => {
@@ -164,6 +171,186 @@ steps:
     validation_exhaustion: {}
 `);
       expect(def.steps['draft']?.validation_exhaustion).toEqual({});
+    });
+  });
+
+  describe('(y) PR-2 fail-open rule-table rows', () => {
+    it('mode value refusal: an unrecognized mode value is a hard error (unvalidatable posture)', () => {
+      expectThrows(
+        `
+id: vx-bad-mode-wf
+name: VX Bad Mode
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      mode: bogus
+`,
+        "'validation_exhaustion.mode' must be 'fail' or 'default'",
+      );
+    });
+
+    it('mode: default without default_output is a hard error (nothing to substitute)', () => {
+      expectThrows(
+        `
+id: vx-default-no-output-wf
+name: VX Default No Output
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      mode: default
+`,
+        "'validation_exhaustion.mode: default' requires 'default_output'",
+      );
+    });
+
+    it('B5: mode: default + default_output but no output_schema is a hard error (unvalidatable default)', () => {
+      expectThrows(
+        `
+id: vx-default-no-schema-wf
+name: VX Default No Schema
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      mode: default
+      default_output: { category: 'x' }
+`,
+        "'validation_exhaustion.default_output' requires the step to declare 'output_schema'",
+      );
+    });
+
+    it('B10: default_output that FAILS the output_schema is refused at load — VERDICT agreement with validateOutputSchema, not error-shape', () => {
+      const schema = {
+        type: 'object',
+        required: ['category'],
+        properties: { category: { type: 'string' } },
+      };
+      // Same (default_output, output_schema) pair a direct validateOutputSchema call rejects.
+      expect(() => validateOutputSchema({ wrong: 1 }, schema, 'draft')).toThrow(WorkflowError);
+      expectThrows(
+        `
+id: vx-b10-fail-wf
+name: VX B10 Fail
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    output_schema:
+      type: object
+      required: [category]
+      properties:
+        category: { type: string }
+    validation_exhaustion:
+      mode: default
+      default_output: { wrong: 1 }
+`,
+        "'validation_exhaustion.default_output' does not validate against the step's own 'output_schema'",
+      );
+    });
+
+    it('B10: default_output that PASSES the output_schema registers clean — same pair validateOutputSchema accepts', () => {
+      const schema = {
+        type: 'object',
+        required: ['category'],
+        properties: { category: { type: 'string' } },
+      };
+      // Same (default_output, output_schema) pair a direct validateOutputSchema call accepts.
+      expect(() => validateOutputSchema({ category: 'billing' }, schema, 'draft')).not.toThrow();
+      const def = loadWorkflowFromString(`
+id: vx-b10-pass-wf
+name: VX B10 Pass
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    output_schema:
+      type: object
+      required: [category]
+      properties:
+        category: { type: string }
+    validation_exhaustion:
+      mode: default
+      default_output: { category: 'billing' }
+`);
+      expect(def.steps['draft']?.validation_exhaustion).toEqual({
+        mode: 'default',
+        default_output: { category: 'billing' },
+      });
+    });
+
+    it('a structurally malformed output_schema on a mode: default step REFUSES at load (the new refusal population — a raw Ajv compile error, not a WorkflowError)', () => {
+      expectThrows(
+        `
+id: vx-malformed-schema-wf
+name: VX Malformed Schema
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    output_schema:
+      type: object
+      properties:
+        category: { type: 12345 }
+    validation_exhaustion:
+      mode: default
+      default_output: { category: 'billing' }
+`,
+        "'validation_exhaustion.default_output' does not validate against the step's own 'output_schema'",
+      );
+    });
+
+    it('dead-config WARN: default_output present without mode: default (mode absent) is ignored, never rejected', () => {
+      const { definition, warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: vx-dead-config-wf
+name: VX Dead Config
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      default_output: { category: 'x' }
+`);
+      expect(definition.steps['draft']?.validation_exhaustion).toEqual({
+        default_output: { category: 'x' },
+      });
+      expect(warnings).toHaveLength(1);
+      const w = warnings[0]!;
+      expect(w.code).toBe('DEAD_VALIDATION_EXHAUSTION_CONFIG');
+      expect(w.severity).toBe('warn');
+      expect(w.message).toContain('default_output');
+      expect(w.message).toContain('mode: default');
+      // NOT in UNKNOWN_KEY_CODES — renders its message verbatim, no ⚠ prefix.
+      expect(renderLoaderWarning(w)).toBe(w.message);
+      expect(renderLoaderWarning(w)).not.toMatch(/^⚠ /);
+    });
+
+    it('dead-config WARN: default_output present with mode: fail (explicit) is also ignored', () => {
+      const { warnings } = loadWorkflowFromStringWithDiagnostics(`
+id: vx-dead-config-explicit-fail-wf
+name: VX Dead Config Explicit Fail
+version: 1
+steps:
+  draft:
+    description: Draft
+    execution: agent
+    validation_exhaustion:
+      mode: fail
+      default_output: { category: 'x' }
+`);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]!.code).toBe('DEAD_VALIDATION_EXHAUSTION_CONFIG');
     });
   });
 

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -8,6 +8,7 @@ import type {
   WorkflowDefinition,
   TemplateDefinition,
   TriggerRule,
+  JsonSchema,
 } from '../types/workflow-definition.js';
 import {
   KNOWN_STEP_KEYS,
@@ -26,6 +27,7 @@ import type { ExtensionRegistry } from '../extensions/registry.js';
 import { normalizeTriggerFilter, validateTriggerStructure } from './trigger-schema.js';
 import { splitComparison, isPathShaped } from '../engine/comparison-expr.js';
 import { DEFAULT_EXECUTION_TIMEOUT_SECONDS } from '../engine/claim-liveness.js';
+import { validateOutputSchema } from '../validation/input-schema.js';
 
 type ConditionSurface = 'when' | 'abort_unless' | 'preconditions';
 
@@ -138,9 +140,8 @@ const SERVICE_ENTRY_JSON_SCHEMA = {
 
 const VALID_EXECUTIONS = new Set(['auto', 'agent', 'guard', 'finalizer']);
 const VALID_FINALIZER_TRIGGERS = new Set(['complete', 'fail', 'abort', 'always']);
-// issue #220 (PR-1 subset): the ONLY validation_exhaustion sub-key this PR recognizes. `mode`/
-// `default_output` are a future PR's surface — declaring them now warns as unknown, never rejects.
-const KNOWN_VALIDATION_EXHAUSTION_KEYS = ['threshold'];
+// issue #220 (PR-2): the full set of recognized validation_exhaustion sub-keys.
+const KNOWN_VALIDATION_EXHAUSTION_KEYS = ['threshold', 'mode', 'default_output'];
 const VALID_SERVICE_METHODS = new Set(['fetch', 'create', 'update', 'delete']);
 const VALID_TRIGGER_RULES = new Set<TriggerRule>([
   'all_success',
@@ -807,11 +808,15 @@ function parseWorkflowString(
       errors.push(`Step '${stepName}': 'output_schema' is only valid on execution: agent steps`);
     }
 
-    // issue #220 (PR-1 subset): validation_exhaustion is only valid on execution: agent steps —
-    // the countable rejection set (VALIDATION_INPUT_SCHEMA/VALIDATION_OUTPUT_SCHEMA) is agent-only
-    // by construction (execution-loop.ts's countRejection). PR-1 supports ONLY `{ threshold? }` —
-    // `mode`/`default_output` are a future PR's surface; declaring them here WARNS (never
-    // rejects) as an unknown sub-key, the loader's warn-don't-reject posture (#144/#169/#170).
+    // issue #220 (PR-2): validation_exhaustion is only valid on execution: agent steps — the
+    // countable rejection set (VALIDATION_INPUT_SCHEMA/VALIDATION_OUTPUT_SCHEMA) is agent-only by
+    // construction (execution-loop.ts's countRejection). Full rule table: `mode` value validated
+    // (REFUSE on an unrecognized value — unvalidatable posture, fail-closed); `mode: 'default'`
+    // requires `default_output` (REFUSE — nothing to substitute) which in turn requires the step's
+    // own `output_schema` (REFUSE — B5, an unvalidatable default) against which `default_output` is
+    // then AJV-proven AT LOAD TIME (REFUSE — B10, reusing the runtime validator so load-time and
+    // runtime verdicts can never diverge); `default_output` present without `mode: 'default'` WARNS
+    // as dead config (never rejects — it's simply inert); an unknown sub-key WARNS.
     if (step['validation_exhaustion'] !== undefined) {
       if (step['execution'] !== 'agent') {
         errors.push(
@@ -826,12 +831,13 @@ function parseWorkflowString(
         const exhaustionBlock = step['validation_exhaustion'] as Record<string, unknown>;
 
         // WARN (do not reject) on an unknown validation_exhaustion sub-key — the retry-block-style
-        // pattern (issue #140's UNKNOWN_RETRY_KEY), reusing the existing UNKNOWN_STEP_KEY code
-        // with the noun overridden (PR-1 mints no new WarningCode for this nested block).
+        // pattern (issue #140's UNKNOWN_RETRY_KEY), its OWN code (issue #220 PR-2 mints
+        // UNKNOWN_VALIDATION_EXHAUSTION_KEY, replacing PR-1's UNKNOWN_STEP_KEY noun-override —
+        // closes the #170-flip incoherence against the structurally identical retry-key family).
         warnings.push(
           ...findUnknownKeys(exhaustionBlock, KNOWN_VALIDATION_EXHAUSTION_KEYS, {
             scope: 'step',
-            code: 'UNKNOWN_STEP_KEY',
+            code: 'UNKNOWN_VALIDATION_EXHAUSTION_KEY',
             step: stepName,
             noun: 'validation_exhaustion',
           }),
@@ -847,6 +853,71 @@ function parseWorkflowString(
               `(1 is legal — it disables in-drive schema-repair, since the first rejection ` +
               `already meets it)`,
           );
+        }
+
+        const modeValue = exhaustionBlock['mode'];
+        if (modeValue !== undefined && modeValue !== 'fail' && modeValue !== 'default') {
+          errors.push(
+            `Step '${stepName}': 'validation_exhaustion.mode' must be 'fail' or 'default' ` +
+              `(got: ${JSON.stringify(modeValue)})`,
+          );
+        }
+
+        const hasDefaultOutput = 'default_output' in exhaustionBlock;
+        if (modeValue === 'default') {
+          if (!hasDefaultOutput) {
+            errors.push(
+              `Step '${stepName}': 'validation_exhaustion.mode: default' requires ` +
+                `'default_output' (nothing to substitute on exhaustion)`,
+            );
+          } else if (step['output_schema'] === undefined) {
+            errors.push(
+              `Step '${stepName}': 'validation_exhaustion.default_output' requires the step to ` +
+                `declare 'output_schema' (an undeclared schema makes the default unvalidatable)`,
+            );
+          } else {
+            // B10 — load-time AJV proof: REUSE the runtime validator so the load-time verdict can
+            // never diverge from the runtime verdict for the exact same (default_output,
+            // output_schema) pair. This is the loader's first load-time Ajv compile of an
+            // output_schema (today output_schema is only compiled at runtime), so the catch below
+            // legitimately sees TWO different populations: a VALIDATION_OUTPUT_SCHEMA
+            // WorkflowError (default_output fails the schema) and a raw Ajv schema-compilation
+            // Error (a structurally malformed output_schema) — both fail-closed to a load refusal,
+            // but they carry their detail DIFFERENTLY: a WorkflowError has `.details.errors`; a raw
+            // Error has NO `.details` at all (reading `.details.errors` on it throws a TypeError
+            // that would escape the loader mid-walk — verified empirically). Discriminate.
+            try {
+              validateOutputSchema(
+                exhaustionBlock['default_output'] as Record<string, unknown>,
+                step['output_schema'] as JsonSchema,
+                stepName,
+              );
+            } catch (err) {
+              const detail =
+                err instanceof WorkflowError
+                  ? JSON.stringify(err.details['errors'])
+                  : err instanceof Error
+                    ? err.message
+                    : String(err);
+              errors.push(
+                `Step '${stepName}': 'validation_exhaustion.default_output' does not validate ` +
+                  `against the step's own 'output_schema': ${detail}`,
+              );
+            }
+          }
+        } else if (hasDefaultOutput) {
+          // default_output present without mode: 'default' (mode: 'fail' or absent) — inert, not
+          // an error: WARN as dead config rather than silently ignoring it.
+          warnings.push({
+            code: 'DEAD_VALIDATION_EXHAUSTION_CONFIG',
+            severity: resolveSeverity('DEAD_VALIDATION_EXHAUSTION_CONFIG'),
+            scope: 'step',
+            step: stepName,
+            message:
+              `Step '${stepName}': 'validation_exhaustion.default_output' is ignored without ` +
+              `'mode: default' — set 'validation_exhaustion.mode: default' to enable it, or ` +
+              `remove 'default_output'.`,
+          });
         }
       }
     }

--- a/packages/testing/src/store/in-memory-store.test.ts
+++ b/packages/testing/src/store/in-memory-store.test.ts
@@ -59,6 +59,7 @@ const ALL_FIELDS: LoadBearingRunRecordField[] = [
   'workflow_context_snapshots',
   'extension_identity',
   'validation_rejections',
+  'defaulted_steps',
 ];
 
 describe('InMemoryStore — RunStore fidelity TCK conformance (issue #188)', () => {

--- a/packages/testing/src/store/in-memory-store.ts
+++ b/packages/testing/src/store/in-memory-store.ts
@@ -29,6 +29,7 @@ export class InMemoryStore implements RunStore {
     'workflow_context_snapshots',
     'extension_identity',
     'validation_rejections',
+    'defaulted_steps',
   ]);
 
   async create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {

--- a/packages/testing/src/store/run-store-fidelity-contract.ts
+++ b/packages/testing/src/store/run-store-fidelity-contract.ts
@@ -60,6 +60,7 @@ const SAMPLE_VALUES: {
   workflow_context_snapshots: Record<string, WorkflowContextSnapshot>;
   extension_identity: ExtensionIdentityEntry[];
   validation_rejections: Record<string, number>;
+  defaulted_steps: string[];
 } = {
   capability_blocks: {
     'tck-step': {
@@ -92,6 +93,7 @@ const SAMPLE_VALUES: {
     },
   ],
   validation_rejections: { 'tck-step': 3 },
+  defaulted_steps: ['tck-step'],
 };
 
 /**


### PR DESCRIPTION
## Context

Issue #220, **PR 2 of 3**. PR-1 (#230, merged) shipped counting + fall-through terminalization: every agent step with a countable schema is auto-enrolled at `mode: 'fail'`, fail-at-6. PR-2 adds the **declared, validated, disclosed fail-open** path. Design converged through the full debate protocol; record `plans/issue-220/design-d3.md` §4/§3b (local). PR-3 (later) adds the `$settlement` evaluation-root namespace that reads PR-2's disclosure data.

## Motivation

Declared fallback with declaration-time proof (K8s CRD defaults / GraphQL definition-time validation) + mandatory same-response disclosure (GraphQL errors-alongside-data) EXCEEDING the silent-fallback industry norm (Hystrix/resilience4j). An author who knows a step's exhaustion is recoverable should be able to opt it into a **schema-proven, bounded, disclosed** default rather than failing the run — but the substitution must never be silent: it is disclosed on the step evidence, the envelope, and a run-level marker.

## Changes

- **`validation_exhaustion: { mode?: 'fail' | 'default'; default_output? }`** (widened from `{ threshold? }`). `mode: 'default'` opts a step into fail-open.
- **Loader rule-chain** (`yaml-loader.ts`): `mode`-value REFUSE; `mode:'default'` requires `default_output` requires `output_schema` (REFUSE — B5); `default_output` AJV-proven against the step's own `output_schema` **at load time, reusing the runtime validator** so load-time and runtime verdicts can never diverge (B10); `default_output` without `mode:'default'` WARNs as dead config.
- **Two new `WarningCode`s** (`diagnostics.ts`): `UNKNOWN_VALIDATION_EXHAUSTION_KEY` (closes the PR-1 `UNKNOWN_STEP_KEY` reuse / #170-flip incoherence) and `DEAD_VALIDATION_EXHAUSTION_CONFIG`.
- **Engine default-settle branch** (`execution-loop.ts`): on exhaustion of a `mode:'default'` step, settle it SUCCESSFULLY with `default_output` (a synthesized success evidence snapshot; `dispatchError` stays `null`, so Step 5/5b-gate/Step 6 all run unmodified). Gated on `exhaustion !== null` so a `mode:'default'` step that succeeds on its own valid submission never reports a false default.
- **Three disclosure surfaces**: step evidence `diagnostics.settled_by_default`; top-level envelope `settled_by_default` (survives the MCP strip); run-level `RunRecord.defaulted_steps` stamped at the seal via a pure `stampDefaultedSteps` helper (complete-seal only; the stamp reads off the pre-persist record so a non-persisting store can't silently drop it) + a store-honesty advisory when the field isn't declared durable. `defaulted_steps` joins #188's `LoadBearingRunRecordField` closed set (the membership criterion is widened to admit write-site disclosure-integrity fields).
- **Trust-gate × default**: a `human_confirmed` step opens the gate on the `default_output` preview (fail-safe — the human sees the substitution); `reject` still settles (does not un-default).

## Verification

```bash
npx turbo run test --force   # core 1881 / cli 799 / testing 81 / mcp-server 265 = 3026 green
npm run lint && npx tsc --noEmit   # clean, all four packages
```

Two review rounds. Every mechanism read from source and confirmed faithful; both novel mutation probes (the `exhaustion !== null` settle-guard; the B10 `WorkflowError`-vs-raw-`Error` discrimination) PINNED; the `stampDefaultedSteps` damage-rail pinned by the correction commit. Note: the Turbo-parallel runner has a known worker-pool-teardown flake on `mcp-server`'s `append-trace-capacity-warning.test.ts` (unrelated) — 265/265 in isolation.

## Rollback

```bash
git revert 29ad9f7 646fd15
```

No out-of-band mutations. Fail-open is strictly opt-in — a workflow that never declares `validation_exhaustion.mode: 'default'` is byte-unaffected. The additive record/envelope fields are unknown-field-tolerant for pre-#220 readers.

## Related

- Issue #220 (PR 2 of 3 — do NOT auto-close)
- #230 (PR-1), #188 (fidelity contract joined), #185/#197 (WAL adoption honored), #170 (WarningCode family coherence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
