### PR TITLE
test(cli): pin issue #224 shared-budget behavior (characterization)

### DIFF
--- a/packages/cli/src/agent/providers/anthropic-provider.test.ts
+++ b/packages/cli/src/agent/providers/anthropic-provider.test.ts
@@ -938,6 +938,83 @@ describe('AnthropicProvider.callStepWithTools — issue #224 in-conversation AJV
 });
 
 // =========================================================================
+// issue #224 — shared-budget characterization (named residual: corrections and tool calls draw
+// on the SAME `tool_call_count`, incremented per tool call AND per correction, no reset/decrement)
+// =========================================================================
+describe('AnthropicProvider.callStepWithTools — issue #224 shared-budget characterization', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  const budgetSchema = {
+    type: 'object',
+    required: ['category'],
+    properties: { category: { type: 'string', enum: ['billing', 'support'] } },
+    additionalProperties: false,
+  };
+
+  it('corrections ALONE exhaust the shared maxToolCalls budget: 2 corrections, ZERO tool calls → performFinalExtraction, correctionCount===2', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}')) // correction #1 (count 0→1)
+      .mockResolvedValueOnce(makeTextResponse('{"category": 43}')) // correction #2 (count 1→2 === maxCalls)
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}')); // performFinalExtraction
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 2,
+      validationOutputSchema: budgetSchema,
+    });
+
+    expect(executor).not.toHaveBeenCalled();
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.correctionCount).toBe(2);
+    // Exactly 3 API calls: 2 correction turns + 1 performFinalExtraction. If corrections did NOT
+    // consume the shared budget, the loop would NOT exhaust at 2 — this is the pin.
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    // performFinalExtraction is the ONLY call carrying `tool_choice` (the main loop never sets it —
+    // it only sets `tools` when tools are offered, and lets the API default `tool_choice`).
+    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('tool_choice');
+    expect(mockCreate.mock.calls[1][0]).not.toHaveProperty('tool_choice');
+    expect(mockCreate.mock.calls[2][0]).toHaveProperty('tool_choice');
+    expect(result.output).toEqual({ category: 'billing' });
+
+    const breadcrumbs = errorSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('output rejected (in-conversation)'));
+    expect(breadcrumbs).toHaveLength(2);
+    errorSpy.mockRestore();
+  });
+
+  it('MIXED: 1 tool call + 1 correction exhausts a maxToolCalls:2 budget (both draw on ONE counter)', async () => {
+    const executor = vi.fn().mockResolvedValue('file data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolUseResponse([{ id: 'c1', name: 'op' }])) // tool call (count 0→1)
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}')) // correction #1 (count 1→2 === maxCalls)
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}')); // performFinalExtraction
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const provider = new AnthropicProvider('claude-sonnet-4-5');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 2,
+      validationOutputSchema: budgetSchema,
+    });
+
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.correctionCount).toBe(1);
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    expect(mockCreate.mock.calls[2][0]).toHaveProperty('tool_choice'); // performFinalExtraction
+    expect(result.output).toEqual({ category: 'billing' });
+
+    const breadcrumbs = errorSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('output rejected (in-conversation)'));
+    expect(breadcrumbs).toHaveLength(1);
+    errorSpy.mockRestore();
+  });
+});
+
+// =========================================================================
 // capabilities() tests
 // =========================================================================
 describe('AnthropicProvider.capabilities', () => {

--- a/packages/cli/src/agent/providers/openai-provider.test.ts
+++ b/packages/cli/src/agent/providers/openai-provider.test.ts
@@ -724,6 +724,88 @@ describe('OpenAIProvider.callStepWithTools — issue #224 in-conversation AJV co
 });
 
 // =========================================================================
+// issue #224 — shared-budget characterization (named residual: corrections and tool calls draw
+// on the SAME `tool_call_count`, incremented per tool call AND per correction, no reset/decrement)
+// =========================================================================
+describe('OpenAIProvider.callStepWithTools — issue #224 shared-budget characterization', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  const budgetSchema = {
+    type: 'object',
+    required: ['category'],
+    properties: { category: { type: 'string', enum: ['billing', 'support'] } },
+    additionalProperties: false,
+  };
+
+  it('corrections ALONE exhaust the shared maxToolCalls budget: 2 corrections, ZERO tool calls → performFinalExtraction, correctionCount===2', async () => {
+    const executor = vi.fn().mockResolvedValue('data');
+    mockCreate
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}')) // correction #1 (count 0→1)
+      .mockResolvedValueOnce(makeTextResponse('{"category": 43}')) // correction #2 (count 1→2 === maxCalls)
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}')); // performFinalExtraction
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 2,
+      validationOutputSchema: budgetSchema,
+    });
+
+    expect(executor).not.toHaveBeenCalled();
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.correctionCount).toBe(2);
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    // The 3rd call is performFinalExtraction — it appends the over-budget prompt as the last user msg.
+    const finalMsgs = mockCreate.mock.calls[2][0].messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const finalUserMsgs = finalMsgs.filter((m) => m.role === 'user');
+    expect(finalUserMsgs.at(-1)?.content).toContain('maximum number of tool calls');
+    expect(result.output).toEqual({ category: 'billing' });
+
+    const breadcrumbs = errorSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('output rejected (in-conversation)'));
+    expect(breadcrumbs).toHaveLength(2);
+    errorSpy.mockRestore();
+  });
+
+  it('MIXED: 1 tool call + 1 correction exhausts a maxToolCalls:2 budget (both draw on ONE counter)', async () => {
+    const executor = vi.fn().mockResolvedValue('file data');
+    mockCreate
+      .mockResolvedValueOnce(makeToolCallResponse([{ id: 'c1', name: 'op' }])) // tool call (count 0→1)
+      .mockResolvedValueOnce(makeTextResponse('{"category": 42}')) // correction #1 (count 1→2 === maxCalls)
+      .mockResolvedValueOnce(makeTextResponse('{"category": "billing"}')); // performFinalExtraction
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const provider = new OpenAIProvider('gpt-4o');
+    const result = await provider.callStepWithTools('prompt', [oneTool()], executor, {
+      maxToolCalls: 2,
+      validationOutputSchema: budgetSchema,
+    });
+
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.correctionCount).toBe(1);
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    const finalMsgs = mockCreate.mock.calls[2][0].messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const finalUserMsgs = finalMsgs.filter((m) => m.role === 'user');
+    expect(finalUserMsgs.at(-1)?.content).toContain('maximum number of tool calls');
+    expect(result.output).toEqual({ category: 'billing' });
+
+    const breadcrumbs = errorSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('output rejected (in-conversation)'));
+    expect(breadcrumbs).toHaveLength(1);
+    errorSpy.mockRestore();
+  });
+});
+
+// =========================================================================
 // capabilities() tests
 // =========================================================================
 describe('OpenAIProvider.capabilities', () => {


### PR DESCRIPTION
## Context

Issue #224 (in-conversation full-AJV correction for tool-using agent steps) shipped on `main`
(PR #237, merged). It carries a named, deliberate residual: in-conversation schema corrections and
real tool calls draw on the **same shared `maxToolCalls` budget** — both providers use a single
`tool_call_count` counter, incremented once per executed tool call **and** once per correction, with
no reset and no decrement. A step that emits several malformed outputs spends those slots on
corrections, leaving fewer for real tool calls. This was a documented design choice at the time
(visibility via a stderr breadcrumb + `correctionCount` was the chosen mitigation, not budget
separation) — but nothing pinned it as an executable contract.

## Motivation

Without a test, a future change that separates the correction budget from the tool budget would
silently alter this contract — no CI signal would flag it as a behavior change, even though it's a
deliberate, load-bearing design decision. This PR adds a **characterization test**: pure test
addition, zero production-code change, whose entire purpose is to fail loudly the moment a future
change decouples corrections from `tool_call_count`.

## Changes

Added 4 tests (2 per provider), appended to the existing `describe` blocks in
`anthropic-provider.test.ts` and `openai-provider.test.ts`:

- **corrections-only**: with `maxToolCalls: 2`, two consecutive schema-invalid (no-tool-call)
  responses exhaust the budget with **zero tool calls**, `correctionCount === 2`, and
  `performFinalExtraction` fires (discriminated by `tool_choice` presence on Anthropic, by the
  "maximum number of tool calls" text on OpenAI's final user message).
- **mixed**: 1 tool call + 1 correction also exhausts a `maxToolCalls: 2` budget — proving both
  kinds of work draw on the one counter, not two independent ones.

No production file changed. No CHANGELOG entry (pure test addition — matches the repo's convention
for prior de-flake-only PRs, e.g. #172/#177).

## Verification

```bash
# 1. The 4 new tests pass, isolated (the reliable signal — turbo run test has a known intermittent
#    parallel-worker flake; it did not fire in this run either, reported for completeness)
cd packages/cli && npx vitest run -t "shared-budget"
#  Test Files  1 passed (1)   Tests  2 passed | 39 skipped (41)   [anthropic-provider.test.ts]
#  Test Files  1 passed (1)   Tests  2 passed | 35 skipped (37)   [openai-provider.test.ts]

# 2. No regression — full cli suite stays green at prior total + 4
npx vitest run
#  Test Files  70 passed (70)   Tests  827 passed (827)   (823 prior + 4 new)
npx tsc --noEmit
#  (clean, exit 0)

npx turbo run test --force   # from repo root, for completeness
#  core 1924/1924, cli 827/827, mcp-server 265/265, testing 81/81 — all green, no flake

# 3. THE non-vacuity proof — mutation probe (both providers): temporarily decoupled corrections
#    from tool_call_count (a separate, independent counter instead of the shared one). The
#    corrections-only test reds in BOTH providers — the budget no longer exhausts at 2, so
#    performFinalExtraction never fires and the tool_choice / "maximum number of tool calls"
#    discriminator assertion fails:
#
#      AnthropicProvider: 2 failed | 39 passed (41) — both new characterization tests red,
#        zero collateral (AssertionError: expected ... to have property "tool_choice")
#      OpenAIProvider:    2 failed | 35 passed (37) — both new characterization tests red,
#        zero collateral (AssertionError: expected '...' to contain 'maximum number of tool calls')
#
#    Reverted byte-identically (`diff` against a /tmp backup taken before each mutation), full
#    suite re-confirmed green (41/41, 37/37) after each revert.
```

All four drop-in tests (from the task's grounding pass) ran and passed **verbatim on first attempt**
against the real helper signatures (`mockCreate`, `makeTextResponse`, `makeToolUseResponse`/
`makeToolCallResponse`, `oneTool`) and the real `performFinalExtraction` discriminators — no harness
adaptation was needed.

## Rollback

```bash
git revert HEAD
```

Test-only change; reverting removes the 4 tests with no other effect. No production behavior,
schema, or data is touched by this PR in either direction.

## Related

- Pins the shared-budget residual from issue #224 (already merged and closed via PR #237) — this PR
  references it for context; there is no open issue to close.
