### PR TITLE
chore(deps): bump github/codeql-action v4.37.1 -> v4.37.3 (the 3 pins, uniformly)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript-typescript
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,6 +27,6 @@ jobs:
           results_format: sarif
           publish_results: true # publishes the score for the badge + REST API (needs id-token:write; default branch only)
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1 (reuse codeql.yml's pin)
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3 (reuse codeql.yml's pin)
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Context

#274 uniformly moved all GitHub Actions to new majors (`checkout` v7.0.1, `setup-node` v7.0.0,
`codeql-action` v4.37.1) and merged to `main` (`51a847f`). `codeql-action` has since shipped two
patch releases — **v4.37.2** (2026-07-21) and **v4.37.3** (2026-07-22, current latest). Both are
grounded and trivial:

- **v4.37.2** — enables the `config-file` remote-address format by default + adds private-registry
  config support. realm's [`codeql.yml`](.github/workflows/codeql.yml) uses only `languages` +
  `category` (no `config-file` input), so neither feature touches realm.
- **v4.37.3** — "No user-facing changes."

## Motivation

This is a proactive bump to latest rather than waiting ~4 days for Dependabot's 7-day cooldown to
open the `github-actions` group PR. Getting `main` to latest means the pending codeql-.3 update is
already satisfied and Dependabot never opens a PR for it. `checkout` (v7.0.1) and `setup-node`
(v7.0.0) are already at latest on `main` and are untouched — this bumps `codeql-action` only.

## Changes

Exactly 3 `uses:` pin lines changed across exactly 2 files:

- `codeql.yml` init step — `github/codeql-action/init@…7188fc36 # v4.37.1` →
  `…@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3`
- `codeql.yml` analyze step — `github/codeql-action/analyze@…7188fc36 # v4.37.1` →
  `…@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3`
- `scorecard.yml` upload-sarif step — `github/codeql-action/upload-sarif@…7188fc36 # v4.37.1
  (reuse codeql.yml's pin)` → `…@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3 (reuse
  codeql.yml's pin)` — the parenthetical preserved.

`v4.37.3`'s tag is **annotated** — the peeled commit `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` is
used, never the tag-object `c54b30b7df092240050e69945842bc67aee0f0f4`. Both independently verified
before editing:

```bash
gh api repos/github/codeql-action/commits/v4.37.3 --jq .sha
#   e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
git ls-remote https://github.com/github/codeql-action refs/tags/v4.37.3
#   c54b30b7df092240050e69945842bc67aee0f0f4  refs/tags/v4.37.3        <- tag object, WRONG
git ls-remote https://github.com/github/codeql-action 'refs/tags/v4.37.3^{}'
#   e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  refs/tags/v4.37.3^{}    <- peeled, correct, used here
```

`codeql.yml`'s `init` and `analyze` steps land on the identical SHA (codeql-action throws at
analyze time on a version mismatch between the two).

**Untouched, confirmed byte-identical**: all 6 `checkout` sites (`v7.0.1`), all 4 `setup-node`
sites (`v7.0.0`), `publish.yml`'s `upload-artifact`/`download-artifact` pins, and `scorecard.yml`'s
`ossf/scorecard-action` pin.

## Verification

```bash
# 1. Swap complete
grep -rn "codeql-action/.*@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81" .github/workflows/ | wc -l   # 3

# 2. No stale codeql pin
grep -rn "codeql-action/.*@7188fc363630916deb702c7fdcf4e481b751f97a\|codeql-action/.* # v4.37.1" .github/workflows/   # (no output)

# 3. Tag-object NOT used
grep -rn "c54b30b7df092240050e69945842bc67aee0f0f4" .github/workflows/   # (no output)

# 4. init==analyze
grep "codeql-action/init\|codeql-action/analyze" .github/workflows/codeql.yml
#   both: @e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

# 5. checkout/setup-node/other-actions untouched (added/removed lines only, excludes diff context noise)
git diff main -- .github/workflows/ | grep -E "^[+-]" | grep -E "checkout|setup-node|upload-artifact|download-artifact|ossf/scorecard-action"
#   (no output)

# 6. YAML parses
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml')); print('OK')"
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml')); print('OK')"
#   OK / OK

# 7. Touch list
git diff --stat main
#   .github/workflows/codeql.yml    | 4 ++--
#   .github/workflows/scorecard.yml | 2 +-
#   2 files changed, 3 insertions(+), 3 deletions(-)
```

## Rollback

```bash
git revert HEAD
```

Pure CI-tooling pin change — reverting restores `codeql-action@v4.37.1` across both files exactly.
No source, no release path, no repo setting touched in either direction.

## Related

- Follows #274 (the uniform actions-majors bump, merged as `51a847f`), which flagged this exact
  follow-up as a surprise finding at the time (`v4.37.2`/`v4.37.3` had just shipped, past the
  `v4.37.1` target #274 was scoped to).
