### PR TITLE
docs(security): SECURITY.md + OpenVEX + CODEOWNERS (issue #238 PR3)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner (solo-maintained). Notification/documentation on this repo — a real review gate only once a
+# ruleset requires code-owner review (deferred, #238 R10/D2). Kept accurate so that day is a one-line flip.
+* @mihai-r-lupu
+
+# Release-critical surfaces, called out explicitly:
+/packages/*/package.json      @mihai-r-lupu
+/.github/workflows/publish.yml @mihai-r-lupu

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please use GitHub's private vulnerability reporting** — this repository's Security tab →
+"Report a vulnerability" → private security advisory form. It is enabled for this repository.
+
+**Do NOT open a public issue or pull request for a suspected vulnerability.** A public report gives
+an attacker a head start before a fix ships.
+
+This is a solo-maintained project. We aim to acknowledge a report within a few business days.
+Response and fix timelines depend on severity and complexity — we'll keep you updated through the
+private advisory thread.
+
+If you cannot use GitHub's private reporting form for some reason, you may email
+`mihai.lupu@sensigo.ro` as a fallback — but the private advisory form is the preferred and
+primary channel.
+
+## Supported versions
+
+realm is pre-1.0 (`0.x`). Only the **latest published version** on npm (across
+`@sensigo/realm`, `@sensigo/realm-cli`, `@sensigo/realm-mcp`, `@sensigo/realm-testing`) receives
+security fixes. There is no back-porting to older minor versions and no long-term-support (LTS)
+track — upgrading to the latest release is the supported path to a fix.
+
+## Scope
+
+This policy covers the four published npm packages in this repository:
+
+- `@sensigo/realm` (core engine)
+- `@sensigo/realm-cli`
+- `@sensigo/realm-mcp`
+- `@sensigo/realm-testing`
+
+## How we triage dependency advisories
+
+When an automated scan (Dependabot, `npm audit`, or the repository's own `audit-ci` gates)
+surfaces an advisory in a dependency, the order of preference is:
+
+1. **Fix-in-range** — bump the dependency within its already-declared semver range, if a patched
+   version is available there.
+2. **Merge the Dependabot pull request**, if one exists and resolves the advisory.
+3. **Only if the code is genuinely not affected** — document it (an [OpenVEX](https://openvex.dev/)
+   statement plus the `audit-ci` allowlist) and dismiss.
+
+**We never downgrade a dependency to dodge an advisory.** A downgrade trades a known, documented
+risk for an unreviewed, older set of risks — that is not an acceptable substitution.
+
+### Single source of truth for suppressions
+
+The `audit-ci` allowlist (`audit-ci.jsonc` for the PR-blocking gate,
+`audit-ci.tier2.jsonc` for the broader weekly scheduled audit) is the **canonical** record of every
+suppressed advisory. Any OpenVEX document (see `security/vex/`) and any Dependabot alert dismissal
+**mirror** that allowlist — they document the same decision, they never originate it. Each
+suppression is scoped to a single GHSA id, carries an `expiry` date, and states a reason.
+
+### Audit boundary — range vs. resolved (an honest limitation)
+
+Our automated audit gates scan **realm's own resolved lockfile** — the exact dependency versions
+this repository currently has installed. A downstream consumer installing a published `@sensigo/*`
+package resolves its **own** transitive dependency tree, within the semver ranges we've declared,
+independently of our lockfile. That resolution can differ from ours — possibly to a newer,
+possibly to an older-but-still-vulnerable transitive version. **Our audit gates do not audit what a
+consumer's install will actually resolve.** If you depend on a `@sensigo/*` package, run your own
+`npm audit` (or equivalent) against your own lockfile.
+
+### Machine-readable VEX records
+
+Suppressed advisories that are `not_affected` are additionally documented as
+[OpenVEX](https://openvex.dev/) statements under [`security/vex/`](security/vex/) — see
+[`security/vex/GHSA-frvp-7c67-39w9.openvex.json`](security/vex/GHSA-frvp-7c67-39w9.openvex.json)
+for the current example.

--- a/security/vex/GHSA-frvp-7c67-39w9.openvex.json
+++ b/security/vex/GHSA-frvp-7c67-39w9.openvex.json
@@ -14,6 +14,10 @@
         {
           "@id": "pkg:npm/%40sensigo/realm-cli",
           "subcomponents": [{ "@id": "pkg:npm/%40hono/node-server" }]
+        },
+        {
+          "@id": "pkg:npm/%40sensigo/realm-mcp",
+          "subcomponents": [{ "@id": "pkg:npm/%40hono/node-server" }]
         }
       ],
       "status": "not_affected",

--- a/security/vex/GHSA-frvp-7c67-39w9.openvex.json
+++ b/security/vex/GHSA-frvp-7c67-39w9.openvex.json
@@ -1,0 +1,24 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/sensigo-hq/realm/security/vex/GHSA-frvp-7c67-39w9",
+  "author": "Mihai Lupu <mihai.lupu@sensigo.ro>",
+  "timestamp": "2026-07-24T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "GHSA-frvp-7c67-39w9",
+        "description": "@hono/node-server serve-static path traversal (CWE-22), Windows-only"
+      },
+      "products": [
+        {
+          "@id": "pkg:npm/%40sensigo/realm-cli",
+          "subcomponents": [{ "@id": "pkg:npm/%40hono/node-server" }]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "realm-cli reaches @hono/node-server only via @modelcontextprotocol/sdk's StreamableHTTPServerTransport (which uses @hono/node-server's getRequestListener) for the 'realm serve' command's JSON-RPC HTTP transport; the vulnerable serve-static handler is never imported or registered anywhere in that transport or in realm's own source, so the vulnerable path is not reachable. The advisory is additionally Windows-only, while realm deploys to macOS/Linux. @sensigo/realm-mcp declares the same @modelcontextprotocol/sdk version but uses only its stdio transport (StdioServerTransport), never loading the HTTP transport module that references @hono/node-server at all."
+    }
+  ]
+}


### PR DESCRIPTION
## Context

Issue #238 (standing supply-chain posture), PR 3 of 5. Design record:
`plans/issue-238/dossier.md`, `## FINAL CONVERGED DESIGN` section (M3, S3, S4). This PR ships the
documentation-grade security surface — the cheap, zero-runtime-risk controls that close the
Scorecard Security-Policy gap: `SECURITY.md`, an OpenVEX not_affected statement, and
`.github/CODEOWNERS`.

**Repo-settings changes are explicitly out of scope for this PR** (architect-applied directly, not
by the implementation agent): Private Vulnerability Reporting is already enabled; the
ruleset-vs-classic-protection consolidation is an admin action. No `gh api` repo-settings mutation
was attempted. **No workflow, script, config, or `package.json` was touched** — confirmed by the
diff below (exactly 3 new files).

## Motivation

`SECURITY.md` gives reporters and OpenSSF Scorecard alike a documented, discoverable security
policy instead of relying on tribal knowledge. The OpenVEX statement makes the existing
`audit-ci.jsonc` `not_affected` decision machine-readable, for any tooling or downstream consumer
that consumes VEX documents. `CODEOWNERS` documents ownership of the release-critical surfaces now,
cheaply, so that flipping it into a real review gate later (once a branch-protection ruleset
requires code-owner review) is a one-line change rather than a fresh design decision.

## Changes

- **`SECURITY.md`** (new, repo root) — reporting via GitHub's private vulnerability reporting only
  (explicitly: do not open a public issue or PR for a suspected vulnerability), the pre-1.0
  latest-published-version-only support policy (no back-porting, no LTS), scope (the four
  published `@sensigo/*` packages), and the dependency-advisory triage stance from the design
  record: fix-in-range → merge the Dependabot PR → document (OpenVEX + the `audit-ci` allowlist)
  and dismiss only if genuinely `not_affected` — **never downgrade to dodge an advisory**. Names the
  `audit-ci` allowlist as the single source of truth (OpenVEX and any Dependabot dismissal mirror
  it, never the reverse) and states the range-vs-resolved audit-boundary limitation honestly:
  realm's gates audit realm's own resolved lockfile, not what a downstream consumer's own install
  will resolve within our declared ranges.
- **`security/vex/GHSA-frvp-7c67-39w9.openvex.json`** (new) — a spec-valid OpenVEX v0.2.0
  `not_affected` statement, cross-checked field-by-field against the live spec (see Verification).
  Mirrors `audit-ci.jsonc`'s existing allowlist entry (same advisory, same rationale) — **the
  allowlist itself is unchanged**, confirmed via `git diff --stat`.
- **`.github/CODEOWNERS`** (new) — catch-all `* @mihai-r-lupu` plus the two release-critical paths
  named explicitly (`/packages/*/package.json`, `/.github/workflows/publish.yml`).

### A real deviation from the prompt's assumed product — corrected, not just noted

The prompt's OpenVEX skeleton assumed `@sensigo/realm-mcp` as the package that reaches
`@hono/node-server`. Tracing the actual dependency and code paths shows this is **wrong** — the
correct product is **`@sensigo/realm-cli`**:

- `npm ls @hono/node-server --all` resolves through `@sensigo/realm-cli` →
  `@modelcontextprotocol/sdk` → `@hono/node-server` — `@sensigo/realm-mcp` never appears in that
  tree at all, despite also declaring `@modelcontextprotocol/sdk` as a dependency.
- Reading the SDK's own `streamableHttp.js` confirms `getRequestListener` (from `@hono/node-server`)
  is imported and used **only** by `StreamableHTTPServerTransport`.
- `packages/cli/src/commands/serve.ts` (the `realm serve` command) imports and instantiates
  `StreamableHTTPServerTransport` — this is realm's one and only HTTP-serving code path.
- `packages/mcp-server/src/server.ts` imports **only** `McpServer` and `StdioServerTransport` —
  it never imports the HTTP transport module, so it never loads or reaches `@hono/node-server` at
  all, despite the shared/hoisted `@modelcontextprotocol/sdk` install technically containing it in
  `node_modules`.
- `serveStatic` (the actual vulnerable handler) is grepped as absent from realm's own source AND
  from the SDK's own transport implementation — confirming it is genuinely unreachable regardless
  of which package is named.

The shipped OpenVEX document's `products[].@id` is `pkg:npm/%40sensigo/realm-cli`, and its
`impact_statement` names the actual mechanism (the `realm serve` command's
`StreamableHTTPServerTransport`) and notes `@sensigo/realm-mcp`'s even-more-categorical
non-exposure (it never loads the HTTP transport module at all).

**Minor, non-blocking observation for a future cleanup (not touched here, not in scope):** the
existing `audit-ci.jsonc` allowlist note reads "realm stdio-only, serve-static never registered" —
accurate for `@sensigo/realm-mcp` alone, but the actual advisory-relevant package
(`@sensigo/realm-cli`) is not purely stdio — it serves HTTP JSON-RPC via
`StreamableHTTPServerTransport`. The bottom-line verdict (not_affected; `serveStatic` never
registered) is unaffected either way, so this is a wording precision note only, left for a future
allowlist-note edit (out of this PR's touch list, which does not include `audit-ci.jsonc`).

## Verification

```bash
# 1. OpenVEX validity — parses, every required field present, justification is a valid
#    not_affected label. Spec cross-checked live (WebFetch of openvex/spec's OPENVEX-SPEC.md)
#    before writing the document — confirmed the prompt's skeleton shape needed zero adjustment:
#    @context/@id/author/timestamp/version(integer)/statements are exactly the spec's required
#    top-level fields; the five valid not_affected justifications are component_not_present,
#    vulnerable_code_not_present, vulnerable_code_not_in_execute_path,
#    vulnerable_code_cannot_be_controlled_by_adversary, inline_mitigations_already_exist.
node -e "
const doc = require('./security/vex/GHSA-frvp-7c67-39w9.openvex.json');
console.log(doc['@context'], doc.version, doc.statements[0].status, doc.statements[0].justification);
"
#   https://openvex.dev/ns/v0.2.0 1 not_affected vulnerable_code_not_in_execute_path

# 2. Product correctness — the corrected path, verified multiple independent ways
npm ls @hono/node-server --all
#   realm@ -> @sensigo/realm-cli -> @modelcontextprotocol/sdk -> @hono/node-server
grep -n "StreamableHTTPServerTransport" packages/cli/src/commands/serve.ts   # imported + instantiated
grep -n "import.*@modelcontextprotocol/sdk" packages/mcp-server/src/server.ts
#   only McpServer + StdioServerTransport — no HTTP transport import
grep -n "@hono/node-server" node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js
#   getRequestListener imported here only
grep -rln "serveStatic" packages/ node_modules/@modelcontextprotocol/sdk/
#   (no output — confirmed unreachable anywhere)

# 3. Allowlist consistency — same advisory, same rationale; allowlist itself unchanged
sed -n '/GHSA-frvp/,/},/p' audit-ci.jsonc
#   "notes": "not_affected (VEX): @hono/node-server serve-static/CWE-22 unreachable — ..."
git diff --stat main -- audit-ci.jsonc audit-ci.tier2.jsonc
#   (no output — both unchanged)

# 4. CODEOWNERS syntax
cat .github/CODEOWNERS
#   * @mihai-r-lupu
#   /packages/*/package.json      @mihai-r-lupu
#   /.github/workflows/publish.yml @mihai-r-lupu

# 5. SECURITY.md — required sections present
grep -n "^#\|private vulnerability reporting\|do NOT open a public\|never downgrade\|Single source of truth" SECURITY.md

# Full suite unaffected (no code/config touched)
npx turbo run test --force   # core 1924/1924, cli 827/827, mcp-server 265/265, testing 81/81
npm run lint && npm run format:check   # both clean
node scripts/check-audit-allowlist.mjs && npm run audit:ci && npm run audit:full   # all still green

# 6. Touch list
git diff --stat main
#  .github/CODEOWNERS                             |  7 +++
#  SECURITY.md                                    | 72 ++++++++++++++++++
#  security/vex/GHSA-frvp-7c67-39w9.openvex.json  | 24 +++++
#  3 files changed, 103 insertions(+)
```

## Rollback

```bash
git revert HEAD
```

Pure documentation addition — reverting removes all three files with no other effect. No runtime
code, workflow, config, or dependency is touched by this PR in either direction.

## Related

- Issue #238 (standing supply-chain posture) — PR 3 of 5. Design record: `plans/issue-238/dossier.md`.
- Follows PR1 (#244) and PR2 (#260, open): the tier-1/tier-2 `audit-ci` gates and their shared
  allowlist, which this PR's OpenVEX document mirrors without modifying.
- Next: PR4 (`publish.yml` hardening + the release-audit step — isolated, canaried), PR5 (OpenSSF
  Scorecard + graduated auto-merge).
