### PR TITLE
feat(cli): in-conversation full-AJV correction for tool-using agent steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **In-conversation full-AJV correction for tool-using agent steps — the "reask layer" (issue
+  #224).** A tool-using `execution: 'agent'` step whose model output has the right keys but the
+  wrong types/enums/nested shapes could not be repaired before this change: the provider's
+  in-conversation correction check (both `AnthropicProvider` and `OpenAIProvider`) validated only
+  that required keys were present, so a type/enum/shape violation passed straight through to the
+  engine's own AJV gate and died at the drive — where issue #217 deliberately declines to repair a
+  tools-path step (a stateless re-call would re-execute every already-completed tool call). The
+  correction loop now runs the SAME full AJV validation the engine itself uses
+  (`validateAgentSubmission`, new in `@sensigo/realm`, alongside newly-exported
+  `validateOutputSchema`/`RawValidationError`/`AgentSubmissionValidation`) — inside the RETAINED
+  conversation, where tool results already survive and nothing re-executes. `validateAgentSubmission`
+  is a provider-side REPLICA of the engine's own two throwing validators (never a unification —
+  issue #220's rejection counting/exhaustion telemetry stays built on the engine's own separate
+  Step 2b/2c checks, byte-unchanged), validates a declared `input_schema` and `output_schema`
+  SEQUENTIALLY (never combined into one `allOf`, which would over-reject under
+  `additionalProperties:false`), and mirrors the engine's `_debug`-field strip before validating
+  either schema. `callStepWithTools`'s options gain two new additive-optional fields,
+  `validationInputSchema`/`validationOutputSchema` (the step's raw declared schemas, consumed only
+  by this correction loop) — the pre-existing `options.inputSchema` field is unchanged and keeps
+  feeding the submit tool and system prompt exactly as before. The correction message itself is
+  leak-safe: field paths/keywords/expected-types and schema-declared `enum`/`const` allowed values,
+  **never the submitted/offending value**. Corrections draw on the same shared `maxToolCalls`
+  budget as tool calls (a deliberate choice, not a gap) — a per-correction stderr breadcrumb
+  (`⚠ output rejected (in-conversation); correcting (n)`) plus a new `correctionCount` on the
+  cli-local `StepWithToolsResult` make that budget consumption visible instead of silent.
+  Separately, **`OpenAIProvider.performFinalExtraction` no longer throws when the tool-call budget
+  is exhausted and the last output is still schema-invalid — it now returns that output, exactly
+  like `AnthropicProvider` already did.** This unifies both providers on the posture issue #220
+  depends on: a returned (even invalid) output flows through the engine's own Step 2c
+  `countRejection`, so the rejection is counted and exhaustion terminalizes normally; a thrown
+  error is instead caught by `run-agent.ts`'s outer catch, which returns `'failed'` without ever
+  reaching the engine — the run is never counted, never sealed, and a re-attach re-executes every
+  tool call from scratch. Only a genuine PARSE failure (no usable JSON object at all) still
+  throws. No behavior change for `callStep`-only (non-tool) agent steps, and no change to the
+  engine's own validation gate, `execute_step` telemetry, or the #217 repair-gate's tools-path
+  refusal.
+
+---
+
 ## [0.30.0] — 2026-07-21
 
 ### Added

--- a/packages/cli/src/agent/mcp/mcp-extensions.ts
+++ b/packages/cli/src/agent/mcp/mcp-extensions.ts
@@ -28,6 +28,14 @@ export interface StepWithToolsResult {
   output: Record<string, unknown>;
   toolCalls: ToolCallRecord[]; // empty array = tools declared but none called
   // (distinct from callStep which returns no toolCalls at all)
+  /**
+   * issue #224 (D6, [audit F2]): number of in-conversation schema corrections this call performed
+   * (0 or absent = none). Corrections consume the SHARED `maxToolCalls` budget invisibly (no
+   * `toolCalls` entry) — this field is the inspection surface for that cost. Deliberately NOT
+   * threaded into `stepMeta` (a CORE type, execution-loop.ts) — this is a cli-local
+   * observability field only.
+   */
+  correctionCount?: number;
 }
 
 // McpClient interface — implemented in mcp-client.ts

--- a/packages/cli/src/agent/providers/agent-utils.ts
+++ b/packages/cli/src/agent/providers/agent-utils.ts
@@ -1,4 +1,5 @@
 // agent-utils.ts — Shared utility functions for LLM provider agentic loops.
+import type { ValidationErrorSummaryEntry, RawValidationError } from '@sensigo/realm';
 
 const SYSTEM_PROMPT_BASE =
   'You are an AI agent executing a step in a structured workflow.\n' +
@@ -185,18 +186,115 @@ export function extractJsonObject(text: string): Record<string, unknown> | null 
   return lastParsedObject(findBalancedObjectCandidates(text));
 }
 
+// issue #224: the required-keys-only `validateSchema` check that used to gate both providers'
+// in-conversation correction loops has been REPLACED at its only two call sites by the full-AJV
+// `validateAgentSubmission` (core) — see anthropic-provider.ts/openai-provider.ts. Removed here
+// rather than left dead: it had no other caller and no test referenced it directly.
+
+const MAX_FIELD_CHARS = 200;
+
+function truncateField(value: string): string {
+  return value.length > MAX_FIELD_CHARS ? value.slice(0, MAX_FIELD_CHARS) : value;
+}
+
+function asStringField(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
 /**
- * Returns true if all required properties from the schema are present in the parsed object.
- * Returns true when no schema is provided.
+ * issue #224 — a #224-LOCAL entry type: `ValidationErrorSummaryEntry`'s exact shape (imported
+ * from core) PLUS an optional `allowedValues`. Deliberately NOT added to core's exported
+ * `ValidationErrorSummaryEntry` (that type feeds issue #217's SHIPPED durable
+ * sidecar/telemetry — widening it would silently change #217's on-disk surface and need
+ * re-running its own leak tests; see failed-attempt-record.ts's #224 note on the same file).
  */
-export function validateSchema(
-  parsed: Record<string, unknown>,
-  schema?: Record<string, unknown>,
-): boolean {
-  if (!schema) return true;
-  const required = schema['required'];
-  if (!Array.isArray(required)) return true;
-  return (required as unknown[]).every((key) => typeof key === 'string' && key in parsed);
+export interface AgentValidationErrorEntry extends ValidationErrorSummaryEntry {
+  /**
+   * The schema's OWN declared `enum` values (`params.allowedValues`) or `const` value
+   * (`params.allowedValue`, normalized to a one-element array here) — present ONLY for those two
+   * keywords. Value-safe: these are SCHEMA constants an author wrote (already present in the
+   * system prompt the model was given), never submitted/user data — see
+   * failed-attempt-record.ts's corrected doc comment for the full distinction from a genuine
+   * leak vector (Ajv's `data`, which is never surfaced here either).
+   */
+  allowedValues?: unknown[];
+}
+
+/**
+ * issue #224 — builds the #224-local entry list DIRECTLY from raw ajv error rows
+ * (`validateAgentSubmission`'s `rawErrors`, never core's private `summarizeAjvErrors`, which
+ * drops `params`/`data` wholesale and has no `allowedValues` field at all — see the design
+ * record's DATA-PATH PIN). Mirrors core's whitelisting shape exactly (instancePath/schemaPath/
+ * keyword/message + the two keyword-conditional key-NAME fields) and ADDS `allowedValues`. Caps
+ * at 10 entries, truncates string fields to 200 chars, like core's summarizer. Never throws.
+ */
+export function summarizeAgentValidationErrors(
+  rawErrors: RawValidationError[],
+): AgentValidationErrorEntry[] {
+  const out: AgentValidationErrorEntry[] = [];
+  for (const entry of rawErrors) {
+    if (out.length >= 10) break;
+    if (entry === null || typeof entry !== 'object') continue;
+    const e = entry as unknown as Record<string, unknown>;
+    const keyword = truncateField(asStringField(e['keyword']));
+    const params =
+      e['params'] !== null && typeof e['params'] === 'object'
+        ? (e['params'] as Record<string, unknown>)
+        : undefined;
+    const additionalProperty =
+      keyword === 'additionalProperties' && typeof params?.['additionalProperty'] === 'string'
+        ? params['additionalProperty']
+        : undefined;
+    const missingProperty =
+      keyword === 'required' && typeof params?.['missingProperty'] === 'string'
+        ? params['missingProperty']
+        : undefined;
+    // enum → params.allowedValues (already an array); const → params.allowedValue (a single
+    // value, normalized into a one-element array so callers have one uniform shape to render).
+    const allowedValues =
+      keyword === 'enum' && Array.isArray(params?.['allowedValues'])
+        ? (params['allowedValues'] as unknown[])
+        : keyword === 'const' && params !== undefined && 'allowedValue' in params
+          ? [params['allowedValue']]
+          : undefined;
+    out.push({
+      instancePath: truncateField(asStringField(e['instancePath'])),
+      schemaPath: truncateField(asStringField(e['schemaPath'])),
+      keyword,
+      message: truncateField(asStringField(e['message'])),
+      ...(additionalProperty !== undefined
+        ? { additional_property: truncateField(additionalProperty) }
+        : {}),
+      ...(missingProperty !== undefined
+        ? { missing_property: truncateField(missingProperty) }
+        : {}),
+      ...(allowedValues !== undefined ? { allowedValues } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * Renders one whitelisted Ajv-error summary entry (issue #217, extended by issue #224 with
+ * `allowedValues`) as a single human-readable line for the schema-repair/in-conversation
+ * correction prompt trailer. Key NAMES + schema-declared allowed VALUES only — never a
+ * submitted/offending value (see `AgentValidationErrorEntry`'s own doc for the leak-safety
+ * argument). RELOCATED from run-agent.ts (issue #217) to here: a provider statically importing
+ * run-agent.ts risks a load cycle, and both providers now need this renderer too (issue #224).
+ */
+export function renderValidationSummaryEntry(entry: AgentValidationErrorEntry): string {
+  const path = entry.instancePath !== '' ? entry.instancePath : '(root)';
+  let line = `- ${path}: ${entry.message} [${entry.keyword}]`;
+  if (entry.additional_property !== undefined) {
+    line += ` (additional property: '${entry.additional_property}')`;
+  }
+  if (entry.missing_property !== undefined) {
+    line += ` (missing property: '${entry.missing_property}')`;
+  }
+  if (entry.allowedValues !== undefined) {
+    line += ` (allowed values: ${JSON.stringify(entry.allowedValues)})`;
+  }
+  return line;
 }
 
 /** Returns a Promise that rejects with a timeout error after `ms` milliseconds. */

--- a/packages/cli/src/agent/providers/anthropic-provider.test.ts
+++ b/packages/cli/src/agent/providers/anthropic-provider.test.ts
@@ -691,6 +691,253 @@ describe('AnthropicProvider.callStepWithTools', () => {
 });
 
 // =========================================================================
+// issue #224 — in-conversation full-AJV correction
+// =========================================================================
+describe('AnthropicProvider.callStepWithTools — issue #224 in-conversation AJV correction', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  const strictSchema = {
+    type: 'object',
+    required: ['category'],
+    properties: { category: { type: 'string', enum: ['billing', 'support'] } },
+    additionalProperties: false,
+  };
+
+  // -----------------------------------------------------------------------
+  // Primary (D4): right keys, WRONG TYPE — corrected in-conversation, tool results retained,
+  // ZERO re-execution, settles without ever reaching a drive error branch.
+  // -----------------------------------------------------------------------
+  it('primary: right-keys-wrong-type output is corrected IN-CONVERSATION — tool executes exactly once, no re-execution', async () => {
+    const executor = vi.fn().mockResolvedValue({ content: 'file data' });
+    mockCreate
+      .mockResolvedValueOnce(
+        makeToolUseResponse([{ id: 'toolu_01', name: 'get_file', input: { path: 'x' } }]),
+      )
+      // Right key, WRONG TYPE (number instead of the required string/enum).
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}'))
+      // Corrected — valid.
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools(
+      'prompt',
+      [oneTool('github:get_file')],
+      executor,
+      {
+        validationOutputSchema: strictSchema,
+      },
+    );
+
+    expect(result.output).toEqual({ category: 'billing' });
+    // Tool results retained, NOTHING re-executed — exactly one executor call, one record.
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.correctionCount).toBe(1);
+  });
+
+  it("probe-equivalent control: a wrong-type output with NO validation*Schema configured is accepted as-is (today's pre-#224 behavior for a plugin that ignores the new fields)", async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {});
+
+    expect(result.output).toEqual({ category: 42 });
+    expect(result.correctionCount).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Leak pin (D5, AC-2): the correction message contains the whitelisted summary + enum
+  // allowedValues, and NEVER the offending value.
+  // -----------------------------------------------------------------------
+  it('leak pin (AC-2): the correction message contains the enum allowedValues but NEVER the offending sentinel value', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "OFFENDING_SENTINEL_XYZ"}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    // The correction message is the LAST 'user' turn in the THIRD call's history (call index 2:
+    // [user:prompt(string), assistant:[tool_use], user:[tool_result], assistant:response.content,
+    // user:correctionMessage(string)]) — the FIRST string-content user message is the original
+    // prompt itself, not the correction, so take the last match, not the first.
+    const thirdCallMsgs = mockCreate.mock.calls[2][0].messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const stringUserMsgs = thirdCallMsgs.filter(
+      (m) => m.role === 'user' && typeof m.content === 'string',
+    );
+    const correctionMsg = stringUserMsgs.at(-1);
+    const text = String(correctionMsg?.content ?? '');
+    expect(text).toContain('did not match the required JSON schema');
+    expect(text).toContain('billing'); // allowedValues (schema constant) present
+    expect(text).toContain('support'); // allowedValues (schema constant) present
+    expect(text).not.toContain('OFFENDING_SENTINEL_XYZ'); // the submitted value — NEVER leaked
+  });
+
+  // -----------------------------------------------------------------------
+  // Observability (D6): one breadcrumb per correction; correctionCount reflects the total.
+  // -----------------------------------------------------------------------
+  it('observability (D6): emits one stderr breadcrumb per correction and surfaces correctionCount', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 1}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 2}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.correctionCount).toBe(2);
+    const breadcrumbs = errorSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('output rejected (in-conversation)'));
+    expect(breadcrumbs).toHaveLength(2);
+    expect(breadcrumbs[0]).toContain('correcting (1)');
+    expect(breadcrumbs[1]).toContain('correcting (2)');
+    errorSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Both-schemas (D2): sequential AND, never allOf-combine.
+  // -----------------------------------------------------------------------
+  it('both-schemas (D2): valid under output_schema but INVALID under input_schema is rejected in-conversation (sequential AND)', async () => {
+    // Deliberately NO additionalProperties:false anywhere in THIS test's schemas (unlike the
+    // shared `strictSchema` used elsewhere in this file) — a submission can satisfy BOTH
+    // simultaneously (an extra 'confirmed' field is harmless under output_schema; an extra
+    // 'category' field is harmless under input_schema), so this test can drive the loop to a
+    // genuine successful completion without constructing an unsatisfiable schema pair.
+    const localOutputSchema = {
+      type: 'object',
+      required: ['category'],
+      properties: { category: { type: 'string' } },
+    };
+    const localInputSchema = {
+      type: 'object',
+      required: ['category', 'confirmed'],
+      properties: { category: { type: 'string' }, confirmed: { type: 'boolean' } },
+    };
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      // Valid under output_schema (has 'category', a string) but missing the input_schema-
+      // required 'confirmed' — rejected by the input-first check.
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'))
+      // Satisfies BOTH schemas.
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing", "confirmed": true}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationInputSchema: localInputSchema,
+      validationOutputSchema: localOutputSchema,
+    });
+
+    // Corrected once — proves the first (output-valid/input-invalid) submission was REJECTED.
+    expect(result.correctionCount).toBe(1);
+    expect(result.output).toEqual({ category: 'billing', confirmed: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // _debug strip (D3): a _debug-bearing output that is valid-after-strip passes with ZERO
+  // corrections.
+  // -----------------------------------------------------------------------
+  it('_debug strip (D3): a _debug-bearing output valid-after-strip passes with ZERO corrections', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(
+        makeTextResponse('{"category": "billing", "_debug": "model reasoning trace"}'),
+      );
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.output).toEqual({ category: 'billing', _debug: 'model reasoning trace' });
+    expect(result.correctionCount).toBeUndefined();
+  });
+
+  it('_debug strip (D3) negative control: dropping the strip would over-reject (genuinely invalid without _debug still rejects with it present)', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42, "_debug": "trace"}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.correctionCount).toBe(1); // genuinely invalid (wrong type) — still corrected
+  });
+
+  // -----------------------------------------------------------------------
+  // Budget-exhaustion terminal (D4 §4): performFinalExtraction RETURNS best-effort on
+  // schema-invalid, never throws (already covered by test 3's rewrite above) — pinned again here
+  // explicitly under the #224 describe block for discoverability.
+  // -----------------------------------------------------------------------
+  it('budget-exhaustion terminal: a still schema-invalid final answer is RETURNED, never thrown', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 999}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 1,
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.output).toEqual({ category: 999 }); // best-effort, still invalid — NOT thrown
+  });
+
+  // -----------------------------------------------------------------------
+  // Contract (D7): every executor invocation — success, error, AND timeout — yields a toolCalls
+  // entry (llm-provider.ts's shipped JSDoc clause, now enforced by a test).
+  // -----------------------------------------------------------------------
+  it('contract (D7): every executor invocation (success, error, timeout) yields a toolCalls entry', async () => {
+    const hangingExecutor = vi
+      .fn()
+      .mockResolvedValueOnce('ok') // success
+      .mockRejectedValueOnce(new Error('boom')) // error
+      .mockReturnValueOnce(new Promise<unknown>(() => {})); // hangs → timeout
+    mockCreate
+      .mockResolvedValueOnce(
+        makeToolUseResponse([
+          { id: 't1', name: 'op' },
+          { id: 't2', name: 'op' },
+          { id: 't3', name: 'op' },
+        ]),
+      )
+      .mockResolvedValueOnce(makeTextResponse('{"done":true}'));
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], hangingExecutor, {
+      toolTimeoutMs: 1,
+    });
+
+    expect(result.toolCalls).toHaveLength(3); // one entry per invocation, regardless of outcome
+    expect(result.toolCalls[0]?.error).toBeUndefined();
+    expect(result.toolCalls[1]?.error).toBe('boom');
+    expect(result.toolCalls[2]?.error).toBeDefined(); // timeout error
+  });
+});
+
+// =========================================================================
 // capabilities() tests
 // =========================================================================
 describe('AnthropicProvider.capabilities', () => {

--- a/packages/cli/src/agent/providers/anthropic-provider.ts
+++ b/packages/cli/src/agent/providers/anthropic-provider.ts
@@ -1,6 +1,6 @@
 // anthropic-provider.ts — Anthropic LLM provider implementation for realm agent.
 // Requires @anthropic-ai/sdk >= 0.20.0 as an optional peer dependency (npm install @anthropic-ai/sdk).
-import { WorkflowError } from '@sensigo/realm';
+import { WorkflowError, validateAgentSubmission, type JsonSchema } from '@sensigo/realm';
 import { ToolCapableLlmProvider } from './llm-provider.js';
 import type {
   ToolCallRecord,
@@ -13,9 +13,10 @@ import {
   serializeToolResult,
   parseNamespacedId,
   extractJsonObject,
-  validateSchema,
   rejectAfter,
   buildSystemPrompt,
+  summarizeAgentValidationErrors,
+  renderValidationSummaryEntry,
 } from './agent-utils.js';
 
 /** The tool offered at `tool_choice:'auto'` so the model can return structured output directly —
@@ -172,6 +173,8 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
     executor: ToolExecutor,
     options: {
       inputSchema?: Record<string, unknown>;
+      validationInputSchema?: Record<string, unknown>;
+      validationOutputSchema?: Record<string, unknown>;
       maxToolCalls?: number;
       maxFanOut?: number;
       toolTimeoutMs?: number;
@@ -222,8 +225,17 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
     let fan_out_count = 0;
     let fan_out_budget_exhausted = false;
     let tool_call_count = 0;
+    // issue #224 (D6): in-conversation schema corrections draw on the SAME shared `maxToolCalls`
+    // budget as tool calls (deliberate — see the design record's shared-budget rationale), with
+    // ZERO `tool_call_records` entry each, so a step can starve its own tool budget invisibly.
+    // This counter + the per-correction stderr breadcrumb below are the chosen mitigation
+    // (visibility, not budget separation).
+    let correction_count = 0;
     const tool_call_records: ToolCallRecord[] = [];
     const system = buildSystemPrompt(options.inputSchema, options.agentProfileInstructions);
+    /** Attaches `correctionCount` to a result only when at least one correction happened. */
+    const withCorrectionCount = (result: StepWithToolsResult): StepWithToolsResult =>
+      correction_count > 0 ? { ...result, correctionCount: correction_count } : result;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const history: any[] = [{ role: 'user', content: prompt }];
@@ -273,18 +285,31 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
       // Extraction mechanism, not an agent-chosen tool — deliberately NOT pushed into
       // tool_call_records (would pollute stepMeta.toolCalls, run-agent.ts:487).
       const toolUse = blocks.find((b) => b.type === 'tool_use' && b.name === SUBMIT_TOOL_NAME);
+      // issue #224 (D4, §4 budget-exhaustion terminal): RETURN the best-effort output here
+      // UNCONDITIONALLY — never gate this return on schema conformance. A still-invalid output
+      // routes back through the engine's Step 2c `countRejection` (execution-loop.ts), so issue
+      // #220 counts the rejection and terminalizes at threshold (or default-substitutes, for a
+      // `mode:'default'` step). Throwing here instead — which is what would happen if this were
+      // gated on validateAgentSubmission — is caught at run-agent.ts:579-584, which returns
+      // 'failed' WITHOUT ever calling executeChain: the run record is never counted, never
+      // sealed, and a re-attach re-executes every tool call from scratch. Only a genuine
+      // PARSE failure (no usable object at all — the throw below) is a distinct class that must
+      // still throw. This was already Anthropic's behavior before #224 (never gated on schema
+      // here) — #224 UNIFIES OpenAI onto the same posture (see openai-provider.ts).
       if (toolUse !== undefined) {
-        return {
+        return withCorrectionCount({
           output: toolUse.input as Record<string, unknown>,
           toolCalls: tool_call_records,
-        };
+        });
       }
       const textBlock = blocks.find((b) => b.type === 'text');
       const text = textBlock?.text ?? '';
       const parsed = extractJsonObject(text);
       if (parsed !== null) {
-        return { output: parsed, toolCalls: tool_call_records };
+        return withCorrectionCount({ output: parsed, toolCalls: tool_call_records });
       }
+      // Parse failure — a DISTINCT class from schema-invalid (no usable object could be
+      // extracted at all) — this is the ONE case that still throws.
       throw new WorkflowError(
         sanitizeError(`max_tool_calls reached; final extraction failed: ${text.slice(0, 200)}`),
         {
@@ -405,22 +430,52 @@ export class AnthropicProvider extends ToolCapableLlmProvider {
         // Normal continuation — single user message with all tool_result blocks.
         history.push({ role: 'user', content: anthropic_result_blocks });
       } else {
-        // No tool calls — attempt to parse the final answer. extractJsonObject (P1) parses a fenced
-        // text answer immediately instead of nudging the model up to maxCalls; validateSchema stays
-        // the cheap required-keys pre-check for this correction loop (NOT the engine's Ajv validator).
+        // No tool calls — attempt to parse the final answer. extractJsonObject (P1) parses a
+        // fenced text answer immediately instead of nudging the model up to maxCalls.
+        // issue #224 (D4, the primary edit): the required-keys-only `validateSchema` pre-check is
+        // REPLACED with the full-AJV `validateAgentSubmission` (core) — right-keys-wrong-type/
+        // enum/nested-shape output is now caught and corrected IN-CONVERSATION (tool results
+        // retained, nothing re-executes), instead of passing through to die at the engine's drive.
         const textBlock = (response.content as Array<{ type: string; text?: string }>).find(
           (b) => b.type === 'text',
         );
         const text = textBlock?.text ?? '';
         const parsed = extractJsonObject(text);
-        if (parsed && validateSchema(parsed, options.inputSchema)) {
-          return { output: parsed, toolCalls: tool_call_records };
+        const verdict =
+          parsed !== null
+            ? validateAgentSubmission(
+                parsed,
+                {
+                  ...(options.validationInputSchema !== undefined
+                    ? { inputSchema: options.validationInputSchema as JsonSchema }
+                    : {}),
+                  ...(options.validationOutputSchema !== undefined
+                    ? { outputSchema: options.validationOutputSchema as JsonSchema }
+                    : {}),
+                },
+                'callStepWithTools',
+              )
+            : undefined;
+        if (parsed !== null && verdict?.valid === true) {
+          return withCorrectionCount({ output: parsed, toolCalls: tool_call_records });
         }
-        // Schema mismatch — append correction and keep looping.
+        // Invalid (schema-invalid OR unparseable) — append a leak-safe correction and keep
+        // looping. D5: names/paths/keywords + expected types + enum/const allowedValues, NEVER
+        // the offending value (ajv 8.18.0's default `message` embeds no offending value for any
+        // AC-2 keyword). D6: one breadcrumb per correction — corrections consume the SHARED
+        // maxToolCalls budget invisibly (no tool_call_records entry), so this is the mitigation.
+        correction_count++;
+        const summary =
+          verdict !== undefined
+            ? summarizeAgentValidationErrors(verdict.rawErrors)
+                .map(renderValidationSummaryEntry)
+                .join('\n')
+            : 'no valid JSON object could be extracted from the response';
+        console.error(`  ⚠ output rejected (in-conversation); correcting (${correction_count})`);
         history.push({ role: 'assistant', content: response.content });
         history.push({
           role: 'user',
-          content: 'Your response did not match the required JSON schema. Try again.',
+          content: `Your response did not match the required JSON schema: ${summary}. Try again.`,
         });
         tool_call_count++; // schema correction consumes a slot
         if (tool_call_count >= maxCalls) {

--- a/packages/cli/src/agent/providers/llm-provider.ts
+++ b/packages/cli/src/agent/providers/llm-provider.ts
@@ -51,7 +51,29 @@ export abstract class ToolCapableLlmProvider extends LlmProvider {
     tools: ToolDefinition[],
     executor: ToolExecutor,
     options: {
+      /**
+       * The EFFECTIVE-OUTPUT schema (`output_schema ?? input_schema`, resolved by the caller) —
+       * a MISNOMER kept for backward compatibility: it feeds the SUBMIT TOOL and the SYSTEM
+       * PROMPT only (never the in-conversation AJV correction below). Do NOT repoint this at the
+       * raw `input_schema` — see `validationInputSchema`/`validationOutputSchema` below for the
+       * two fields the correction loop actually consumes.
+       */
       inputSchema?: Record<string, unknown>;
+      /**
+       * issue #224 (D2): the step's RAW `input_schema`, separate from the effective-output
+       * `inputSchema` above. Consumed ONLY by the in-conversation `validateAgentSubmission`
+       * correction loop — never feeds the submit tool or the system prompt. Additive-optional: a
+       * `--provider-module` plugin that ignores this field simply doesn't in-conversation-correct
+       * against it (backward-compatible).
+       */
+      validationInputSchema?: Record<string, unknown>;
+      /**
+       * issue #224 (D2): the step's RAW `output_schema`, separate from the effective-output
+       * `inputSchema` above. Consumed ONLY by the in-conversation `validateAgentSubmission`
+       * correction loop — never feeds the submit tool or the system prompt. Additive-optional,
+       * same backward-compatibility posture as `validationInputSchema`.
+       */
+      validationOutputSchema?: Record<string, unknown>;
       maxToolCalls?: number;
       maxFanOut?: number;
       toolTimeoutMs?: number;

--- a/packages/cli/src/agent/providers/openai-provider.test.ts
+++ b/packages/cli/src/agent/providers/openai-provider.test.ts
@@ -172,9 +172,14 @@ describe('OpenAIProvider.callStepWithTools', () => {
   });
 
   // -----------------------------------------------------------------------
-  // 3. max_tool_calls reached → final extraction fails schema → throws ENGINE_STEP_FAILED
+  // 3. issue #224 (D4 §4): performFinalExtraction no longer gates on schema conformance — that's
+  // the engine Ajv validators' job (and the in-conversation correction loop's, before this point
+  // is ever reached). A parseable-but-schema-invalid final answer is now RETURNED as best-effort,
+  // never thrown — this UNIFIES OpenAI onto Anthropic's pre-existing posture (see the twin test
+  // in anthropic-provider.test.ts, "final extraction produces no usable object"). Only a genuine
+  // PARSE failure (no usable object at all) still throws — see test 3b below.
   // -----------------------------------------------------------------------
-  it('max_tool_calls reached → final extraction fails schema → throws ENGINE_STEP_FAILED', async () => {
+  it('max_tool_calls reached, parseable-but-schema-invalid final answer → RETURNS best-effort, never throws', async () => {
     const schema = { required: ['answer', 'confidence'] };
     const executor = vi.fn().mockResolvedValue('data');
     mockCreate
@@ -182,11 +187,26 @@ describe('OpenAIProvider.callStepWithTools', () => {
       .mockResolvedValueOnce(makeTextResponse('{"answer":"yes"}')); // 'confidence' missing
 
     const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 1,
+      inputSchema: schema,
+    });
+
+    expect(result.output).toEqual({ answer: 'yes' });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3b. The one remaining throw class — a genuinely unparseable final answer.
+  // -----------------------------------------------------------------------
+  it('max_tool_calls reached, no usable JSON object at all → throws ENGINE_STEP_FAILED', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('I was unable to determine a final answer.'));
+
+    const provider = new OpenAIProvider('gpt-4o');
     const err = await provider
-      .callStepWithTools('prompt', [oneTool()], executor, {
-        maxToolCalls: 1,
-        inputSchema: schema,
-      })
+      .callStepWithTools('prompt', [oneTool()], executor, { maxToolCalls: 1 })
       .catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(WorkflowError);
@@ -485,6 +505,221 @@ describe('OpenAIProvider.callStepWithTools', () => {
 
     expect(result.output).toEqual({ done: true });
     expect(executor).toHaveBeenCalledTimes(2);
+  });
+});
+
+// =========================================================================
+// issue #224 — in-conversation full-AJV correction (OpenAI-chat is IN SCOPE)
+// =========================================================================
+describe('OpenAIProvider.callStepWithTools — issue #224 in-conversation AJV correction', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  const strictSchema = {
+    type: 'object',
+    required: ['category'],
+    properties: { category: { type: 'string', enum: ['billing', 'support'] } },
+    additionalProperties: false,
+  };
+
+  // -----------------------------------------------------------------------
+  // Primary (D4): right keys, WRONG TYPE — corrected in-conversation, tool results retained,
+  // ZERO re-execution, settles without ever reaching a drive error branch.
+  // -----------------------------------------------------------------------
+  it('primary: right-keys-wrong-type output is corrected IN-CONVERSATION — tool executes exactly once, no re-execution', async () => {
+    const executor = vi.fn().mockResolvedValue({ content: 'file data' });
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'call_1', name: 'get_file' }]))
+      // Right key, WRONG TYPE (number instead of the required string/enum).
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}'))
+      // Corrected — valid.
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools(
+      'prompt',
+      [oneTool('github:get_file')],
+      executor,
+      { validationOutputSchema: strictSchema },
+    );
+
+    expect(result.output).toEqual({ category: 'billing' });
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.correctionCount).toBe(1);
+  });
+
+  it("probe-equivalent control: a wrong-type output with NO validation*Schema configured is accepted as-is (today's pre-#224 behavior for a plugin that ignores the new fields)", async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}'));
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {});
+
+    expect(result.output).toEqual({ category: 42 });
+    expect(result.correctionCount).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Leak pin (D5, AC-2): the correction message contains the whitelisted summary + enum
+  // allowedValues, and NEVER the offending value.
+  // -----------------------------------------------------------------------
+  it('leak pin (AC-2): the correction message contains the enum allowedValues but NEVER the offending sentinel value', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "OFFENDING_SENTINEL_XYZ"}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+
+    const provider = new OpenAIProvider('gpt-4o');
+    await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    // Third call's messages: [system, user:prompt, assistant:tool_calls, tool:result,
+    // assistant:wrong-type-text, user:correction] — the FIRST string-content user message is the
+    // original prompt, not the correction; take the LAST match.
+    const thirdCallMsgs = mockCreate.mock.calls[2][0].messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const stringUserMsgs = thirdCallMsgs.filter(
+      (m) => m.role === 'user' && typeof m.content === 'string',
+    );
+    const text = String(stringUserMsgs.at(-1)?.content ?? '');
+    expect(text).toContain('did not match the required JSON schema');
+    expect(text).toContain('billing');
+    expect(text).toContain('support');
+    expect(text).not.toContain('OFFENDING_SENTINEL_XYZ');
+  });
+
+  // -----------------------------------------------------------------------
+  // Observability (D6): one breadcrumb per correction; correctionCount reflects the total.
+  // -----------------------------------------------------------------------
+  it('observability (D6): emits one stderr breadcrumb per correction and surfaces correctionCount', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 1}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 2}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.correctionCount).toBe(2);
+    const breadcrumbs = errorSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('output rejected (in-conversation)'));
+    expect(breadcrumbs).toHaveLength(2);
+    expect(breadcrumbs[0]).toContain('correcting (1)');
+    expect(breadcrumbs[1]).toContain('correcting (2)');
+    errorSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Both-schemas (D2): sequential AND, never allOf-combine.
+  // -----------------------------------------------------------------------
+  it('both-schemas (D2): valid under output_schema but INVALID under input_schema is rejected in-conversation (sequential AND)', async () => {
+    const localOutputSchema = {
+      type: 'object',
+      required: ['category'],
+      properties: { category: { type: 'string' } },
+    };
+    const localInputSchema = {
+      type: 'object',
+      required: ['category', 'confirmed'],
+      properties: { category: { type: 'string' }, confirmed: { type: 'boolean' } },
+    };
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}'))
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing", "confirmed": true}'));
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationInputSchema: localInputSchema,
+      validationOutputSchema: localOutputSchema,
+    });
+
+    expect(result.correctionCount).toBe(1);
+    expect(result.output).toEqual({ category: 'billing', confirmed: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // _debug strip (D3): a _debug-bearing output that is valid-after-strip passes with ZERO
+  // corrections.
+  // -----------------------------------------------------------------------
+  it('_debug strip (D3): a _debug-bearing output valid-after-strip passes with ZERO corrections', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(
+        makeTextResponse('{"category": "billing", "_debug": "model reasoning trace"}'),
+      );
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.output).toEqual({ category: 'billing', _debug: 'model reasoning trace' });
+    expect(result.correctionCount).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Budget-exhaustion terminal (D4 §4) — pinned again here explicitly under the #224 describe
+  // block (already covered by the rewritten test 3/3b above).
+  // -----------------------------------------------------------------------
+  it('budget-exhaustion terminal: a still schema-invalid final answer is RETURNED, never thrown', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }]))
+      .mockResolvedValueOnce(makeTextResponse('{"category": 999}'));
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 1,
+      validationOutputSchema: strictSchema,
+    });
+
+    expect(result.output).toEqual({ category: 999 });
+  });
+
+  // -----------------------------------------------------------------------
+  // Contract (D7): every executor invocation — success, error, AND timeout — yields a toolCalls
+  // entry (llm-provider.ts's shipped JSDoc clause, now enforced by a test).
+  // -----------------------------------------------------------------------
+  it('contract (D7): every executor invocation (success, error, timeout) yields a toolCalls entry', async () => {
+    const hangingExecutor = vi
+      .fn()
+      .mockResolvedValueOnce('ok')
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockReturnValueOnce(new Promise<unknown>(() => {}));
+    mockCreate
+      .mockResolvedValueOnce(
+        makeToolCallResponse([
+          { id: 't1', name: 'op' },
+          { id: 't2', name: 'op' },
+          { id: 't3', name: 'op' },
+        ]),
+      )
+      .mockResolvedValueOnce(makeTextResponse('{"done":true}'));
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], hangingExecutor, {
+      toolTimeoutMs: 1,
+    });
+
+    expect(result.toolCalls).toHaveLength(3);
+    expect(result.toolCalls[0]?.error).toBeUndefined();
+    expect(result.toolCalls[1]?.error).toBe('boom');
+    expect(result.toolCalls[2]?.error).toBeDefined();
   });
 });
 

--- a/packages/cli/src/agent/providers/openai-provider.ts
+++ b/packages/cli/src/agent/providers/openai-provider.ts
@@ -1,6 +1,6 @@
 // openai-provider.ts — OpenAI LLM provider implementation for realm agent.
 // Requires openai >= 4.0.0 as an optional peer dependency (npm install openai).
-import { WorkflowError } from '@sensigo/realm';
+import { WorkflowError, validateAgentSubmission, type JsonSchema } from '@sensigo/realm';
 import { ToolCapableLlmProvider, type ProviderCapabilities } from './llm-provider.js';
 import type {
   ToolCallRecord,
@@ -13,9 +13,10 @@ import {
   serializeToolResult,
   parseNamespacedId,
   extractJsonObject,
-  validateSchema,
   rejectAfter,
   buildSystemPrompt,
+  summarizeAgentValidationErrors,
+  renderValidationSummaryEntry,
 } from './agent-utils.js';
 
 /**
@@ -117,6 +118,8 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
     executor: ToolExecutor,
     options: {
       inputSchema?: Record<string, unknown>;
+      validationInputSchema?: Record<string, unknown>;
+      validationOutputSchema?: Record<string, unknown>;
       maxToolCalls?: number;
       maxFanOut?: number;
       toolTimeoutMs?: number;
@@ -172,7 +175,16 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
     let fan_out_count = 0;
     let fan_out_budget_exhausted = false;
     let tool_call_count = 0;
+    // issue #224 (D6): in-conversation schema corrections draw on the SAME shared `maxToolCalls`
+    // budget as tool calls (deliberate — see the design record's shared-budget rationale), with
+    // ZERO `tool_call_records` entry each, so a step can starve its own tool budget invisibly.
+    // This counter + the per-correction stderr breadcrumb below are the chosen mitigation
+    // (visibility, not budget separation).
+    let correction_count = 0;
     const tool_call_records: ToolCallRecord[] = [];
+    /** Attaches `correctionCount` to a result only when at least one correction happened. */
+    const withCorrectionCount = (result: StepWithToolsResult): StepWithToolsResult =>
+      correction_count > 0 ? { ...result, correctionCount: correction_count } : result;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const history: any[] = [
@@ -209,8 +221,17 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
       );
       const text: string = (final.choices[0].message.content as string | null) ?? '';
       const parsed = extractJsonObject(text);
-      if (parsed && validateSchema(parsed, options.inputSchema)) {
-        return { output: parsed, toolCalls: tool_call_records };
+      // issue #224 (D4, §4 budget-exhaustion terminal): RETURN the best-effort output
+      // UNCONDITIONALLY here — never gate this return on schema conformance (this UNIFIES OpenAI
+      // onto Anthropic's pre-existing posture; see anthropic-provider.ts's twin comment for the
+      // full #220-terminalization rationale). A still-invalid output routes back through the
+      // engine's Step 2c `countRejection`, so issue #220 counts the rejection and terminalizes at
+      // threshold (or default-substitutes for a `mode:'default'` step) — throwing here instead
+      // would be caught at run-agent.ts:579-584 and return 'failed' WITHOUT ever calling
+      // executeChain, leaving the run record uncounted and re-executing every tool call on
+      // re-attach. Only a genuine PARSE failure (no usable object at all) still throws.
+      if (parsed !== null) {
+        return withCorrectionCount({ output: parsed, toolCalls: tool_call_records });
       }
       throw new WorkflowError('max_tool_calls reached; final extraction failed', {
         code: 'ENGINE_STEP_FAILED',
@@ -305,16 +326,45 @@ export class OpenAIProvider extends ToolCapableLlmProvider {
         }
       } else {
         // No tool calls — attempt to parse the final answer.
+        // issue #224 (D4, the primary edit): the required-keys-only `validateSchema` pre-check is
+        // REPLACED with the full-AJV `validateAgentSubmission` (core) — right-keys-wrong-type/
+        // enum/nested-shape output is now caught and corrected IN-CONVERSATION (tool results
+        // retained, nothing re-executes), instead of passing through to die at the engine's drive.
         const text: string = (message.content as string | null) ?? '';
         const parsed = extractJsonObject(text);
-        if (parsed && validateSchema(parsed, options.inputSchema)) {
-          return { output: parsed, toolCalls: tool_call_records };
+        const verdict =
+          parsed !== null
+            ? validateAgentSubmission(
+                parsed,
+                {
+                  ...(options.validationInputSchema !== undefined
+                    ? { inputSchema: options.validationInputSchema as JsonSchema }
+                    : {}),
+                  ...(options.validationOutputSchema !== undefined
+                    ? { outputSchema: options.validationOutputSchema as JsonSchema }
+                    : {}),
+                },
+                'callStepWithTools',
+              )
+            : undefined;
+        if (parsed !== null && verdict?.valid === true) {
+          return withCorrectionCount({ output: parsed, toolCalls: tool_call_records });
         }
-        // Schema mismatch — append correction message and continue the loop.
+        // Invalid (schema-invalid OR unparseable) — append a leak-safe correction and keep
+        // looping. D5: names/paths/keywords + expected types + enum/const allowedValues, NEVER
+        // the offending value. D6: one breadcrumb per correction.
+        correction_count++;
+        const summary =
+          verdict !== undefined
+            ? summarizeAgentValidationErrors(verdict.rawErrors)
+                .map(renderValidationSummaryEntry)
+                .join('\n')
+            : 'no valid JSON object could be extracted from the response';
+        console.error(`  ⚠ output rejected (in-conversation); correcting (${correction_count})`);
         history.push({ role: 'assistant', content: text });
         history.push({
           role: 'user',
-          content: 'Your response did not match the required JSON schema. Try again.',
+          content: `Your response did not match the required JSON schema: ${summary}. Try again.`,
         });
         tool_call_count++; // schema correction consumes a slot
         if (tool_call_count >= maxCalls) {

--- a/packages/cli/src/agent/run-agent.test.ts
+++ b/packages/cli/src/agent/run-agent.test.ts
@@ -1282,6 +1282,89 @@ describe('runAgent — schema-feedback repair loop (issue #217)', () => {
     errorSpy.mockRestore();
   });
 
+  // ---------------------------------------------------------------------------
+  // issue #224 D4(b) — the provider RETURNING a still-invalid output (its own in-conversation
+  // correction having been exhausted, per D4's budget-terminal fix) must still be COUNTED by the
+  // engine's Step 2c countRejection (issue #220), even though run-agent's OWN #217 repair loop
+  // declines to retry (toolCalls.length > 0). Per [audit F4]: assert on RUN-RECORD state, not on
+  // runAgent's return value (which stays 'failed' either way — a #220 terminalization IS an error
+  // envelope).
+  // ---------------------------------------------------------------------------
+  it("D4(b): tools-path — a still-invalid RETURNED output (post-#224 provider posture) increments validation_rejections via the engine's countRejection", async () => {
+    const def = toolsWorkflow();
+    const toolCalls: ToolCallRecord[] = [
+      {
+        tool: 'get_pull_request',
+        server_id: 'github',
+        args: {},
+        result: 'x',
+        duration_ms: 1,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    const provider = new (class extends ToolCapableLlmProvider {
+      callStepWithTools = vi.fn().mockResolvedValue({ output: { category: 'WRONG' }, toolCalls });
+    })();
+    const mockClient = makeMockMcpClient();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = new InMemoryStore();
+    const { run } = await store.create({
+      workflowId: def.id,
+      workflowVersion: def.version,
+      params: {},
+    });
+
+    const result = await runAgent(
+      {
+        store,
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+        mcpClientFactory: () => mockClient,
+      },
+      { existingRunId: run.id, definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed'); // unchanged — a #220 rejection/terminalization is still an error envelope
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['draft']).toBe(1); // COUNTED — proves Step 2c engaged
+    errorSpy.mockRestore();
+  });
+
+  it("D4(b) mutation-probe comparison: a THROWN provider error (the pre-#224 posture) is NEVER counted — validation_rejections stays unset, because run-agent's catch block returns 'failed' without ever reaching executeChain", async () => {
+    const def = toolsWorkflow();
+    const provider = new (class extends ToolCapableLlmProvider {
+      callStepWithTools = vi
+        .fn()
+        .mockRejectedValue(new Error('max_tool_calls reached; schema-invalid'));
+    })();
+    const mockClient = makeMockMcpClient();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = new InMemoryStore();
+    const { run } = await store.create({
+      workflowId: def.id,
+      workflowVersion: def.version,
+      params: {},
+    });
+
+    const result = await runAgent(
+      {
+        store,
+        workflowStore: makeWorkflowStore(def),
+        provider,
+        registry: createDefaultRegistry(),
+        mcpClientFactory: () => mockClient,
+      },
+      { existingRunId: run.id, definition: def, params: {} },
+    );
+
+    expect(result).toBe('failed');
+    const after = await store.get(run.id);
+    expect(after.validation_rejections?.['draft']).toBeUndefined(); // uncounted — never claimed/settled
+    expect(after.terminal_state).toBe(false); // not even a #220 terminalization — the run was never touched
+    errorSpy.mockRestore();
+  });
+
   it('test 10: chained-auto no-false-repair — an agent step chaining into an auto step with a required-prop input_schema does not falsely repair the already-settled agent step', async () => {
     const def: WorkflowDefinition = {
       id: 'chained-auto-wf',

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -22,11 +22,13 @@ import {
   type McpServerConfig,
   type ToolCallRecord,
   type TraceBufferStore,
-  type ValidationErrorSummaryEntry,
 } from '@sensigo/realm';
 import type { WorkflowRegistrar } from '@sensigo/realm';
 import type { LlmProvider } from './providers/llm-provider.js';
-import { setAdditionalRedactionValues } from './providers/agent-utils.js';
+import {
+  setAdditionalRedactionValues,
+  renderValidationSummaryEntry,
+} from './providers/agent-utils.js';
 import { isToolCapable } from './providers/llm-provider.js';
 import type { McpClient, ToolDefinition, ToolExecutor } from './mcp/mcp-extensions.js';
 import { McpClient as McpClientImpl } from './mcp/mcp-client.js';
@@ -188,25 +190,6 @@ async function pollUntilGateResolved(
     if (run.terminal_state) break;
     if (run.pending_gate === undefined || run.pending_gate.gate_id !== gateId) break;
   }
-}
-
-/**
- * Renders one whitelisted Ajv-error summary entry (issue #217, core's
- * `buildFailedAttemptRecord(...).validation_error_summary`) as a single human-readable line for
- * the schema-repair prompt trailer. Key NAMES only — the summary entry already strips value
- * echoes (see failed-attempt-record.ts's `summarizeAjvErrors`), so nothing rendered here can leak
- * a submitted or schema-declared VALUE (e.g. `enum.allowedValues`).
- */
-function renderValidationSummaryEntry(entry: ValidationErrorSummaryEntry): string {
-  const path = entry.instancePath !== '' ? entry.instancePath : '(root)';
-  let line = `- ${path}: ${entry.message} [${entry.keyword}]`;
-  if (entry.additional_property !== undefined) {
-    line += ` (additional property: '${entry.additional_property}')`;
-  }
-  if (entry.missing_property !== undefined) {
-    line += ` (missing property: '${entry.missing_property}')`;
-  }
-  return line;
 }
 
 /**
@@ -558,7 +541,9 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
                 );
               }
               // #robust-anthropic-provider Part 1: same output-over-input precedence as the callStep
-              // path above.
+              // path above. This EFFECTIVE-OUTPUT schema still feeds ONLY the submit tool + system
+              // prompt (unchanged) — issue #224 [gate] SCHEMA-ROUTING PIN: do NOT repoint it at the
+              // newly-separated raw schemas below.
               const toolsEffectiveOutputSchema =
                 (stepDef.output_schema as Record<string, unknown> | undefined) ??
                 (stepDef.input_schema as Record<string, unknown> | undefined);
@@ -569,6 +554,19 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
                 {
                   ...(toolsEffectiveOutputSchema !== undefined
                     ? { inputSchema: toolsEffectiveOutputSchema }
+                    : {}),
+                  // issue #224 (D2): the RAW schemas, separate from the effective-output schema
+                  // above — consumed ONLY by the in-conversation validateAgentSubmission
+                  // correction loop (never the submit tool / system prompt).
+                  ...(stepDef.input_schema !== undefined
+                    ? {
+                        validationInputSchema: stepDef.input_schema as Record<string, unknown>,
+                      }
+                    : {}),
+                  ...(stepDef.output_schema !== undefined
+                    ? {
+                        validationOutputSchema: stepDef.output_schema as Record<string, unknown>,
+                      }
                     : {}),
                   maxToolCalls: stepDef.max_tool_calls ?? 20,
                   ...(stepDef.max_fan_out !== undefined ? { maxFanOut: stepDef.max_fan_out } : {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,7 +183,12 @@ export { TRACE_POLICY_VERSION, TRACE_POLICY, TRACE_POLICY_HASH } from './engine/
 export type { TracePolicyDescriptor, TracePolicyVersion } from './engine/trace-policy.js';
 
 // Validation
-export { validateInputSchema } from './validation/input-schema.js';
+export {
+  validateInputSchema,
+  validateOutputSchema,
+  validateAgentSubmission,
+} from './validation/input-schema.js';
+export type { RawValidationError, AgentSubmissionValidation } from './validation/input-schema.js';
 
 // Workflow
 export {

--- a/packages/core/src/observability/failed-attempt-record.ts
+++ b/packages/core/src/observability/failed-attempt-record.ts
@@ -97,13 +97,20 @@ function safeStringify(value: unknown): string {
 }
 
 /**
- * Map raw Ajv errors to the whitelisted summary. Drops `params`/`data` WHOLESALE (Ajv embeds
- * offending/schema VALUES there — a leak vector, e.g. `enum.allowedValues`) EXCEPT for two
- * keyword-conditional KEY-NAME-ONLY fields (issue #217) that carry no value: `additional_property`
- * (from `params.additionalProperty` on an `additionalProperties` error) and `missing_property`
- * (from `params.missingProperty` on a `required` error) — both gated on keyword AND a string-typed
- * params field, so no other keyword's `params` is ever touched. Skips non-object entries, caps at
- * the first 10, truncates path/message/the two new fields to 200 chars. Never throws.
+ * Map raw Ajv errors to the whitelisted summary. Drops `params`/`data` WHOLESALE — Ajv's `data`
+ * echoes the SUBMITTED value (the genuine leak vector: it can carry arbitrary caller/model
+ * content) EXCEPT for two keyword-conditional KEY-NAME-ONLY fields (issue #217) that carry no
+ * value: `additional_property` (from `params.additionalProperty` on an `additionalProperties`
+ * error) and `missing_property` (from `params.missingProperty` on a `required` error) — both
+ * gated on keyword AND a string-typed params field, so no other keyword's `params` is ever
+ * touched. issue #224 correction: a prior version of this comment mis-framed `params.allowedValues`
+ * (the `enum` keyword's own value) as a leak vector alongside `data` — it is NOT: `allowedValues`
+ * is a SCHEMA constant (author-controlled, already present in the system prompt the model was
+ * given), never submitted/user data, so dropping it here is conservative-but-unnecessary rather
+ * than a leak fix. This distinction is why issue #224's #224-local formatter (agent-utils.ts) is
+ * able to surface `allowedValues` safely from its OWN raw-error read without reusing (or needing
+ * to widen) this whitelist. Skips non-object entries, caps at the first 10, truncates
+ * path/message/the two new fields to 200 chars. Never throws.
  */
 function summarizeAjvErrors(ajvErrors: unknown[]): ValidationErrorSummaryEntry[] {
   if (!Array.isArray(ajvErrors)) return [];

--- a/packages/core/src/validation/input-schema.test.ts
+++ b/packages/core/src/validation/input-schema.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { validateInputSchema, validateTraceSchema } from './input-schema.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  validateInputSchema,
+  validateTraceSchema,
+  validateAgentSubmission,
+} from './input-schema.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import type { JsonSchema } from '../types/workflow-definition.js';
 import type { TraceEntry } from '../types/run-record.js';
+import { executeStep } from '../engine/execution-loop.js';
+import { JsonFileStore } from '../store/json-file-store.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
 
 const schema: JsonSchema = {
   type: 'object',
@@ -156,5 +168,183 @@ describe('validateTraceSchema', () => {
     const result = validateTraceSchema(invalidEntries, traceSchema, 'my-step', 'warn');
     // Ajv reports a type error for seq (string instead of number)
     expect(result.warning.toLowerCase()).toMatch(/must be number|type/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #224 — validateAgentSubmission (the provider-replicate non-throwing validator)
+// ---------------------------------------------------------------------------
+
+describe('validateAgentSubmission (issue #224)', () => {
+  const outputSchema: JsonSchema = {
+    type: 'object',
+    required: ['category'],
+    properties: { category: { type: 'string' } },
+    additionalProperties: false,
+  };
+
+  it('valid === true, rawErrors === [] when the submission satisfies the schema', () => {
+    const result = validateAgentSubmission({ category: 'billing' }, { outputSchema }, 'my-step');
+    expect(result.valid).toBe(true);
+    expect(result.rawErrors).toEqual([]);
+  });
+
+  it('valid === false with populated rawErrors on a schema-invalid submission (right key, wrong type)', () => {
+    const result = validateAgentSubmission({ category: 42 }, { outputSchema }, 'my-step');
+    expect(result.valid).toBe(false);
+    expect(result.rawErrors.length).toBeGreaterThan(0);
+    expect(result.rawErrors[0]?.keyword).toBe('type');
+  });
+
+  it('never throws, even on a schema-invalid submission', () => {
+    expect(() => validateAgentSubmission({}, { outputSchema }, 'my-step')).not.toThrow();
+  });
+
+  it('no schemas given ⇒ always valid (mirrors the pre-#224 required-keys check\'s "no schema ⇒ true")', () => {
+    const result = validateAgentSubmission({ anything: 'goes' }, {}, 'my-step');
+    expect(result.valid).toBe(true);
+  });
+
+  describe('pin (a): source-text guard — no fresh Ajv, references the two throwing validators', () => {
+    const source = readFileSync(fileURLToPath(new URL('./input-schema.ts', import.meta.url)), {
+      encoding: 'utf8',
+    });
+    const fnStart = source.indexOf('export function validateAgentSubmission');
+    const fnBody = source.slice(fnStart, source.indexOf('\n}\n', fnStart) + 3);
+
+    it('validateAgentSubmission calls validateInputSchema and validateOutputSchema', () => {
+      expect(fnStart).toBeGreaterThan(-1);
+      expect(fnBody).toContain('validateInputSchema(');
+      expect(fnBody).toContain('validateOutputSchema(');
+    });
+
+    it('validateAgentSubmission constructs NO fresh Ajv (mutation-probe target)', () => {
+      expect(fnBody).not.toContain('new Ajv(');
+    });
+  });
+
+  describe("D3: _debug strip mirrors the engine's effectiveInput exactly", () => {
+    it('a _debug-bearing output that is valid-after-strip passes (additionalProperties:false schema)', () => {
+      const strictSchema: JsonSchema = {
+        type: 'object',
+        required: ['category'],
+        properties: { category: { type: 'string' } },
+        additionalProperties: false,
+      };
+      const result = validateAgentSubmission(
+        { category: 'billing', _debug: 'reasoning trace...' },
+        { outputSchema: strictSchema },
+        'my-step',
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('a _debug-bearing output that is genuinely invalid even after the strip still fails', () => {
+      const result = validateAgentSubmission(
+        { category: 42, _debug: 'reasoning trace...' },
+        { outputSchema },
+        'my-step',
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('D2: both-schemas SEQUENTIAL AND, never allOf-combine', () => {
+    // additionalProperties:false on BOTH schemas — an allOf-combine would reject an object
+    // valid under one schema alone, because the other schema's branch rejects its properties.
+    const inputSchema: JsonSchema = {
+      type: 'object',
+      required: ['note'],
+      properties: { note: { type: 'string' } },
+      additionalProperties: false,
+    };
+
+    it('valid under output_schema but INVALID under input_schema ⇒ rejected (sequential AND, input-first)', () => {
+      // { category: 'billing' } satisfies outputSchema but fails inputSchema (missing 'note',
+      // and 'category' is not an allowed property under inputSchema's additionalProperties:false).
+      const result = validateAgentSubmission(
+        { category: 'billing' },
+        { inputSchema, outputSchema },
+        'my-step',
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('valid under BOTH schemas ⇒ accepted only when the object satisfies each independently (not a merged allOf shape)', () => {
+      // Note: input_schema and output_schema here describe DIFFERENT objects in the engine's real
+      // usage (Step 2b validates the AGENT'S INPUT shape, Step 2c the OUTPUT shape) — this
+      // provider-side helper validates the SAME submitted object against both, sequentially,
+      // exactly mirroring the engine's own Step 2b→2c order for the identical (obj, schemas) pair.
+      const result = validateAgentSubmission({ note: 'hi' }, { inputSchema }, 'my-step');
+      expect(result.valid).toBe(true);
+    });
+
+    it("invalid under input_schema (checked first) ⇒ short-circuits before output_schema is ever checked (single failure population, mirrors the engine's input-first short-circuit)", () => {
+      // An object satisfying NEITHER schema — if output_schema were checked too, rawErrors would
+      // differ; asserting the FIRST rawError's schemaPath/keyword pins that only input_schema ran.
+      const result = validateAgentSubmission(
+        {}, // fails input_schema's required:['note'] AND would also fail outputSchema's required
+        { inputSchema, outputSchema },
+        'my-step',
+      );
+      expect(result.valid).toBe(false);
+      expect(result.rawErrors.some((e) => e.keyword === 'required')).toBe(true);
+    });
+  });
+
+  describe('pin (b): verdict-parity — validateAgentSubmission agrees with a real executeStep/executeChain agent step', () => {
+    const def: WorkflowDefinition = {
+      id: 'parity-wf',
+      name: 'Parity WF',
+      version: 1,
+      steps: {
+        draft: {
+          description: 'Draft',
+          execution: 'agent',
+          output_schema: outputSchema,
+        },
+      },
+    };
+    const echoDispatcher = async (
+      _step: string,
+      input: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => input;
+
+    const table: Array<{
+      label: string;
+      submission: Record<string, unknown>;
+      expectValid: boolean;
+    }> = [
+      { label: 'valid submission', submission: { category: 'billing' }, expectValid: true },
+      { label: 'wrong type', submission: { category: 42 }, expectValid: false },
+      { label: 'missing required key', submission: {}, expectValid: false },
+      {
+        label: 'extra property (additionalProperties:false)',
+        submission: { category: 'billing', extra: 'nope' },
+        expectValid: false,
+      },
+    ];
+
+    for (const { label, submission, expectValid } of table) {
+      it(`${label}: executeStep and validateAgentSubmission agree (both ${expectValid ? 'accept' : 'reject'})`, async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'realm-parity-test-'));
+        const store = new JsonFileStore(dir);
+        const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+        const envelope = await executeStep(store, def, {
+          runId: run.id,
+          command: 'draft',
+          input: submission,
+          dispatcher: echoDispatcher,
+        });
+        const engineValid = envelope.status === 'ok';
+
+        const verdict = validateAgentSubmission(submission, { outputSchema }, 'draft');
+
+        expect(engineValid).toBe(expectValid);
+        expect(verdict.valid).toBe(expectValid);
+        expect(verdict.valid).toBe(engineValid); // the parity assertion itself
+      });
+    }
   });
 });

--- a/packages/core/src/validation/input-schema.ts
+++ b/packages/core/src/validation/input-schema.ts
@@ -50,6 +50,94 @@ export function validateOutputSchema(
   }
 }
 
+/**
+ * issue #224 [audit F3] — the ajv-VERSION type trap. `cli` resolves ajv@6 from the repo root
+ * (hoisted; `ErrorObject` is a NAMESPACE member there, `ajv.ErrorObject`, carrying `dataPath`);
+ * `core` resolves its OWN ajv@8 (`ErrorObject` is a top-level named export, carrying
+ * `instancePath`). A cli file that did `import type { ErrorObject } from 'ajv'` would resolve
+ * against the WRONG major version and the wrong shape (or fail to resolve the named export at
+ * all). This alias is exported FROM CORE (so it resolves against core's own ajv@8) — `cli` must
+ * import `RawValidationError` from `@sensigo/realm`, never `from 'ajv'` directly. Runtime rows are
+ * always ajv@8 (this module's own `new Ajv()` calls are the only mint site, both bare, both
+ * ajv@8) — this type is a type-resolution fix only, not a runtime behavior change.
+ */
+export type RawValidationError = import('ajv').ErrorObject;
+
+/** Result of {@link validateAgentSubmission}. */
+export interface AgentSubmissionValidation {
+  valid: boolean;
+  /**
+   * Raw (un-whitelisted) Ajv error rows from whichever validator rejected first — empty when
+   * `valid` is true. Callers must whitelist these themselves before rendering/logging (core's own
+   * `summarizeAjvErrors`, in `observability/failed-attempt-record.ts`, is private and drops fields
+   * a caller may need, e.g. `params.allowedValues` — see that module's #224 note).
+   */
+  rawErrors: RawValidationError[];
+}
+
+/**
+ * issue #224 — a NON-THROWING validator for the provider's IN-CONVERSATION correction loop
+ * (never the engine — see below). PROVIDER-REPLICATE, not a unification: calls the exact same two
+ * exported THROWING validators above, SEQUENTIALLY — `validateInputSchema` (when `inputSchema` is
+ * given) THEN `validateOutputSchema` (when `outputSchema` is given) — each in its own try/catch,
+ * mirroring the engine's Step 2b→2c order and its INPUT-FIRST SHORT-CIRCUIT (an input-schema
+ * rejection returns immediately; output_schema is never checked that call, exactly like the
+ * engine's own single-increment-per-rejection behavior). Both this function and the engine's Step
+ * 2b/2c bottom on the SAME two functions + the same bare `new Ajv()` construction (see
+ * `validateInputSchema`/`validateOutputSchema` above) — this is what makes the AJV verdict
+ * divergence-proof between the provider's in-conversation check and the engine's drive-time gate,
+ * WITHOUT touching or unifying the engine's own Step 2b/2c (issue #220's counting/exhaustion/
+ * `last_ajv_errors` telemetry are built on those two separate throwing try-catches and must stay
+ * byte-unchanged — see execution-loop.ts's `countRejection`).
+ *
+ * Mirrors the engine's `_debug` strip (execution-loop.ts:996-1002) before validating either
+ * schema: the engine never validates a submission's `_debug` field, so a `_debug`-bearing object
+ * that would PASS after stripping must also pass here — otherwise, under
+ * `additionalProperties:false`, this function would OVER-REJECT an object the engine would
+ * happily accept, burning the shared tool-call budget on a would-succeed step.
+ *
+ * Returns the RAW error rows only (never a pre-summarized shape) — the caller does its own
+ * whitelisting; see `AgentSubmissionValidation.rawErrors`'s own doc for why.
+ *
+ * **Do NOT construct a fresh `Ajv()` anywhere in this function** (pin (a), the source-text guard)
+ * — every verdict must route through `validateInputSchema`/`validateOutputSchema` above.
+ */
+export function validateAgentSubmission(
+  obj: Record<string, unknown>,
+  schemas: { inputSchema?: JsonSchema; outputSchema?: JsonSchema },
+  stepId: string,
+): AgentSubmissionValidation {
+  // Mirror execution-loop.ts's _debug strip exactly — never validated, never hashed.
+  let effectiveObj = obj;
+  if (Object.prototype.hasOwnProperty.call(obj, '_debug')) {
+    const { _debug: _omit, ...rest } = obj;
+    effectiveObj = rest;
+  }
+
+  if (schemas.inputSchema !== undefined) {
+    try {
+      validateInputSchema(effectiveObj, schemas.inputSchema, stepId);
+    } catch (err) {
+      return { valid: false, rawErrors: extractRawErrors(err) };
+    }
+  }
+  if (schemas.outputSchema !== undefined) {
+    try {
+      validateOutputSchema(effectiveObj, schemas.outputSchema, stepId);
+    } catch (err) {
+      return { valid: false, rawErrors: extractRawErrors(err) };
+    }
+  }
+  return { valid: true, rawErrors: [] };
+}
+
+/** Pulls the raw ajv error rows off a caught `WorkflowError`; `[]` for anything else. */
+function extractRawErrors(err: unknown): RawValidationError[] {
+  if (!(err instanceof WorkflowError)) return [];
+  const errors = err.details['errors'];
+  return Array.isArray(errors) ? (errors as RawValidationError[]) : [];
+}
+
 export interface TraceSchemaWarnResult {
   errorCount: number;
   warning: string;


### PR DESCRIPTION
## Context

Issue #224. A tool-using `execution: 'agent'` step whose model output has the **right keys but wrong types/enums/nested shapes** could not be repaired. The provider's in-conversation correction check (`AnthropicProvider`, `OpenAIProvider`) validated only that required top-level keys were present (`validateSchema`, required-keys-only), so any type/enum/shape violation passed straight through to the engine's own AJV gate and **died at the drive** — where issue #217 deliberately declines to repair a tools-path step (a stateless re-call would re-execute every already-completed tool call and fabricate evidence). The retained conversation — where the tool results already survive and nothing re-executes — was the natural place to correct, but the check there was too weak to catch the failure.

## Motivation

This is the **reask layer** of a layered structured-output-robustness architecture (design record: `plans/issue-224/design-v2.md`, grounded by a 4-lane dossier + a design-review round + a completeness gate). Upgrading the in-conversation check to the **full AJV validation the engine itself uses** lets the model fix a malformed submission in-place, before the output ever reaches the drive — with zero tool re-execution. The prevention layer (Anthropic `strict:true` / `output_config.format`) is deliberately **out of scope**, split to issue #236 for its own debate.

## Changes

**Core (`@sensigo/realm`) — the provider-replica validator (never a unification):**
- New non-throwing `validateAgentSubmission(obj, { inputSchema?, outputSchema? }, stepId) → { valid, rawErrors }`. Calls the **same two exported throwing validators the engine uses**, sequentially (`validateInputSchema` then `validateOutputSchema`, input-first short-circuit), each in its own try/catch. Mirrors the engine's `_debug`-field strip before validating. Returns raw AJV error rows only.
- The engine's own Step 2b/2c gate is **byte-unchanged** — issue #220's rejection counting/exhaustion telemetry stays built on the engine's separate throwing checks. Both the provider and the engine bottom on the identical validators + identical bare `new Ajv()`, so their AJV verdicts are divergence-proof by construction.
- Newly exported: `validateOutputSchema`, `validateAgentSubmission`, and the type alias `RawValidationError` (= `ajv.ErrorObject`, exported from core so cli never imports `ajv` directly and picks up the wrong major version) + `AgentSubmissionValidation`.

**CLI providers — the correction-loop swap + the budget terminal:**
- Both providers' in-conversation correction loops replace the required-keys `validateSchema` with `validateAgentSubmission`. On invalid, a **leak-safe** correction message is appended and the loop continues within the existing `maxToolCalls` budget.
- `callStepWithTools` options gain two additive-optional fields, `validationInputSchema` / `validationOutputSchema` (the step's raw declared schemas, consumed **only** by the correction loop). The pre-existing `inputSchema` field (the effective-output schema) is unchanged and keeps feeding the submit tool + system prompt exactly as before.
- **`OpenAIProvider.performFinalExtraction` no longer throws** when the budget is exhausted and the last output is still schema-invalid — it returns the best-effort output, exactly as `AnthropicProvider` already did. This unifies both providers on the posture #220 depends on: a returned (even invalid) output flows through the engine's Step 2c `countRejection` and terminalizes normally; a thrown error would instead be caught by `run-agent.ts`'s outer catch (→ `'failed'`, never counted, tools re-executed on re-attach). Only a genuine parse failure still throws.

**Leak-safety, observability, hygiene:**
- The correction message carries field paths / keywords / expected types / schema-declared `enum`/`const` allowed values — **never the submitted/offending value**. `renderValidationSummaryEntry` relocated to `agent-utils.ts` (avoids a provider→run-agent load cycle) and extended with `allowedValues`; a #224-local `summarizeAgentValidationErrors` whitelists directly from raw error rows (core's shipped `summarizeAjvErrors`/#217 telemetry surface is untouched — one doc-comment correction only).
- Per-correction stderr breadcrumb (`⚠ output rejected (in-conversation); correcting (n)`) + a new `correctionCount?` on the cli-local `StepWithToolsResult` make the shared-budget consumption visible.
- `validateSchema` removed (replaced at its only two call sites, no other caller); a record-per-invocation contract test added (#217 clause enforced).

No behavior change for `callStep`-only (non-tool) agent steps.

## Verification

```bash
# Full 4-package suite (forced), lint, typecheck
npx turbo run test --force        # 8/8 tasks green (core 1924, cli 823, testing 81, mcp 265)
npx turbo run lint                # 4/4 clean
# per-package: npx tsc --noEmit in core, cli, mcp-server, testing → clean

# Primary behavior (both providers): a tools-path step emitting right-keys-wrong-type output is
# corrected IN the retained conversation (tools execute once, never re-run) and settles without
# reaching the drive's error branch:
npx vitest run packages/cli/src/agent/providers/anthropic-provider.test.ts
npx vitest run packages/cli/src/agent/providers/openai-provider.test.ts

# Engine-count coupling (D4b): a provider RETURNING a still-invalid output increments
# validation_rejections via the engine's Step 2c countRejection; a THROWN error is never counted:
npx vitest run packages/cli/src/agent/run-agent.test.ts -t "D4(b)"

# Core validator (sequential, _debug-strip, no fresh Ajv, verdict parity vs the real engine):
npx vitest run packages/core/src/validation/input-schema.test.ts
```

Eight mutation probes were run against the new mechanism (revert-to-required-keys, output-only/allOf, drop-`_debug`-strip, throw-on-schema-invalid, forward-offending-value, fresh-`new Ajv()`), each reproduced its predicted red and was reverted byte-identically.

## Rollback

```bash
git revert HEAD
```

Pure code change — no data migrations, no out-of-band mutations. The engine's own validation gate and #220/#217 telemetry surfaces are byte-unchanged, so reverting cannot strand any run record.

## Related

Closes #224
Prevention layer split to #236 (its own debate). Design record: `plans/issue-224/design-v2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
