### PR TITLE
docs(changelog): note the hono 4.12.31 security bump (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ All notable changes to this project are documented here.
   `fast-uri` only to parse author-controlled schema `$id`/`$ref` references, never for a host-based
   security decision, so the host-confusion path is not weaponizable in realm. Clears the
   pre-publication `npm audit` gate.
+- **`hono` bumped 4.12.25 → 4.12.31 (via Dependabot #241) — clears three MODERATE advisories**
+  ([GHSA-xgm2-5f3f-mvvc](https://github.com/advisories/GHSA-xgm2-5f3f-mvvc) API-Gateway-v1 header
+  de-duplication, [GHSA-hvrm-45r6-mjfj](https://github.com/advisories/GHSA-hvrm-45r6-mjfj) `hono/jsx`
+  per-request context isolation, [GHSA-w62v-xxxg-mg59](https://github.com/advisories/GHSA-w62v-xxxg-mg59)
+  `hono/css` `cx()` JSX escaping bypass), a transitive dependency of `@modelcontextprotocol/sdk`.
+  Within the SDK's existing `^4.11.4` range (lockfile-only; no `package.json` change, no `overrides`).
+  **Realm exposure is NONE:** all three advisories live in optional hono entrypoints (`hono/aws-lambda`,
+  `hono/jsx`, `hono/css`); realm's only HTTP surface is the SDK's `StreamableHTTPServerTransport`
+  (JSON-RPC over HTTP), which exercises hono _core_ routing only — it renders no JSX, uses no `cx()`,
+  and runs no API-Gateway adapter.
 
 ---
 


### PR DESCRIPTION
## Context

Dependabot **#241** (`hono` 4.12.25 → 4.12.31) merged, clearing three MODERATE advisories in `hono`
(a runtime transitive of `@modelcontextprotocol/sdk`, shipped in `@sensigo/realm-cli` and
`@sensigo/realm-mcp`): GHSA-xgm2-5f3f-mvvc, GHSA-hvrm-45r6-mjfj, GHSA-w62v-xxxg-mg59. Because `hono`
**ships**, the bump belongs in the consumer-facing `### Security` changelog (like the `fast-uri`
entry) — but Dependabot's PR carries only the lockfile change, no changelog line. This tiny follow-up
adds it.

## Motivation

Keep `[Unreleased] ### Security` complete as the security triage lands each shipped fix, so the
eventual bundled release's notes are accurate and consumers running `npm audit` against a realm
install can see the bump and realm's actual exposure. Consistent with the `fast-uri` (#239) entry.

## Changes

Adds one `### Security` entry under `[Unreleased]` for the `hono` bump. It cites the three GHSAs and
states plainly that **realm's exposure is NONE**: all three advisories live in optional hono
entrypoints (`hono/aws-lambda`, `hono/jsx`, `hono/css` `cx()`), and realm's only HTTP surface — the
SDK's `StreamableHTTPServerTransport` (JSON-RPC over HTTP) — exercises hono *core* routing only,
rendering no JSX, using no `cx()`, and running no API-Gateway adapter. Documentation-only; no code or
lockfile change (the bump itself is already on `main` via #241).

## Verification

```bash
# the entry is under [Unreleased] ### Security, after fast-uri:
sed -n '/## \[Unreleased\]/,/## \[0.30.0\]/p' CHANGELOG.md | grep -n "hono"

# the hono bump itself is already on main and cleared:
grep -A1 '"node_modules/hono"' package-lock.json | grep version   # 4.12.31
npm audit | grep -i '^hono' || echo "hono: cleared"
```

Exposure claim substantiated by grounding: an exhaustive grep across the full `@modelcontextprotocol/sdk`
dist, `@hono/node-server` dist, and all `packages/*/src` for `hono/jsx | hono/css | aws-lambda | cx(`
returned zero reachable hits; the SDK transport's only hono touchpoint is `@hono/node-server`'s
`getRequestListener` (hono core).

## Rollback

```bash
git revert HEAD
```

Documentation-only — no runtime or dependency impact.

## Related

- Dependabot #241 (the `hono` 4.12.25 → 4.12.31 bump this documents)
- Advisories: GHSA-xgm2-5f3f-mvvc, GHSA-hvrm-45r6-mjfj, GHSA-w62v-xxxg-mg59
- Item #3 of the dependency-security triage; standing-posture follow-up #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
