### PR TITLE
chore(deps): bump the github-actions group uniformly (checkout v7.0.1, setup-node v7.0.0, codeql-action v4.37.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     env:
       TURBO_TELEMETRY_DISABLED: '1'
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,14 +17,14 @@ jobs:
     name: Analyse TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript-typescript
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
             echo "::error::id-token must not be available in the build job"; exit 1
           fi
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
       - run: npm ci --ignore-scripts
@@ -58,8 +58,8 @@ jobs:
     env:
       DRY_RUN: ${{ github.event_name != 'push' }} # real publish ONLY on a v* tag PUSH; ANY workflow_dispatch → dry-run (can never real-publish)
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -14,8 +14,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
       security-events: write # upload the SARIF to the code-scanning dashboard
       id-token: write # OIDC token required by publish_results (the public badge + OpenSSF API)
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false # Scorecard best practice — reduces credential exposure
       - name: Run Scorecard analysis
@@ -27,6 +27,6 @@ jobs:
           results_format: sarif
           publish_results: true # publishes the score for the badge + REST API (needs id-token:write; default branch only)
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3 (reuse codeql.yml's pin)
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1 (reuse codeql.yml's pin)
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Context

Dependabot PR #266 bumps the pinned GitHub Actions in the `github-actions` group to new majors:
`actions/checkout` v5→v7.0.1, `actions/setup-node` v5→v7.0.0, `github/codeql-action` v3→v4.37.1.
Each bump was independently grounded and verified safe to take:

- **checkout v5→v7.0.1** — no realm-relevant behaviour change (realm uses no
  `pull_request_target`/`workflow_run`, no post-checkout git auth ops; the Node action-runtime is
  node24 throughout v5–v7).
- **setup-node v5→v7.0.0** — v7 removes the dummy `NODE_AUTH_TOKEN` placeholder, which is
  **pro-OIDC** (it fixes `.npmrc` corruption during trusted publishing); realm sets `cache: 'npm'`
  explicitly so v6's auto-cache restriction is a no-op. Net-positive for the publish path.
- **codeql-action v3→v4.37.1** — the entire v3→v4 major is a Node20→Node24 action-runtime move
  (Node 20 EOLs April 2026; there is no v4.0.0 — the major landed at v4.30.7 continuing v3's minor
  numbering). realm runs on `ubuntu-latest`, unaffected; v3 is scheduled for deprecation
  ~December 2026, so moving now clears its future warnings.

## Motivation

#266 touches `ci.yml`, `codeql.yml`, `publish.yml`, and `scheduled-audit.yml` but **misses
`scorecard.yml`** (added later, in issue #238 PR5, #268). Merging #266 as-is would strand
`scorecard.yml` on checkout v5 + codeql-action v3 — a split-version state, and self-defeating for
the very workflow that scores Pinned-Dependencies. This PR bumps **all five** workflows uniformly
instead.

**Explicitly not this PR's job** (architect-only, post-merge): closing #266 (Dependabot will also
auto-close it once `main` reaches its target versions), running the `publish.yml` dry-run canary,
or gating the next real release on the OIDC path. None of that is attempted here.

## Changes

Exactly 13 `uses:` pin lines changed across exactly 5 files — a 1-for-1 SHA+comment swap on each,
nothing else touched:

- **`actions/checkout`** (6 sites: `ci.yml:17`, `codeql.yml:20`, `scorecard.yml:20`,
  `publish.yml:28`, `publish.yml:61`, `scheduled-audit.yml:17`) — `fbc6f39… # v5` →
  `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`.
- **`actions/setup-node`** (4 sites: `ci.yml:18`, `publish.yml:29`, `publish.yml:62`,
  `scheduled-audit.yml:18`) — `a0853c2… # v5` → `820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`.
- **`github/codeql-action`** (3 sites: `codeql.yml:23` init, `codeql.yml:28` analyze,
  `scorecard.yml:30` upload-sarif) — `4187e74… # v3` →
  `7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1` (the **peeled** commit — v4.37.1 is an
  **annotated** tag; the tag-object SHA `bb16b9baa2ec4010b29f5c606d57d01190139edd` is explicitly
  NOT used). `codeql.yml`'s `init` and `analyze` steps land on the identical SHA (codeql-action
  throws at analyze time if it loads a config generated by a different-version init).

**Untouched, confirmed byte-identical** (out of scope — already current or a different action):
`publish.yml:44` `actions/upload-artifact@043fb46… # v7`, `publish.yml:67`
`actions/download-artifact@3e5f45b… # v8`, `scorecard.yml:23` `ossf/scorecard-action@2d114668… #
v2.4.4`.

### A surprise worth flagging (not acted on)

Independently checking `github/codeql-action`'s release history at implementation time found the
repo has shipped **two newer patches since #266/this task's grounding**: `v4.37.2` (2026-07-21) and
`v4.37.3` (2026-07-22), both after `v4.37.1`'s 2026-07-16 release. This PR still targets the exact
`v4.37.1` SHA the prompt specifies (matching #266's own proposal precisely, so Dependabot's
auto-close condition and the prompt's safety grounding both stay exactly valid) — **not** a
unilateral bump to the newer patch. Flagging this for the architect to decide whether a follow-up
bump to `v4.37.3` is worth a separate, small PR.

## Verification

```bash
# 1. Pin swap complete + correct
grep -rn "checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"   .github/workflows/ | wc -l   # 6
grep -rn "setup-node@820762786026740c76f36085b0efc47a31fe5020" .github/workflows/ | wc -l   # 4
grep -rn "codeql-action/.*@7188fc363630916deb702c7fdcf4e481b751f97a" .github/workflows/ | wc -l  # 3

# 2. No stale pins remain
grep -rn "checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09\|setup-node@a0853c24544627f65ddf259abe73b1d18a591444\|codeql-action/.*@4187e74d05793876e9989daffde9c3e66b4acd07" .github/workflows/   # (no output)
grep -rn "actions/checkout@.* # v5\|actions/setup-node@.* # v5\|codeql-action/.* # v3" .github/workflows/   # (no output)

# 3. Tag-object NOT used
grep -rn "bb16b9baa2ec4010b29f5c606d57d01190139edd" .github/workflows/   # (no output)

# 4. codeql init==analyze SHA match
grep "codeql-action/init\|codeql-action/analyze" .github/workflows/codeql.yml
#   both: @7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

# 5. Out-of-scope pins byte-unchanged
git diff main -- .github/workflows/ | grep -E "upload-artifact|download-artifact|ossf/scorecard-action"   # (no output)

# 6. YAML still parses (all 5)
for f in ci codeql scorecard publish scheduled-audit; do
  python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('OK')" ".github/workflows/$f.yml"
done   # OK x5

# 7. Touch list
git diff --stat main
#   .github/workflows/ci.yml              | 4 ++--
#   .github/workflows/codeql.yml          | 6 +++---
#   .github/workflows/publish.yml         | 8 ++++----
#   .github/workflows/scheduled-audit.yml | 4 ++--
#   .github/workflows/scorecard.yml       | 4 ++--
#   5 files changed, 13 insertions(+), 13 deletions(-)
# Confirmed via an independent /tmp-backup diff (not just `git diff`) that these are the ONLY 13
# line changes anywhere in the repo.
```

**SHA resolution** — all three independently verified two ways before editing (`git ls-remote` +
`gh api commits/<tag>`), including reproducing the codeql-action annotated-tag trap directly:

```bash
git ls-remote https://github.com/github/codeql-action refs/tags/v4.37.1
#   bb16b9baa2ec4010b29f5c606d57d01190139edd  refs/tags/v4.37.1        <- tag object, WRONG
git ls-remote https://github.com/github/codeql-action 'refs/tags/v4.37.1^{}'
#   7188fc363630916deb702c7fdcf4e481b751f97a  refs/tags/v4.37.1^{}    <- peeled, correct, used here
```

## Rollback

```bash
git revert HEAD
```

Pure CI-tooling pin change — reverting restores checkout v5 / setup-node v5 / codeql-action v3
across all five workflows exactly. No source, no release path, no repo setting touched in either
direction.

## Related

- Supersedes Dependabot's #266 (bumps the same 3 actions but only 4 of the 5 workflows) — the
  architect will close #266 after this merges.
- Follows issue #238's supply-chain posture program (PR1 #244 established the pin convention;
  PR5 #268 added `scorecard.yml`, the file #266 missed).
