### PR TITLE
fix(deps): bump fast-uri 3.1.2 -> 3.1.4 (GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ All notable changes to this project are documented here.
   engine's own validation gate, `execute_step` telemetry, or the #217 repair-gate's tools-path
   refusal.
 
+### Security
+
+- **`fast-uri` bumped 3.1.2 → 3.1.4 — fixes two HIGH host-confusion advisories**
+  ([GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) failed-IDN-canonicalization
+  and [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) literal-backslash
+  authority delimiter, both CVSS 7.5), a transitive dependency of `ajv`. Within the existing `^3.0.1`
+  range (lockfile-only; no `package.json` change, no `overrides`). Realm exposure is LOW: `ajv` uses
+  `fast-uri` only to parse author-controlled schema `$id`/`$ref` references, never for a host-based
+  security decision, so the host-confusion path is not weaponizable in realm. Clears the
+  pre-publication `npm audit` gate.
+
 ---
 
 ## [0.30.0] — 2026-07-21

--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,9 +2249,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4591,7 +4591,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4642,7 +4642,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -4687,7 +4687,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4708,7 +4708,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",


### PR DESCRIPTION
## Context

Triage item #1 of a dependency-security list. `fast-uri@3.1.2` is a **shipped runtime transitive**
(`ajv@8.18.0` → `fast-uri`, present in both `@sensigo/realm` (core) and `@sensigo/realm-cli`)
carrying two HIGH-severity host-confusion advisories (CVSS 7.5 each, not a DoS):

- **[GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6)** (CVE-2026-13676) —
  host confusion via failed IDN canonicalization. Patched in `3.1.3`.
- **[GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx)** (CVE-2026-16221) —
  host confusion via literal backslash authority delimiter. Patched in `3.1.4`.

`3.1.4` clears both. Neither was among Dependabot's open alerts (those are `brace-expansion`,
dev-scoped, and `hono`/`@hono`, separate triage items) — `npm audit` and the pre-publication audit
gate do see it, so it must be cleared before the next release.

## Motivation

Both advisories describe a **policy/use desynchronization**: a consumer that parses a URL with
`fast-uri` to make a host-based decision (an allowlist, a loopback/SSRF filter, a redirect check)
can see a different host than what Node's own `URL`/`fetch` actually resolves, letting a crafted
URL slip past a filter. `3.1.4` fixes both root causes and is within `ajv`'s existing declared
range (`^3.0.1`), so the fix is a pure lockfile resolution bump — no code change anywhere in this
repo.

**Realm's own exposure is LOW** (verified in this PR, not just asserted): `ajv` calls
`fast-uri.parse()` exactly once, in `compile/index.js`'s `resolveSchema()`, to build an
**internal schema-reference cache key** when resolving a `$ref`/`$id` during schema compilation
(confirmed by reading the installed `ajv@8.18.0` dist source). It never reads the parsed
`.host`/`.authority` for a trust decision and performs no network I/O — the host-confusion class
this pair of advisories describes doesn't apply to this call site. The bump is still worth taking
immediately because it's free (behavior-neutral, lockfile-only) and it clears the release gate.

## Changes

- **`package-lock.json`**: `npm update fast-uri --package-lock-only` resolves the single hoisted
  `fast-uri` node from `3.1.2` → `3.1.4` (version + `resolved` + `integrity`). No `package.json`
  change, no `ajv` bump, no `overrides`/`resolutions` block — the fix is entirely within `ajv`'s
  existing `^3.0.1` range.
- **Incidental, expected, unrelated to `fast-uri`**: the same lockfile write also reconciles a
  pre-existing drift where the four workspace self-versions (`packages/cli`, `packages/core`,
  `packages/mcp-server`, `packages/testing`) were recorded as `0.29.0` in the lockfile while
  `package.json` already says `0.30.0` (since the last release bump). This PR's diff flips those
  four lines `0.29.0` → `0.30.0`. This is correct and benign — flagging it explicitly here so it
  isn't mistaken for scope creep.
- **`CHANGELOG.md`**: new `[Unreleased]` → `### Security` entry (this repo had no `[Unreleased]`
  section yet; created it, mirroring the `v0.30.0` `js-yaml` security entry's style). This does
  **not** cut a release — it rides `[Unreleased]` and will be bundled into one `### Security`
  release at the end of the full dependency-security triage.

The full `package-lock.json` diff (nothing else changed):

```diff
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
...
     "packages/cli": {       "version": "0.29.0" → "0.30.0"
     "packages/core": {      "version": "0.29.0" → "0.30.0"
     "packages/mcp-server": {"version": "0.29.0" → "0.30.0"
     "packages/testing": {   "version": "0.29.0" → "0.30.0"
```

## Verification

```bash
# 1. Before: npm audit shows both fast-uri HIGH advisories (plus unrelated brace-expansion/hono
#    items, out of scope for this PR)
git stash && npm audit | grep -A2 -i fast-uri && git stash pop
# → fast-uri  3.0.0 - 3.1.3 / Severity: high / GHSA-4c8g-83qw-93j6 + GHSA-v2hh-gcrm-f6hx

# 2. After: both advisories cleared, only the pre-existing unrelated items remain
npm audit | grep -i fast-uri
# → (no output)
npm audit
# → 4 vulnerabilities (3 moderate, 1 high) — down from 5 (3 moderate, 2 high); the remaining
#   items are brace-expansion/hono/@hono, all pre-existing and out of scope for this PR

# 3. Every fast-uri node resolves to 3.1.4 (run `npm install` first to materialize node_modules
#    from the updated lockfile — package-lock.json itself is unchanged by this step, confirmed via
#    md5sum before/after)
npm install && npm ls fast-uri --all
# → every entry: fast-uri@3.1.4 (or "deduped")

# 4. Diff scope — package-lock.json changes are EXACTLY the fast-uri node + the 4 workspace
#    self-version lines; nothing else
git diff --stat main
#  CHANGELOG.md      | 15 +++++++++++++++
#  package-lock.json | 14 +++++++-------
#  2 files changed, 22 insertions(+), 7 deletions(-)

# 5. Full 4-package suite forced + typecheck — must stay green (fast-uri is used only for opaque
#    $ref parsing, so the bump is behavior-neutral)
npx turbo run test --force
#  core: 1909/1909, cli: 803/803, mcp-server: 265/265, testing: 81/81 — all green, no flake
npx tsc --noEmit   # run in each of packages/{core,cli,mcp-server,testing} — clean in all four

# 6. PoC differential, run against the actual installed fast-uri@3.1.4 (and cross-checked against
#    a scratch install of the pre-bump 3.1.2 for comparison):
node -e "
const { parse } = require('fast-uri');
console.log(parse('http://127。0。0。1/'));
console.log(parse('http://evil.com\\\\@allowed.com'));
"
# 3.1.4 case 1 (IDN):  { scheme: 'http', host: '127.0.0.1', path: '/', ... }  — no .error,
#   canonicalizes to match Node's own `new URL(...).host` exactly (was left as the raw
#   un-canonicalized "127。0。0。1" on 3.1.2, silently, alongside an internal domainToASCII crash
#   logged into `.error` that callers weren't expected to check).
# 3.1.4 case 2 (backslash): { host: 'allowed.com', error: 'URI authority must not contain a
#   literal backslash.', ... } — the fix is NOT a host realignment; it FLAGS the authority as
#   malformed via `.error` (3.1.2 returned the same confused host silently, with no `.error` at
#   all). A consumer that checks `.error` before trusting the parse (the correct usage contract)
#   now refuses the input outright rather than accepting an ambiguous host.
```

## Rollback

```bash
git revert HEAD
```

Pure lockfile + changelog change — reverting restores `fast-uri@3.1.2` with no other side effects
(no `package.json` touched, no code path depends on the bump). No out-of-band data mutation of any
kind.

## Related

- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676
- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / CVE-2026-16221
- Item #1 of the dependency-security triage (items #2 `brace-expansion`, #3 `hono`/`@hono` are
  separate, deliberately out of scope here)
- Posture follow-up: #238
