### PR TITLE
chore: release v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.31.1] — 2026-07-24
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4733,7 +4733,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4784,7 +4784,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -4829,7 +4829,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4850,7 +4850,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.31.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.31.1');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,7 +106,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.31.0';
+export const VERSION = '0.31.1';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.31.0';
+export const VERSION = '0.31.1';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.31.0',
+    version: '0.31.1',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -57,4 +57,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.31.0';
+export const VERSION = '0.31.1';


### PR DESCRIPTION
## Context

Release **v0.31.1** (patch). Ships the `ajv` 8.20 dependency bump, and — deliberately — is the **first release through the hardened split `publish.yml`** (#238 PR4), validating the real OIDC-publish + SLSA-provenance path end-to-end (the dry-run canary is provenance-blind by design).

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `[0.31.1] — 2026-07-24`.
- Version 0.31.0 → 0.31.1 across all four `package.json`, the five source `VERSION` constants, and the lockfile self-versions (atomic, via `scripts/release.mjs`).
- Consumer-facing content: `ajv` 8.18 → 8.20 (core prod dependency; behaviour-neutral — realm never enables `$data`, requires Node ≥22).

## Verification

- Release script ran clean: build sanity-check green; 4 packages + 5 `VERSION` + lockfile bumped atomically; tag `v0.31.1` on the release commit.
- **Post-merge** (`git push --tags`) triggers the new split `publish.yml`: build job (no id-token) → publish job (`--provenance` fail-closed). Provenance then confirmed on all four via `npm view <pkg>@0.31.1 --json` → `predicateType == slsa.dev/provenance/v1` + `npm audit signatures`, plus a clean-install ESM `VERSION` check.

## Rollback

npm is immutable; `--provenance` is fail-closed (a broken publish ships nothing). On a partial/failed publish, re-cut at 0.31.2 — never re-run the same tag after a successful PUT.

## Related

#238 PR4 — this release is its first-real-release validation gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
