### PR TITLE
chore: release v0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.31.2] — 2026-07-25
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,7 +4529,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.31.1",
+      "version": "0.31.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4580,7 +4580,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.31.1",
+      "version": "0.31.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.31.1",
+      "version": "0.31.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4646,7 +4646,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.31.1",
+      "version": "0.31.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.31.1');
+program.name('realm').description('Realm workflow engine CLI').version('0.31.2');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,7 +106,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.31.1';
+export const VERSION = '0.31.2';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.31.1';
+export const VERSION = '0.31.2';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.31.1',
+    version: '0.31.2',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -57,4 +57,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.31.1';
+export const VERSION = '0.31.2';


### PR DESCRIPTION
## Context

Cut **v0.31.2** (patch) to clear `[Unreleased]` and — critically — to serve as the **first real `v*` release since #274/#275**, exercising the hardened publish path on the new action majors end-to-end (checkout v7.0.1, setup-node v7.0.0, codeql-action v4.37.3). This is the **fail-closed OIDC gate** for setup-node v7's real-token `.npmrc`/provenance path (the one surface the dry-run canary can't reach).

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.31.2] — 2026-07-25`.
- Release bump (via `npm run release`): all 4 `package.json` + 5 `VERSION` constants → `0.31.2`; lockfile.

**Payload** (both behaviour-neutral `### Changed` dependency updates, no API change):
- `uuid` 13 → 14 (`@sensigo/realm` core) — v4 ID-generation API unchanged.
- `commander` 14 → 15 (`@sensigo/realm-cli`) — ESM import path, `Command`/subcommand API unchanged.

## Verification

- The hardened split publish.yml was validated pre-release by a `workflow_dispatch` dry-run canary (`30151968720`): build job all-green (I7 no-token guard), publish job green through `setup-node v7 + registry-url` `.npmrc` generation + artifact round-trip; only red was the expected `0.31.1` version-collision.
- The real publish (SLSA provenance via OIDC) runs on the tag push and is **fail-closed**: `--provenance` + the pre-flight id-token assert block any partial/unsigned publish.

## Rollback

If the publish job fail-closes on setup-node v7's real-OIDC path: revert **only** publish.yml's two `setup-node` pins to v5 (`a0853c2`, the v0.31.1-proven baseline) — keep checkout v7 + codeql v4.37.3 — and re-cut a patch.

## Related

#274 (action majors), #275 (codeql v4.37.3), #238 (supply-chain program). Merge-commit (not squash) — the tag is on the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
