### PR TITLE
docs(changelog): record commander 15 bump under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project are documented here.
 - Bumped `uuid` from 13 to 14 (a `@sensigo/realm` core production dependency). The `v4` ID-generation API is
   unchanged, and uuid 14's raised Node floor (20) sits below realm's own `>=22` requirement — behaviour-neutral;
   consumers receive only a resolved-version update.
+- Bumped `commander` from 14 to 15 (a `@sensigo/realm-cli` production dependency). realm-cli imports it as ESM, so
+  commander 15's ESM migration is transparent and its `require(esm)` Node-22.12 note (which applies only to
+  CommonJS `require('commander')`) does not affect realm — the `Command`/subcommand API is unchanged and the full
+  CLI test suite passes. Behaviour-neutral.
 
 ---
 


### PR DESCRIPTION
## Context

Records the `commander` 14→15 major bump merged in #264. commander is a `@sensigo/realm-cli` **production** dependency, so it ships to consumers and belongs in the changelog (per the established pattern, cf. #271 uuid / #257 ajv).

## Changes

- Add a `### Changed` entry under `[Unreleased]` for the commander 14→15 bump, noting it is behaviour-neutral for realm: realm-cli imports commander as **ESM**, so commander 15's ESM migration is transparent and its `require(esm)`-only Node-22.12 requirement does **not** apply (that path is for CommonJS `require('commander')`, which realm never uses). The `Command`/subcommand API is unchanged; the full CLI suite passes. **No `engines` change** — realm's `>=22.0.0` already satisfies commander 15 (`engines: >=20`).

## Verification

- `commander` resolves to 15.x in `packages/cli` on `main`; realm's `engines` unchanged at `>=22.0.0`.
- CI's 827 cli tests passed on #264 — behaviour-neutral confirmed.

## Rollback

```bash
git revert HEAD
```

Docs-only.

## Related

- #264 (the commander bump) · #238 (supply-chain program)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
