### PR TITLE
chore: release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.31.0] — 2026-07-23
 
 ### Changed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.30.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.31.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,7 +106,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.30.0';
+export const VERSION = '0.31.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.30.0';
+export const VERSION = '0.31.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.30.0',
+    version: '0.31.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -57,4 +57,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.30.0';
+export const VERSION = '0.31.0';


### PR DESCRIPTION
## Context

Release **v0.31.0** (minor) — bundles the #224 structured-output-robustness arc and two shipped
dependency-security fixes accumulated under `[Unreleased]`. All constituent PRs are merged, reviewed,
and CI-green; this PR carries the atomic version bump (4 × `package.json` + 5 × `VERSION`) and the tag
`v0.31.0` created by `scripts/release.mjs`.

## Motivation

`[Unreleased]` had a `### Changed` (feature) plus two `### Security` entries; per the release policy,
cut a release rather than let it accumulate. #224 adds new backwards-compatible exports and a behaviour
change (no breaking changes) → **minor**.

## Changes

**Changed**
- **#224 — in-conversation full-AJV correction for tool-using agent steps ("reask layer").** Both LLM
  providers now run the engine's full AJV validation inside the retained conversation (new core
  `validateAgentSubmission` + exports `validateOutputSchema`/`RawValidationError`/`AgentSubmissionValidation`);
  `OpenAIProvider.performFinalExtraction` unified to return (not throw) on schema-invalid so #220 counts.
  Additive `callStepWithTools` option fields. No behaviour change for non-tool steps.

**Security** (both shipped transitives, lockfile-only, within the intermediary's range)
- **`fast-uri` 3.1.2 → 3.1.4** — two HIGH host-confusion advisories (GHSA-4c8g-83qw-93j6,
  GHSA-v2hh-gcrm-f6hx); realm exposure LOW (ajv `$ref` parsing only).
- **`hono` 4.12.25 → 4.12.31** — three MODERATE advisories (GHSA-xgm2-5f3f-mvvc, GHSA-hvrm-45r6-mjfj,
  GHSA-w62v-xxxg-mg59); realm exposure NONE (SDK uses hono core only).

Also on `main` since v0.30.0 but intentionally no changelog line: `brace-expansion` (dev-only, #233) and
`@hono/node-server` (GHSA-frvp-7c67-39w9 — `not_affected`, deferred; alert dismissed).

## Verification

```bash
npx turbo run test lint --force    # 12/12 tasks green (core 1924, cli 827, mcp 265, testing 81)
tsc --noEmit                       # clean ×4 packages
npm audit --omit=dev --audit-level=high   # exit 0 (2 moderate = deferred @hono/node-server item, below gate)
```

Version bump verified by value: 4 × `package.json` = 0.31.0, 5 × `VERSION` = 0.31.0, tag `v0.31.0` → the release commit.

## Rollback

Do not merge if CI fails. Post-merge, if publish breaks: this is tag-driven — re-push/re-trigger per the
pre-publication rollback note. To revert the release entirely, revert the merge commit and delete the tag
before it is pushed.

**Merge with a MERGE COMMIT (not squash/rebase)** — the tag points at the release commit on this branch; a
rebase/squash would orphan the tag and break the publish workflow.

## Related

Bundles #224 (+ shared-budget test #240) · security: #239 (fast-uri), #241/#242 (hono) · standing posture #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
