### PR TITLE
ci(deps): isolate formatters/linters from auto-merge groups (issue #238)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,17 +15,39 @@ updates:
     ignore:
       - dependency-name: '@sensigo/*' # workspace-linked, resolve locally
     groups:
-      build-toolchain: # FIRST (first-match-wins priority)
+      build-toolchain: # FIRST (first-match-wins priority) — shipped-byte/CI-infra toolchain, never auto-merge
         dependency-type: 'development'
         patterns: ['typescript', 'turbo', 'audit-ci']
+      linters: # formatter/linter bumps change CI format:check/lint OUTPUT → deterministically red ci → never auto-merge, need a manual reformat/rule-fix (see #238 canary PRs #248 prettier / #249 @eslint/js)
+        dependency-type: 'development'
+        patterns: ['prettier', 'eslint', '@eslint/js', 'typescript-eslint']
       prod:
         dependency-type: 'production'
         update-types: ['minor', 'patch']
       dev-patch:
         dependency-type: 'development'
         update-types: ['patch']
-        exclude-patterns: ['typescript', 'turbo', 'audit-ci'] # structural exclusion (order-independent)
+        # structural exclusion (order-independent) — build-toolchain + linters must never fall into an auto-merge-eligible group
+        exclude-patterns:
+          [
+            'typescript',
+            'turbo',
+            'audit-ci',
+            'prettier',
+            'eslint',
+            '@eslint/js',
+            'typescript-eslint',
+          ]
       dev-minor:
         dependency-type: 'development'
         update-types: ['minor']
-        exclude-patterns: ['typescript', 'turbo', 'audit-ci']
+        exclude-patterns:
+          [
+            'typescript',
+            'turbo',
+            'audit-ci',
+            'prettier',
+            'eslint',
+            '@eslint/js',
+            'typescript-eslint',
+          ]


### PR DESCRIPTION
## Context

Issue #238, follow-up to PR1 (#244). The **first live Dependabot canary** validated the grouping design — Dependabot opened 5 correctly-partitioned PRs (#245–#249) — and in doing so exposed a real refinement needed **before** the graduated auto-merge (#238 PR5).

## The finding (investigated, not guessed)

Two canary PRs red `ci`, and I traced the exact failing steps:

| PR | Bump | Fails | Why |
|---|---|---|---|
| #248 | prettier 3.8.1→3.9.5 (dev-minor) | `format:check` | new prettier reformats → `prettier --check` reds against old-formatted files |
| #249 | @eslint/js 9→10 (major, solo) | `lint` | new eslint rules → `lint` reds |

This is the `ci` gate **working correctly**. But it reveals that formatter/linter bumps *deterministically* change CI pass/fail output — they always need a manual reformat/rule-fix and can **never cleanly auto-merge**.

## The problem left unfixed

With `prettier`/`eslint`/`@eslint/js`/`typescript-eslint` in the auto-merge-eligible `dev-patch`/`dev-minor` groups:
1. **At PR5:** they'd red `ci` → their whole group can't auto-merge (fail-safe, but noisy).
2. **Now:** a formatter bump grouped with an innocuous dep blocks the good dep too (prettier blocks `jiti` in #248).

## Change

A dedicated, self-documenting **`linters` group** (never auto-merged, same posture as `build-toolchain`), placed **before** the dev groups (first-match-wins), plus the four linter names added to `dev-patch`/`dev-minor` `exclude-patterns` for order-independence. Verified: YAML parses, group order is `build-toolchain → linters → prod → dev-patch → dev-minor`, and both dev groups exclude all seven tool/linter patterns.

Dependabot config only — no release, runtime, or published-artifact impact.

## Related

#238 (prerequisite for the graduated auto-merge in PR5). Independent of PR1 (#244, merged) and the R11 hardening (#251, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
