### PR TITLE
feat(engine): the $settlement evaluation-root namespace (issue #220, PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,25 @@ Record<string, number>` (additive, joins the #188 `LoadBearingRunRecordField` cl
   disclosure-integrity advisory, alongside the existing read-site-consumer class) — a store that
   doesn't declare it durable draws an explicit warning rather than silently losing the marker.
 
+- **The `$settlement` evaluation-root namespace, PR-3 (issue #220) — the final piece.** Exposes
+  PR-2's fallback-provenance disclosure to every workflow evaluation surface: for each step that
+  has SETTLED (`completed_steps ∪ failed_steps`), `$settlement.<step>.settled_by_default` and
+  `$settlement.<step>.validation_rejections` let an author branch on whether a dependency
+  default-settled — `when: ["$settlement.<dep>.settled_by_default == false"]`,
+  `abort_unless: [...]` on a guard, a `precondition`, or (via the nested
+  `context.resources.$settlement.<dep>.…` spelling) `input_map`/gate messages/template filters.
+  Minted by a new pure exported helper, `buildSettlementNamespace(run)`
+  (`packages/core/src/engine/eligibility.ts`), called from the ONE core chokepoint
+  (`buildEvidenceByStep`) so every engine surface inherits it for free, and separately from
+  `realm replay` (which builds its own evidence map) so a replayed precondition can never diverge
+  from the live verdict. A `$settlement.<dep>` reference where `<dep>` is not a direct dependency
+  of the referencing step is **load-refused** on `when`/`abort_unless`/`preconditions` (the same
+  one-hop rule `when` already enforces for ordinary step references) — see the new `$settlement`
+  section in `docs/reference/yaml-schema.md` for the full per-root spelling table and the named
+  residual (a bad FIELD name, as opposed to a bad dependency name, is not load-refused anywhere;
+  `input_map`/templates resolve it to `undefined` silently, matching their existing behavior for
+  any other unresolvable reference).
+
 ### Changed
 
 - **AUTO-ENROLLMENT (issue #220): every `execution: 'agent'` step with a countable schema now
@@ -84,6 +103,12 @@ Record<string, number>` (additive, joins the #188 `LoadBearingRunRecordField` cl
 string[]` (mirrors `RunRecord.defaulted_steps` on a terminal `complete` envelope).** Both are
   absent on every envelope for a workflow that doesn't use `mode: 'default'` — no observable change
   for existing consumers.
+- **`buildEvidenceByStep` (a PUBLIC core export, issue #220 PR-3) now always includes a
+  `$settlement` key in its returned map — any external consumer iterating its keys as step ids
+  will now also see `$settlement`.** No workflow BEHAVIOUR changes: a workflow that never
+  references `$settlement` evaluates identically to before (the added key is inert unless
+  referenced) — but the public-export OUTPUT SHAPE does gain the key on every call, hence the
+  `Changed` grade rather than a claim of byte-identical output.
 
 ---
 

--- a/docs/reference/yaml-schema.md
+++ b/docs/reference/yaml-schema.md
@@ -710,8 +710,25 @@ exhaustion in PR-1**, only to retune it.
 | `threshold` | integer | Overrides the default threshold (6) for this step. Must be a positive integer. `1` is legal and documented as disabling in-drive schema-repair (`realm agent`'s `--schema-retries`), since the very first rejection already meets it. |
 
 Only valid on `execution: 'agent'` steps — the countable rejection classes are agent-only by
-construction. `mode`/`default_output` sub-keys are **not yet supported** (a later PR's surface);
-declaring them today draws an unknown-key warning, never a rejection.
+construction.
+
+`mode` (`'fail'` | `'default'`) and `default_output` (issue #220 PR-2) let a step declare a
+**bounded, validated, disclosed fallback** instead of failing on exhaustion: `mode: 'default'`
+requires `default_output` and requires the step to declare `output_schema` (against which
+`default_output` is AJV-validated **at load time**, using the exact same validator the runtime
+uses — a fallback that would itself fail runtime validation is refused before the workflow ever
+registers). On exhaustion the engine settles the step SUCCESSFULLY with `default_output` instead
+of failing the run. See `$settlement` below for how a downstream step can branch on whether this
+happened.
+
+```yaml
+draft:
+  execution: agent
+  output_schema: { type: object, required: [category], properties: { category: { type: string } } }
+  validation_exhaustion:
+    mode: default
+    default_output: { category: 'uncategorized', source: 'fallback' }
+```
 
 > **`realm agent` coherence warning:** when `--schema-retries`'s own in-drive repair budget
 > (`schemaRetries + 1` attempts) exceeds a step's effective exhaustion threshold, the drive prints
@@ -722,6 +739,82 @@ declaring them today draws an unknown-key warning, never a rejection.
 > dynamically-created workflow cannot declare it, and draws a targeted warning naming the
 > disposition if submitted. Every dynamic agent step with a countable schema is still auto-enrolled
 > at the default threshold; there is no reachable override or opt-out for a dynamic workflow.
+
+---
+
+## `$settlement` namespace (fallback-provenance branching)
+
+Issue #220 PR-3. `$settlement` is a reserved, engine-minted evaluation-root namespace exposing —
+for every step that has SETTLED (completed or failed) — whether it settled via its own submission
+or via a declared `validation_exhaustion.mode: 'default'` fallback:
+
+```
+$settlement.<step>.settled_by_default   →  boolean
+$settlement.<step>.validation_rejections →  integer (count of schema rejections before settling)
+```
+
+An entry exists **only** for a step in `completed_steps ∪ failed_steps` — a skipped step, a
+still-in-progress step, or a step whose only evidence is a non-settling snapshot (e.g. an
+in-flight gate preview) has **no** `$settlement` entry at all; absence is never a third status.
+For a settled step that never used `mode: 'default'`, `settled_by_default` is explicitly `false`
+(never merely absent) and `validation_rejections` is `0` if it never accrued any.
+
+### Per-root spelling
+
+`$settlement` is available on every evaluation surface, but the ROOT it hangs off differs, exactly
+like every other evidence reference on that surface:
+
+| Surface                                          | Spelling                                                  |
+| ------------------------------------------------ | --------------------------------------------------------- |
+| `when`                                           | `$settlement.<step>.settled_by_default`                   |
+| `abort_unless` (guard steps)                     | `$settlement.<step>.settled_by_default`                   |
+| `preconditions`                                  | `$settlement.<step>.settled_by_default`                   |
+| `input_map`                                      | `context.resources.$settlement.<step>.settled_by_default` |
+| Template filters (`{{ }}`, incl. `gate.message`) | `context.resources.$settlement.<step>.settled_by_default` |
+
+```yaml
+route:
+  execution: auto
+  depends_on: [classify]
+  when: ['$settlement.classify.settled_by_default == false']
+
+approve:
+  execution: guard
+  depends_on: [classify]
+  abort_unless: ['$settlement.classify.settled_by_default == false']
+
+notify:
+  execution: agent
+  depends_on: [classify]
+  input_map:
+    was_fallback: 'context.resources.$settlement.classify.settled_by_default'
+```
+
+### One-hop rule (load-time enforced on `when`/`abort_unless`/`preconditions`)
+
+`<step>` in a `$settlement.<step>.…` reference must be a **direct** dependency of the referencing
+step (the same one-hop rule `when` already enforces for ordinary step references) — a
+`$settlement.<step>` where `<step>` is not in `depends_on` is **load-refused**, on all three of
+`when`/`abort_unless`/`preconditions`. `input_map` and template filters do **not** get this
+check — see the residual below.
+
+### Per-surface consequence disparity (a bad FIELD name, e.g. a typo'd `settled_by_defalut`)
+
+Only the `<step>` segment is load-time-validated (the one-hop rule above); a typo in the FIELD
+segment is never load-refused anywhere, and its RUNTIME consequence differs by surface:
+
+| Surface                 | Consequence of an unresolvable field                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------ |
+| `when`                  | The leaf resolves `undefined` → traced as `lhs_present: false` in `skip_details` (visible) |
+| `abort_unless` (guard)  | Unresolvable path → `resolution_error` → the guard step FAILS the run                      |
+| `preconditions`         | Unresolvable path → the precondition never passes → the step blocks forever                |
+| `input_map` / templates | Resolves to `undefined` **silently** — no trace, no refusal                                |
+
+**Named residual:** `input_map` has no load-time reference validation at all (this predates
+`$settlement` and is unchanged by it) — a typo'd `$settlement` path there is indistinguishable,
+at load time, from a correctly-spelled one that simply hasn't settled yet. This is a known,
+accepted gap, not a bug; do not expect `input_map` to catch a `$settlement` typo the way `when`
+does.
 
 ---
 

--- a/packages/cli/src/commands/replay.test.ts
+++ b/packages/cli/src/commands/replay.test.ts
@@ -22,7 +22,18 @@ function makeRun(evidence: EvidenceSnapshot[]): RunRecord {
     id: 'run_test1',
     workflow_id: 'test-workflow',
     workflow_version: 1,
-    state: 'completed',
+    // issue #220 §4c (PR-3): replayRun now also mints `$settlement` via
+    // buildSettlementNamespace(run), which iterates completed_steps/failed_steps — this fixture
+    // predates the DAG step-set model (it carried a stale `state` field the real RunRecord type
+    // no longer has, and never set these arrays at all; nothing runtime-read them before this
+    // PR). Empty arrays here preserve every existing test's behavior exactly (no step in this
+    // fixture is "settled", so buildSettlementNamespace returns {} — zero observable change to
+    // any assertion in this file).
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: [],
+    skipped_steps: [],
+    run_phase: 'completed',
     version: 1,
     params: {},
     evidence,
@@ -174,6 +185,114 @@ describe('replayRun', () => {
 
     // Original evidence must not have been mutated.
     expect(originalOutput.result.accepted_count).toBe(3);
+  });
+
+  // issue #220 §4c (PR-3, pin ee): replay parity — replayRun mints $settlement via the SAME
+  // shared helper (buildSettlementNamespace) the live engine's buildEvidenceByStep uses, so a
+  // $settlement-referencing precondition's replay verdict can never structurally diverge from
+  // what the live run actually decided. Replay evaluates ONLY preconditions (never when/guards),
+  // so the fixture below uses a precondition — a MINT-DEPENDENT-TRUE fixture (a both-absent
+  // vacuous pass is impossible: step1 genuinely default-settled, so $settlement.step1
+  // .settled_by_default is genuinely `true` in the live record).
+  describe('pin (ee): $settlement replay parity', () => {
+    function makeSettlementRun(): RunRecord {
+      return {
+        id: 'run_settlement1',
+        workflow_id: 'settlement-workflow',
+        workflow_version: 1,
+        completed_steps: ['step1'],
+        in_progress_steps: [],
+        failed_steps: [],
+        skipped_steps: [],
+        run_phase: 'completed',
+        version: 3,
+        params: {},
+        evidence: [
+          {
+            step_id: 'step1',
+            started_at: '2024-01-01T00:00:00.000Z',
+            completed_at: '2024-01-01T00:00:01.000Z',
+            duration_ms: 100,
+            input_summary: {},
+            output_summary: { category: 'fallback' },
+            status: 'success',
+            evidence_hash: 'abc123',
+            diagnostics: {
+              input_token_estimate: 0,
+              precondition_trace: [],
+              settled_by_default: true,
+              validation_rejections: 6,
+            },
+          },
+        ],
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:01.000Z',
+        terminal_state: true,
+      };
+    }
+
+    // NOTE on polarity: this precondition is deliberately `== true`, NOT `== false`. A
+    // `== false` polarity would be a COINCIDENTAL-PASS trap here: precondition.ts's absent-LHS
+    // rule always resolves an unresolvable path to `false` (never true) — so with the mint
+    // missing entirely, `$settlement.step1.settled_by_default == false` would ALSO evaluate to
+    // `false` (LHS undefined ⇒ false, matching the assertion below by ACCIDENT), and a
+    // replay-missing-mint mutant would pass this suite vacuously. `== true` is the only polarity
+    // where "mint present, genuinely true" (passes) and "mint absent, undefined LHS" (always
+    // fails) actually disagree — verified via an explicit mutation probe during this PR's review.
+    const settlementDef: WorkflowDefinition = {
+      id: 'settlement-workflow',
+      name: 'Settlement Workflow',
+      version: 1,
+      steps: {
+        step1: { description: 'Step1', execution: 'agent' },
+        step2: {
+          description: 'Step2',
+          execution: 'auto',
+          preconditions: ['$settlement.step1.settled_by_default == true'],
+        },
+      },
+    };
+
+    it('MINT-DEPENDENT-TRUE: replay reproduces the live verdict for a $settlement-referencing precondition (a both-absent vacuous pass is impossible — step1 genuinely default-settled)', () => {
+      const run = makeSettlementRun();
+      const results = replayRun(run, settlementDef, []);
+      const step2Row = results.find((r) => r.step_id === 'step2')!;
+      // Live truth: settled_by_default === true ⇒ the precondition ("== true") PASSES.
+      expect(step2Row.preconditions_original).toBe(true);
+      // No override supplied — replay must reproduce the SAME verdict (mint parity).
+      expect(step2Row.preconditions_replay).toBe(true);
+      expect(step2Row.changed).toBe(false);
+    });
+
+    it('--with $settlement.step1.settled_by_default=false overrides ON TOP of the mint, flipping the REPLAY verdict only', () => {
+      const run = makeSettlementRun();
+      const results = replayRun(run, settlementDef, [
+        { step: '$settlement', field: 'step1.settled_by_default', value: false },
+      ]);
+      const step2Row = results.find((r) => r.step_id === 'step2')!;
+      expect(step2Row.preconditions_original).toBe(true); // untouched by the override
+      expect(step2Row.preconditions_replay).toBe(false); // override flips it
+      expect(step2Row.changed).toBe(true);
+    });
+
+    it('ALIASING FOOTGUN: the override does NOT mutate the ORIGINAL verdict — preconditions_original stays reflective of the genuinely-minted true, not corrupted by the clone override (a shared-reference mutant would flip this too)', () => {
+      const run = makeSettlementRun();
+      const results = replayRun(run, settlementDef, [
+        { step: '$settlement', field: 'step1.settled_by_default', value: false },
+      ]);
+      const step2Row = results.find((r) => r.step_id === 'step2')!;
+      // The internal evidenceByStep map is never exposed by replayRun — this IS the observable
+      // surface for the aliasing footgun (issue #220 §4c prompt-audit F2).
+      expect(step2Row.preconditions_original).toBe(true);
+    });
+
+    it('a replay-missing-mint regression (no override, no $settlement key at all) would show up as an undefined-LHS precondition failure — sanity: a step with NO preconditions is always unchanged regardless', () => {
+      const run = makeSettlementRun();
+      const results = replayRun(run, settlementDef, []);
+      const step1Row = results.find((r) => r.step_id === 'step1')!;
+      expect(step1Row.has_preconditions).toBe(false);
+      expect(step1Row.changed).toBe(false);
+    });
   });
 });
 

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -1,7 +1,7 @@
 // replay command — re-evaluates preconditions with modified step outputs (read-only simulation).
 import { Command } from 'commander';
 import type { RunRecord, WorkflowDefinition } from '@sensigo/realm';
-import { checkPreconditions } from '@sensigo/realm';
+import { checkPreconditions, buildSettlementNamespace } from '@sensigo/realm';
 import { formatPrecondColumn } from './replay-format.js';
 import type { ReplayStore } from '../store/replay-store.js';
 
@@ -87,6 +87,15 @@ export function replayRun(
     if (snap.kind === 'gate_response') continue;
     evidenceByStep[snap.step_id] = snap.output_summary;
   }
+  // issue #220 §4c (PR-3, D5/M7): mint `$settlement` via the SAME shared helper core's
+  // buildEvidenceByStep uses, so a $settlement-referencing precondition's replay verdict can
+  // never structurally diverge from the live engine's. Set BEFORE the clone loop below — that
+  // loop's own structuredClone(...) then deep-copies this object into replayEvidenceByStep as an
+  // INDEPENDENT copy for free (mint ONCE, clone generically — never call
+  // buildSettlementNamespace a second time, and never assign the same object reference to both
+  // maps: a shared reference would let a `--with` override's deepSet mutate the "original"
+  // baseline too, corrupting preconditions_original).
+  evidenceByStep['$settlement'] = buildSettlementNamespace(run);
 
   // Build replay evidence as a deep clone, then apply overrides.
   // structuredClone prevents nested object mutations from affecting the original evidence map.

--- a/packages/core/src/engine/eligibility.test.ts
+++ b/packages/core/src/engine/eligibility.test.ts
@@ -14,10 +14,11 @@ import {
   propagateSkips,
   isWorkflowComplete,
   buildEvidenceByStep,
+  buildSettlementNamespace,
 } from './eligibility.js';
 import { JsonFileStore } from '../store/json-file-store.js';
 import type { WorkflowDefinition, StepDefinition } from '../types/workflow-definition.js';
-import type { RunRecord, PendingGate } from '../types/run-record.js';
+import type { RunRecord, PendingGate, EvidenceSnapshot } from '../types/run-record.js';
 
 function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
   return {
@@ -1475,5 +1476,156 @@ describe('finalizer steps — held out of the DAG', () => {
         }),
       ),
     ).toBe('failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSettlementNamespace + the `$settlement` mint (issue #220 §4c, PR-3)
+// ---------------------------------------------------------------------------
+
+describe('buildSettlementNamespace — the $settlement mint (issue #220 §4c)', () => {
+  function snap(overrides: { step_id: string } & Partial<EvidenceSnapshot>): EvidenceSnapshot {
+    return {
+      started_at: '2024-01-01T00:00:00.000Z',
+      completed_at: '2024-01-01T00:00:01.000Z',
+      duration_ms: 100,
+      input_summary: {},
+      output_summary: {},
+      status: 'success',
+      evidence_hash: 'abc',
+      ...overrides,
+    };
+  }
+
+  it('(ff) membership-gated presence: a clean-settled dep gets a PRESENT entry with settled_by_default === false', () => {
+    const run = makeRun({
+      completed_steps: ['clean_step'],
+      evidence: [snap({ step_id: 'clean_step' })], // no diagnostics at all
+    });
+    const result = buildSettlementNamespace(run);
+    expect(result['clean_step']).toEqual({ settled_by_default: false, validation_rejections: 0 });
+  });
+
+  it('(ff) membership-gated presence: an UNSETTLED step with evidence (compensating-unclaim audit / guard-abort) gets NO entry — an evidence-derived-domain mutant would fabricate one', () => {
+    const run = makeRun({
+      completed_steps: [], // 'audited_step' is NOT here — it never actually settled
+      failed_steps: [],
+      skipped_steps: ['aborted_guard'], // guard-abort lands in skipped_steps, never completed/failed
+      evidence: [
+        snap({ step_id: 'audited_step' }), // a compensating-unclaim AUDIT snapshot
+        snap({ step_id: 'aborted_guard' }), // guard-abort evidence
+      ],
+    });
+    const result = buildSettlementNamespace(run);
+    expect(result['audited_step']).toBeUndefined();
+    expect(result['aborted_guard']).toBeUndefined();
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('(ff) a SKIPPED dep (when_false) gets NO entry, even with zero evidence at all', () => {
+    const run = makeRun({ skipped_steps: ['skipped_step'], evidence: [] });
+    expect(buildSettlementNamespace(run)['skipped_step']).toBeUndefined();
+  });
+
+  it('(hh) explicit-false materialization: a settled step whose diagnostics OBJECT exists but omits settled_by_default entirely still gets EXPLICIT false, never undefined (a passthrough mutant reds this — `toBe(false)` fails against `undefined`)', () => {
+    const run = makeRun({
+      completed_steps: ['normal_step'],
+      evidence: [
+        snap({
+          step_id: 'normal_step',
+          diagnostics: { input_token_estimate: 0, precondition_trace: [] }, // no settled_by_default key
+        }),
+      ],
+    });
+    const entry = buildSettlementNamespace(run)['normal_step'];
+    expect(entry).toBeDefined();
+    expect(entry!.settled_by_default).toBe(false);
+    expect(entry!.validation_rejections).toBe(0);
+  });
+
+  it('(4b) BLOCKING no-throw: a settled GUARD step (pass, no diagnostics object) + a settled guard (resolution_error, no diagnostics) + a settled FINALIZER (no diagnostics) all materialize false/0 without throwing', () => {
+    const run = makeRun({
+      completed_steps: ['guard_pass', 'finalizer_ok'],
+      failed_steps: ['guard_resolution_error'],
+      evidence: [
+        // Mirrors executeGuardStep's 'pass' captureEvidence call EXACTLY — no diagnostics param.
+        snap({ step_id: 'guard_pass', output_summary: { conditions: [], aborted: false } }),
+        // Mirrors executeGuardStep's 'resolution_error' captureEvidence call — no diagnostics.
+        snap({
+          step_id: 'guard_resolution_error',
+          status: 'error',
+          error: 'Guard resolution error',
+          output_summary: { error: 'Unresolvable path: x' },
+        }),
+        // Mirrors buildFinalizedSeal's success captureEvidence call — no diagnostics.
+        snap({ step_id: 'finalizer_ok', output_summary: {} }),
+      ],
+    });
+    expect(() => buildSettlementNamespace(run)).not.toThrow();
+    const result = buildSettlementNamespace(run);
+    expect(result['guard_pass']).toEqual({ settled_by_default: false, validation_rejections: 0 });
+    expect(result['guard_resolution_error']).toEqual({
+      settled_by_default: false,
+      validation_rejections: 0,
+    });
+    expect(result['finalizer_ok']).toEqual({ settled_by_default: false, validation_rejections: 0 });
+  });
+
+  it('THE gate-response inversion: for a step with an EXECUTION snapshot (settled_by_default: true) followed chronologically by a gate_response snapshot (no diagnostics), the mint reads the EXECUTION snapshot — NOT "the last snapshot"', () => {
+    const run = makeRun({
+      completed_steps: ['gated_default_step'],
+      evidence: [
+        snap({
+          step_id: 'gated_default_step',
+          output_summary: { category: 'fallback' },
+          diagnostics: {
+            input_token_estimate: 0,
+            precondition_trace: [],
+            settled_by_default: true,
+            validation_rejections: 6,
+          },
+        }),
+        // Chronologically LAST — a gate_response snapshot recording the human's choice, no diagnostics.
+        {
+          ...snap({ step_id: 'gated_default_step', output_summary: { choice: 'approve' } }),
+          kind: 'gate_response' as const,
+        },
+      ],
+    });
+    const entry = buildSettlementNamespace(run)['gated_default_step'];
+    expect(entry?.settled_by_default).toBe(true);
+    expect(entry?.validation_rejections).toBe(6);
+  });
+
+  it('(ii) hostile-evidence-id mint-wins: buildEvidenceByStep\'s $settlement key is the MINTED namespace, never a hostile snapshot literally step_id === "$settlement"', () => {
+    const run = makeRun({
+      completed_steps: ['$settlement', 'real_step'],
+      evidence: [
+        // A synthetic pre-reservation record carrying a snapshot literally named '$settlement'.
+        snap({ step_id: '$settlement', output_summary: { hostile: true } }),
+        snap({
+          step_id: 'real_step',
+          diagnostics: {
+            input_token_estimate: 0,
+            precondition_trace: [],
+            settled_by_default: true,
+            validation_rejections: 3,
+          },
+        }),
+      ],
+    });
+    const evidenceByStep = buildEvidenceByStep(run);
+    expect(evidenceByStep['$settlement']).not.toEqual({ hostile: true });
+    expect(evidenceByStep['$settlement']).toHaveProperty('real_step');
+    expect((evidenceByStep['$settlement'] as Record<string, unknown>)['real_step']).toEqual({
+      settled_by_default: true,
+      validation_rejections: 3,
+    });
+  });
+
+  it('a run with zero settled steps mints an empty $settlement object (never absent, never throws)', () => {
+    const run = makeRun({});
+    const evidenceByStep = buildEvidenceByStep(run);
+    expect(evidenceByStep['$settlement']).toEqual({});
   });
 });

--- a/packages/core/src/engine/eligibility.ts
+++ b/packages/core/src/engine/eligibility.ts
@@ -6,7 +6,7 @@ import type {
   StepDefinition,
   TriggerRule,
 } from '../types/workflow-definition.js';
-import type { RunRecord, SkipDetail } from '../types/run-record.js';
+import type { RunRecord, SkipDetail, StepDiagnostics } from '../types/run-record.js';
 import type { RunPhase } from '../types/run-record.js';
 import { resolvePath } from './render-template.js';
 import { splitComparison, type ComparisonOp } from './comparison-expr.js';
@@ -294,7 +294,82 @@ export function buildEvidenceByStep(run: RunRecord): Record<string, Record<strin
       evidenceByStep[snap.step_id] = snap.output_summary;
     }
   }
+  // issue #220 §4c (PR-3): mint the `$settlement` evaluation-root namespace AFTER the per-step
+  // loop above — so the engine's own key wins over any hostile pre-upgrade evidence snapshot
+  // that happens to carry `step_id === '$settlement'` (pin ii; `$settlement` has been a reserved,
+  // load-refused step name since PR-1, so no LEGITIMATE run can ever produce one, but a synthetic
+  // or pre-reservation record could). This single assignment is the ONE chokepoint through which
+  // every evaluation surface (when/guards/preconditions/input_map/gate contexts/handler
+  // context.resources/template rendering) inherits the namespace — see buildSettlementNamespace's
+  // own doc for the mint's domain/materialization/perf contract.
+  evidenceByStep['$settlement'] = buildSettlementNamespace(run);
   return evidenceByStep;
+}
+
+/**
+ * Builds the `$settlement` evaluation-root namespace (issue #220 §4c, PR-3) — one entry per
+ * SETTLED step (`completed_steps ∪ failed_steps` — membership-gated, §4c-pass S3), each carrying
+ * that step's fallback-provenance: `{ settled_by_default, validation_rejections }`, derived from
+ * its last non-gate_response evidence snapshot's `diagnostics` (issue #220 PR-2 fields).
+ *
+ * **DOMAIN — membership-gated, NOT evidence-derived.** `run.evidence` over-includes steps that
+ * are NOT settled: a compensating-unclaim AUDIT snapshot, a guard-ABORT snapshot (the step lands
+ * in `skipped_steps`, never completed/failed), a gate-open preview snapshot for a still-pending
+ * gate. Keying on the evidence array directly would fabricate a `settled_by_default: false` entry
+ * for every one of those — so this function iterates `completed_steps ∪ failed_steps` ONLY.
+ * Skipped steps get NO entry; absence is never a third status.
+ *
+ * **DATA SOURCE — the step's LAST snapshot with `kind !== 'gate_response'`, never simply "the
+ * last snapshot".** For a `human_confirmed` × `mode: 'default'` step, the settling EXECUTION
+ * snapshot (`diagnostics.settled_by_default: true`) is immediately followed, chronologically LAST,
+ * by a `gate_response` snapshot that carries NO `diagnostics` at all (the human's choice, not a
+ * re-execution). Reading "the last snapshot" unconditionally would read the gate_response, find no
+ * `diagnostics`, and materialize `settled_by_default: false` — silently ERASING the very
+ * disclosure PR-2 exists to deliver. This is the single most subtle load-bearing rule in this
+ * function; do not "simplify" it to a plain last-write-wins scan.
+ *
+ * **MATERIALIZATION — explicit, and OPTIONAL-CHAIN THE DIAGNOSTICS OBJECT, not just the field.**
+ * Every settled GUARD step (`pass` → `completed_steps`, `resolution_error` → `failed_steps`) and
+ * every settled FINALIZER step pushes its settle snapshot via `captureEvidence` WITHOUT a
+ * `diagnostics` param at all (the param is optional) — both classes are squarely IN this
+ * function's domain (any workflow with an `abort_unless` guard hits this). A raw
+ * `diag.settled_by_default ?? false` THROWS a `TypeError` on those (the property access happens
+ * BEFORE `??` ever runs), crashing every evaluation surface on any run containing a guard or
+ * finalizer step. `diag?.settled_by_default ?? false` is required: `?.` covers the missing
+ * DIAGNOSTICS OBJECT, `?? false`/`?? 0` covers the missing FIELD (present-but-not-default settles
+ * never set `settled_by_default` at all — it is absent, never `false` — so the fallback does real
+ * work even when `diag` itself exists).
+ *
+ * **PERFORMANCE — one O(E) pass, never a per-step reverse-scan.** This function (transitively,
+ * via `buildEvidenceByStep`) runs on every eligibility pass AND repeatedly inside
+ * `propagateSkips`'s `while (changed)` loop — a `[...run.evidence].reverse().find(...)` per
+ * settled step would make the whole call O(steps × evidence), quadratic on the hot path. Instead:
+ * one pass over `run.evidence` records the last non-gate_response `diagnostics` per `step_id`
+ * (last-write-wins, since evidence is append-ordered), then the domain is projected onto that map.
+ *
+ * Pure, no I/O. Exported (beside `buildEvidenceByStep`) so `replay.ts` can mint an IDENTICAL
+ * namespace from the live run record — the shared helper is what makes replay's verdict
+ * structurally unable to diverge from the live engine's for a `$settlement`-referencing
+ * precondition (issue #220 §4c-M7).
+ */
+export function buildSettlementNamespace(
+  run: RunRecord,
+): Record<string, { settled_by_default: boolean; validation_rejections: number }> {
+  const lastDiag: Record<string, StepDiagnostics | undefined> = {};
+  for (const snap of run.evidence) {
+    if (snap.kind !== 'gate_response') {
+      lastDiag[snap.step_id] = snap.diagnostics;
+    }
+  }
+  const result: Record<string, { settled_by_default: boolean; validation_rejections: number }> = {};
+  for (const step of [...run.completed_steps, ...run.failed_steps]) {
+    const diag = lastDiag[step];
+    result[step] = {
+      settled_by_default: diag?.settled_by_default ?? false,
+      validation_rejections: diag?.validation_rejections ?? 0,
+    };
+  }
+  return result;
 }
 
 /**

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -1893,6 +1893,59 @@ describe('executeStep', () => {
       expect(updatedRun.pending_gate).toBeUndefined();
     });
 
+    // issue #220 §4c (PR-3, pin jj): the unresolved-placeholder regex widened to admit a
+    // `$`-leading reference — a typo'd $settlement path in a gate message must be DETECTED as
+    // unresolved, not silently left unmatched (renderTemplate itself already leaves the
+    // placeholder text verbatim when unresolved; this is a detection-side widening).
+    it('pin (jj): gate.message with an unresolvable $settlement reference is detected as an unresolved placeholder', async () => {
+      const gateMessageSettlementWf: WorkflowDefinition = {
+        id: 'gate-msg-settlement-wf',
+        name: 'Gate Message Settlement',
+        version: 1,
+        steps: {
+          step1: {
+            description: 'Prior step — never settles a field named bogus_field',
+            execution: 'auto',
+            depends_on: [],
+          },
+          gate_step: {
+            description: 'Gate step referencing an unresolvable $settlement field',
+            execution: 'auto',
+            trust: 'human_confirmed',
+            depends_on: ['step1'],
+            gate: {
+              choices: ['approve', 'reject'],
+              message: 'Defaulted: {{ $settlement.step1.bogus_field }}',
+            },
+          },
+        },
+      };
+      const { run: run } = await store.create({
+        workflowId: 'gate-msg-settlement-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await executeStep(store, gateMessageSettlementWf, {
+        runId: run.id,
+        command: 'step1',
+        input: {},
+        dispatcher: async () => ({}),
+      });
+
+      const envelope = await executeStep(store, gateMessageSettlementWf, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({}),
+      });
+
+      expect(envelope.status).toBe('error');
+      expect(envelope.errors[0]).toContain('gate.message has unresolvable references');
+      expect(envelope.errors[0]).toContain('$settlement.step1.bogus_field');
+      const updatedRun = await store.get(run.id);
+      expect(updatedRun.pending_gate).toBeUndefined();
+    });
+
     it('happy path: gate.message with self-reference resolves and populates gate.display and resolved_message', async () => {
       const gateMessageWf: WorkflowDefinition = {
         id: 'gate-msg-happy-wf',

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -2433,7 +2433,12 @@ export async function executeStep(
         }
         throw err;
       }
-      const unresolved = [...raw.matchAll(/\{\{\s*([\w.-]+)\s*\}\}/g)].map((m) => m[1]);
+      // issue #220 §4c (PR-3, D4): widened to admit a `$`-leading reference (e.g.
+      // `{{ $settlement.step.field }}`) so a typo'd $settlement path in a gate message is
+      // DETECTED as an unresolved placeholder here, not silently left unmatched by this regex
+      // (renderTemplate itself already leaves an unresolved ref's placeholder text verbatim in
+      // `raw` — this is purely a detection-side widening, no change to render behavior).
+      const unresolved = [...raw.matchAll(/\{\{\s*([\w.$-]+)\s*\}\}/g)].map((m) => m[1]);
       if (unresolved.length > 0) {
         return makeErrorEnvelope(
           options,

--- a/packages/core/src/engine/input-map.test.ts
+++ b/packages/core/src/engine/input-map.test.ts
@@ -234,6 +234,74 @@ describe('input_map', () => {
     );
   });
 
+  // issue #220 §4c (PR-3, pin gg): input_map forwarding round-trips the raw boolean via the
+  // NESTED `context.resources.$settlement.<dep>.<field>` spelling — no code change was needed
+  // for this (resolvePath treats `$settlement` as one ordinary literal segment), so this test is
+  // purely a pin, not a feature test.
+  it('pin (gg): input_map forwards $settlement.<dep>.settled_by_default via the NESTED context.resources spelling', async () => {
+    const def: WorkflowDefinition = {
+      id: 'imap-settlement-wf',
+      name: 'InputMap Settlement',
+      version: 1,
+      services: { svc: { adapter: 'mock', trust: 'engine_delivered' } },
+      steps: {
+        step1: {
+          description: 'Agent step with a declared default',
+          execution: 'agent',
+          output_schema: {
+            type: 'object',
+            required: ['category'],
+            properties: { category: { type: 'string' } },
+          },
+          validation_exhaustion: {
+            mode: 'default',
+            default_output: { category: 'fallback' },
+          },
+        },
+        step2: {
+          description: 'Auto step forwarding $settlement.step1 via input_map',
+          execution: 'auto',
+          depends_on: ['step1'],
+          uses_service: 'svc',
+          input_map: { was_fallback: 'context.resources.$settlement.step1.settled_by_default' },
+        },
+      },
+    };
+    const adapter = new MockAdapter('mock', { step2: { status: 200, data: {} } });
+    const fetchSpy = vi.spyOn(adapter, 'fetch');
+    const registry = new ExtensionRegistry();
+    registry.register('adapter', 'mock', adapter);
+    const store = new JsonFileStore(dir);
+    const { run } = await store.create({
+      workflowId: 'imap-settlement-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await store.update({ ...run, validation_rejections: { step1: 5 } }); // threshold - 1
+
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'step1',
+      input: {}, // fails output_schema — the 6th rejection exhausts and default-settles
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'step2',
+      input: {},
+      dispatcher: noOpDispatcher,
+      registry,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'step2',
+      { was_fallback: true },
+      expect.any(Object),
+      expect.any(AbortSignal),
+    );
+  });
+
   it('input_map step records resolved_params in evidence snapshot', async () => {
     const def: WorkflowDefinition = {
       id: 'imap-wf',

--- a/packages/core/src/engine/settlement-namespace.test.ts
+++ b/packages/core/src/engine/settlement-namespace.test.ts
@@ -1,0 +1,264 @@
+// Integration tests for issue #220 §4c (PR-3) — the `$settlement` evaluation-root namespace,
+// exercised through the REAL engine (executeStep/executeChain/submitHumanResponse), as opposed to
+// eligibility.test.ts's direct unit tests of buildSettlementNamespace/buildEvidenceByStep.
+// Letter labels match the design record's §5 pin set (aa, bb, ff) for mechanical diffing against
+// mutation probes.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  executeStep,
+  executeChain,
+  submitHumanResponse,
+  DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD,
+} from './execution-loop.js';
+import type { StepDispatcher } from './execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+
+const echoDispatcher: StepDispatcher = async (_step, input) => ({ ...input });
+
+const OUTPUT_SCHEMA = {
+  type: 'object',
+  required: ['category'],
+  properties: { category: { type: 'string' } },
+};
+const DEFAULT_OUTPUT = { category: 'fallback' };
+const INVALID_OUTPUT = {}; // missing 'category' — fails output_schema
+const VALID_OUTPUT = { category: 'ok' };
+
+describe('issue #220 §4c (PR-3) — $settlement namespace, end-to-end', () => {
+  let store: JsonFileStore;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-settlement-test-'));
+    store = new JsonFileStore(dir);
+  });
+
+  describe('(aa) when-branch flips eligibility on $settlement', () => {
+    const def: WorkflowDefinition = {
+      id: 'settlement-aa-wf',
+      name: 'Settlement AA',
+      version: 1,
+      steps: {
+        step1: {
+          description: 'Step1',
+          execution: 'agent',
+          output_schema: OUTPUT_SCHEMA,
+          validation_exhaustion: { mode: 'default', default_output: DEFAULT_OUTPUT },
+        },
+        step2: {
+          description: 'Step2 — eligible only when step1 did NOT default-settle',
+          execution: 'auto',
+          depends_on: ['step1'],
+          when: ['$settlement.step1.settled_by_default == false'],
+        },
+      },
+    };
+
+    it('step1 settles NORMALLY (its own valid output) ⇒ $settlement.step1.settled_by_default === false ⇒ step2 becomes ELIGIBLE', async () => {
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      await executeStep(store, def, {
+        runId: run.id,
+        command: 'step1',
+        input: VALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+      const step2Envelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'step2',
+        input: {},
+        dispatcher: echoDispatcher,
+      });
+      expect(step2Envelope.status).toBe('ok');
+      const after = await store.get(run.id);
+      expect(after.completed_steps).toContain('step2');
+    });
+
+    it('step1 DEFAULT-settles (exhaustion) ⇒ $settlement.step1.settled_by_default === true ⇒ step2 is NEVER eligible (skipped)', async () => {
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      await store.update({
+        ...run,
+        validation_rejections: { step1: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+      });
+      await executeStep(store, def, {
+        runId: run.id,
+        command: 'step1',
+        input: INVALID_OUTPUT,
+        dispatcher: echoDispatcher,
+      });
+      // step2 is not eligible — a direct executeStep call on it must be 'blocked'.
+      const step2Envelope = await executeStep(store, def, {
+        runId: run.id,
+        command: 'step2',
+        input: {},
+        dispatcher: echoDispatcher,
+      });
+      expect(step2Envelope.status).toBe('blocked');
+      const after = await store.get(run.id);
+      expect(after.completed_steps).not.toContain('step2');
+      // propagateSkips: once step1 is settled and step2's when is false, step2 is provably
+      // never-eligible and gets skipped (surfacing the run as complete).
+      expect(after.skipped_steps).toContain('step2');
+      expect(after.terminal_state).toBe(true);
+    });
+  });
+
+  it('THE gate-response inversion, end-to-end: a human_confirmed × mode:default step default-settles via submitHumanResponse; a downstream step reading $settlement.<step>.settled_by_default sees TRUE, not the gate_response-erased false', async () => {
+    const def: WorkflowDefinition = {
+      id: 'settlement-gate-inversion-wf',
+      name: 'Settlement Gate Inversion',
+      version: 1,
+      steps: {
+        step1: {
+          description: 'Step1 — human_confirmed default-settle',
+          execution: 'agent',
+          trust: 'human_confirmed',
+          output_schema: OUTPUT_SCHEMA,
+          validation_exhaustion: { mode: 'default', default_output: DEFAULT_OUTPUT },
+        },
+        step2: {
+          description: 'Step2 — reads $settlement.step1 AFTER the gate resolves',
+          execution: 'auto',
+          depends_on: ['step1'],
+          when: ['$settlement.step1.settled_by_default == true'],
+        },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { step1: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+    const gateEnvelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'step1',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    expect(gateEnvelope.status).toBe('confirm_required');
+
+    await submitHumanResponse(store, def, {
+      runId: run.id,
+      gateId: gateEnvelope.gate!.gate_id,
+      choice: 'approve',
+    });
+
+    // step2's evidence-chain for step1 now has [execution snap (settled_by_default:true),
+    // gate_response snap (no diagnostics)] — chronologically the gate_response is LAST. Reading
+    // "the last snapshot" naively would materialize false and step2 would never become eligible.
+    const step2Envelope = await executeStep(store, def, {
+      runId: run.id,
+      command: 'step2',
+      input: {},
+      dispatcher: echoDispatcher,
+    });
+    expect(step2Envelope.status).toBe('ok');
+    const after = await store.get(run.id);
+    expect(after.completed_steps).toContain('step2');
+  });
+
+  it('(ff) a typoed $settlement field on `when` traces lhs_present:false (never silently truthy/falsy without a trace) and the step is skipped', async () => {
+    const def: WorkflowDefinition = {
+      id: 'settlement-ff-typo-wf',
+      name: 'Settlement FF Typo',
+      version: 1,
+      steps: {
+        step1: {
+          description: 'Step1',
+          execution: 'agent',
+          output_schema: OUTPUT_SCHEMA,
+        },
+        step2: {
+          description: 'Step2 — typo in the FIELD segment (not the dep segment)',
+          execution: 'auto',
+          depends_on: ['step1'],
+          when: ['$settlement.step1.bogus_field == true'],
+        },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await executeStep(store, def, {
+      runId: run.id,
+      command: 'step1',
+      input: VALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    const after = await store.get(run.id);
+    expect(after.skipped_steps).toContain('step2');
+    const detail = after.skip_details?.['step2'];
+    if (detail?.kind !== 'when_false') throw new Error('expected when_false detail');
+    expect(detail.leaves[0]).toMatchObject({ lhs_present: false, passed: false });
+  });
+
+  it('(bb) guard abort_unless blocks (aborts) the run when the dep default-settled', async () => {
+    const def: WorkflowDefinition = {
+      id: 'settlement-bb-wf',
+      name: 'Settlement BB',
+      version: 1,
+      steps: {
+        step1: {
+          description: 'Step1',
+          execution: 'agent',
+          output_schema: OUTPUT_SCHEMA,
+          validation_exhaustion: { mode: 'default', default_output: DEFAULT_OUTPUT },
+        },
+        guard_step: {
+          description: 'Guard — aborts unless step1 settled on its own (not via default)',
+          execution: 'guard',
+          depends_on: ['step1'],
+          abort_unless: ['$settlement.step1.settled_by_default == false'],
+        },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      validation_rejections: { step1: DEFAULT_VALIDATION_EXHAUSTION_THRESHOLD - 1 },
+    });
+    await executeChain(store, def, {
+      runId: run.id,
+      command: 'step1',
+      input: INVALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    const after = await store.get(run.id);
+    expect(after.run_phase).toBe('aborted');
+    expect(after.terminal_state).toBe(true);
+    expect(after.aborted_at?.step_id).toBe('guard_step');
+  });
+
+  it('(bb) negative: the SAME guard PASSES when step1 settles on its own (not via default)', async () => {
+    const def: WorkflowDefinition = {
+      id: 'settlement-bb-neg-wf',
+      name: 'Settlement BB Negative',
+      version: 1,
+      steps: {
+        step1: {
+          description: 'Step1',
+          execution: 'agent',
+          output_schema: OUTPUT_SCHEMA,
+          validation_exhaustion: { mode: 'default', default_output: DEFAULT_OUTPUT },
+        },
+        guard_step: {
+          description: 'Guard — aborts unless step1 settled on its own (not via default)',
+          execution: 'guard',
+          depends_on: ['step1'],
+          abort_unless: ['$settlement.step1.settled_by_default == false'],
+        },
+      },
+    };
+    const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+    await executeChain(store, def, {
+      runId: run.id,
+      command: 'step1',
+      input: VALID_OUTPUT,
+      dispatcher: echoDispatcher,
+    });
+    const after = await store.get(run.id);
+    expect(after.run_phase).not.toBe('aborted');
+    expect(after.completed_steps).toContain('guard_step');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export {
   isWorkflowComplete,
   deriveRunPhase,
   buildEvidenceByStep,
+  buildSettlementNamespace,
   propagateSkips,
   isStepSettledOrInFlight,
 } from './engine/eligibility.js';

--- a/packages/core/src/workflow/settlement-namespace-loader.test.ts
+++ b/packages/core/src/workflow/settlement-namespace-loader.test.ts
@@ -1,0 +1,280 @@
+// Loader validation for issue #220 §4c (PR-3) — the `$settlement.<dep>.<field>` reference on the
+// three condition surfaces (when/abort_unless/preconditions). Letter labels match the design
+// record's §5 pin set (dd, kk, cc) for mechanical diffing against mutation probes.
+import { describe, it, expect } from 'vitest';
+import { loadWorkflowFromString } from './yaml-loader.js';
+import { WorkflowError } from '../types/workflow-error.js';
+
+function expectThrows(yaml: string, substring: string): void {
+  expect(() => loadWorkflowFromString(yaml)).toThrow(WorkflowError);
+  try {
+    loadWorkflowFromString(yaml);
+    throw new Error('expected loadWorkflowFromString to throw');
+  } catch (err) {
+    expect((err as WorkflowError).message).toContain(substring);
+  }
+}
+
+function expectRegistersClean(yaml: string): void {
+  expect(() => loadWorkflowFromString(yaml)).not.toThrow();
+}
+
+describe('yaml-loader — issue #220 §4c $settlement references', () => {
+  describe('(dd) isPathShaped carve-out is prefix-EXACT — never a general $ allowance', () => {
+    it('a bare `$foo` (not $settlement) on `when` is refused by the GENERIC path-shape check, not the $settlement one', () => {
+      expectThrows(
+        `
+id: settlement-dd-foo-wf
+name: Settlement DD Foo
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    when: ["$foo"]
+`,
+        'is not a valid path or comparison',
+      );
+    });
+
+    it('a bare `$` alone on `when` is refused', () => {
+      expectThrows(
+        `
+id: settlement-dd-bare-wf
+name: Settlement DD Bare
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    when: ["$"]
+`,
+        'is not a valid path or comparison',
+      );
+    });
+
+    it('$settlement.a b (garbage remainder — an internal space) is refused via the $settlement-SPECIFIC path-shape message, not the generic one', () => {
+      expectThrows(
+        `
+id: settlement-dd-garbage-wf
+name: Settlement DD Garbage
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    when: ["$settlement.a b"]
+`,
+        "invalid '$settlement' reference",
+      );
+    });
+  });
+
+  describe('(kk) one-hop load-refusal fires on ALL THREE surfaces', () => {
+    it('`when`: $settlement.<non-dep> is load-refused with the one-hop/depends_on message', () => {
+      expectThrows(
+        `
+id: settlement-kk-when-wf
+name: Settlement KK When
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  other:
+    description: Other
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    when: ["$settlement.other.settled_by_default == false"]
+`,
+        'one-hop rule',
+      );
+    });
+
+    it('`abort_unless` (guard): $settlement.<non-dep> is load-refused with the one-hop/depends_on message', () => {
+      expectThrows(
+        `
+id: settlement-kk-guard-wf
+name: Settlement KK Guard
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  other:
+    description: Other
+    execution: auto
+    handler: h
+    depends_on: []
+  guard_step:
+    description: Guard
+    execution: guard
+    depends_on: [a]
+    abort_unless: ["$settlement.other.settled_by_default == false"]
+`,
+        'one-hop rule',
+      );
+    });
+
+    it('`preconditions`: $settlement.<non-dep> (COMPARISON spelling, not a bare path) is load-refused with the one-hop/depends_on message — NOT the must-be-comparison message', () => {
+      expectThrows(
+        `
+id: settlement-kk-precond-wf
+name: Settlement KK Precondition
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  other:
+    description: Other
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    preconditions: ["$settlement.other.settled_by_default == false"]
+`,
+        'one-hop rule',
+      );
+    });
+
+    it('`preconditions`: a BARE $settlement path (no comparison) is refused for the PRE-EXISTING must-be-comparison reason, not the one-hop reason (the wrong-reason pass this pin guards against)', () => {
+      expectThrows(
+        `
+id: settlement-kk-precond-bare-wf
+name: Settlement KK Precondition Bare
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    preconditions: ["$settlement.a.settled_by_default"]
+`,
+        'must be a comparison',
+      );
+    });
+  });
+
+  describe('positive registration — a valid $settlement.<dep>.<field> leaf registers clean on all three surfaces', () => {
+    it('`when`', () => {
+      expectRegistersClean(`
+id: settlement-pos-when-wf
+name: Settlement Positive When
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    when: ["$settlement.a.settled_by_default == false"]
+`);
+    });
+
+    it('`abort_unless` (guard)', () => {
+      expectRegistersClean(`
+id: settlement-pos-guard-wf
+name: Settlement Positive Guard
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  guard_step:
+    description: Guard
+    execution: guard
+    depends_on: [a]
+    abort_unless: ["$settlement.a.settled_by_default == false"]
+`);
+    });
+
+    it('`preconditions`', () => {
+      expectRegistersClean(`
+id: settlement-pos-precond-wf
+name: Settlement Positive Precondition
+version: 1
+steps:
+  a:
+    description: A
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [a]
+    preconditions: ["$settlement.a.settled_by_default == false"]
+`);
+    });
+  });
+
+  describe('(cc) reserved-name refusal still holds (PR-1, verify only)', () => {
+    it('$settlement is still refused as a step id', () => {
+      expectThrows(
+        `
+id: settlement-cc-wf
+name: Settlement CC
+version: 1
+steps:
+  $settlement:
+    description: Work
+    execution: auto
+    handler: h
+`,
+        "Step name '$settlement' is reserved",
+      );
+    });
+  });
+});

--- a/packages/core/src/workflow/settlement-namespace-loader.test.ts
+++ b/packages/core/src/workflow/settlement-namespace-loader.test.ts
@@ -89,6 +89,39 @@ steps:
         "invalid '$settlement' reference",
       );
     });
+
+    // issue #220 PR-3 ReDoS correction (CodeQL HIGH, CWE-1333): the vulnerable regex's inner
+    // character class included `.`, so a `.` could be consumed either by the inner `*` or by the
+    // next outer-group's leading `\.` — an ambiguous nested quantifier. One directly observable
+    // symptom of that ambiguity: the vulnerable regex ACCEPTED consecutive dots
+    // (`$settlement.dep..field`), since the inner `*` could swallow the second `.` as an ordinary
+    // character. The fixed regex (no `.` in the inner class) rejects them — a NON-FLAKY
+    // structural pin on the exact property the fix changes, with no timing dependency. `dep` here
+    // is a REAL dependency, so the one-hop check would otherwise pass — isolating the assertion to
+    // the path-shape check alone. A mutant that re-adds `.` to the inner class
+    // (`[A-Za-z0-9_.-]`) makes this input pass path-shape → this test reds.
+    it('$settlement.dep..field (consecutive dots) is refused at the path-shape check — the structural property that removes the ReDoS', () => {
+      expectThrows(
+        `
+id: settlement-dd-consecutive-dots-wf
+name: Settlement DD Consecutive Dots
+version: 1
+steps:
+  dep:
+    description: Dep
+    execution: auto
+    handler: h
+    depends_on: []
+  b:
+    description: B
+    execution: auto
+    handler: h
+    depends_on: [dep]
+    when: ["$settlement.dep..field"]
+`,
+        "invalid '$settlement' reference",
+      );
+    });
   });
 
   describe('(kk) one-hop load-refusal fires on ALL THREE surfaces', () => {

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -64,11 +64,25 @@ function validateConditionLeaf(
   }
 
   if (split.kind === 'path') {
-    // A precondition is always a comparison; a bare path is not a valid precondition.
+    // A precondition is always a comparison; a bare path is not a valid precondition. This check
+    // stays FIRST (before the `$settlement` branch below) — a bare `$settlement.<dep>.<field>` on
+    // `preconditions` is refused HERE, for the pre-existing "must be a comparison" reason, not the
+    // $settlement one-hop reason (issue #220 §4c pin kk: the precondition witness for a
+    // $settlement leaf must use the comparison spelling).
     if (surface === 'preconditions') {
       errors.push(
         `Step '${stepName}': precondition '${leaf}' must be a comparison (e.g. "step.field >= 1").`,
       );
+      return;
+    }
+    // issue #220 §4c (PR-3): `$settlement.<dep>.<field>` handling lives HERE, in
+    // validateConditionLeaf, branching on the LHS first segment — NOT in isPathShaped (a
+    // documented generic zero-dependency splitter; embedding `$settlement` there would widen its
+    // contract for every caller) and NOT as an arm on validateWhenReference (invoked only under
+    // `surface === 'when'` — an arm there would never fire for abort_unless/preconditions). This
+    // fires on ALL THREE surfaces since it runs BEFORE the generic isPathShaped check below.
+    if (split.path.split('.')[0] === '$settlement') {
+      validateSettlementReference(split.path, surface, leaf, stepName, dependsOn, errors);
       return;
     }
     if (!isPathShaped(split.path)) {
@@ -82,6 +96,10 @@ function validateConditionLeaf(
   }
 
   // comparison
+  if (split.lhsPath.split('.')[0] === '$settlement') {
+    validateSettlementReference(split.lhsPath, surface, leaf, stepName, dependsOn, errors);
+    return;
+  }
   if (!isPathShaped(split.lhsPath)) {
     errors.push(
       `Step '${stepName}': '${surface}' leaf '${leaf}' must have a path on the left-hand side (got '${split.lhsPath}').`,
@@ -89,6 +107,50 @@ function validateConditionLeaf(
     return;
   }
   if (surface === 'when') validateWhenReference(split.lhsPath, stepName, dependsOn, errors);
+}
+
+/**
+ * issue #220 §4c (PR-3): validates a `$settlement.<dep>.<field>` reference reached from ANY of
+ * the three condition surfaces (when/abort_unless/preconditions) — unlike the legacy
+ * depends_on/run.params check ({@link validateWhenReference}, `when`-only), this fires on all
+ * three because it is invoked directly from {@link validateConditionLeaf}, before the
+ * `surface === 'when'` gate. The caller must NOT fall through to the generic `isPathShaped` check
+ * afterward (which rejects `$` outright) — this function's callers always `return` immediately.
+ */
+function validateSettlementReference(
+  path: string,
+  surface: ConditionSurface,
+  leaf: string,
+  stepName: string,
+  dependsOn: string[],
+  errors: string[],
+): void {
+  // Path-shape: a NARROWING for this ONE prefix only (never a general `$` allowance) — the
+  // remainder after `$settlement` must itself be path-shaped. Rejects `$foo`, a bare `$`, and
+  // garbage remainders like `$settlement.a b`.
+  if (!/^\$settlement(\.[A-Za-z_][A-Za-z0-9_.-]*)*$/.test(path)) {
+    errors.push(
+      `Step '${stepName}': '${surface}' leaf '${leaf}' has an invalid '$settlement' reference ` +
+        `'${path}' — expected '$settlement.<dep>.<field>'.`,
+    );
+    return;
+  }
+  // One-hop (§4c-S4): the SECOND segment must be a DIRECT dependency of this step.
+  const dep = path.split('.')[1];
+  if (dep === undefined) {
+    errors.push(
+      `Step '${stepName}': '${surface}' leaf '${leaf}' references '$settlement' with no ` +
+        `dependency segment — expected '$settlement.<dep>.<field>' where '<dep>' is a direct dependency.`,
+    );
+    return;
+  }
+  if (!dependsOn.includes(dep)) {
+    errors.push(
+      `Step '${stepName}': '${surface}' references '$settlement.${dep}' — '${dep}' is not in ` +
+        `its depends_on [${dependsOn.join(', ')}]. '$settlement' paths must reference a direct ` +
+        `dependency (one-hop rule).`,
+    );
+  }
 }
 
 /**
@@ -627,6 +689,17 @@ function parseWorkflowString(
       continue;
     }
     const step = stepRaw as Record<string, unknown>;
+
+    // issue #220 §4c (PR-3): HOISTED out of the `when`-only block below (was block-local there) so
+    // ALL THREE condition surfaces (when/abort_unless/preconditions) can thread the real
+    // depends_on list into validateConditionLeaf's `$settlement` one-hop check. Previously
+    // abort_unless/preconditions passed a literal `[]` (no reference validation existed for them
+    // at all); the legacy when-only depends_on/run.params check (validateWhenReference) is
+    // UNCHANGED — it still fires ONLY for `surface === 'when'`. This is a LIFT, not a new
+    // computation — byte-identical to the previous block-local `dependsOn` for `when`'s own use.
+    const dependsOn = Array.isArray(step['depends_on'])
+      ? (step['depends_on'] as unknown[]).filter((d): d is string => typeof d === 'string')
+      : [];
 
     // WARN (do not reject) on an unknown step key — runs after template resolution above, so a
     // template-expanded step's keys are checked too. Same non-breaking posture as the
@@ -1258,9 +1331,6 @@ function parseWorkflowString(
     // Validate when: string | string[] of single-comparison/bare-path leaves (implicit AND).
     if ('when' in step && step['when'] !== undefined) {
       const rawWhen = step['when'];
-      const dependsOn = Array.isArray(step['depends_on'])
-        ? (step['depends_on'] as unknown[]).filter((d): d is string => typeof d === 'string')
-        : [];
       if (typeof rawWhen === 'string') {
         if (rawWhen.trim() === '') {
           errors.push(`Step '${stepName}': 'when' must be a non-empty string`);
@@ -1284,14 +1354,16 @@ function parseWorkflowString(
       }
     }
 
-    // Validate abort_unless leaf shape (guard steps only; reference check is when-only).
+    // Validate abort_unless leaf shape (guard steps only; the LEGACY depends_on/run.params
+    // reference check is when-only — but issue #220 §4c's `$settlement` one-hop check fires here
+    // too, via the hoisted `dependsOn`, SCOPED to `$settlement.`-prefixed paths only).
     if (step['abort_unless'] !== undefined && step['execution'] === 'guard') {
       const rawAbort = step['abort_unless'];
       if (typeof rawAbort === 'string') {
         if (rawAbort.trim() === '') {
           errors.push(`Step '${stepName}': 'abort_unless' must be a non-empty string`);
         } else {
-          validateConditionLeaf('abort_unless', rawAbort, stepName, [], errors);
+          validateConditionLeaf('abort_unless', rawAbort, stepName, dependsOn, errors);
         }
       } else if (Array.isArray(rawAbort)) {
         if (rawAbort.length === 0) {
@@ -1303,7 +1375,7 @@ function parseWorkflowString(
                 `Step '${stepName}': 'abort_unless' array entries must be non-empty strings`,
               );
             } else {
-              validateConditionLeaf('abort_unless', leaf, stepName, [], errors);
+              validateConditionLeaf('abort_unless', leaf, stepName, dependsOn, errors);
             }
           }
         }
@@ -1312,7 +1384,9 @@ function parseWorkflowString(
       }
     }
 
-    // Validate preconditions leaf shape (each must be a single comparison).
+    // Validate preconditions leaf shape (each must be a single comparison). Reference check is
+    // `$settlement`-scoped only (issue #220 §4c) — a non-`$settlement` precondition has no
+    // depends_on/run.params check (unchanged from before this PR).
     if (step['preconditions'] !== undefined) {
       const rawPre = step['preconditions'];
       if (!Array.isArray(rawPre)) {
@@ -1322,7 +1396,7 @@ function parseWorkflowString(
           if (typeof leaf !== 'string' || leaf.trim() === '') {
             errors.push(`Step '${stepName}': 'preconditions' entries must be non-empty strings`);
           } else {
-            validateConditionLeaf('preconditions', leaf, stepName, [], errors);
+            validateConditionLeaf('preconditions', leaf, stepName, dependsOn, errors);
           }
         }
       }

--- a/packages/core/src/workflow/yaml-loader.ts
+++ b/packages/core/src/workflow/yaml-loader.ts
@@ -128,7 +128,15 @@ function validateSettlementReference(
   // Path-shape: a NARROWING for this ONE prefix only (never a general `$` allowance) — the
   // remainder after `$settlement` must itself be path-shaped. Rejects `$foo`, a bare `$`, and
   // garbage remainders like `$settlement.a b`.
-  if (!/^\$settlement(\.[A-Za-z_][A-Za-z0-9_.-]*)*$/.test(path)) {
+  //
+  // issue #220 PR-3 ReDoS correction (CodeQL HIGH, CWE-1333): the inner character class must NOT
+  // include `.` — `[A-Za-z0-9_.-]` let a `.` be consumed either by the inner `*` or by the next
+  // outer-group iteration's leading `\.`, an ambiguous nested quantifier causing catastrophic
+  // backtracking on inputs like `$settlement.a.a.a…!`. With `.` removed from the inner class
+  // (`[A-Za-z0-9_-]`), each `.` can ONLY start a new group — the parse is unambiguous, linear-time,
+  // no backtracking. Accepts every valid `$settlement.<dep>.<field>` path identically; stricter
+  // only on pathological consecutive dots (`$settlement.dep..field`), which is more correct.
+  if (!/^\$settlement(\.[A-Za-z_][A-Za-z0-9_-]*)*$/.test(path)) {
     errors.push(
       `Step '${stepName}': '${surface}' leaf '${leaf}' has an invalid '$settlement' reference ` +
         `'${path}' — expected '$settlement.<dep>.<field>'.`,


### PR DESCRIPTION
## Context

Issue #220, **PR 3 of 3** — the final piece. PR-1 (#230) shipped counting + terminalization; PR-2 (#231) shipped declared fail-open + the disclosure DATA (`evidence[].diagnostics.settled_by_default`). PR-3 exposes that data to the workflow's **evaluation surfaces** via a reserved `$settlement` namespace, making fallback-provenance first-class, branchable workflow state. Design record `plans/issue-220/design-d3.md` §4c (RATIFIED in the #220 debate); grounding + audit trail in `plans/issue-220/pr3-dossier.md` (local).

## Motivation

SFN's `$$`-reserved-prefix mechanism + GitHub-Actions' outputs-vs-outcome content precedent, generalized: an author who declared a step's fail-open (`validation_exhaustion.mode: 'default'`) can now branch on whether a dependency actually took the default — `when: ["$settlement.<dep>.settled_by_default == false"]`. Fallback-provenance-as-branchable-state is novel across the surveyed field (GH Actions / Argo / SFN / Airflow); it closes the downstream-blindness residual of PR-2.

## Changes

- **`buildSettlementNamespace(run)`** (core, exported): one entry per settled step (`completed_steps ∪ failed_steps` — membership-gated), each `{ settled_by_default, validation_rejections }`, derived from the step's **last non-`gate_response`** evidence snapshot's diagnostics (skipping the trailing gate_response of a human_confirmed×default step — else the disclosure erases to false), optional-chained against diagnostics-less guard/finalizer snapshots, in a single O(E) pass.
- **The mint** is a single assignment after `buildEvidenceByStep`'s loop → all evaluation surfaces (when/guards/preconditions/input_map/gate contexts/handler `context.resources`/templates) inherit `$settlement` through the one chokepoint. Mint-after-loop ⇒ the engine key wins any hostile `step_id === '$settlement'` evidence.
- **Legislation** (loader): all `$settlement` handling in `validateConditionLeaf`, LHS-branched, firing on ALL THREE condition surfaces before the `surface === 'when'` gate — a `$settlement.<dep>.<field>` path is admitted (prefix-exact narrowing, never a general `$`) and one-hop-validated (`<dep>` must be a direct dependency); `isPathShaped` and `validateWhenReference` stay generic/`when`-only. `dependsOn` hoisted so the guard/precondition surfaces can thread it.
- **Loudness**: the gate-message unresolved-placeholder regex widened to detect `$`-leading refs.
- **Replay parity** (§4c-M7): `replay.ts` mints via the SAME shared helper before its clone loop, so a `$settlement`-referencing precondition's replay verdict can never diverge from live; `--with $settlement.<step>.<field>=value` override lands on the clone only.
- Docs (`yaml-schema.md`): the `$settlement` reference section (per-root spelling, one-hop rule, per-surface consequence disparity, the named input_map silent-undefined residual). CHANGELOG `Added` + `Changed`.

## Verification

```bash
npx turbo run test --force   # core 1908 / cli 803 / testing 81 / mcp 265 = 3057 green
npm run lint && npx tsc --noEmit   # clean, all four packages
```

Pre-ship: 4-lane grounding + 5-lens REFUTE panel (caught a BLOCKING optional-chaining crash — diagnostics-less guard/finalizer settles) + premortem (caught the F1 all-surfaces one-hop review-failer). Post-ship review reproduced the key probes independently: dropping the `?.` reds 19 tests (all TypeError); gating the one-hop to when-only reds exactly the abort_unless+preconditions witnesses (the all-surfaces fix is pinned); the gate-response-inversion and drop-branch probes reproduced exactly.

## Rollback

```bash
git revert cb34665
```

No out-of-band mutations. Strictly additive — a workflow that never references `$settlement` evaluates identically (the minted key is inert unless referenced). The `buildEvidenceByStep` public-export output gains a `$settlement` key (hence the `Changed` grade — not byte-identical output, but no behaviour change).

## Related

- Issue #220 (PR 3 of 3 — closes the arc; safe to auto-close on merge)
- #230 (PR-1), #231 (PR-2), #232 (follow-up run-level default-settle visibility)

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
