### PR TITLE
fix(release): sync package-lock.json self-versions in the release script

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -119,6 +119,15 @@ for (const { file, pattern, replacement } of SOURCE_VERSIONS) {
   console.log(`  ${file} → ${version}`);
 }
 
+// ─── Step 3b: Sync package-lock.json self-versions ──────────────────────────
+// The four workspace self-version entries in package-lock.json must match the
+// just-bumped package.json versions, or the committed lockfile drifts — a stale
+// self-version that the next `npm install` reconciles as a noisy, unrelated diff.
+// `--package-lock-only` rewrites the lockfile from package.json without touching
+// node_modules; on an otherwise-in-sync tree the only change is the four self-versions.
+console.log('Syncing package-lock.json...');
+execSync('npm install --package-lock-only', { stdio: 'inherit', cwd: ROOT });
+
 // ─── Step 4: Build ───────────────────────────────────────────────────────────
 
 console.log('Building...');
@@ -128,7 +137,7 @@ execSync('npm run build', { stdio: 'inherit', cwd: ROOT });
 
 console.log('Creating git commit and tag...');
 execSync(
-  'git add packages/*/package.json packages/*/src/index.ts packages/mcp-server/src/server.ts',
+  'git add package-lock.json packages/*/package.json packages/*/src/index.ts packages/mcp-server/src/server.ts',
   { stdio: 'inherit', cwd: ROOT },
 );
 execSync(`git commit -m "chore: release v${version}"`, { stdio: 'inherit', cwd: ROOT });


### PR DESCRIPTION
## Context

The release script has produced a lockfile with **stale workspace self-versions** on every release —
the committed `package-lock.json` kept the *previous* version in its four `packages/*` self-version
entries, and the next PR to run `npm install` reconciled them as a noisy, unrelated diff. Observed in
#239 (`0.29.0`→`0.30.0`) and again in #244 (`0.30.0`→`0.31.0`).

## Root Cause

`scripts/release.mjs` bumps the four `package.json` `version` fields (Step 3) and the five source
`VERSION` strings (Step 3a), runs the build, then stages **only** `packages/*/package.json` + the source
files and commits. It **never updates or stages `package-lock.json`**, so the lockfile's four workspace
self-version entries stay at the prior version until an unrelated later `npm install` fixes them.

## Changes

- **Step 3b (new):** after the version bumps, run `npm install --package-lock-only` — rewrites the
  lockfile from `package.json` without touching `node_modules`. On an otherwise-in-sync tree (which a
  release branch off a clean `main` is) the *only* change is the four self-versions.
- **Stage it:** add `package-lock.json` to the release commit's `git add`.

## Verification

```bash
node --check scripts/release.mjs          # parses
# no-op on an already-in-sync tree (proves no spurious changes):
cp package-lock.json /tmp/b && npm install --package-lock-only && diff /tmp/b package-lock.json   # identical
# reconciles a drifted self-version (proves it fixes the drift):
#   temporarily set packages/core version to 0.99.0 → npm install --package-lock-only
#   → lockfile packages/core self-version becomes 0.99.0, exactly 2 lines changed, nothing else → revert
```

Both checked: no-op when in sync; a surgical 2-line (per package) reconciliation when drifted.

## Rollback

```bash
git revert HEAD
```

Pure release-tooling change; no runtime/published-artifact impact. The next release exercises it (a clean
`package-lock.json` self-version diff, or none).

## Related

Recurring drift seen in #239 and #244 (#238 PR1); independent of the #238 program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
