### PR TITLE
docs(changelog): record ajv 8.20 bump under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Bumped the `ajv` schema validator (a `@sensigo/realm` core production dependency) from 8.18 to 8.20.
+  Routine dependency maintenance — realm's own usage is unaffected (it never enables ajv's `$data` option
+  and requires Node ≥22), so there is no behaviour or API change; consumers receive only a
+  resolved-version update.
+
+---
+
 ## [0.31.0] — 2026-07-23
 
 ### Changed


### PR DESCRIPTION
## Context

Dependabot PR #246 (prod group) bumped `ajv` 8.18→8.20 (a `@sensigo/realm` core production dependency) and was merged after triage. Because ajv **ships to consumers**, its version change belongs in the changelog — but the Dependabot PR carries no changelog entry. This adds it, following the established "merge the bot bump clean + tiny Mihai-authored changelog PR" pattern (cf. #241/#242).

## Motivation

Keep `[Unreleased]` complete-as-we-go so the next minor's changelog is accurate. The v0.31.0 release consumed the previous `[Unreleased]` section, so this re-opens it.

## Changes

- Re-add `## [Unreleased]` at the top of `CHANGELOG.md` with a `### Changed` entry recording the ajv 8.18→8.20 bump.
- The entry states the bump is behaviour-neutral for realm (never enables ajv's `$data` option; requires Node ≥22) — consumers receive only a resolved-version update.

The openai half of #246 is intentionally **not** recorded: its root spec was unchanged (lockfile-only resolution bump on the private root + an optional CLI peer), so it does not ship.

## Verification

- `grep -A6 '## \[Unreleased\]' CHANGELOG.md` shows the ajv entry under `### Changed`.
- `ajv` resolves to `^8.20.0` in `packages/core/package.json` on `main` (the bump this documents).
- Markdown-only change; lint/build/test unaffected.

## Rollback

```bash
git revert HEAD
```

Docs-only; no runtime, artifact, or release impact.

## Related

- #246 (the ajv/openai prod-group bump this documents)
- #238 (supply-chain posture — the canary triage that surfaced #246)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
