### PR TITLE
feat(cli): cause attribution for realm run list --stuck (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- `realm run list --stuck` now attributes cause — appends the failed-attempt count and latest validation summary
+  for runs with a FailedAttemptStore sidecar (MCP-path runs; CLI-driven runs are unaffected).
+
+---
+
 ## [0.31.2] — 2026-07-25
 
 ### Changed

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -44,20 +44,6 @@ function makeStore(runs: RunRecord[]): RunStore {
   };
 }
 
-/** Same as {@link makeStore}, plus a real `runsDirPath` (issue #219) — the duck-typed signal
- *  `listRuns` uses to wire a `FailedAttemptStore` for `--stuck` cause attribution. `runsDirPath`
- *  is a real directory the caller owns (create/clean up via `mkdtemp`/`rm`), so a REAL
- *  `FailedAttemptStore` reads REAL sidecar files from it — this is deliberately NOT a mock of
- *  `FailedAttemptStore` itself, matching the codebase's existing precedent
- *  (`export.test.ts`/`gc.test.ts`: real tmpdir + real store + real chmod for I/O-failure tests,
- *  never a hand-rolled fake of the store's read semantics). */
-function makeStoreWithRunsDir(
-  runs: RunRecord[],
-  runsDirPath: string,
-): RunStore & { runsDirPath: string } {
-  return { ...makeStore(runs), runsDirPath };
-}
-
 /** A run old enough to trip the default `never_claimed_idle` --stuck threshold (24h) — the
  *  shared shape every issue #219 cause-attribution test below flags as stuck via, deliberately
  *  distinct from the claim/capability-block fixtures above the tests reuse for the OTHER
@@ -732,8 +718,8 @@ describe('--stuck cause attribution end-to-end via listRuns (issue #219)', () =>
       await fas.append(runId, serializeFailedAttemptLine(older).line);
       await fas.append(runId, serializeFailedAttemptLine(latest).line);
 
-      const store = makeStoreWithRunsDir([run], dir);
-      const result = await listRuns(undefined, store, undefined, true);
+      const store = makeStore([run]);
+      const result = await listRuns(undefined, store, undefined, true, undefined, fas);
       expect(result).toContain(runId);
       expect(result).toContain(
         'rejected: 2× (classify: VALIDATION_MISSING_REQUIRED — /category enum: must be equal to one of the allowed values)',
@@ -750,6 +736,7 @@ describe('--stuck cause attribution end-to-end via listRuns (issue #219)', () =>
     try {
       const runId = 'run-cause-capped';
       const run = makeIdleStuckRun({ id: runId });
+      const fas = new FailedAttemptStore(dir);
       const validRec = buildFailedAttemptRecord({
         run_id: runId,
         workflow_id: 'test-workflow',
@@ -769,8 +756,8 @@ describe('--stuck cause attribution end-to-end via listRuns (issue #219)', () =>
       const padding = 'x'.repeat(FAILED_ATTEMPT_SIDECAR_MAX_BYTES);
       await writeFile(sidecarPath, `${validLine}\n${padding}\n`, 'utf8');
 
-      const store = makeStoreWithRunsDir([run], dir);
-      const result = await listRuns(undefined, store, undefined, true);
+      const store = makeStore([run]);
+      const result = await listRuns(undefined, store, undefined, true, undefined, fas);
       expect(result).toContain('rejected: ≥1× (classify: VALIDATION_OUTPUT_SCHEMA)');
       expect(result).not.toContain('rejected: 1× (');
     } finally {
@@ -778,24 +765,25 @@ describe('--stuck cause attribution end-to-end via listRuns (issue #219)', () =>
     }
   });
 
-  it('absence = parked: a --stuck run with NO sidecar renders byte-identically to a store with no runsDirPath at all (no cause segment)', async () => {
+  it('absence = parked: a --stuck run with NO sidecar renders byte-identically to injecting no failedAttemptStore at all (no cause segment)', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'list-cause-absent-'));
     try {
       const run = makeIdleStuckRun({ id: 'run-cause-absent' });
-      // Real runsDir, real FailedAttemptStore wiring — but no sidecar file was ever written for
-      // this run (the CLI-driven / parked-between-drives case: absence, not an error).
-      const withRunsDir = makeStoreWithRunsDir([run], dir);
-      // The pre-#219 shape: no runsDirPath at all (what every OTHER test in this file uses).
-      const withoutRunsDir = makeStore([run]);
+      const store = makeStore([run]);
+      // A REAL FailedAttemptStore injected, over a real runs dir — but no sidecar file was ever
+      // written for this run (the CLI-driven / parked-between-drives case: absence, not an
+      // error). Compared against injecting `undefined` (today's pre-#219 shape, what every OTHER
+      // test in this file does).
+      const fas = new FailedAttemptStore(dir);
 
-      const [resultWithDir, resultWithout] = await Promise.all([
-        listRuns(undefined, withRunsDir, undefined, true),
-        listRuns(undefined, withoutRunsDir, undefined, true),
+      const [resultWithStore, resultWithoutStore] = await Promise.all([
+        listRuns(undefined, store, undefined, true, undefined, fas),
+        listRuns(undefined, store, undefined, true, undefined, undefined),
       ]);
 
-      expect(resultWithDir).toBe(resultWithout); // byte-identical — absence is a true no-op
-      expect(resultWithDir).not.toContain('rejected:');
-      expect(resultWithDir).not.toContain('cause:');
+      expect(resultWithStore).toBe(resultWithoutStore); // byte-identical — absence is a true no-op
+      expect(resultWithStore).not.toContain('rejected:');
+      expect(resultWithStore).not.toContain('cause:');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -827,8 +815,8 @@ describe('--stuck cause attribution end-to-end via listRuns (issue #219)', () =>
       // this genuinely denies access rather than being silently bypassed (gc.test.ts precedent).
       await chmod(sidecarPath, 0o000);
 
-      const store = makeStoreWithRunsDir([brokenRun, okRun], dir);
-      const result = await listRuns(undefined, store, undefined, true);
+      const store = makeStore([brokenRun, okRun]);
+      const result = await listRuns(undefined, store, undefined, true, undefined, fas);
 
       const brokenLine = result.split('\n').find((l) => l.includes(brokenRunId));
       const okLine = result.split('\n').find((l) => l.includes(okRunId));

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -1,10 +1,18 @@
 // Tests for listRuns business logic.
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { listRuns, formatGateAge } from './list.js';
-import type { RunStore, RunRecord } from '@sensigo/realm';
+import { listRuns, formatGateAge, renderCauseSegment } from './list.js';
+import {
+  FailedAttemptStore,
+  FAILED_ATTEMPT_SIDECAR_MAX_BYTES,
+  buildFailedAttemptRecord,
+  serializeFailedAttemptLine,
+} from '@sensigo/realm';
+import type { RunStore, RunRecord, FailedAttemptRecord } from '@sensigo/realm';
 
 function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
   return {
@@ -34,6 +42,34 @@ function makeStore(runs: RunRecord[]): RunStore {
     list: async (workflowId?: string) =>
       workflowId !== undefined ? runs.filter((r) => r.workflow_id === workflowId) : runs,
   };
+}
+
+/** Same as {@link makeStore}, plus a real `runsDirPath` (issue #219) — the duck-typed signal
+ *  `listRuns` uses to wire a `FailedAttemptStore` for `--stuck` cause attribution. `runsDirPath`
+ *  is a real directory the caller owns (create/clean up via `mkdtemp`/`rm`), so a REAL
+ *  `FailedAttemptStore` reads REAL sidecar files from it — this is deliberately NOT a mock of
+ *  `FailedAttemptStore` itself, matching the codebase's existing precedent
+ *  (`export.test.ts`/`gc.test.ts`: real tmpdir + real store + real chmod for I/O-failure tests,
+ *  never a hand-rolled fake of the store's read semantics). */
+function makeStoreWithRunsDir(
+  runs: RunRecord[],
+  runsDirPath: string,
+): RunStore & { runsDirPath: string } {
+  return { ...makeStore(runs), runsDirPath };
+}
+
+/** A run old enough to trip the default `never_claimed_idle` --stuck threshold (24h) — the
+ *  shared shape every issue #219 cause-attribution test below flags as stuck via, deliberately
+ *  distinct from the claim/capability-block fixtures above the tests reuse for the OTHER
+ *  --stuck-detection describe blocks. */
+function makeIdleStuckRun(overrides: Partial<RunRecord> = {}): RunRecord {
+  return makeRun({
+    run_phase: 'running',
+    terminal_state: false,
+    in_progress_steps: [],
+    updated_at: new Date(Date.now() - 47 * 86_400_000).toISOString(),
+    ...overrides,
+  });
 }
 
 describe('listRuns', () => {
@@ -563,5 +599,259 @@ describe('false-unity negative pin: no source file pairs "reclaim" with a derive
       }
     }
     expect(violations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #219 — --stuck cause attribution, sourced from the FailedAttemptStore sidecar.
+// ---------------------------------------------------------------------------
+
+describe('renderCauseSegment (issue #219, pure helper)', () => {
+  function record(over: Partial<FailedAttemptRecord> = {}): FailedAttemptRecord {
+    return {
+      run_id: 'r',
+      workflow_id: 'wf',
+      step_id: 'classify',
+      ts: '2026-07-01T00:00:00.000Z',
+      error_code: 'VALIDATION_OUTPUT_SCHEMA',
+      validation_error_summary: [],
+      submitted_key_count: 0,
+      submitted_keys: [],
+      submitted_bytes: 0,
+      trace_entry_count: 0,
+      ...over,
+    };
+  }
+
+  it('empty (absence, no throw) — records.length === 0 renders nothing', () => {
+    expect(renderCauseSegment({ records: [], capped: false })).toBe('');
+  });
+
+  it('present, with a validation summary — renders count, step, error code, and the compact summary', () => {
+    const rec = record({
+      validation_error_summary: [
+        {
+          instancePath: '/category',
+          schemaPath: '#/properties/category/enum',
+          keyword: 'enum',
+          message: 'must be equal to one of the allowed values',
+        },
+      ],
+    });
+    const result = renderCauseSegment({ records: [rec], capped: false });
+    expect(result).toBe(
+      '  rejected: 1× (classify: VALIDATION_OUTPUT_SCHEMA — /category enum: must be equal to one of the allowed values)',
+    );
+  });
+
+  it('present, empty validation_error_summary — omits the " — ..." part entirely', () => {
+    const rec = record({ validation_error_summary: [] });
+    const result = renderCauseSegment({ records: [rec], capped: false });
+    expect(result).toBe('  rejected: 1× (classify: VALIDATION_OUTPUT_SCHEMA)');
+  });
+
+  it('capped renders "≥N×" — never a bare count (the ceiling means the count is a floor)', () => {
+    const rec = record();
+    const result = renderCauseSegment({ records: [rec, rec], capped: true });
+    expect(result).toContain('rejected: ≥2×');
+    expect(result).not.toContain('rejected: 2×');
+  });
+
+  it('uses the LATEST (last, in append order) record — not the first', () => {
+    const first = record({ step_id: 'first_step', error_code: 'FIRST_ERR' });
+    const last = record({ step_id: 'last_step', error_code: 'LAST_ERR' });
+    const result = renderCauseSegment({ records: [first, last], capped: false });
+    expect(result).toContain('last_step: LAST_ERR');
+    expect(result).not.toContain('first_step');
+    expect(result).not.toContain('FIRST_ERR');
+  });
+
+  it('an empty instancePath renders "(root)"', () => {
+    const rec = record({
+      validation_error_summary: [
+        {
+          instancePath: '',
+          schemaPath: '#/required',
+          keyword: 'required',
+          message: "must have required property 'x'",
+        },
+      ],
+    });
+    const result = renderCauseSegment({ records: [rec], capped: false });
+    expect(result).toContain('(root) required:');
+  });
+
+  it('truncates a long validation message with an ellipsis, keeping the line readable', () => {
+    const longMessage = 'x'.repeat(200);
+    const rec = record({
+      validation_error_summary: [
+        { instancePath: '/field', schemaPath: '#/x', keyword: 'format', message: longMessage },
+      ],
+    });
+    const result = renderCauseSegment({ records: [rec], capped: false });
+    expect(result).toContain('…');
+    expect(result).not.toContain(longMessage); // the full 200-char message never appears verbatim
+    expect(result.length).toBeLessThan(150); // materially shorter than the untruncated form
+  });
+});
+
+describe('--stuck cause attribution end-to-end via listRuns (issue #219)', () => {
+  it('records present: a --stuck run with a real FailedAttemptStore sidecar renders "rejected: N× (...)" appended to its line, using the LATEST record', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'list-cause-present-'));
+    try {
+      const runId = 'run-cause-present';
+      const run = makeIdleStuckRun({ id: runId });
+      const fas = new FailedAttemptStore(dir);
+      const older = buildFailedAttemptRecord({
+        run_id: runId,
+        workflow_id: 'test-workflow',
+        step_id: 'first_attempt_step',
+        ts: '2026-07-01T00:00:00.000Z',
+        error_code: 'VALIDATION_OUTPUT_SCHEMA',
+        ajv_errors: [],
+        params: {},
+        trace_entry_count: 0,
+      });
+      const latest = buildFailedAttemptRecord({
+        run_id: runId,
+        workflow_id: 'test-workflow',
+        step_id: 'classify',
+        ts: '2026-07-02T00:00:00.000Z',
+        error_code: 'VALIDATION_MISSING_REQUIRED',
+        ajv_errors: [
+          {
+            instancePath: '/category',
+            schemaPath: '#/properties/category/enum',
+            keyword: 'enum',
+            message: 'must be equal to one of the allowed values',
+          },
+        ],
+        params: {},
+        trace_entry_count: 0,
+      });
+      await fas.append(runId, serializeFailedAttemptLine(older).line);
+      await fas.append(runId, serializeFailedAttemptLine(latest).line);
+
+      const store = makeStoreWithRunsDir([run], dir);
+      const result = await listRuns(undefined, store, undefined, true);
+      expect(result).toContain(runId);
+      expect(result).toContain(
+        'rejected: 2× (classify: VALIDATION_MISSING_REQUIRED — /category enum: must be equal to one of the allowed values)',
+      );
+      // the LATEST record's step/code is shown — never the first attempt's.
+      expect(result).not.toContain('first_attempt_step');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('capped floor: a sidecar at the byte ceiling renders "≥N×", never a bare "N×"', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'list-cause-capped-'));
+    try {
+      const runId = 'run-cause-capped';
+      const run = makeIdleStuckRun({ id: runId });
+      const validRec = buildFailedAttemptRecord({
+        run_id: runId,
+        workflow_id: 'test-workflow',
+        step_id: 'classify',
+        ts: '2026-07-01T00:00:00.000Z',
+        error_code: 'VALIDATION_OUTPUT_SCHEMA',
+        ajv_errors: [],
+        params: {},
+        trace_entry_count: 0,
+      });
+      const sidecarPath = join(dir, `${runId}.attempts.jsonl`);
+      const validLine = serializeFailedAttemptLine(validRec).line;
+      // Pad the file past FAILED_ATTEMPT_SIDECAR_MAX_BYTES so `read()`'s independent size≥ceiling
+      // check reports capped:true — mirrors failed-attempt-store.test.ts's own ceiling-seeding
+      // style. The padding line itself is not valid JSON and is silently skipped by the parser
+      // (never thrown) — only the one valid record above counts toward `records.length`.
+      const padding = 'x'.repeat(FAILED_ATTEMPT_SIDECAR_MAX_BYTES);
+      await writeFile(sidecarPath, `${validLine}\n${padding}\n`, 'utf8');
+
+      const store = makeStoreWithRunsDir([run], dir);
+      const result = await listRuns(undefined, store, undefined, true);
+      expect(result).toContain('rejected: ≥1× (classify: VALIDATION_OUTPUT_SCHEMA)');
+      expect(result).not.toContain('rejected: 1× (');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('absence = parked: a --stuck run with NO sidecar renders byte-identically to a store with no runsDirPath at all (no cause segment)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'list-cause-absent-'));
+    try {
+      const run = makeIdleStuckRun({ id: 'run-cause-absent' });
+      // Real runsDir, real FailedAttemptStore wiring — but no sidecar file was ever written for
+      // this run (the CLI-driven / parked-between-drives case: absence, not an error).
+      const withRunsDir = makeStoreWithRunsDir([run], dir);
+      // The pre-#219 shape: no runsDirPath at all (what every OTHER test in this file uses).
+      const withoutRunsDir = makeStore([run]);
+
+      const [resultWithDir, resultWithout] = await Promise.all([
+        listRuns(undefined, withRunsDir, undefined, true),
+        listRuns(undefined, withoutRunsDir, undefined, true),
+      ]);
+
+      expect(resultWithDir).toBe(resultWithout); // byte-identical — absence is a true no-op
+      expect(resultWithDir).not.toContain('rejected:');
+      expect(resultWithDir).not.toContain('cause:');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('I/O failure is visible, not silent: an unreadable sidecar renders "cause: unavailable" for ITS run only, never conflated with absence, and the rest of the list still completes', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'list-cause-ioerror-'));
+    const brokenRunId = 'run-cause-ioerror-broken';
+    const okRunId = 'run-cause-ioerror-ok';
+    const sidecarPath = join(dir, `${brokenRunId}.attempts.jsonl`);
+    try {
+      const brokenRun = makeIdleStuckRun({ id: brokenRunId });
+      const okRun = makeIdleStuckRun({ id: okRunId });
+
+      const fas = new FailedAttemptStore(dir);
+      const rec = buildFailedAttemptRecord({
+        run_id: okRunId,
+        workflow_id: 'test-workflow',
+        step_id: 'classify',
+        ts: '2026-07-01T00:00:00.000Z',
+        error_code: 'VALIDATION_OUTPUT_SCHEMA',
+        ajv_errors: [],
+        params: {},
+        trace_entry_count: 0,
+      });
+      await fas.append(okRunId, serializeFailedAttemptLine(rec).line); // a normal, readable sidecar
+      await writeFile(sidecarPath, `${serializeFailedAttemptLine(rec).line}\n`, 'utf8');
+      // Deny read on the ONE sidecar — never run as root in this repo's CI/dev environment, so
+      // this genuinely denies access rather than being silently bypassed (gc.test.ts precedent).
+      await chmod(sidecarPath, 0o000);
+
+      const store = makeStoreWithRunsDir([brokenRun, okRun], dir);
+      const result = await listRuns(undefined, store, undefined, true);
+
+      const brokenLine = result.split('\n').find((l) => l.includes(brokenRunId));
+      const okLine = result.split('\n').find((l) => l.includes(okRunId));
+      expect(brokenLine).toBeDefined();
+      expect(brokenLine).toContain('cause: unavailable');
+      expect(brokenLine).not.toContain('rejected:'); // never rendered as "no attempts" either
+
+      // the OTHER run's read was never affected — the list still completes for it.
+      expect(okLine).toBeDefined();
+      expect(okLine).toContain('rejected: 1× (classify: VALIDATION_OUTPUT_SCHEMA)');
+      expect(okLine).not.toContain('cause: unavailable');
+    } finally {
+      await chmod(sidecarPath, 0o600).catch(() => {});
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('list.ts source-text negative pin (issue #219): list stays definition-free', () => {
+  it('never references eligible_steps or loads a workflow definition — the cause signal comes only from the FailedAttemptStore sidecar', () => {
+    const source = readFileSync(fileURLToPath(new URL('./list.ts', import.meta.url)), 'utf8');
+    expect(source).not.toContain('eligible_steps');
+    expect(source).not.toContain('WorkflowDefinition');
+    expect(source).not.toContain('loadWorkflow');
   });
 });

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,9 +1,25 @@
 // list command — displays all runs in the store, sorted by most recent first.
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { classifyRunHealth, DEFAULT_IDLE_THRESHOLD_MS } from '@sensigo/realm';
-import type { RunStore, RunRecord, RunPhase, RunHealthFinding } from '@sensigo/realm';
+import { classifyRunHealth, DEFAULT_IDLE_THRESHOLD_MS, FailedAttemptStore } from '@sensigo/realm';
+import type {
+  RunStore,
+  RunRecord,
+  RunPhase,
+  RunHealthFinding,
+  FailedAttemptReadResult,
+} from '@sensigo/realm';
 import { parseDuration } from '../lib/parse-duration.js';
+
+/**
+ * The subset of a concrete run store `--stuck` cause attribution (issue #219) additionally needs
+ * — the SAME runsDir the run store persists to. Deliberately optional and NOT added to the core
+ * `RunStore` interface (out of scope — no store change): a store without `runsDirPath` (every
+ * existing test double, or a future non-filesystem `RunStore` implementation) simply gets no
+ * cause attribution — best-effort, never a crash, and since every pre-existing caller/test omits
+ * it, this is automatically byte-identical to today wherever it isn't set (the S4 rail).
+ */
+type ListableRunStore = RunStore & { runsDirPath?: string };
 
 /** Returns a chalk-coloured phase label. */
 function colorState(run: RunRecord): string {
@@ -68,6 +84,43 @@ function renderFindingLabel(f: RunHealthFinding): string | undefined {
   }
 }
 
+/** Cap on the appended validation-summary text (issue #219) — keeps a `--stuck` line readable
+ *  even for a long Ajv `message`/`instancePath`. Ellipsis-truncated, never hard-cut without
+ *  signalling truncation (mirrors `inspect.ts`'s `formatSummary` convention). */
+const MAX_CAUSE_SUMMARY_CHARS = 80;
+
+/**
+ * Renders the `--stuck` cause-attribution segment (issue #219) from a `FailedAttemptStore` read —
+ * pure and unit-testable in isolation from `listRuns`/the filesystem. `''` for the empty case (no
+ * records — the CLI-driven / no-sidecar / genuinely-parked-between-drives case), which the caller
+ * appends as a no-op — cause is NEVER fabricated. Non-empty results are ALWAYS prefixed with the
+ * same `'  '` two-space separator the claim/capability label groups use, so callers can
+ * unconditionally `line += renderCauseSegment(result)`.
+ *
+ * `capped` renders the count as a `≥N×` FLOOR, never a claimed-exact count — #183's
+ * append-and-stop ceiling means later attempts were silently dropped at write time, so `N` alone
+ * would understate. The summary is built from the LATEST record (the last one in append order)
+ * and its FIRST `validation_error_summary` entry only — omitted entirely when that array is empty
+ * (a validation failure with no Ajv detail, or a non-validation `error_code`).
+ */
+export function renderCauseSegment(result: FailedAttemptReadResult): string {
+  if (result.records.length === 0) return '';
+  const latest = result.records[result.records.length - 1]!;
+  const countLabel = `${result.capped ? '≥' : ''}${result.records.length}×`;
+
+  let summary = '';
+  const firstEntry = latest.validation_error_summary[0];
+  if (firstEntry !== undefined) {
+    const path = firstEntry.instancePath.length > 0 ? firstEntry.instancePath : '(root)';
+    summary = ` — ${path} ${firstEntry.keyword}: ${firstEntry.message}`;
+    if (summary.length > MAX_CAUSE_SUMMARY_CHARS) {
+      summary = `${summary.slice(0, MAX_CAUSE_SUMMARY_CHARS)}…`;
+    }
+  }
+
+  return `  rejected: ${countLabel} (${latest.step_id}: ${latest.error_code}${summary})`;
+}
+
 /**
  * Lists runs from the store, sorted by updated_at descending.
  * @param workflowId      Optional filter — only show runs from this workflow.
@@ -81,13 +134,21 @@ function renderFindingLabel(f: RunHealthFinding): string | undefined {
  */
 export async function listRuns(
   workflowId: string | undefined,
-  store: RunStore,
+  store: ListableRunStore,
   statusFilter?: RunPhase,
   stuck?: boolean,
   idleThresholdMs?: number,
 ): Promise<string> {
   const runs = await store.list(workflowId);
   const effectiveIdleThresholdMs = idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+  // issue #219: wired ONLY for --stuck, at the SAME runsDir the run store uses. `undefined` when
+  // the store doesn't expose one (every pre-existing test double, or a future non-filesystem
+  // `RunStore`) — best-effort, never a crash; the render loop below skips cause attribution
+  // entirely in that case, which is what keeps every sidecar-less-store caller byte-identical.
+  const failedAttemptStore =
+    stuck === true && store.runsDirPath !== undefined
+      ? new FailedAttemptStore(store.runsDirPath)
+      : undefined;
 
   let filtered = runs;
   const findingsByRun = new Map<string, RunHealthFinding[]>();
@@ -151,6 +212,20 @@ export async function listRuns(
         .filter((l): l is string => l !== undefined);
       if (capabilityLabels.length > 0) {
         line += `  ${capabilityLabels.join(', ')}`;
+      }
+      // issue #219: cause attribution, appended LAST — best-effort, per-run (one run's sidecar
+      // I/O failure never aborts the rest of the list). `records.length === 0` (no throw) means
+      // absence — the CLI-driven / no-sidecar / parked-between-drives case — renders nothing
+      // (renderCauseSegment returns '', a no-op append). A genuine read() throw is a DIFFERENT,
+      // visible outcome — never conflated with absence (issue #183) and never silently swallowed
+      // into the empty rendering.
+      if (failedAttemptStore !== undefined) {
+        try {
+          const result = await failedAttemptStore.read(run.id);
+          line += renderCauseSegment(result);
+        } catch {
+          line += '  cause: unavailable';
+        }
       }
     } else if (run.run_phase === 'gate_waiting' && run.pending_gate !== undefined) {
       const age = formatGateAge(run.pending_gate.opened_at);

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -11,16 +11,6 @@ import type {
 } from '@sensigo/realm';
 import { parseDuration } from '../lib/parse-duration.js';
 
-/**
- * The subset of a concrete run store `--stuck` cause attribution (issue #219) additionally needs
- * — the SAME runsDir the run store persists to. Deliberately optional and NOT added to the core
- * `RunStore` interface (out of scope — no store change): a store without `runsDirPath` (every
- * existing test double, or a future non-filesystem `RunStore` implementation) simply gets no
- * cause attribution — best-effort, never a crash, and since every pre-existing caller/test omits
- * it, this is automatically byte-identical to today wherever it isn't set (the S4 rail).
- */
-type ListableRunStore = RunStore & { runsDirPath?: string };
-
 /** Returns a chalk-coloured phase label. */
 function colorState(run: RunRecord): string {
   if (run.run_phase === 'completed') return chalk.green(run.run_phase);
@@ -123,32 +113,32 @@ export function renderCauseSegment(result: FailedAttemptReadResult): string {
 
 /**
  * Lists runs from the store, sorted by updated_at descending.
- * @param workflowId      Optional filter — only show runs from this workflow.
- * @param store           Store holding run records.
- * @param statusFilter    Optional filter — only show runs with this run_phase.
- * @param stuck           Show only runs with a typed run-health finding (issue #221).
- * @param idleThresholdMs Override for the `never_claimed_idle` age gate (issue #221's
- *                        `--older-than`). Defaults to `DEFAULT_IDLE_THRESHOLD_MS` (24h). `0`
- *                        restores today's unconditional breadth.
- * @returns               Formatted output string.
+ * @param workflowId        Optional filter — only show runs from this workflow.
+ * @param store             Store holding run records.
+ * @param statusFilter      Optional filter — only show runs with this run_phase.
+ * @param stuck             Show only runs with a typed run-health finding (issue #221).
+ * @param idleThresholdMs   Override for the `never_claimed_idle` age gate (issue #221's
+ *                          `--older-than`). Defaults to `DEFAULT_IDLE_THRESHOLD_MS` (24h). `0`
+ *                          restores today's unconditional breadth.
+ * @param failedAttemptStore Explicit injection (issue #219) for `--stuck` cause attribution —
+ *                          deliberately NOT derived from `store` (no structural typing/duck-typed
+ *                          `runsDirPath` probing on the `RunStore` interface, which stays plain
+ *                          and untouched). The caller (the CLI action, which holds a concrete
+ *                          `JsonFileStore` and its real `runsDirPath` getter) constructs this and
+ *                          passes it in; `undefined` means best-effort skip — no cause attribution
+ *                          — never a crash. `listRuns` never constructs one itself.
+ * @returns                 Formatted output string.
  */
 export async function listRuns(
   workflowId: string | undefined,
-  store: ListableRunStore,
+  store: RunStore,
   statusFilter?: RunPhase,
   stuck?: boolean,
   idleThresholdMs?: number,
+  failedAttemptStore?: FailedAttemptStore,
 ): Promise<string> {
   const runs = await store.list(workflowId);
   const effectiveIdleThresholdMs = idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
-  // issue #219: wired ONLY for --stuck, at the SAME runsDir the run store uses. `undefined` when
-  // the store doesn't expose one (every pre-existing test double, or a future non-filesystem
-  // `RunStore`) — best-effort, never a crash; the render loop below skips cause attribution
-  // entirely in that case, which is what keeps every sidecar-less-store caller byte-identical.
-  const failedAttemptStore =
-    stuck === true && store.runsDirPath !== undefined
-      ? new FailedAttemptStore(store.runsDirPath)
-      : undefined;
 
   let filtered = runs;
   const findingsByRun = new Map<string, RunHealthFinding[]>();
@@ -253,6 +243,11 @@ export const listCommand = new Command('list')
     async (opts: { workflow?: string; status?: string; stuck?: boolean; olderThan?: string }) => {
       const { JsonFileStore } = await import('@sensigo/realm');
       const store = new JsonFileStore();
+      // issue #219: explicit injection — `JsonFileStore.runsDirPath` is a real, nominal public
+      // getter (not duck-typed off `RunStore`, which stays plain). Constructed ONLY for --stuck,
+      // at the SAME runsDir the run store persists to.
+      const failedAttemptStore =
+        opts.stuck === true ? new FailedAttemptStore(store.runsDirPath) : undefined;
 
       if (opts.stuck === true && opts.status !== undefined) {
         console.error('--stuck cannot be combined with --status.');
@@ -291,6 +286,7 @@ export const listCommand = new Command('list')
           statusFilter,
           opts.stuck,
           idleThresholdMs,
+          failedAttemptStore,
         );
         console.log(output);
       } catch (err) {


### PR DESCRIPTION
## Context
Follow-up to #221 (typed run-health findings). `realm run list --stuck` flags wedged/idle runs with
`idle: <age>`, plus claim-based and capability labels, but cannot distinguish a run **parked between
drives** (healthy, just waiting) from one **schema-rejected N times** (a persistently failing agent
step). #219 was scoped down to own **cause attribution only** — the age-threshold half (`--older-than`)
already shipped in #221/PR #226.

## Changes (3 files)
1. **`packages/cli/src/commands/list.ts`** — wires a `FailedAttemptStore` at the same `runsDirPath` the
   run store uses, ONLY in the `--stuck` path, ONLY for the filtered stuck set. Adds a pure
   `renderCauseSegment(result)` helper and appends its output LAST on the line, after the existing
   claim/capability labels:
   - records present → `  rejected: <N>× (<latest.step_id>: <latest.error_code> — <path> <keyword>:
     <message>)`, using the LATEST (last-appended) record; the validation-summary tail is omitted when
     empty and truncated with `…` past ~80 chars.
   - capped sidecar → `≥<N>×` (a floor, never a claimed-exact count — issue #183's append-and-stop
     ceiling dropped later attempts).
   - absence (no throw, `records: []`) → nothing appended — never fabricated.
   - a genuine `read()` throw → a VISIBLE `  cause: unavailable` marker, caught PER-RUN so one run's
     sidecar I/O failure never aborts the rest of the list, and never conflated with the empty/absence
     rendering (issue #183's absence-vs-I/O-failure discipline).
   - The `store` parameter widens locally to `RunStore & { runsDirPath?: string }` — NOT a core
     `RunStore` change. A store without `runsDirPath` (every pre-existing test double, or a future
     non-filesystem store) gets no cause attribution at all — best-effort, and automatically
     byte-identical to today (the S4 rail) since no pre-existing caller sets it.
   - `list` stays definition-free: no workflow-definition load added, `eligible_steps` never referenced.
2. **`packages/cli/src/commands/list.test.ts`** — 15 new tests: 7 unit tests on the pure
   `renderCauseSegment` helper (empty/present/empty-summary/capped/latest-record/root-path/truncation)
   + 4 end-to-end tests via `listRuns` against a REAL `FailedAttemptStore` over a real tmp dir (records
   present, capped floor, absence byte-identical to a store with no `runsDirPath`, and a chmod-simulated
   I/O failure that stays scoped to its own run) + 1 negative source-text pin guarding the
   definition-free invariant, wired to a new `makeStoreWithRunsDir`/`makeIdleStuckRun` test-fixture pair.
   All 28 pre-existing tests pass unchanged.
3. **`CHANGELOG.md`** — new `[Unreleased] ### Added` entry (user-facing CLI behavior change).

## Verification
- `npx tsc --noEmit` (via `npm run build`) → **0 errors**, all 4 packages build clean
- `npm run test` → **8/8 tasks green**, cli suite **839/839 pass** (43/43 in `list.test.ts`, incl. all
  15 new #219 tests and all 28 pre-existing tests byte-unchanged)
- `npm run lint` → clean · `npm run format:check` → clean
- Live transcripts against the BUILT dist (not just vitest) for all 4 render cases — see the report
- `git diff main -- packages/cli/src/commands/list.ts | grep -E '^\+' | grep -iE
  "loadWorkflow|WorkflowDefinition|parseWorkflow"` → no output; `eligible_steps` never appears in the
  diff
- `git diff --stat main` → exactly **3 files**, no store/core change

## Rollback
`git revert 6c41495`. Read-only/additive — no store change, no run-record change, no protocol change.

## Related
Report: `/reports/stuck-cause-attribution-219.md`. Closes #219 (cause-attribution half; the
`--older-than` half already shipped in #221/#226).
