### PR TITLE
ci(repo): OpenSSF Scorecard + README Security + graduated Dependabot auto-merge (issue #238 PR5)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write # enable + complete the merge
+  pull-requests: write # enable auto-merge on the PR
+
+jobs:
+  auto-merge:
+    # Only Dependabot's OWN PRs. user.login (not github.actor — a human re-run would flip github.actor to the human).
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0 (lightweight tag; commit SHA is the pin)
+      # GRADUATED rollout — dev-patch ONLY for now. The `dependency-group == 'dev-patch'` clause is the LOAD-BEARING
+      # exclusion: security-updates, prod, majors, build-toolchain, linters, and the github-actions group are all NOT
+      # members of the dev-patch group, so every one of them fails this clause. dependency-type + update-type are
+      # defense-in-depth. All `==` (never `!=`) so any empty/unexpected/errored metadata ⇒ false ⇒ NO merge (fail-safe).
+      # WIDEN to dev-minor LATER (a separate change, after a clean dev-patch canary) by pairing update-type WITH group:
+      #   ( (update-type == 'version-update:semver-patch' && dependency-group == 'dev-patch') ||
+      #     (update-type == 'version-update:semver-minor' && dependency-group == 'dev-minor') )
+      - name: Enable native auto-merge for eligible dev-patch updates
+        if: >
+          steps.meta.outputs.dependency-type == 'direct:development' &&
+          steps.meta.outputs.update-type == 'version-update:semver-patch' &&
+          steps.meta.outputs.dependency-group == 'dev-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule: # re-scores Branch-Protection when the ruleset changes (default branch only)
+  schedule:
+    - cron: '30 1 * * 6' # weekly, Sat 01:30 UTC — refreshes the Maintained check + the published badge
+  push:
+    branches: [main]
+
+permissions: read-all # Scorecard's Token-Permissions check rewards a read-only workflow default
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF to the code-scanning dashboard
+      id-token: write # OIDC token required by publish_results (the public badge + OpenSSF API)
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false # Scorecard best practice — reduces credential exposure
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4 (PEELED commit, not the tag-object)
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true # publishes the score for the badge + REST API (needs id-token:write; default branch only)
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3 (reuse codeql.yml's pin)
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Realm
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sensigo-hq/realm/badge)](https://scorecard.dev/viewer/?uri=github.com/sensigo-hq/realm)
+
 **The agent calls Realm. Every other tool calls the agent.**
 
 Most AI workflow platforms orchestrate LLMs as services: the platform decides when to call the model, what to send, and what to do with the result. Realm inverts this. The agent calls `execute_step` via MCP. Realm's state machine responds with the current step's task and schema. The agent executes. It cannot skip steps, produce malformed output, or proceed past a human gate — not because of instructions it might ignore, but because the state cannot change until valid output is submitted.
@@ -198,6 +200,20 @@ npm run build        # compile all packages
 npm run test         # run all tests
 npm run lint         # lint all packages
 ```
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for how to report a vulnerability (GitHub private vulnerability
+reporting — do not open a public issue or PR) and for how dependency advisories are triaged.
+
+Every `@sensigo/*` package is published from CI via npm **trusted publishing**, with **SLSA build
+provenance** attached to every release. Verify the provenance of an installed package with:
+
+```bash
+npm audit signatures
+```
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sensigo-hq/realm/badge)](https://scorecard.dev/viewer/?uri=github.com/sensigo-hq/realm)
 
 ## License
 


### PR DESCRIPTION
## Context

Issue #238 (standing supply-chain posture) — PR 5 of 5, **the last one**. Design record:
`plans/issue-238/dossier.md` (S1 auto-merge, S2 Scorecard, S5 README Security). This PR adds the
measurement layer (Scorecard + badge), the visible signal (README Security section), and the
velocity differentiator (graduated Dependabot auto-merge). It measures what PR1–4 built; it does
not touch the release path.

Repo settings this PR depends on are already in place (architect-verified, not changed here):
`allow_auto_merge` + `allow_squash_merge` are on; the `main` ruleset requires `ci` + `Analyse
TypeScript` + `CodeQL` with no review requirement, so `gh pr merge --auto` needs no approval to
eventually complete.

## Motivation

Scorecard gives a continuously-refreshed, third-party-comparable score for everything PR1–4
built (pinned actions, least-privilege tokens, the audit-ci gate, SECURITY.md, CodeQL/SAST). The
README Security section makes that posture visible to anyone landing on the repo. Graduated
auto-merge is the velocity payoff: routine dev-patch bumps (a narrow, low-risk, well-understood
class) merge themselves once CI is green, while everything else — prod, majors, the build
toolchain, linters, GitHub Actions, and any security update — still needs a human, by construction
of the same `if:` clause.

## Changes

- **`.github/workflows/scorecard.yml`** (new) — `branch_protection_rule` + weekly schedule + `push:
  [main]` triggers (deliberately **no** `pull_request` — `publish_results` only works from the
  default branch; a PR run would publish nothing). Top-level `permissions: read-all` (rewards
  Scorecard's own Token-Permissions check); job permissions exactly `{security-events: write,
  id-token: write}` (`contents`/`actions: read` are correctly omitted — those are only needed for
  private repos, and realm is public). Runs `ossf/scorecard-action` SHA-pinned to its **peeled**
  `v2.4.4` commit (it's an annotated tag — the same trap PR1 found in `codeql-action`, reproduced
  and independently re-verified here) with `publish_results: true` and `persist-credentials:
  false`, then uploads the SARIF via `codeql.yml`'s existing `upload-sarif` pin.
- **`.github/workflows/dependabot-auto-merge.yml`** (new) — `on: pull_request` (never
  `pull_request_target`: since 2021-10, `pull_request` runs from the same repo respect the
  workflow's own `permissions:` key, restoring write scopes without `pull_request_target`'s
  untrusted-checkout hazard — and this workflow has no checkout at all). Gated on
  `github.event.pull_request.user.login == 'dependabot[bot]'` (not `github.actor`, which flips to
  the human on a manual re-run). `dependabot/fetch-metadata` (SHA-pinned) feeds a fail-safe,
  all-`==` `if:` — `dependency-type == 'direct:development' && update-type ==
  'version-update:semver-patch' && dependency-group == 'dev-patch'` — graduated to **dev-patch
  only** for now. `gh pr merge --auto --squash` only *queues* the merge; GitHub completes it only
  once the ruleset's required checks (`ci` including the audit-ci gate, `Analyse TypeScript`,
  `CodeQL`) actually pass, so a red CI blocks it indefinitely.
- **`README.md`** — an OpenSSF Scorecard badge (`api.scorecard.dev`, the current domain, not the
  legacy `securityscorecards.dev`) near the top, and a new `## Security` section before `##
  License`: a link to `SECURITY.md` for reporting + the triage stance, a statement that every
  `@sensigo/*` package publishes via npm trusted publishing with SLSA build provenance (with the
  `npm audit signatures` verification command), and the badge again.

## Verification

```bash
# 1. Scorecard YAML — structure, triggers, permissions
node -e "const yaml=require('js-yaml'),fs=require('fs');
  const doc=yaml.load(fs.readFileSync('.github/workflows/scorecard.yml','utf8'));
  console.log(Object.keys(doc.on), 'push:', JSON.stringify(doc.on.push));
  console.log('has pull_request:', 'pull_request' in doc.on);
  console.log(doc.permissions, JSON.stringify(doc.jobs.analysis.permissions))"
#   [ 'branch_protection_rule', 'schedule', 'push' ] push: {"branches":["main"]}
#   has pull_request: false
#   read-all {"security-events":"write","id-token":"write"}

# SHA-pin resolution — scorecard-action's annotated-tag trap, reproduced and confirmed
gh api repos/ossf/scorecard-action/commits/v2.4.4 --jq .sha
#   2d1146689b8cda280b9bc96326124645441f03bc
git ls-remote https://github.com/ossf/scorecard-action refs/tags/v2.4.4
#   55891bbd73f2425e97637d96e306fc9d491d0b21  refs/tags/v2.4.4        <- WRONG (tag object)
git ls-remote https://github.com/ossf/scorecard-action 'refs/tags/v2.4.4^{}'
#   2d1146689b8cda280b9bc96326124645441f03bc  refs/tags/v2.4.4^{}    <- correct (peeled), matches
# checkout + codeql-action/upload-sarif SHAs re-verified identical to ci.yml/codeql.yml's existing pins.
# dependabot/fetch-metadata@v3.1.0 confirmed a LIGHTWEIGHT tag (ls-remote resolves it directly,
# matching gh api commits/v3.1.0): 25dd0e34f4fe68f24cc83900b1fe3fe149efef98

# 2. Auto-merge YAML — structure + the fail-safe if: reasoning for every excluded class
node -e "const yaml=require('js-yaml'),fs=require('fs');
  const doc=yaml.load(fs.readFileSync('.github/workflows/dependabot-auto-merge.yml','utf8'));
  console.log('on:', doc.on, '(not pull_request_target)');
  console.log(JSON.stringify(doc.permissions));
  console.log('has checkout:', doc.jobs['auto-merge'].steps.some(s=>s.uses&&s.uses.includes('checkout')));
  console.log('has npm ci:', JSON.stringify(doc).includes('npm ci'))"
#   on: pull_request (not pull_request_target)
#   {"contents":"write","pull-requests":"write"}
#   has checkout: false / has npm ci: false
```

Fail-safe `if:` reasoning, per excluded class (every `==`, never `!=`, so any empty/unexpected
value defaults to false — verified against `dependabot/fetch-metadata`'s own documented outputs,
not assumed):

| Excluded class | Fails on |
|---|---|
| A **prod** PR | `dependency-type` is `direct:production` ≠ `direct:development` (conjunct 1), and `dependency-group` is `prod` ≠ `dev-patch` (conjunct 3) — two conjuncts fail |
| A **major** update | `update-type` is `version-update:semver-major` ≠ `...semver-patch` (conjunct 2); majors also fall outside every configured group in `dependabot.yml` (all groups scope to minor/patch only), so `dependency-group` is empty — conjunct 3 also fails |
| A **build-toolchain** PR | `dependency-group` is `build-toolchain` ≠ `dev-patch` (conjunct 3) |
| A **linters** PR | `dependency-group` is `linters` ≠ `dev-patch` (conjunct 3) |
| A **github-actions**-group PR | `dependency-group` is `github-actions` ≠ `dev-patch` (conjunct 3) |
| A **security update** | `fetch-metadata`'s own docs: `dependency-group` is "otherwise... an empty string" for any PR not in a group opted into `applies-to: security-updates` — none of realm's groups declare that — so `dependency-group` is `''` ≠ `dev-patch` (conjunct 3), **regardless of what `update-type` happens to be** (a security patch could otherwise satisfy conjunct 2) |

`dependency-group == 'dev-patch'` (conjunct 3) is therefore the single clause sufficient to exclude
every one of these classes on its own — confirmed against `dependabot/fetch-metadata`'s documented
output semantics (fetched live before writing this analysis), not merely asserted.

```bash
# 3. README
grep -n "scorecard.dev\|## Security\|SECURITY.md\|npm audit signatures\|trusted publishing\|SLSA" README.md
#   (badge line, ## Security heading, SECURITY.md link, npm audit signatures, trusted publishing + SLSA mentions, badge again)

# 4. Touch list
git diff --stat main
#   .github/workflows/dependabot-auto-merge.yml | 33 +++++++++++++++++++++++++++++
#   .github/workflows/scorecard.yml             | 32 ++++++++++++++++++++++++++++
#   README.md                                   | 16 ++++++++++++++
#   3 files changed, 81 insertions(+)
# Confirmed absent from the diff: ci.yml, codeql.yml, publish.yml, scheduled-audit.yml,
# dependabot.yml, package.json, and every source file.

# Full suite unaffected (no source touched)
npx turbo run test --force && npm run lint && npm run build
```

**Item 5 — honest expectations, not overclaimed.** After PR1–4, realm should score well on
Pinned-Dependencies, Token-Permissions, Dependency-Update-Tool, Security-Policy, SAST,
Dangerous-Workflow, and Maintained. Accepted, expected deductions: Code-Review (solo repo, no
second reviewer available), Fuzzing, CII-Best-Practices, and — explicitly **not** claimed as a win
here — **Signed-Releases**, which Scorecard scores from GitHub *Release assets* carrying signed
provenance, not from npm-registry provenance; realm has zero GitHub Releases today, so this PR does
not claim that check. The badge will show **no data** immediately after merge — it only populates
once the first `publish_results` run completes on `main`, post-merge.

## Rollback

```bash
git revert HEAD
```

Pure CI-infra + documentation addition — reverting removes both workflows and the README changes
with no other effect. The auto-merge workflow has not merged any PR yet (this repo's Dependabot
PRs so far predate it), so there is no in-flight auto-merge state to reconcile.

## Related

- Issue #238 (standing supply-chain posture) — **PR 5 of 5, the last one.** Design record:
  `plans/issue-238/dossier.md`. Full verification transcripts:
  `reports/scorecard-automerge-238-pr5.md` (local-only).
- Follows PR1 (#244), PR2 (#260), PR3 (#261), PR4 (#262, merged + validated by the v0.31.1
  release).
- Post-merge / architect follow-ups (not this PR): observe the first dev-patch Dependabot PR
  auto-merge cleanly, then widen the `if:` to dev-minor; create GitHub Releases with attached
  `.intoto.jsonl` provenance assets to earn Signed-Releases; optionally add a read-only
  `SCORECARD_TOKEN` PAT for full Branch-Protection scoring.
