### PR TITLE
ci(repo): split publish.yml build/publish + provenance hardening (issue #238 PR4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,15 @@ updates:
             '@eslint/js',
             'typescript-eslint',
           ]
+
+  - package-ecosystem: 'github-actions'
+    directory: '/' # scans ALL of .github/workflows — NO per-file scope exists (B1 is procedural, see below)
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7 # github-actions supports ONLY default-days (semver-*-days are unsupported here)
+    groups:
+      github-actions: # one human-reviewed, NEVER-auto-merged PR for every action bump across all workflows
+        patterns: ['*']

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,48 +2,102 @@ name: Publish
 
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*']
+  workflow_dispatch: {} # a dispatch is ALWAYS a dry-run canary (see DRY_RUN below) — it can NEVER real-publish
 
-permissions:
-  contents: read
-  id-token: write # required for OIDC trusted publishing
+# Serialize releases; NEVER cancel-in-progress — cancelling a run mid-partial-publish (e.g. after core's PUT)
+# would strand a release. cancel-in-progress:true would be a REGRESSION here.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {} # workflow-level: none; each job declares its own least-privilege set
 
 jobs:
-  publish:
-    name: Publish to npm
+  build:
+    name: Build (no publish credential)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # NO id-token — the I7 boundary
     steps:
-      - uses: actions/checkout@v5
+      - name: Assert NO OIDC token in the build job (I7 guard)
+        run: |
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::id-token must not be available in the build job"; exit 1
+          fi
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '24'
+      - run: npm ci --ignore-scripts
+      - name: Release audit (prod-high backstop — same gate as PR-time)
+        run: npm run audit:ci
+      - run: npm run build
+      # Deterministic dist hand-off: pack a tarball from the workspace root so paths are exactly
+      # `packages/<pkg>/dist/...`. This AVOIDS actions/upload-artifact's least-common-ancestor
+      # path-stripping — a `path: packages/*/dist` glob would store files relative to `packages/`
+      # (dropping the prefix), and the publish job would restore dist to the WRONG location and
+      # publish empty/broken tarballs. A tarball sidesteps the LCA behaviour entirely.
+      - name: Archive built dist
+        run: tar -czf dist.tar.gz packages/*/dist
+      - name: Upload built dist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist
+          path: dist.tar.gz
+          if-no-files-found: error
+          retention-days: 1
 
-      - uses: actions/setup-node@v5
+  publish:
+    name: Publish to npm (provenance, fail-closed)
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing + SLSA provenance
+    env:
+      DRY_RUN: ${{ github.event_name != 'push' }} # real publish ONLY on a v* tag PUSH; ANY workflow_dispatch → dry-run (can never real-publish)
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          # `cache` is intentionally unset — setup-node only caches when `cache` is
-          # provided, so release builds run uncached without any extra input.
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Pin inter-package dependency ranges
-        run: node scripts/pin-deps.mjs
-
+      - name: Download built dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: . # the single tarball lands at ./dist.tar.gz
+      - name: Restore dist (tar preserves packages/<pkg>/dist exactly)
+        run: |
+          tar -xzf dist.tar.gz
+          for p in core mcp-server testing cli; do
+            test -d "packages/$p/dist" || { echo "::error::packages/$p/dist missing after artifact restore"; exit 1; }
+          done
+      - name: Assert id-token IS present before any publish (pre-flight — avoids a partial release from a token failure)
+        if: ${{ env.DRY_RUN != 'true' }}
+        run: |
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::id-token:write not granted to the publish job; refusing to publish"; exit 1
+          fi
+      - run: node scripts/pin-deps.mjs
+      # --provenance is FAIL-CLOSED and load-bearing — do NOT remove it. --ignore-scripts is defense-in-depth.
+      # DRY_RUN is 'true' for ANY workflow_dispatch and 'false' ONLY for a v* TAG PUSH — a tag push always
+      # publishes for real; a dispatch can never real-publish.
       - name: Publish @sensigo/realm
-        run: npm publish
         working-directory: packages/core
-
+        run: npm publish --provenance --ignore-scripts ${{ env.DRY_RUN == 'true' && '--dry-run' || '' }}
       - name: Publish @sensigo/realm-mcp
-        run: npm publish
         working-directory: packages/mcp-server
-
+        run: npm publish --provenance --ignore-scripts ${{ env.DRY_RUN == 'true' && '--dry-run' || '' }}
       - name: Publish @sensigo/realm-testing
-        run: npm publish
         working-directory: packages/testing
-
+        run: npm publish --provenance --ignore-scripts ${{ env.DRY_RUN == 'true' && '--dry-run' || '' }}
       - name: Publish @sensigo/realm-cli
-        run: npm publish
         working-directory: packages/cli
+        run: npm publish --provenance --ignore-scripts ${{ env.DRY_RUN == 'true' && '--dry-run' || '' }}
+      # NO in-workflow registry-query verify: --provenance is FAIL-CLOSED, so a SUCCESSFUL publish
+      # already guarantees provenance was generated (npm throws EUSAGE before the PUT otherwise).
+      # A `npm view --json` right after publish would risk a false failure from registry-propagation
+      # delay on a release that actually succeeded. The queryable confirmation (npm view predicateType
+      # + npm audit signatures) is the ARCHITECT's post-release step, after propagation.


### PR DESCRIPTION
## Context

Issue #238 (standing supply-chain posture), PR 4 of 5 — the **release-critical** one (M6 in
`plans/issue-238/dossier.md`). This PR hardens the npm publish path: it is **isolated** (only
`publish.yml` + `dependabot.yml` change — no source, no other workflow, no `package.json`) and
**canaried** (a post-merge dry-run before the next real release, run by the architect, not this
PR).

**The I7 hazard being fixed:** today's `publish.yml` grants `id-token: write` workflow-wide, so
`npm ci` and `npm run build` — which execute untrusted dependency and build code — run *with
access to the OIDC token*. A compromised build-time dependency could exfiltrate it and forge
provenance or publish malicious packages. This PR splits build (no token) from publish (token), so
no dependency code ever sees the credential.

## Motivation

Three facts were established by grounding before writing any YAML (source-traced, not assumed):

1. **`--provenance` is fail-closed and is real hardening.** With the explicit flag, npm throws
   `EUSAGE` *before* the registry PUT if it cannot generate provenance. realm's *current* plain
   `npm publish` only gets provenance via a silent best-effort auto-enable, wrapped in a
   failure-swallowing try/catch — it would publish provenance-*less* without erroring on any
   failure. The explicit flag converts best-effort into fail-closed.
2. **The build/publish split is provenance-safe** (verified against `libnpmpublish`): the
   provenance subject digest is packed in the *publish* job and every predicate field is read from
   the *publish* job's `GITHUB_*` env — the no-token build job neither needs nor touches OIDC. Both
   jobs run in one workflow run at one commit (the `v*` tag), so the attestation stays truthful.
3. **`npm publish --dry-run` is provenance-blind** — npm skips the provenance packaging entirely
   under `--dry-run`. So the post-merge dry-run canary validates plumbing only (checkout, artifact
   round-trip, pin-deps, pack, version-collision check) — never OIDC/provenance/the actual PUT.

## Changes

- **`.github/workflows/publish.yml`** — split into two jobs:
  - **`build`** (`permissions: {contents: read}` — no `id-token`, asserted at runtime via an
    `ACTIONS_ID_TOKEN_REQUEST_URL` guard step): `npm ci --ignore-scripts` → `npm run audit:ci` (the
    same prod-high gate CI uses, as a release-time backstop) → `npm run build` → archives
    `packages/*/dist` into a single `dist.tar.gz` (from the workspace root, so paths round-trip
    exactly as `packages/<pkg>/dist/...` — sidestepping `upload-artifact`'s
    least-common-ancestor path-stripping, which a `packages/*/dist` glob upload would trigger) →
    uploads that one tarball as the `dist` artifact.
  - **`publish`** (`needs: build`, `permissions: {contents: read, id-token: write}`): downloads and
    untars the artifact, asserts each of the four `packages/<pkg>/dist` directories exists, runs
    `pin-deps.mjs` (Node builtins only, no install needed), then publishes all four packages —
    **never running `npm ci`/`npm install`/`npm run build` itself.** Every `npm publish` call now
    carries `--provenance --ignore-scripts`, comment-flagged as load-bearing so a future edit can't
    silently drop `--provenance`. Publish order unchanged: `core → mcp-server → testing → cli`.
  - **`workflow_dispatch`** added as a manually-triggerable dry-run canary. The safety invariant:
    `DRY_RUN: ${{ github.event_name != 'push' }}`. This workflow's only `push` trigger is
    `tags: ['v*']`, so any push-triggered run of *this* workflow is, by construction, a `v*` tag
    push (a non-matching push never creates a run at all) — `DRY_RUN='false'`, real publish, always.
    Any `workflow_dispatch` — regardless of ref or inputs — always reports
    `github.event_name == 'workflow_dispatch'` → `DRY_RUN='true'` → `--dry-run` appended to every
    publish call, so a dispatch can **never** real-publish. Full evaluation proof in Verification.
  - `concurrency: {group: publish-${{ github.ref }}, cancel-in-progress: false}` serializes
    releases without ever cancelling a run mid-partial-publish (which would strand a release).
  - No in-workflow registry-query provenance verify — a successful `--provenance` publish already
    *is* the fail-closed guarantee; querying `npm view`/`npm audit signatures` right after publish
    risks a false failure from registry-propagation delay on a release that actually succeeded.
    That confirmation is the architect's post-release, post-propagation step (see below).
- **`.github/dependabot.yml`** — a second, independent `github-actions` ecosystem update block:
  weekly, `cooldown: {default-days: 7}` (the *only* cooldown sub-key this ecosystem supports —
  `semver-*-days` and `dependency-type` are both unsupported for `github-actions`, confirmed against
  the live Dependabot docs, not assumed), one `github-actions` group with `patterns: ['*']` so every
  action bump across every workflow lands in a single PR. This block is honored **procedurally, not
  by config** — `github-actions` has no per-file scope and `ignore` is repo-wide, so a shared-action
  bump (checkout/setup-node) will touch `publish.yml` in the same grouped PR as the other workflows;
  the teeth are that this group must stay **out of PR5's auto-merge allow-list** and CODEOWNERS
  already routes `publish.yml` to `@mihai-r-lupu`. This block also auto-covers the two new
  `upload-artifact`/`download-artifact` actions with zero extra config. The existing `npm` block is
  byte-unchanged (confirmed via diff — this is a pure addition).

### SHA-pin resolution (all four actions, independently verified)

`actions/checkout`/`actions/setup-node` reuse the exact SHAs the other workflows already pin
(re-verified, not assumed). `actions/upload-artifact` and `actions/download-artifact` are on
**independent** version lines — resolved to their own current majors (v7 and v8 respectively, *not*
the 3-4-majors-stale v4 a supply-chain-hardening PR must not ship), each cross-checked two
independent ways:

```
gh api repos/actions/upload-artifact/commits/v7        # 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
gh api repos/actions/upload-artifact/commits/v7.0.1     # 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  (same)
git ls-remote https://github.com/actions/upload-artifact refs/tags/v7
  043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  refs/tags/v7   (lightweight tag — no peel needed)

gh api repos/actions/download-artifact/commits/v8       # 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
gh api repos/actions/download-artifact/commits/v8.0.1    # 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c (same)
git ls-remote https://github.com/actions/download-artifact refs/tags/v8
  3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  refs/tags/v8   (lightweight tag — no peel needed)
```

Both are lightweight tags (unlike `codeql-action`'s annotated `v3` from PR1) — `git ls-remote`
resolves them directly to the commit, matching `gh api`'s result exactly.

## Verification

```bash
# 1. YAML valid + structure
node -e "const yaml=require('js-yaml'),fs=require('fs');
  const doc=yaml.load(fs.readFileSync('.github/workflows/publish.yml','utf8'));
  console.log('on:', JSON.stringify(doc.on));
  console.log('workflow permissions:', JSON.stringify(doc.permissions));
  console.log('build permissions:', JSON.stringify(doc.jobs.build.permissions));
  console.log('publish needs:', doc.jobs.publish.needs, 'permissions:', JSON.stringify(doc.jobs.publish.permissions))"
#   on: {"push":{"tags":["v*"]},"workflow_dispatch":{}}
#   workflow permissions: {}
#   build permissions: {"contents":"read"}          <- no id-token
#   publish needs: build permissions: {"contents":"read","id-token":"write"}

# 2. Tag-push ⇒ real-publish AND dispatch ⇒ always-dry-run — evaluated computationally
node -e "
function simulate(eventName) {
  const DRY_RUN = String(eventName !== 'push');
  const flag = (DRY_RUN === 'true' && '--dry-run') || '';
  return { eventName, DRY_RUN, flag: flag || '(none — real publish)' };
}
console.log(simulate('push'));               // { eventName: 'push', DRY_RUN: 'false', flag: '(none — real publish)' }
console.log(simulate('workflow_dispatch'));  // { eventName: 'workflow_dispatch', DRY_RUN: 'true', flag: '--dry-run' }
"
# GitHub's own docs (events-that-trigger-workflows): the push webhook event reports
# github.event_name == 'push' for BOTH branch and tag pushes, differentiated only by github.ref
# (refs/heads/... vs refs/tags/...) — and workflow_dispatch always reports
# github.event_name == 'workflow_dispatch' regardless of which ref/inputs triggered it. Since this
# workflow's `on:` block declares ONLY `push: {tags: ['v*']}` (so a push to anything NOT matching
# v* never creates a run of THIS workflow at all — the tag filter is enforced before the workflow
# starts) and `workflow_dispatch: {}`, every run's event_name is one of exactly these two values,
# and "push-triggered run of this workflow" and "v* tag push" are equivalent by construction.
# No ref/input lets a dispatch real-publish; no event makes a tag push dry-run.

# 3. SHA-pins — all four 40-hex + # vN, independent majors
grep -oP 'uses:\s*\S+@\K[a-f0-9]+(?=\s)' .github/workflows/publish.yml | awk '{print length($0), $0}'
#   40 fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09   (checkout, x2)
#   40 a0853c24544627f65ddf259abe73b1d18a591444   (setup-node, x2)
#   40 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   (upload-artifact v7)
#   40 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c   (download-artifact v8)

# 4. --provenance --ignore-scripts on all 4 steps; order; no npm ci/build in the publish job
sed -n '/^  publish:/,$p' .github/workflows/publish.yml > /tmp/publish-job-only.yml
grep -c -- "--provenance --ignore-scripts" /tmp/publish-job-only.yml   # 4
grep -E "npm ci|npm install|npm run build" /tmp/publish-job-only.yml   # (no output)
grep "name: Publish @" /tmp/publish-job-only.yml
#   Publish @sensigo/realm / @sensigo/realm-mcp / @sensigo/realm-testing / @sensigo/realm-cli
# Artifact round-trip: build's `tar -czf dist.tar.gz packages/*/dist` runs from the workspace root
# (right after checkout, no working-directory override) so archived paths are exactly
# packages/<pkg>/dist/...; upload path is the single dist.tar.gz FILE (not a directory glob), so
# upload-artifact's LCA path-stripping never applies; publish downloads to `.` (workspace root) and
# `tar -xzf dist.tar.gz` restores the identical relative paths, then asserts each of
# packages/{core,mcp-server,testing,cli}/dist exists before any publish call.

# 5. dependabot.yml — new block parses, npm block unchanged
node -e "const yaml=require('js-yaml'),fs=require('fs');
  const doc=yaml.load(fs.readFileSync('.github/dependabot.yml','utf8'));
  console.log(doc.updates.length, doc.updates[1]['package-ecosystem'],
    JSON.stringify(doc.updates[1].cooldown), JSON.stringify(doc.updates[1].groups))"
#   2 github-actions {"default-days":7} {"github-actions":{"patterns":["*"]}}
git diff main -- .github/dependabot.yml   # (shows a pure addition at EOF — npm block untouched)

# 6. Touch list
git diff --stat main
#   .github/dependabot.yml        |  12 +++++
#   .github/workflows/publish.yml | 110 +++++++++++++++++++++++++++++++-----------
#   2 files changed, 94 insertions(+), 28 deletions(-)

# Full suite unaffected (no source touched)
npx turbo run test --force && npm run lint && npm run format:check && npm run build
```

**Item 7 — the live canary/publish was NOT and cannot be run by this PR.** `workflow_dispatch` is
not dispatchable on a branch until the workflow file exists on the repository's default branch (a
GitHub platform constraint, not a choice), and a real publish needs a version bump + a `v*` tag —
neither exists yet on this branch. This PR therefore verifies structure, permissions, the
`DRY_RUN` logic, the SHA-pins, the artifact round-trip, and the dependabot block — never a live
run. **The architect runs the post-merge dry-run canary and gates the first real release** (see
"Post-merge — architect" in the prompt / report for the exact runbook: trigger
`gh workflow run publish.yml --ref main` post-merge to validate plumbing only; after the first real
release, confirm SLSA provenance out-of-band via `npm view <pkg>@<ver> --json` +
`npm audit signatures`, post-propagation).

## Rollback

```bash
git revert HEAD
```

Reverting restores the single-job, `npm ci`+`npm run build`-with-token workflow exactly. No
release has been cut under the new workflow yet (this PR predates the next real release), so there
is no partial-release state to reconcile — a straight revert is safe. If a release WERE ever
partially published under the new workflow, npm's immutability means the fix is always a re-cut at
the next patch (never a same-tag re-run — already-published packages 409).

## Related

- Issue #238 (standing supply-chain posture) — PR 4 of 5. Design record: `plans/issue-238/dossier.md`
  (M6). Full report with per-item verification transcripts: `reports/publish-hardening-238-pr4.md`
  (local-only, not part of this diff).
- Follows PR1 (#244), PR2 (#260), PR3 (#261) — this PR reuses PR1's `audit:ci` script (via the
  build job's release-audit backstop) and the checkout/setup-node SHA-pin precedent.
- Next: PR5 (OpenSSF Scorecard + graduated auto-merge — the `github-actions` Dependabot group added
  here must stay out of PR5's auto-merge allow-list, same as `build-toolchain`/`linters`).
