### PR TITLE
ci(repo): automated dependency updates + PR-blocking audit gate (issue #238 PR1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/' # single root lockfile covers all hoisted workspaces (no per-pkg dirs)
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 3
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
+    ignore:
+      - dependency-name: '@sensigo/*' # workspace-linked, resolve locally
+    groups:
+      build-toolchain: # FIRST (first-match-wins priority)
+        dependency-type: 'development'
+        patterns: ['typescript', 'turbo', 'audit-ci']
+      prod:
+        dependency-type: 'production'
+        update-types: ['minor', 'patch']
+      dev-patch:
+        dependency-type: 'development'
+        update-types: ['patch']
+        exclude-patterns: ['typescript', 'turbo', 'audit-ci'] # structural exclusion (order-independent)
+      dev-minor:
+        dependency-type: 'development'
+        update-types: ['minor']
+        exclude-patterns: ['typescript', 'turbo', 'audit-ci']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,34 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     env:
       TURBO_TELEMETRY_DISABLED: '1'
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
+      # issue #238 PR1 (D6) — the allowlist GHSA-id guard: audit-ci.jsonc's allowlist is the single
+      # source of truth for every accepted advisory suppression; this asserts every entry is
+      # GHSA-id-scoped (never a bare-string module-wide suppression).
+      - run: node scripts/check-audit-allowlist.mjs
+      # issue #238 PR1 (D5) — the PR-blocking audit gate. Pinned local binary (never a bare
+      # network `npx audit-ci`), the only required check this repo has for dependency advisories.
+      - run: npx --no-install audit-ci --config ./audit-ci.jsonc
+      # issue #238 PR1 (D7) — positive coverage assertion (R7 mitigation). `ajv` is
+      # @sensigo/realm's declared prod dependency; if audit-ci's `skip-dev` (or a future
+      # `--omit=dev`/`--production` narrowing) ever silently excluded the workspace prod tree from
+      # scan coverage, this reds — a synthetic proof the gate above is actually scanning what it
+      # claims to scan, not just passing vacuously on an empty/under-scoped tree.
+      - run: npm ls ajv --omit=dev
       - run: node scripts/check-versions.mjs
       - run: npm run format:check
       - run: npm run lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,14 +17,14 @@ jobs:
     name: Analyse TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           languages: javascript-typescript
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           category: '/language:javascript-typescript'

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "high": true,
+  "skip-dev": true,
+  "allowlist": [
+    {
+      "GHSA-frvp-7c67-39w9": {
+        "active": true,
+        "notes": "not_affected (VEX): @hono/node-server serve-static/CWE-22 unreachable — realm stdio-only, serve-static never registered. MODERATE<high so inert here; kept as the future re-score-to-HIGH escape hatch. Upstream fix: @modelcontextprotocol/sdk -> @hono/node-server >=2.0.5.",
+        "expiry": "2027-01-31",
+      },
+    },
+  ],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
+        "audit-ci": "^7.1.0",
         "eslint": "^9.0.0",
         "jiti": "^2.0.0",
+        "json5": "^2.2.3",
         "lefthook": "^2.1.6",
         "prettier": "^3.2.0",
-        "turbo": "*",
+        "turbo": "^2.9.16",
         "typescript": "^5.4.0",
         "typescript-eslint": "^8.0.0",
         "vitest": "^4.1.0"
@@ -264,6 +266,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -1485,6 +1500,16 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1515,6 +1540,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/balanced-match": {
@@ -1657,6 +1706,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -1842,10 +1906,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1892,6 +1970,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2136,6 +2224,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -2354,6 +2458,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2376,6 +2487,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2609,6 +2730,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2643,6 +2774,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -2701,6 +2839,46 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3183,6 +3361,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3461,6 +3646,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3624,6 +3822,41 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3701,6 +3934,27 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3882,6 +4136,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3905,17 +4172,53 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -3929,6 +4232,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tinybench": {
@@ -4007,8 +4327,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/turbo": {
       "version": "2.9.16",
@@ -4320,6 +4639,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
@@ -4552,11 +4878,68 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -4591,7 +4974,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4642,7 +5025,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -4687,7 +5070,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4708,7 +5091,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "audit-ci": "^7.1.0",
     "eslint": "^9.0.0",
     "jiti": "^2.0.0",
+    "json5": "^2.2.3",
     "lefthook": "^2.1.6",
     "prettier": "^3.2.0",
-    "turbo": "latest",
+    "turbo": "^2.9.16",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.0.0",
     "vitest": "^4.1.0"

--- a/scripts/check-audit-allowlist.mjs
+++ b/scripts/check-audit-allowlist.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// issue #238 PR1, D6 — the allowlist GHSA-id guard.
+//
+// audit-ci.jsonc's `allowlist` is the single source of truth for every accepted advisory
+// suppression in the release-audit gate. Its entries have two legal shapes (per audit-ci's own
+// AllowlistObject type): a bare STRING (suppresses ALL advisories for a package/module — the
+// module-allowlist hazard) or an object with exactly one key (an advisory id scoped to a single
+// GHSA). This script asserts EVERY entry — whichever shape — resolves to a GHSA id, so a future
+// edit can never silently widen the gate into a package-wide bypass.
+//
+// The config file uses `//` line comments (JSONC) AND — since it's formatted by this repo's own
+// `prettier --write .` (wired into `npm run format`/`format:check`) — trailing commas on its
+// multi-line objects/arrays. A bare `JSON.parse` throws on BOTH; `strip-json-comments` alone only
+// strips comments and still throws on the trailing commas prettier adds. `json5` parses both
+// constructs natively (a strict superset of JSON), so this script parses with it, never with
+// `JSON.parse` directly.
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import JSON5 from 'json5';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const CONFIG_PATH = join(ROOT, 'audit-ci.jsonc');
+
+const GHSA_PATTERN = /^GHSA-/;
+
+function loadAllowlist(configPath) {
+  const raw = readFileSync(configPath, 'utf-8');
+  const config = JSON5.parse(raw);
+  return Array.isArray(config.allowlist) ? config.allowlist : [];
+}
+
+/**
+ * Returns the id string(s) an allowlist entry actually suppresses, or throws a descriptive error
+ * if the entry's shape is not one of audit-ci's two legal forms.
+ */
+function extractIds(entry, index) {
+  if (typeof entry === 'string') {
+    // A bare-string entry suppresses ALL advisories for the named package — the module-allowlist
+    // hazard. It is only acceptable here if the "package name" is itself spelled as a GHSA id
+    // (which would be nonsensical) — in practice this branch exists to REJECT bare-string entries
+    // outright, since no legitimate GHSA-scoped suppression is ever expressed as a bare string.
+    return [entry];
+  }
+  if (entry !== null && typeof entry === 'object' && !Array.isArray(entry)) {
+    const keys = Object.keys(entry);
+    if (keys.length !== 1) {
+      throw new Error(
+        `allowlist[${index}]: object entries must have exactly one key (the GHSA id) — found ${keys.length}: ${JSON.stringify(keys)}`,
+      );
+    }
+    return keys;
+  }
+  throw new Error(
+    `allowlist[${index}]: unrecognized entry shape (expected a string or a single-key object): ${JSON.stringify(entry)}`,
+  );
+}
+
+function main() {
+  const allowlist = loadAllowlist(CONFIG_PATH);
+  let failed = false;
+
+  if (allowlist.length === 0) {
+    console.log('✓ audit-ci.jsonc allowlist guard: allowlist is empty — nothing to check.');
+    return;
+  }
+
+  for (let i = 0; i < allowlist.length; i++) {
+    const entry = allowlist[i];
+    let ids;
+    try {
+      ids = extractIds(entry, i);
+    } catch (err) {
+      console.error(`✗ ${err.message}`);
+      failed = true;
+      continue;
+    }
+    for (const id of ids) {
+      if (!GHSA_PATTERN.test(id)) {
+        console.error(
+          `✗ allowlist[${i}]: '${id}' is not a GHSA id (must match /^GHSA-/). A non-GHSA-scoped ` +
+            `entry — especially a bare string — suppresses ALL advisories for that package, which ` +
+            `defeats the audit gate. Replace it with a GHSA-id-keyed object entry.`,
+        );
+        failed = true;
+      } else {
+        console.log(`✓ allowlist[${i}]: '${id}' is a valid GHSA-scoped entry.`);
+      }
+    }
+  }
+
+  if (failed) {
+    console.error('\naudit-ci.jsonc allowlist guard FAILED — see errors above.');
+    process.exit(1);
+  }
+
+  console.log('\naudit-ci.jsonc allowlist guard passed — every entry is GHSA-scoped.');
+}
+
+main();


### PR DESCRIPTION
## Context

Issue #238 (standing supply-chain posture) — PR 1 of 5. Design record + verdict trail:
`plans/issue-238/dossier.md`, `## FINAL CONVERGED DESIGN` section (authoritative; everything above
it in the file is superseded). This PR ships the controls that touch **no release-critical path**:
automated dependency updates, the PR-blocking audit gate, GitHub Actions SHA-pinning for `ci.yml`
and `codeql.yml` only, and least-privilege CI tokens.

**`publish.yml` is untouched by this PR** — its own SHA-pinning, split build/publish jobs, and
release-audit step are isolated to a later, canaried PR4 (per finding B1 in the design record: any
`publish.yml` diff carries release-path risk and must ship alone, dress-rehearsed).

## Motivation

The repo currently has no automated dependency-update mechanism and no PR-time advisory gate —
every dependency bump has been a manually-triggered, manually-audited PR (as in the recent
`fast-uri`/`hono` triage). That doesn't scale and leaves a window between a CVE's disclosure and a
human noticing it. This PR is the foundation: Dependabot proposes updates on a schedule (grouped so
routine dev-patch bumps are cheap to review while the build toolchain and anything production-facing
always gets a human look), and every PR — including Dependabot's own — is now blocked from merging
if it introduces a HIGH+ advisory in the production dependency tree.

## Changes

- **`.github/dependabot.yml`** (new) — npm ecosystem, weekly (Monday), `cooldown` (3/3/7/30 days by
  default/patch/minor/major — verified against the live GitHub docs, the shape's sub-key spelling is
  exact), `versioning-strategy: increase-if-necessary`, `@sensigo/*` ignored (workspace-linked).
  Four groups, in file order (Dependabot assigns each dependency to the FIRST group it matches):
  `build-toolchain` (typescript/turbo/audit-ci, dev, **first** so it always wins) → `prod`
  (production, minor+patch) → `dev-patch` / `dev-minor` (dev, patch/minor respectively) — both dev
  groups also carry `exclude-patterns` for the toolchain packages, so the exclusivity holds
  structurally even if the groups were ever reordered.
- **`turbo`** pinned `latest` → `^2.9.16` in root `package.json` (the resolved version, 2.9.16, is
  unchanged — confirmed via `npm ls turbo`).
- **`ci.yml` + `codeql.yml`** — every `uses:` SHA-pinned to the exact commit the tag currently
  points to, tag kept as a trailing comment (`actions/checkout@v5`, `actions/setup-node@v5`,
  `github/codeql-action/init@v3`, `github/codeql-action/analyze@v3`). `codeql-action`'s `v3` is an
  **annotated** tag — `git ls-remote refs/tags/v3` returns the tag-OBJECT sha
  (`3b0bd1d1…`, wrong, would fail at runtime); the correct commit is the PEELED ref
  (`refs/tags/v3^{}`) or `gh api .../commits/v3`, both independently confirmed to return
  `4187e74d05793876e9989daffde9c3e66b4acd07`. `checkout`/`setup-node` are lightweight tags — no
  peeling needed, `ls-remote` and `gh api` agree directly. **`publish.yml` is byte-identical to
  `main`** (confirmed via `diff`) — not part of this PR's touch list.
- **`ci.yml`** gains a top-level `permissions:\n  contents: read` (it runs untrusted PR code and had
  no explicit scoping before — implicit broad default). `codeql.yml` was already correctly scoped;
  left as-is. `publish.yml`'s permissions are PR4's concern.
- **`audit-ci`** added as a pinned root devDependency (`^7.1.0`, never fetched at latest), invoked
  as the local binary (`npx --no-install audit-ci --config ./audit-ci.jsonc`) in the `ci` job — the
  only required check, so a PR-blocking gate rather than an advisory-only side workflow.
- **`audit-ci.jsonc`** (new) — `{high: true, skip-dev: true}` plus an allowlist carrying the
  existing `GHSA-frvp-7c67-39w9` VEX entry (the `@hono/node-server` Windows-only path-traversal
  finding — moderate, unreachable in realm's stdio-only deployment; kept allowlisted as a
  re-score-to-HIGH escape hatch, per the existing triage decision).
- **`scripts/check-audit-allowlist.mjs`** (new) — a mechanical guard, wired into the `ci` job, that
  parses `audit-ci.jsonc` and asserts every allowlist entry is GHSA-id-scoped. Catches BOTH hazard
  shapes audit-ci's allowlist accepts: an object keyed by something other than a GHSA id, and — the
  load-bearing case — a bare STRING entry (which suppresses ALL advisories for that package/module,
  not just one). Uses `json5` (new devDependency) rather than `strip-json-comments` + `JSON.parse`:
  `audit-ci.jsonc` is formatted by this repo's own `prettier --write .`, which adds trailing commas
  to multi-line JSON objects/arrays — `strip-json-comments` only strips `//` comments and left the
  file un-parseable by a strict `JSON.parse` (a mismatch discovered empirically while implementing
  this, not assumed from the prompt). `json5` parses both comments and trailing commas natively.
- **A positive coverage assertion** (`npm ls ajv --omit=dev` in the `ci` job) — `ajv` is
  `@sensigo/realm`'s declared production dependency; if `audit-ci`'s `skip-dev` scoping (or any
  future `--omit=dev`/`--production` narrowing) ever silently excluded the workspace's production
  dependency tree from the scan, this step reds. Without it, a scope regression would make the
  audit gate pass **silently and vacuously** rather than loudly.

**Incidental, expected, unrelated to this PR's substance:** the `package-lock.json` diff also
reconciles the four workspace self-versions (`packages/cli`/`core`/`mcp-server`/`testing`), which
had drifted to `0.30.0` in the lockfile while `package.json` already says `0.31.0` since the last
release — the same benign drift pattern seen in the recent `fast-uri` PR (#239). It also adds
`audit-ci`'s and `json5`'s own transitive dependency trees, and relocates one pre-existing
transitive package (`strip-json-comments@3.1.1`, already used by `eslint`'s config loader) from a
top-level hoisted position to a nested one under `@eslint/eslintrc` — same version, same integrity
hash, a pure npm re-hoisting artifact with no behavioral effect.

**Known accepted window (per the design record):** the `ci`/`codeql` SHA-pins are unmanaged — no
automated re-pinning — until PR4 adds the `github-actions` Dependabot ecosystem block (deliberately
deferred to after `publish.yml` is itself SHA-pinned, so a `github-actions` Dependabot PR never
proposes editing a still-tag-pinned `publish.yml`).

## Verification

```bash
# 1. Gate green today (no false-block) — 2 moderate, 0 high; does not block on the allowlisted item
npx --no-install audit-ci --config ./audit-ci.jsonc
#   "vulnerabilities": {"moderate": 2, "high": 0, ...}
#   Passed npm security audit.

# 2. dependabot.yml parses; four groups, build-toolchain first, exclude-patterns present
node -e "const yaml=require('js-yaml'),fs=require('fs');
  const doc=yaml.load(fs.readFileSync('.github/dependabot.yml','utf8'));
  console.log(Object.keys(doc.updates[0].groups))"
#   [ 'build-toolchain', 'prod', 'dev-patch', 'dev-minor' ]

# 3. SHA-pins resolve correctly (verified independently, both by gh api and by git ls-remote,
#    INCLUDING reproducing the annotated-tag trap for codeql-action)
gh api repos/actions/checkout/commits/v5 --jq .sha        # fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
gh api repos/actions/setup-node/commits/v5 --jq .sha      # a0853c24544627f65ddf259abe73b1d18a591444
gh api repos/github/codeql-action/commits/v3 --jq .sha    # 4187e74d05793876e9989daffde9c3e66b4acd07
git ls-remote https://github.com/github/codeql-action refs/tags/v3        # 3b0bd1d1... (WRONG — tag object)
git ls-remote https://github.com/github/codeql-action 'refs/tags/v3^{}'   # 4187e74d... (correct, peeled)
git diff --stat main -- .github/workflows/publish.yml      # (no output — untouched)
# This PR's own CI + CodeQL runs are the live green/red signal — see the checks below.

# 4. Least-privilege: ci.yml top-level permissions
grep -A1 '^permissions:' .github/workflows/ci.yml   #   contents: read

# 5. turbo pinned; resolved version unchanged
npm ls turbo --all   # turbo@2.9.16 (same as before the pin)

# 6. Guard — two mutation probes (both reverted byte-identically afterward)
#    (a) object entry keyed by a non-GHSA id -> guard reds
#    (b) bare-STRING entry ("axios") -> guard reds (the load-bearing case: proves the guard
#        catches a module-wide suppression, not just a mistyped object key)
node scripts/check-audit-allowlist.mjs
#   ✓ allowlist[0]: 'GHSA-frvp-7c67-39w9' is a valid GHSA-scoped entry.

# 7. Coverage assertion passes today; a narrowed-scope mutation (checking a dev-only package
#    instead of ajv) reds it exactly like a real skip-dev regression would
npm ls ajv --omit=dev      # resolves — exit 0
npm ls vitest --omit=dev   # (mutation fixture) — empty, exit 1: proves the assertion actually bites

# 8. Full ci job green locally, plus lint + tsc
npm ci && node scripts/check-audit-allowlist.mjs && npx --no-install audit-ci --config ./audit-ci.jsonc \
  && npm ls ajv --omit=dev && node scripts/check-versions.mjs && npm run format:check \
  && npm run lint && npm run test && npm run build
npx tsc --noEmit   # run in each of packages/{core,cli,mcp-server,testing} — clean in all four
# Full suite: core 1924/1924, cli 827/827, mcp-server 265/265, testing 81/81 — all green

# 9. Touch list matches exactly (publish.yml absent)
git diff --stat main
#  .github/dependabot.yml            |  31 +++
#  .github/workflows/ci.yml          |  20 +-
#  .github/workflows/codeql.yml      |   6 +-
#  audit-ci.jsonc                    |  14 ++
#  package-lock.json                 | 409 ++++++++++++++++++++++++++++++++++++--
#  package.json                      |   4 +-
#  scripts/check-audit-allowlist.mjs | 102 ++++++++++
#  7 files changed, 567 insertions(+), 19 deletions(-)
```

## Rollback

```bash
git revert HEAD
```

Pure CI/repo-infra change — reverting removes the Dependabot config, the audit gate, the SHA-pins,
and the least-privilege token scoping, restoring today's behavior exactly. No runtime data, no
release artifacts, no npm-published package is touched by this PR in either direction.

## Related

- Issue #238 (standing supply-chain posture) — PR 1 of 5. Design record: `plans/issue-238/dossier.md`.
- Next: PR2 (tier-2 scheduled full audit + release-audit config prep), PR3 (SECURITY.md + Private
  Vulnerability Reporting + OpenVEX + CODEOWNERS), PR4 (`publish.yml` hardening — isolated,
  canaried), PR5 (OpenSSF Scorecard + graduated auto-merge).
- Builds on the recent dependency-security triage: `fast-uri` (#239), `hono`/`@hono/node-server`
  (bundled in v0.31.0) — the `GHSA-frvp-7c67-39w9` allowlist entry here mirrors that triage's
  `not_affected` VEX decision.
