### PR TITLE
ci(repo): tier-2 weekly scheduled audit + release-audit config prep (issue #238 PR2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ jobs:
       # source of truth for every accepted advisory suppression; this asserts every entry is
       # GHSA-id-scoped (never a bare-string module-wide suppression).
       - run: node scripts/check-audit-allowlist.mjs
-      # issue #238 PR1 (D5) — the PR-blocking audit gate. Pinned local binary (never a bare
-      # network `npx audit-ci`), the only required check this repo has for dependency advisories.
-      - run: npx --no-install audit-ci --config ./audit-ci.jsonc
+      # issue #238 PR1 (D5) — the PR-blocking audit gate. Invoked via the `audit:ci` npm script
+      # (issue #238 PR2, D2) — `npm run` prepends node_modules/.bin to PATH, so this resolves the
+      # same pinned local binary as before, network-free, and is the same invocation PR4's
+      # release-audit step reuses. The only required check this repo has for dependency advisories.
+      - run: npm run audit:ci
       # issue #238 PR1 (D7) — positive coverage assertion (R7 mitigation). `ajv` is
       # @sensigo/realm's declared prod dependency; if audit-ci's `skip-dev` (or a future
       # `--omit=dev`/`--production` narrowing) ever silently excluded the workspace prod tree from

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -1,0 +1,44 @@
+name: Scheduled dependency audit (tier-2)
+
+on:
+  schedule:
+    # Weekly, Monday ~06:17 UTC — off-:00 to dodge cron congestion on the hour.
+    - cron: '17 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      # issue #238 PR2 (D4) — validates BOTH audit-ci.jsonc and audit-ci.tier2.jsonc (and the
+      # tier-1 ⊆ tier-2 subset invariant) before the audit itself runs.
+      - run: node scripts/check-audit-allowlist.mjs
+      # Tier-2: the broader safety net (moderate+, incl. devDependencies) — does NOT block PRs
+      # (this is a scheduled workflow, not a required check); a finding fails this run (failure
+      # email) and, via the next step, files/updates a tracking issue.
+      - name: Tier-2 audit (moderate, incl. devDependencies)
+        id: audit
+        run: |
+          set -o pipefail
+          npm run audit:full 2>&1 | tee "$RUNNER_TEMP/audit-output.txt"
+      # Only a genuine audit finding files/updates the tracking issue — `steps.audit.outcome ==
+      # 'failure'` is load-bearing: a failed `npm ci`/guard step ABOVE this also reds the run (the
+      # failure email still fires), but must NOT be mistaken for "advisories found" and must NOT
+      # file this issue.
+      - name: File or update the tracking issue
+        if: failure() && steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUDIT_OUTPUT_FILE: ${{ runner.temp }}/audit-output.txt
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/file-audit-issue.mjs

--- a/audit-ci.tier2.jsonc
+++ b/audit-ci.tier2.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "moderate": true,
+  // skip-dev intentionally OMITTED → defaults false → devDependencies ARE audited (the broader tier-2 net).
+  "allowlist": [
+    // MUST be identical to audit-ci.jsonc's allowlist (the guard enforces tier-1 ⊆ tier-2).
+    // Copied VERBATIM from audit-ci.jsonc (same notes + expiry).
+    {
+      "GHSA-frvp-7c67-39w9": {
+        "active": true,
+        "notes": "not_affected (VEX): @hono/node-server serve-static/CWE-22 unreachable — realm stdio-only, serve-static never registered. MODERATE<high so inert here; kept as the future re-score-to-HIGH escape hatch. Upstream fix: @modelcontextprotocol/sdk -> @hono/node-server >=2.0.5.",
+        "expiry": "2027-01-31",
+      },
+    },
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check:versions": "node scripts/check-versions.mjs",
+    "audit:ci": "audit-ci --config ./audit-ci.jsonc",
+    "audit:full": "audit-ci --config ./audit-ci.tier2.jsonc",
     "release": "node scripts/release.mjs",
     "setup": "lefthook install"
   },

--- a/scripts/check-audit-allowlist.mjs
+++ b/scripts/check-audit-allowlist.mjs
@@ -1,31 +1,46 @@
 #!/usr/bin/env node
-// issue #238 PR1, D6 — the allowlist GHSA-id guard.
+// issue #238 PR1 (D6), extended by PR2 (D3) — the allowlist GHSA-id guard.
 //
-// audit-ci.jsonc's `allowlist` is the single source of truth for every accepted advisory
-// suppression in the release-audit gate. Its entries have two legal shapes (per audit-ci's own
-// AllowlistObject type): a bare STRING (suppresses ALL advisories for a package/module — the
-// module-allowlist hazard) or an object with exactly one key (an advisory id scoped to a single
-// GHSA). This script asserts EVERY entry — whichever shape — resolves to a GHSA id, so a future
-// edit can never silently widen the gate into a package-wide bypass.
+// audit-ci.jsonc (tier-1, PR-blocking) and audit-ci.tier2.jsonc (tier-2, weekly scheduled) are
+// the single sources of truth for every accepted advisory suppression. Their `allowlist` entries
+// have two legal shapes (per audit-ci's own AllowlistObject type): a bare STRING (suppresses ALL
+// advisories for a package/module — the module-allowlist hazard) or an object with exactly one
+// key (an advisory id scoped to a single GHSA). This script asserts EVERY entry in BOTH configs —
+// whichever shape — resolves to a GHSA id, so a future edit can never silently widen either gate
+// into a package-wide bypass.
 //
-// The config file uses `//` line comments (JSONC) AND — since it's formatted by this repo's own
-// `prettier --write .` (wired into `npm run format`/`format:check`) — trailing commas on its
+// PR2 (R12, single-source allowlist): tier-2 is the BROADER audit (moderate+, incl. dev), so
+// anything tier-1 (the strict, prod+high gate) suppresses as not_affected must ALSO be suppressed
+// at tier-2 — otherwise the weekly scheduled run would file a tracking issue for an advisory
+// already adjudicated. This script therefore also asserts tier-1 ⊆ tier-2 (tier-2 may carry
+// additional entries tier-1 lacks; tier-1 may not carry any tier-2 lacks). A missing tier-2 config
+// file is a fail-closed THROW, never a silent pass — the two allowlists must never drift apart,
+// and an absent tier-2 config makes that guarantee unverifiable.
+//
+// The config files use `//` line comments (JSONC) AND — since they're formatted by this repo's
+// own `prettier --write .` (wired into `npm run format`/`format:check`) — trailing commas on their
 // multi-line objects/arrays. A bare `JSON.parse` throws on BOTH; `strip-json-comments` alone only
 // strips comments and still throws on the trailing commas prettier adds. `json5` parses both
 // constructs natively (a strict superset of JSON), so this script parses with it, never with
 // `JSON.parse` directly.
 
 import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import JSON5 from 'json5';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
-const CONFIG_PATH = join(ROOT, 'audit-ci.jsonc');
+const TIER1_CONFIG_PATH = join(ROOT, 'audit-ci.jsonc');
+const TIER2_CONFIG_PATH = join(ROOT, 'audit-ci.tier2.jsonc');
 
 const GHSA_PATTERN = /^GHSA-/;
 
+/**
+ * Reads and JSON5-parses one audit-ci config's `allowlist` array. Deliberately does NOT catch a
+ * missing-file error here — an absent config (tier-1 OR tier-2) must fail this script loudly
+ * (fail-closed), never silently return an empty allowlist.
+ */
 function loadAllowlist(configPath) {
   const raw = readFileSync(configPath, 'utf-8');
   const config = JSON5.parse(raw);
@@ -58,13 +73,19 @@ function extractIds(entry, index) {
   );
 }
 
-function main() {
-  const allowlist = loadAllowlist(CONFIG_PATH);
+/**
+ * Validates one config's allowlist — every entry GHSA-id-scoped. Returns the set of valid GHSA
+ * ids found (for the cross-config subset check) and whether validation failed.
+ */
+function validateAllowlist(configPath) {
+  const label = basename(configPath);
+  const allowlist = loadAllowlist(configPath);
   let failed = false;
+  const validIds = new Set();
 
   if (allowlist.length === 0) {
-    console.log('✓ audit-ci.jsonc allowlist guard: allowlist is empty — nothing to check.');
-    return;
+    console.log(`✓ ${label} allowlist guard: allowlist is empty — nothing to check.`);
+    return { failed, validIds };
   }
 
   for (let i = 0; i < allowlist.length; i++) {
@@ -73,30 +94,66 @@ function main() {
     try {
       ids = extractIds(entry, i);
     } catch (err) {
-      console.error(`✗ ${err.message}`);
+      console.error(`✗ ${label}: ${err.message}`);
       failed = true;
       continue;
     }
     for (const id of ids) {
       if (!GHSA_PATTERN.test(id)) {
         console.error(
-          `✗ allowlist[${i}]: '${id}' is not a GHSA id (must match /^GHSA-/). A non-GHSA-scoped ` +
-            `entry — especially a bare string — suppresses ALL advisories for that package, which ` +
-            `defeats the audit gate. Replace it with a GHSA-id-keyed object entry.`,
+          `✗ ${label}: allowlist[${i}]: '${id}' is not a GHSA id (must match /^GHSA-/). A ` +
+            `non-GHSA-scoped entry — especially a bare string — suppresses ALL advisories for ` +
+            `that package, which defeats the audit gate. Replace it with a GHSA-id-keyed object entry.`,
         );
         failed = true;
       } else {
-        console.log(`✓ allowlist[${i}]: '${id}' is a valid GHSA-scoped entry.`);
+        console.log(`✓ ${label}: allowlist[${i}]: '${id}' is a valid GHSA-scoped entry.`);
+        validIds.add(id);
       }
     }
   }
 
+  return { failed, validIds };
+}
+
+function main() {
+  let failed = false;
+
+  const tier1 = validateAllowlist(TIER1_CONFIG_PATH);
+  failed = failed || tier1.failed;
+
+  const tier2 = validateAllowlist(TIER2_CONFIG_PATH);
+  failed = failed || tier2.failed;
+
+  // R12: single-source allowlist — tier-1 ⊆ tier-2. Every id tier-1 (the strict gate) suppresses
+  // must also be suppressed at tier-2 (the broad gate), or the weekly scheduled run would file a
+  // tracking issue for an advisory already adjudicated not_affected. Tier-2 may carry additional
+  // entries tier-1 lacks (a moderate-only finding tier-1 never even sees); tier-1 may not carry
+  // any id tier-2 lacks. Only checked when both configs individually passed their own GHSA-id
+  // validation — a malformed entry has no well-defined id to check membership for.
+  if (!tier1.failed && !tier2.failed) {
+    const missingFromTier2 = [...tier1.validIds].filter((id) => !tier2.validIds.has(id));
+    if (missingFromTier2.length > 0) {
+      for (const id of missingFromTier2) {
+        console.error(
+          `✗ tier-1 ⊆ tier-2 violation: '${id}' is allowlisted in audit-ci.jsonc (tier-1) but ` +
+            `MISSING from audit-ci.tier2.jsonc (tier-2). Add the identical GHSA-id-keyed entry ` +
+            `(same notes + expiry) to audit-ci.tier2.jsonc, or the weekly scheduled audit will file ` +
+            `a tracking issue for an advisory already adjudicated not_affected at tier-1.`,
+        );
+      }
+      failed = true;
+    } else {
+      console.log('✓ tier-1 ⊆ tier-2: every tier-1 allowlist entry is also present in tier-2.');
+    }
+  }
+
   if (failed) {
-    console.error('\naudit-ci.jsonc allowlist guard FAILED — see errors above.');
+    console.error('\naudit allowlist guard FAILED — see errors above.');
     process.exit(1);
   }
 
-  console.log('\naudit-ci.jsonc allowlist guard passed — every entry is GHSA-scoped.');
+  console.log('\naudit allowlist guard passed — every entry is GHSA-scoped, tier-1 ⊆ tier-2.');
 }
 
 main();

--- a/scripts/file-audit-issue.mjs
+++ b/scripts/file-audit-issue.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// issue #238 PR2 (D4) — files or updates the tracking issue for the tier-2 weekly scheduled
+// audit. Invoked ONLY when the tier-2 audit step itself failed (an advisory was found) — see
+// `.github/workflows/scheduled-audit.yml`'s `steps.audit.outcome == 'failure'` gate, which keeps
+// a failed `npm ci`/guard step from filing a spurious "advisories found" issue.
+//
+// Dedup by a STABLE title: an open issue with that title gets a comment (the new run's evidence),
+// never a duplicate issue. Uses `--body-file`, NEVER inline `--body`, so the captured audit
+// output (arbitrary text, potentially containing shell-special characters) can never corrupt the
+// `gh` invocation via shell-quoting.
+//
+// DRY_RUN=1: the dedup lookup (a read-only `gh issue list`) still runs for real — it's needed to
+// print the CORRECT create-vs-comment decision — but the mutating step (create/comment) is only
+// PRINTED, never executed. This makes the whole decision path testable locally without filing a
+// real issue.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TITLE = 'Weekly dependency audit surfaced advisories (tier-2)';
+const LABEL = 'dependencies';
+const ASSIGNEE = 'mihai-r-lupu';
+const DRY_RUN = process.env['DRY_RUN'] === '1';
+
+function readRequiredEnv(name) {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    throw new Error(`${name} is required (set as an env var before running this script).`);
+  }
+  return value;
+}
+
+/** Runs a `gh` subcommand via argv (never a shell string) and returns trimmed stdout. Throws on
+ * a non-zero exit. */
+function runGh(args) {
+  const result = spawnSync('gh', args, { encoding: 'utf-8' });
+  if (result.error) {
+    throw new Error(`Failed to run 'gh ${args.join(' ')}': ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `'gh ${args.join(' ')}' exited ${String(result.status)}: ${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+/** Renders a `gh` argv array as a readable, copy-pasteable command line (for DRY_RUN output and
+ * error messages only — never used to actually invoke a shell). */
+function renderCommand(args) {
+  return ['gh', ...args.map((a) => (/[\s"]/.test(a) ? `'${a}'` : a))].join(' ');
+}
+
+function findOpenIssueNumber() {
+  const searchArgs = [
+    'issue',
+    'list',
+    '--state',
+    'open',
+    '--search',
+    `"${TITLE}" in:title`,
+    '--json',
+    'number',
+    '--jq',
+    '.[0].number // empty',
+  ];
+  const stdout = runGh(searchArgs);
+  return stdout === '' ? undefined : stdout;
+}
+
+function buildBody(auditOutput, runUrl) {
+  return [
+    `The weekly tier-2 dependency audit (\`npm run audit:full\` — moderate+, including ` +
+      `devDependencies) surfaced one or more advisories not already covered by the shared ` +
+      `allowlist.`,
+    '',
+    `Run: ${runUrl}`,
+    '',
+    '<details>',
+    '<summary>Audit output</summary>',
+    '',
+    '```',
+    auditOutput.trimEnd(),
+    '```',
+    '',
+    '</details>',
+    '',
+    '**Triage:** fix-in-range (bump the dependency within its declared range) / merge the ' +
+      'corresponding Dependabot PR if one exists / only-if-genuinely-`not_affected`, add a ' +
+      'GHSA-id-keyed entry with `expiry` and a reason to `audit-ci.tier2.jsonc` (the guard ' +
+      'enforces GHSA-id-only entries and tier-1 ⊆ tier-2 — see `scripts/check-audit-allowlist.mjs`). ' +
+      '**Do not auto-suppress.** Owner: @mihai-r-lupu.',
+  ].join('\n');
+}
+
+function main() {
+  const auditOutputFile = readRequiredEnv('AUDIT_OUTPUT_FILE');
+  const runUrl = readRequiredEnv('RUN_URL');
+  const auditOutput = readFileSync(auditOutputFile, 'utf-8');
+
+  const body = buildBody(auditOutput, runUrl);
+
+  const tmpDir = mkdtempSync(join(tmpdir(), 'audit-issue-'));
+  const bodyPath = join(tmpDir, 'body.md');
+  writeFileSync(bodyPath, body, 'utf-8');
+
+  try {
+    // Read-only — safe to run for real even under DRY_RUN, and required to print the CORRECT
+    // create-vs-comment decision.
+    const existingIssueNumber = findOpenIssueNumber();
+
+    const mutatingArgs =
+      existingIssueNumber !== undefined
+        ? ['issue', 'comment', existingIssueNumber, '--body-file', bodyPath]
+        : [
+            'issue',
+            'create',
+            '--title',
+            TITLE,
+            '--body-file',
+            bodyPath,
+            '--label',
+            LABEL,
+            '--assignee',
+            ASSIGNEE,
+          ];
+
+    if (DRY_RUN) {
+      console.log(
+        existingIssueNumber !== undefined
+          ? `[DRY_RUN] Open issue #${existingIssueNumber} found ('${TITLE}') — would COMMENT.`
+          : `[DRY_RUN] No open issue titled '${TITLE}' found — would CREATE a new one.`,
+      );
+      console.log(`[DRY_RUN] Would run: ${renderCommand(mutatingArgs)}`);
+      console.log('[DRY_RUN] Assembled body:');
+      console.log('---');
+      console.log(body);
+      console.log('---');
+      return;
+    }
+
+    runGh(mutatingArgs);
+    console.log(
+      existingIssueNumber !== undefined
+        ? `Commented on existing issue #${existingIssueNumber}.`
+        : `Created a new tracking issue: '${TITLE}'.`,
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main();


### PR DESCRIPTION
## Context

Issue #238 (standing supply-chain posture), PR 2 of 5. Design record + verdict trail:
`plans/issue-238/dossier.md`, `## FINAL CONVERGED DESIGN` section. PR1 (#244, merged) shipped the
tier-1 PR-blocking gate: `audit-ci --config ./audit-ci.jsonc` with `{ high, skip-dev }` (prod,
high+critical) as a required step in the `ci` job. This PR adds the tier-2 safety net — the
broader audit that does not block PRs — and the reusable audit invocation PR4's release-audit step
will call.

**`publish.yml` and `codeql.yml` are untouched by this PR** — confirmed byte-identical to `main`.
The release-audit *step* itself lands in the isolated, canaried PR4; this PR only prepares the
reusable *invocation* (`npm run audit:ci`) it will call.

## Motivation

Two-tier model, from the design record: tier-1 (PR gate, already shipped) covers production
dependencies at high+critical severity — narrow and strict, so it can safely block every merge.
Tier-2 (this PR) covers ALL dependencies (including dev) at moderate+ severity — broader, so it
runs on a schedule instead of blocking, and surfaces findings as a tracking issue rather than a red
PR check. Without tier-2, a moderate-severity advisory in a dev-only dependency (or anything below
tier-1's `high` threshold) would never be seen by anyone.

**Single-source allowlist (R12) is load-bearing and independently verified in this PR**:
`GHSA-frvp-7c67-39w9` (`@hono/node-server`, moderate, `not_affected`) is inert at tier-1 (moderate
< high) but fires at tier-2 (moderate+dev audit of the current tree flags exactly that one
advisory) — so tier-2 carries the identical allowlist entry, and a mechanical guard now asserts
tier-1's allowlist is always a subset of tier-2's, so the two can never silently drift apart.

## Changes

- **`audit-ci.tier2.jsonc`** (new) — `{ moderate: true }`, `skip-dev` intentionally omitted
  (defaults `false` → devDependencies ARE audited). Allowlist is a verbatim copy of
  `audit-ci.jsonc`'s `GHSA-frvp-7c67-39w9` entry (identical `notes`/`expiry`).
- **Two new root `package.json` scripts**: `audit:ci` (`audit-ci --config ./audit-ci.jsonc`) and
  `audit:full` (`audit-ci --config ./audit-ci.tier2.jsonc`) — both resolve the pinned local binary
  via `npm run`'s `PATH` prepend, network-free. `ci.yml`'s audit step now runs `npm run audit:ci`
  instead of the bare `npx --no-install audit-ci --config ./audit-ci.jsonc` — a behavior-preserving
  refactor (same binary, same config, same result) that also gives PR4's release-audit step a
  ready-made invocation to reuse. No other line in `ci.yml` changed.
- **`scripts/check-audit-allowlist.mjs` extended** — now validates BOTH `audit-ci.jsonc` and
  `audit-ci.tier2.jsonc` (same GHSA-id-only check, parametrized rather than duplicated), plus a new
  tier-1 ⊆ tier-2 assertion: every GHSA id tier-1 allowlists must also appear in tier-2's allowlist,
  or the script fails and names exactly which id is missing. Tier-2 may carry additional entries
  tier-1 lacks; tier-1 may not carry any tier-2 lacks. A missing `audit-ci.tier2.jsonc` throws
  (fail-closed) rather than silently skipping the check.
- **`.github/workflows/scheduled-audit.yml`** (new) — `schedule` (weekly, `17 6 * * 1` — Monday
  ~06:17 UTC, off-the-hour to dodge cron congestion) + `workflow_dispatch` (manual smoke-test).
  `permissions: { contents: read, issues: write }` only, no `id-token`. `actions/checkout` +
  `actions/setup-node` SHA-pinned to the exact same commits as `ci.yml` (independently re-verified
  below). Steps: `npm ci` → the extended guard (validates both configs before auditing) → the
  tier-2 audit (`npm run audit:full`, output captured to `$RUNNER_TEMP/audit-output.txt`) → file/
  update a tracking issue, gated on `steps.audit.outcome == 'failure'` specifically (so a failed
  `npm ci` or guard step still reds the run — and sends the failure email — without ever filing a
  spurious "advisories found" issue).
- **`scripts/file-audit-issue.mjs`** (new) — dedups by a stable issue title (comments on an
  existing open issue instead of creating a duplicate), uses `--body-file` exclusively (never
  inline `--body`, avoiding shell-quoting corruption of arbitrary captured audit output), and
  supports `DRY_RUN=1` (the dedup lookup still runs for real — it's read-only — but the actual
  create/comment call is only printed, never executed).

**No advisory beyond `GHSA-frvp-7c67-39w9` was found** by `npm run audit:full` against the current
tree — nothing was suppressed to make the gate pass; this is the one pre-existing, already-VEXed
finding from PR1.

**Known accepted window (same as PR1):** `scheduled-audit.yml`'s action pins are unmanaged until
PR4 adds the `github-actions` Dependabot ecosystem block.

## Verification

```bash
# 1. Tier-1 unaffected
npm run audit:ci
#   "vulnerabilities": {"moderate": 2, "high": 0, ...} / Passed npm security audit.

# 2. Tier-2 clean today, AND the allowlist entry is load-bearing (not decorative)
npm run audit:full
#   "vulnerabilities": {"moderate": 2, ...} / Found vulnerable allowlisted advisories:
#   GHSA-frvp-7c67-39w9. / Passed npm security audit.
#
# Temporarily removed the GHSA-frvp entry from audit-ci.tier2.jsonc:
npm run audit:full
#   Found vulnerable advisory paths: GHSA-frvp-7c67-39w9|... / Failed security audit due to
#   moderate vulnerabilities. [exit 1]
# Reverted byte-identically (diff confirmed), re-ran — green again.

# 3. Guard (extended) — three mutation probes, all reverted byte-identically afterward
node scripts/check-audit-allowlist.mjs
#   ✓ audit-ci.jsonc: ... / ✓ audit-ci.tier2.jsonc: ... / ✓ tier-1 ⊆ tier-2: ... / passed
#
# (a) delete the GHSA-frvp entry from audit-ci.tier2.jsonc only:
#     ✗ tier-1 ⊆ tier-2 violation: 'GHSA-frvp-7c67-39w9' is allowlisted in audit-ci.jsonc
#       (tier-1) but MISSING from audit-ci.tier2.jsonc (tier-2). ... [exit 1]
# (b) add a bare-string entry ("axios") to audit-ci.tier2.jsonc:
#     ✗ audit-ci.tier2.jsonc: allowlist[0]: 'axios' is not a GHSA id ... [exit 1]
# (c) rename audit-ci.tier2.jsonc away:
#     Error: ENOENT: no such file or directory, open '.../audit-ci.tier2.jsonc' [uncaught, exit 1]

# 4. ci.yml refactor is behavior-preserving — this PR's own `ci` check (see below) is green,
#    and publish.yml/codeql.yml are absent from the diff
git diff --stat main -- .github/workflows/publish.yml .github/workflows/codeql.yml
#   (no output — both untouched)

# 5. Issue-filing logic (DRY_RUN) — both decision branches exercised
DRY_RUN=1 RUN_URL="https://github.com/.../actions/runs/12345" \
  AUDIT_OUTPUT_FILE=/tmp/fake-audit-output.txt node scripts/file-audit-issue.mjs
#   [DRY_RUN] No open issue titled '...' found — would CREATE a new one.
#   [DRY_RUN] Would run: gh issue create --title '...' --body-file <tmp> --label dependencies
#     --assignee mihai-r-lupu
#   [DRY_RUN] Assembled body: <one-line summary, RUN_URL, fenced audit output, triage line
#     with "Do not auto-suppress.", owner @mihai-r-lupu>
# (Temporarily pointed the script's dedup title at a real open issue's title to exercise the
# COMMENT branch too — printed the correct `gh issue comment <n> --body-file <tmp>` decision,
# never executed; reverted the temporary change byte-identically afterward. No real issue was
# ever created or commented on by this verification.)

# 6. Workflow validity
node -e "const yaml=require('js-yaml'),fs=require('fs');
  const doc=yaml.load(fs.readFileSync('.github/workflows/scheduled-audit.yml','utf8'));
  console.log(Object.keys(doc.on), doc.on.schedule, doc.permissions)"
#   [ 'schedule', 'workflow_dispatch' ] [ { cron: '17 6 * * 1' } ] { contents: 'read', issues: 'write' }
grep uses .github/workflows/scheduled-audit.yml .github/workflows/ci.yml
#   both files: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
#               actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
#   (identical SHAs, independently re-confirmed against ci.yml's own pins)

# Full suite + tsc, unaffected
npm run build && npm run test   # core 1924/1924, cli 827/827, mcp-server 265/265, testing 81/81
npx tsc --noEmit   # clean in packages/{core,cli,mcp-server,testing}
npm run lint && npm run format:check   # both clean

# 7. Touch list
git diff --stat main
#  .github/workflows/ci.yml              |   8 +-
#  .github/workflows/scheduled-audit.yml |  44 ++++
#  audit-ci.tier2.jsonc                  |  16 ++
#  package.json                          |   2 +
#  scripts/check-audit-allowlist.mjs     | 101 +++++++++++++-----
#  scripts/file-audit-issue.mjs          | 155 +++++++++++++++++++++++
#  6 files changed, 301 insertions(+), 25 deletions(-)
```

Note: no `package-lock.json` change in this PR — D2 adds two `package.json` *scripts* only, no new
dependency, so there's nothing for `npm install` to re-lock.

## Rollback

```bash
git revert HEAD
```

Pure CI/repo-infra change — reverting removes the tier-2 config, the scheduled workflow, the
issue-filing script, the two npm scripts, and the guard's tier-2 extension, restoring PR1's
tier-1-only posture exactly. No runtime data, no release artifacts, no npm-published package is
touched by this PR in either direction. The scheduled workflow has not fired for real yet (its
first natural trigger is the next Monday ~06:17 UTC after merge, or a manual
`workflow_dispatch` smoke-test) — a revert before then has zero live-run history to worry about.

## Related

- Issue #238 (standing supply-chain posture) — PR 2 of 5. Design record: `plans/issue-238/dossier.md`.
- Follows PR1 (#244, merged): dependabot.yml + SHA-pinned `ci.yml`/`codeql.yml` + the tier-1 audit
  gate + the original `check-audit-allowlist.mjs` guard.
- Next: PR3 (SECURITY.md + Private Vulnerability Reporting + OpenVEX + CODEOWNERS), PR4
  (`publish.yml` hardening + the release-audit step reusing `audit:ci` — isolated, canaried), PR5
  (OpenSSF Scorecard + graduated auto-merge).
