### PR TITLE
chore(repo): harden installs with ignore-scripts (issue #238 R11)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+; Supply-chain hardening (issue #238): dependency lifecycle scripts
+; (preinstall/install/postinstall) do NOT run automatically on `npm install`/`npm ci`,
+; so a compromised dependency cannot execute code on a developer or CI machine during
+; install. Verified that no dependency in this tree relies on install scripts — `turbo`
+; ships its platform binary via optionalDependencies, and the only install script in the
+; whole tree was this repo's own `lefthook install`.
+;
+; One-time after cloning, run `npm run setup` to install the git hooks (lefthook).
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format:check": "prettier --check .",
     "check:versions": "node scripts/check-versions.mjs",
     "release": "node scripts/release.mjs",
-    "postinstall": "lefthook install"
+    "setup": "lefthook install"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Context

Issue #238 residual **R11** (dev-machine postinstall exposure), surfaced by the Phase-2 REFUTE panel.
An auto-merged dependency (the graduated auto-merge lands in #238 PR5) — or any dependency, however it
enters — can run arbitrary `preinstall`/`install`/`postinstall` code on a developer or CI machine during
`npm install`/`npm ci`. This PR closes that vector and is a **prerequisite for enabling auto-merge**.

## Motivation

`--ignore-scripts` on the publish job (PR4) protects the release path; this protects the *dev/CI* install
path. Together they mean a compromised dependency cannot execute code in any realm context.

## Changes

- **`.npmrc` (new):** `ignore-scripts=true` repo-wide, with a comment explaining the rationale and the
  one-time `npm run setup`.
- **`package.json`:** the `lefthook install` was in `postinstall` (which `ignore-scripts` now skips). Re-homed
  to a plain **`setup`** script — deliberately *not* `prepare`, because `prepare` also runs during
  `npm publish` and would try to install git hooks mid-release.

## Verification

Confirmed empirically that **nothing in the build/test path relies on install scripts** (the only install
script in the entire tree was realm's own `lefthook install`; `turbo` ships its binary via
`optionalDependencies`):

```bash
npm ci                    # succeeds under ignore-scripts
npm run build             # FULL TURBO, green
npx turbo run test --force # core 1924 / cli 827 / mcp 265 / testing 81 — 8/8 tasks green
npm run setup             # "sync hooks: ✔️ (pre-commit)" — lefthook installs on demand
```

Diff is exactly `.npmrc` (new) + `package.json` (one script rename); `package-lock.json` unaffected.

## Rollback

```bash
git revert HEAD
```

Repo/dev-infra only; no runtime or published-artifact impact (consumers never receive realm's root `.npmrc`).
No CHANGELOG entry (not consumer-facing).

## Related

#238 residual R11; prerequisite for the graduated auto-merge (#238 PR5). Independent of PR1 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
