### PR TITLE
docs(changelog): record uuid 14 bump under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Bumped `uuid` from 13 to 14 (a `@sensigo/realm` core production dependency). The `v4` ID-generation API is
+  unchanged, and uuid 14's raised Node floor (20) sits below realm's own `>=22` requirement — behaviour-neutral;
+  consumers receive only a resolved-version update.
+
+---
+
 ## [0.31.1] — 2026-07-24
 
 ### Changed


### PR DESCRIPTION
## Context

A doc-accuracy nuance surfaced during issue #238 PR3's OpenVEX work (and confirmed again during
PR5's grounding): the `notes` field on the `GHSA-frvp-7c67-39w9` allowlist entry in **both**
`audit-ci.jsonc` and `audit-ci.tier2.jsonc` read "…realm **stdio-only**, serve-static never
registered…". That "stdio-only" characterization is imprecise — `@sensigo/realm-cli`'s `realm
serve` command does use an HTTP transport (`@modelcontextprotocol/sdk`'s
`StreamableHTTPServerTransport`, which imports `@hono/node-server`'s `getRequestListener`).

## Motivation

The suppression's **conclusion was always correct** — the vulnerable `serve-static` (CWE-22)
handler is never imported or registered anywhere, so `not_affected` holds regardless — but the
*rationale* was wrong. `SECURITY.md` (issue #238 PR3) designates the `audit-ci` allowlist as the
**canonical** suppression record that the OpenVEX document (`security/vex/GHSA-frvp-7c67-39w9.openvex.json`)
mirrors. The canonical record should not carry a false rationale while its own mirror already
states the accurate one.

## Changes

Replaced the `notes` string on the `GHSA-frvp-7c67-39w9` allowlist entry in both `audit-ci.jsonc`
and `audit-ci.tier2.jsonc` — the exact same edit in both files, since the guard
(`scripts/check-audit-allowlist.mjs`) enforces tier-1 ⊆ tier-2 and the two entries are meant to
stay byte-identical.

```diff
- "notes": "not_affected (VEX): @hono/node-server serve-static/CWE-22 unreachable — realm
-   stdio-only, serve-static never registered. MODERATE<high so inert here; kept as the future
-   re-score-to-HIGH escape hatch. Upstream fix: @modelcontextprotocol/sdk ->
-   @hono/node-server >=2.0.5.",
+ "notes": "not_affected (VEX): @hono/node-server's vulnerable serve-static (CWE-22) handler is
+   never imported or registered — neither by realm's own source nor by the only
+   @hono/node-server code path realm reaches (@modelcontextprotocol/sdk's
+   StreamableHTTPServerTransport -> getRequestListener, used by realm-cli's serve command). So
+   the vulnerable path is unreachable. Windows-only advisory; realm deploys to macOS/Linux.
+   MODERATE<high so inert here; kept as the future re-score-to-HIGH escape hatch. Upstream fix:
+   @modelcontextprotocol/sdk -> @hono/node-server >=2.0.5.",
```

Everything else in the entry is unchanged: `active: true`, `expiry: "2027-01-31"`, the GHSA id,
the `MODERATE<high so inert here`/re-score-to-HIGH-escape-hatch/upstream-fix clauses. No config
structure, no `high`/`skip-dev`/`moderate` gate setting, no other file touched.

## Verification

```bash
# 1. Guard still passes (GHSA-id-only + tier-1 ⊆ tier-2 — the note change is invisible to the
#    guard's own checks, confirming no regression)
node scripts/check-audit-allowlist.mjs
#   ✓ audit-ci.jsonc: allowlist[0]: 'GHSA-frvp-7c67-39w9' is a valid GHSA-scoped entry.
#   ✓ audit-ci.tier2.jsonc: allowlist[0]: 'GHSA-frvp-7c67-39w9' is a valid GHSA-scoped entry.
#   ✓ tier-1 ⊆ tier-2: every tier-1 allowlist entry is also present in tier-2.
#   audit allowlist guard passed — every entry is GHSA-scoped, tier-1 ⊆ tier-2.

# 2. Both audit gates still pass (the suppression is functional, unaffected by the note text)
npm run audit:ci    # Passed npm security audit. (prod-high clean)
npm run audit:full  # Found vulnerable allowlisted advisories: GHSA-frvp-7c67-39w9. / Passed npm security audit.

# 3. The two files' notes are byte-identical
diff <(node -e "console.log(require('json5').parse(require('fs').readFileSync('audit-ci.jsonc','utf8')).allowlist[0]['GHSA-frvp-7c67-39w9'].notes)") \
     <(node -e "console.log(require('json5').parse(require('fs').readFileSync('audit-ci.tier2.jsonc','utf8')).allowlist[0]['GHSA-frvp-7c67-39w9'].notes)")
#   (no output — identical)

# 4. Wording content check
node -e "
const note = require('json5').parse(require('fs').readFileSync('audit-ci.jsonc','utf8')).allowlist[0]['GHSA-frvp-7c67-39w9'].notes;
console.log('stdio-only present:', note.includes('stdio-only'));               // false
console.log('StreamableHTTPServerTransport present:', note.includes('StreamableHTTPServerTransport')); // true
console.log('getRequestListener present:', note.includes('getRequestListener'));           // true
console.log('realm-cli present:', note.includes('realm-cli'));                 // true
console.log('never imported or registered present:', note.includes('never imported or registered')); // true
console.log('MODERATE<high preserved:', note.includes('MODERATE<high'));       // true
console.log('upstream fix preserved:', note.includes('>=2.0.5'));              // true
"

# 5. Touch list
git diff --stat main
#   audit-ci.jsonc       | 2 +-
#   audit-ci.tier2.jsonc | 2 +-
#   2 files changed, 2 insertions(+), 2 deletions(-)

# Full suite unaffected (config-note-only change)
npx turbo run test --force && npm run lint && npm run format:check
```

## Rollback

```bash
git revert HEAD
```

Pure documentation-string change inside two config files — reverting restores the prior (accurate
conclusion, imprecise rationale) wording with no functional effect either way.

## Related

- Follows issue #238 PR3 (#261, OpenVEX + SECURITY.md — designates the allowlist canonical) and
  PR5 (#268, where the grounding for this fix was reconfirmed).
