### PR TITLE
feat(engine): surface default-settled steps at the run level via read-time derivation (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented here.
 
 - `realm run list --stuck` now attributes cause — appends the failed-attempt count and latest validation summary
   for runs with a FailedAttemptStore sidecar (MCP-path runs; CLI-driven runs are unaffected).
+- `get_run_state` and `realm inspect` now report a run's default-settled steps regardless of how the run sealed
+  (complete, failed, or aborted), derived from evidence — closing the failure-path disclosure gap from #220.
 
 ---
 

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -778,3 +778,61 @@ describe('run_health rendering (issue #221)', () => {
     expect(result).not.toContain('idle\n'); // never a bare dead-end
   });
 });
+
+describe('defaulted-steps rendering (issue #232)', () => {
+  function defaultSettledSnapshot(stepId: string): EvidenceSnapshot {
+    return makeSnapshot(stepId, {
+      diagnostics: { input_token_estimate: 1, precondition_trace: [], settled_by_default: true },
+    });
+  }
+
+  it('AC-1 failure path: a FAILED run that default-settled a step earlier ⇒ shows the Defaulted line, grouped right after Skipped', async () => {
+    const run = makeRun(
+      [defaultSettledSnapshot('draft'), makeSnapshot('finish', { status: 'error' })],
+      { run_phase: 'failed', failed_steps: ['finish'], terminal_state: true },
+    );
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Defaulted (settled by default): draft');
+    const skippedIdx = result.indexOf('Skipped:');
+    const defaultedIdx = result.indexOf('Defaulted (settled by default)');
+    const createdIdx = result.indexOf('Created:');
+    expect(skippedIdx).toBeGreaterThan(-1);
+    expect(defaultedIdx).toBeGreaterThan(skippedIdx); // grouped right after the Skipped block
+    expect(defaultedIdx).toBeLessThan(createdIdx);
+  });
+
+  it('AC-1 abort path: an ABORTED run that default-settled a step earlier ⇒ shows the Defaulted line', async () => {
+    const run = makeRun([defaultSettledSnapshot('draft')], {
+      run_phase: 'aborted',
+      terminal_state: true,
+    });
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Defaulted (settled by default): draft');
+  });
+
+  it('multi-default and dedup: joins distinct step names, comma-separated, first-occurrence order', async () => {
+    const run = makeRun(
+      [
+        defaultSettledSnapshot('first'),
+        makeSnapshot('untouched'),
+        defaultSettledSnapshot('second'),
+        defaultSettledSnapshot('first'), // duplicate step_id — must not double-list
+      ],
+      { run_phase: 'failed', terminal_state: true },
+    );
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).toContain('Defaulted (settled by default): first, second');
+  });
+
+  it('AC-3 negative: renders nothing extra when there are no default-settled steps', async () => {
+    const run = makeRun([makeSnapshot('draft')], { run_phase: 'completed', terminal_state: true });
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).not.toContain('Defaulted');
+  });
+
+  it('AC-3 negative, empty evidence: renders nothing extra', async () => {
+    const run = makeRun([], { run_phase: 'completed', terminal_state: true });
+    const result = await inspectRun('run_test1', makeRunStore(run), makeWorkflowStore(basicDef));
+    expect(result).not.toContain('Defaulted');
+  });
+});

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -6,7 +6,7 @@
 // import, no createRequire), never the extensions loader.
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { classifyRunHealth } from '@sensigo/realm';
+import { classifyRunHealth, deriveDefaultedSteps } from '@sensigo/realm';
 // issue #221 correction: the CLI's first command→command import (sanctioned — harmless
 // module-level Command construction; `listCommand` is a standalone Commander object never
 // auto-registered anywhere by being imported). Reused so inspect's never_claimed_idle age
@@ -253,6 +253,14 @@ export async function inspectRun(
     lines.push(
       `  ${stepName}: ${detail !== undefined ? formatSkipDetail(detail) : 'skipped (reason unavailable)'}`,
     );
+  }
+  // issue #232: read-time derivation, computed UNIFORMLY regardless of terminal state or seal
+  // outcome (complete/failed/aborted/still running) — via the SAME shared helper the persisted
+  // RunRecord.defaulted_steps field is stamped from (issue #220 PR-2, complete-only). Omitted
+  // entirely when empty (AC-3) — never a "Defaulted: (none)" line.
+  const defaultedSteps = deriveDefaultedSteps(run.evidence);
+  if (defaultedSteps.length > 0) {
+    lines.push(`Defaulted (settled by default): ${defaultedSteps.join(', ')}`);
   }
   lines.push(`Created: ${run.created_at}`);
   lines.push(`Updated: ${run.updated_at}`);

--- a/packages/core/src/engine/defaulted-steps.test.ts
+++ b/packages/core/src/engine/defaulted-steps.test.ts
@@ -1,0 +1,103 @@
+// Tests for deriveDefaultedSteps — the shared default-settled-step derivation (issue #232).
+import { describe, it, expect } from 'vitest';
+import { deriveDefaultedSteps } from './defaulted-steps.js';
+import type { EvidenceSnapshot } from '../types/run-record.js';
+
+function makeSnapshot(stepId: string, overrides: Partial<EvidenceSnapshot> = {}): EvidenceSnapshot {
+  return {
+    step_id: stepId,
+    started_at: '2026-01-01T00:00:00.000Z',
+    completed_at: '2026-01-01T00:00:01.000Z',
+    duration_ms: 1,
+    input_summary: {},
+    output_summary: {},
+    status: 'success',
+    evidence_hash: 'x',
+    ...overrides,
+  };
+}
+
+describe('deriveDefaultedSteps (issue #232)', () => {
+  it('empty evidence → []', () => {
+    expect(deriveDefaultedSteps([])).toEqual([]);
+  });
+
+  it('no default-settled entries → []', () => {
+    const evidence = [
+      makeSnapshot('a'),
+      makeSnapshot('b', { diagnostics: { input_token_estimate: 1, precondition_trace: [] } }),
+    ];
+    expect(deriveDefaultedSteps(evidence)).toEqual([]);
+  });
+
+  it('one default-settled step → [step]', () => {
+    const evidence = [
+      makeSnapshot('draft', {
+        diagnostics: {
+          input_token_estimate: 1,
+          precondition_trace: [],
+          settled_by_default: true,
+        },
+      }),
+    ];
+    expect(deriveDefaultedSteps(evidence)).toEqual(['draft']);
+  });
+
+  it('multiple distinct default-settled steps → all present, in evidence declaration order', () => {
+    const evidence = [
+      makeSnapshot('first', {
+        diagnostics: { input_token_estimate: 1, precondition_trace: [], settled_by_default: true },
+      }),
+      makeSnapshot('middle'), // not settled — excluded
+      makeSnapshot('second', {
+        diagnostics: { input_token_estimate: 1, precondition_trace: [], settled_by_default: true },
+      }),
+    ];
+    expect(deriveDefaultedSteps(evidence)).toEqual(['first', 'second']);
+  });
+
+  it('dedups a step appearing in multiple settled snapshots — first-occurrence order, once only', () => {
+    const evidence = [
+      makeSnapshot('other'),
+      makeSnapshot('draft', {
+        diagnostics: { input_token_estimate: 1, precondition_trace: [], settled_by_default: true },
+      }),
+      makeSnapshot('draft', {
+        // a second snapshot for the SAME step_id (e.g. a later evidence entry that also happens
+        // to carry the diagnostic) must not duplicate the entry — deduped, first occurrence kept.
+        diagnostics: { input_token_estimate: 2, precondition_trace: [], settled_by_default: true },
+      }),
+    ];
+    expect(deriveDefaultedSteps(evidence)).toEqual(['draft']);
+  });
+
+  it('settled_by_default: false is excluded (never treated as truthy)', () => {
+    const evidence = [
+      makeSnapshot('draft', {
+        diagnostics: {
+          input_token_estimate: 1,
+          precondition_trace: [],
+          settled_by_default: false,
+        },
+      }),
+    ];
+    expect(deriveDefaultedSteps(evidence)).toEqual([]);
+  });
+
+  it('a snapshot with no diagnostics object at all is excluded, never throws (optional chaining)', () => {
+    const evidence = [makeSnapshot('draft')]; // diagnostics undefined
+    expect(() => deriveDefaultedSteps(evidence)).not.toThrow();
+    expect(deriveDefaultedSteps(evidence)).toEqual([]);
+  });
+
+  it('a gate_response snapshot (no settled_by_default diagnostic) is excluded — no special-casing needed', () => {
+    const evidence = [
+      makeSnapshot('human_review', {
+        kind: 'gate_response',
+        input_summary: { choice: 'approve' },
+        output_summary: { choice: 'approve' },
+      }),
+    ];
+    expect(deriveDefaultedSteps(evidence)).toEqual([]);
+  });
+});

--- a/packages/core/src/engine/defaulted-steps.ts
+++ b/packages/core/src/engine/defaulted-steps.ts
@@ -1,0 +1,35 @@
+// defaulted-steps.ts — the SHARED, pure derivation for default-settled step names (issue #232).
+//
+// Extracted from stampDefaultedSteps (execution-loop.ts, issue #220 PR-2, D6) so the exact same
+// scan feeds BOTH the persisted-record stamp (complete-only, unchanged) and the READ-time surfaces
+// (get_run_state, inspect) that need the same answer for a run regardless of how it sealed. A
+// single shared derivation is what makes AC-2 (read surface matches evidence exactly) and AC-4
+// (a complete run's derived set == its persisted defaulted_steps) hold BY CONSTRUCTION — there is
+// no second, parallel scan anywhere that could silently drift from this one.
+import type { RunRecord } from '../types/run-record.js';
+
+/**
+ * Scans `evidence` for entries stamped `diagnostics.settled_by_default === true` and returns their
+ * distinct `step_id`s, deduped in first-occurrence (declaration) order — identical to
+ * `stampDefaultedSteps`'s own loop, now shared. Pure, no I/O, and safe to call on ANY evidence
+ * array regardless of the run's terminal state or how it sealed (complete/failed/aborted/still
+ * running) — the derivation itself carries no seal-outcome assumption; callers decide what to do
+ * with an empty result (e.g. `stampDefaultedSteps` still applies it ONLY at the `'complete'` seal;
+ * the read surfaces call it unconditionally and simply omit the field when empty).
+ *
+ * `gate_response` evidence snapshots carry no `diagnostics.settled_by_default` (that diagnostic is
+ * only ever stamped on the ONE synthesized SUCCESS execution snapshot a declared default-settle
+ * mints — see `StepDiagnostics.settled_by_default`'s own doc) — no special-casing needed here
+ * beyond reusing the same `=== true` predicate every other consumer of this diagnostic uses.
+ */
+export function deriveDefaultedSteps(evidence: RunRecord['evidence']): string[] {
+  const steps: string[] = [];
+  const seen = new Set<string>();
+  for (const snap of evidence) {
+    if (snap.diagnostics?.settled_by_default === true && !seen.has(snap.step_id)) {
+      seen.add(snap.step_id);
+      steps.push(snap.step_id);
+    }
+  }
+  return steps;
+}

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -27,6 +27,7 @@ import { persistsField } from '../store/store-fidelity.js';
 import type { TraceBufferStore, BufferedEntry } from '../store/trace-buffer-store.js';
 import { storeDeclaresSeal, storeDeclaresNonceCarriage } from '../store/trace-buffer-store.js';
 import { partitionBufferedEntries, type BufferedEntryPartition } from './trace-adoption.js';
+import { deriveDefaultedSteps } from './defaulted-steps.js';
 import { captureEvidence } from '../evidence/snapshot.js';
 import {
   validateInputSchema,
@@ -628,11 +629,11 @@ function mergeWarnings(
 }
 
 /**
- * Pure helper (issue #220 PR-2, D6): scans `sealDraft`'s evidence for entries stamped
- * `diagnostics.settled_by_default === true` and, if any exist, returns the record with
- * `defaulted_steps` set to their distinct step names (declaration order of first occurrence) —
- * else returns the SAME record reference unchanged, so a run with no default-settle anywhere is
- * byte-identical to pre-PR-2 behavior (the damage-rail this preserves). Pure, no I/O.
+ * Pure helper (issue #220 PR-2, D6): if `sealDraft`'s evidence has any entries default-settled
+ * (per {@link deriveDefaultedSteps}, issue #232 — the SHARED derivation the read surfaces also
+ * use), returns the record with `defaulted_steps` set to their distinct step names — else returns
+ * the SAME record reference unchanged, so a run with no default-settle anywhere is byte-identical
+ * to pre-PR-2 behavior (the damage-rail this preserves). Pure, no I/O.
  *
  * Applied by WRAPPING the `buildFinalizedSeal` call inside the TERMINAL branch of each seal
  * ternary — `buildFinalizedSeal` itself stays byte-untouched (a chokepoint insertion was
@@ -640,17 +641,13 @@ function mergeWarnings(
  * fragile two-touch above the damage-rail fast-path). Callers must pass ONLY a sealed record from
  * the `'complete'` branch — never a non-terminal draft, and never a fail/abort seal — so
  * `defaulted_steps` never leaks onto a persisted non-terminal record that a later FAIL seal
- * inherits (the FM-5 residual this guards).
+ * inherits (the FM-5 residual this guards). issue #232 note: this complete-only stamping is
+ * UNCHANGED — a run that fails/aborts still carries no persisted `defaulted_steps`; the failure-
+ * path disclosure gap is closed by the READ surfaces calling `deriveDefaultedSteps` directly, not
+ * by widening what gets persisted here.
  */
 function stampDefaultedSteps(sealDraft: RunRecord): RunRecord {
-  const steps: string[] = [];
-  const seen = new Set<string>();
-  for (const snap of sealDraft.evidence) {
-    if (snap.diagnostics?.settled_by_default === true && !seen.has(snap.step_id)) {
-      seen.add(snap.step_id);
-      steps.push(snap.step_id);
-    }
-  }
+  const steps = deriveDefaultedSteps(sealDraft.evidence);
   if (steps.length === 0) return sealDraft;
   return { ...sealDraft, defaulted_steps: steps };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,9 @@ export {
 // see trace-adoption.ts's own module doc for the full contract.
 export { adoptsLine, partitionBufferedEntries } from './engine/trace-adoption.js';
 export type { BufferedEntryPartition } from './engine/trace-adoption.js';
+// The shared default-settled-step derivation (issue #232) — the ONE authoritative scan of
+// `evidence[].diagnostics.settled_by_default`; see defaulted-steps.ts's own module doc.
+export { deriveDefaultedSteps } from './engine/defaulted-steps.js';
 export {
   TERMINAL_PHASES,
   RESUMABLE_PHASES,

--- a/packages/mcp-server/src/tools/get-run-state-defaulted-steps.test.ts
+++ b/packages/mcp-server/src/tools/get-run-state-defaulted-steps.test.ts
@@ -1,0 +1,145 @@
+// get_run_state's defaulted_steps field (issue #232) — read-time derivation via the shared
+// deriveDefaultedSteps helper, computed UNIFORMLY regardless of how the run sealed.
+//
+// A minimal hand-rolled RunStore double — handleGetRunState only ever calls `.get()`, so the
+// double only needs to implement that faithfully (mirrors get-run-state-run-health.test.ts's own
+// double, minus the fidelity-gate concerns that are out of scope here).
+import { describe, it, expect } from 'vitest';
+import type { RunRecord, RunStore, EvidenceSnapshot } from '@sensigo/realm';
+import { deriveDefaultedSteps } from '@sensigo/realm';
+import { handleGetRunState } from './get-run-state.js';
+
+function makeSnapshot(stepId: string, overrides: Partial<EvidenceSnapshot> = {}): EvidenceSnapshot {
+  return {
+    step_id: stepId,
+    started_at: '2026-01-01T00:00:00.000Z',
+    completed_at: '2026-01-01T00:00:01.000Z',
+    duration_ms: 1,
+    input_summary: {},
+    output_summary: {},
+    status: 'success',
+    evidence_hash: 'x',
+    ...overrides,
+  };
+}
+
+function defaultSettledSnapshot(stepId: string): EvidenceSnapshot {
+  return makeSnapshot(stepId, {
+    diagnostics: { input_token_estimate: 1, precondition_trace: [], settled_by_default: true },
+  });
+}
+
+function makeRun(over: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: 'r1',
+    workflow_id: 'wf',
+    workflow_version: 1,
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: [],
+    skipped_steps: [],
+    run_phase: 'completed',
+    version: 1,
+    params: {},
+    evidence: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    terminal_state: true,
+    ...over,
+  };
+}
+
+function makeStore(run: RunRecord): RunStore {
+  return {
+    persistsClaims: true,
+    async get() {
+      return run;
+    },
+    async create() {
+      throw new Error('not exercised by get_run_state');
+    },
+    async update() {
+      throw new Error('not exercised by get_run_state');
+    },
+    async list() {
+      throw new Error('not exercised by get_run_state');
+    },
+    async claimStep() {
+      throw new Error('not exercised by get_run_state');
+    },
+  };
+}
+
+describe('get_run_state — defaulted_steps (issue #232)', () => {
+  it('AC-1 failure path: a FAILED run that default-settled step "draft" earlier ⇒ defaulted_steps: ["draft"], without scanning evidence', async () => {
+    const run = makeRun({
+      run_phase: 'failed',
+      failed_steps: ['finish'],
+      evidence: [defaultSettledSnapshot('draft'), makeSnapshot('finish', { status: 'error' })],
+    });
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: makeStore(run) });
+
+    expect(summary.run_phase).toBe('failed');
+    expect(summary.defaulted_steps).toEqual(['draft']);
+  });
+
+  it('AC-1 abort path: an ABORTED run that default-settled step "draft" earlier ⇒ defaulted_steps: ["draft"]', async () => {
+    const run = makeRun({
+      run_phase: 'aborted',
+      evidence: [defaultSettledSnapshot('draft')],
+    });
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: makeStore(run) });
+
+    expect(summary.run_phase).toBe('aborted');
+    expect(summary.defaulted_steps).toEqual(['draft']);
+  });
+
+  it('AC-2 exact match: defaulted_steps equals exactly the set of evidence[].diagnostics.settled_by_default===true step_ids, including a multi-default and a dedup case', async () => {
+    const evidence = [
+      defaultSettledSnapshot('first'),
+      makeSnapshot('untouched'), // not settled
+      defaultSettledSnapshot('second'),
+      defaultSettledSnapshot('first'), // duplicate step_id, still settled — must not double-count
+    ];
+    const run = makeRun({ run_phase: 'failed', evidence });
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: makeStore(run) });
+
+    expect(summary.defaulted_steps).toEqual(deriveDefaultedSteps(evidence));
+    expect(summary.defaulted_steps).toEqual(['first', 'second']);
+  });
+
+  it('AC-4 complete-run parity: for a COMPLETE run, the derived defaulted_steps equals the persisted RunRecord.defaulted_steps', async () => {
+    const evidence = [defaultSettledSnapshot('draft'), makeSnapshot('finish')];
+    // Stamped exactly as stampDefaultedSteps would at the 'complete' seal (issue #220 PR-2) — the
+    // persisted-field shape this run-level parity check compares against.
+    const run = makeRun({
+      run_phase: 'completed',
+      completed_steps: ['draft', 'finish'],
+      evidence,
+      defaulted_steps: deriveDefaultedSteps(evidence),
+    });
+    expect(run.defaulted_steps).toEqual(['draft']); // sanity on the fixture itself
+
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: makeStore(run) });
+    expect(summary.defaulted_steps).toEqual(run.defaulted_steps);
+  });
+
+  it('AC-3 negative: a run with NO default-settled step ⇒ defaulted_steps is ABSENT, never an empty array', async () => {
+    const run = makeRun({
+      run_phase: 'completed',
+      completed_steps: ['draft'],
+      evidence: [makeSnapshot('draft')],
+    });
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: makeStore(run) });
+
+    expect(summary.defaulted_steps).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(summary, 'defaulted_steps')).toBe(false);
+  });
+
+  it('AC-3 negative, empty evidence ⇒ defaulted_steps is ABSENT', async () => {
+    const run = makeRun({ run_phase: 'completed', evidence: [] });
+    const summary = await handleGetRunState({ run_id: 'r1' }, { runStore: makeStore(run) });
+
+    expect(summary.defaulted_steps).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/tools/get-run-state.ts
+++ b/packages/mcp-server/src/tools/get-run-state.ts
@@ -12,6 +12,7 @@ import {
   findCapabilityBlockedSteps,
   classifyRunHealth,
   persistsField,
+  deriveDefaultedSteps,
   type RunPhase,
   type NextAction,
   type ClaimState,
@@ -129,6 +130,17 @@ export interface RunStateSummary {
    * cannot show it (notably a `gate_waiting` run, whose status MUST stay `awaiting_human`).
    */
   run_health?: RunHealthFinding[];
+  /**
+   * Names of steps that settled via their declared `validation_exhaustion.default_output`
+   * substitution (issue #232) — present only when non-empty. Derived on demand from
+   * `evidence[].diagnostics.settled_by_default` via the SAME shared `deriveDefaultedSteps` helper
+   * `RunRecord.defaulted_steps` itself is stamped from (issue #220 PR-2), so this field is exact
+   * (AC-2) and — for a `'complete'` run — identical to the persisted field (AC-4). Unlike the
+   * persisted field, this is computed UNIFORMLY regardless of how the run sealed (complete,
+   * failed, or aborted): a run that default-settles a step and then fails still surfaces it here,
+   * closing the failure-path disclosure gap `defaulted_steps`'s complete-only stamping leaves.
+   */
+  defaulted_steps?: string[];
   /**
    * Advisory diagnostics for this response (issue #119: WARN-never-gate — never a throw, never a
    * behavior change). Independent sources, any subset may be present:
@@ -266,6 +278,11 @@ export async function handleGetRunState(
     );
   }
 
+  // issue #232: read-time derivation (approach 2, DECIDED) — computed UNIFORMLY for every run
+  // regardless of terminal state or seal outcome (no guard here, unlike stampDefaultedSteps'
+  // complete-only stamping), via the SAME shared helper that stamping itself now calls.
+  const defaultedSteps = deriveDefaultedSteps(run.evidence);
+
   return {
     run_id: run.id,
     workflow_id: run.workflow_id,
@@ -298,6 +315,7 @@ export async function handleGetRunState(
       ? { skip_details: run.skip_details }
       : {}),
     ...(runHealth.length > 0 ? { run_health: runHealth } : {}),
+    ...(defaultedSteps.length > 0 ? { defaulted_steps: defaultedSteps } : {}),
     ...(warnings.length > 0 ? { warnings } : {}),
   };
 }


### PR DESCRIPTION
## Context
When a step settles by default (`validation_exhaustion.mode: 'default'`), the substitution is disclosed
per-step via `evidence[].diagnostics.settled_by_default === true`, and aggregated at the run level into
`RunRecord.defaulted_steps` — but that aggregate is stamped **only on a `'complete'` seal** (a
deliberate #220 PR-2 residual). A run that default-settles a step and then **fails or aborts** carries
no run-level signal; an on-call engineer triaging a failed run via `get_run_state`/`realm inspect`
can't see "a default fired earlier" without scanning the whole evidence array. #232 closes that hole via
**read-time derivation (approach 2, DECIDED)** — no persisted-record change.

## Changes (6 non-test files + 3 test files)
1. **`packages/core/src/engine/defaulted-steps.ts`** (new) — extracts `stampDefaultedSteps`'s scan into
   a shared, exported pure helper: `deriveDefaultedSteps(evidence: RunRecord['evidence']): string[]`.
   Returns `step_id`s with `diagnostics?.settled_by_default === true`, deduped in first-occurrence
   order — byte-identical logic to the original inline loop.
2. **`packages/core/src/engine/execution-loop.ts`** — `stampDefaultedSteps` refactored to call
   `deriveDefaultedSteps` instead of its own inline loop. Its complete-only stamping behavior, the
   3 call sites (`'complete'` seal / gate-approval seal / guard-complete seal), and the early-return
   damage rail (`if (steps.length === 0) return sealDraft`) are all **unchanged** — confirmed by diff
   (only the helper's own body + one import line touched; all 3 call sites byte-identical).
3. **`packages/core/src/index.ts`** — exports `deriveDefaultedSteps` from `@sensigo/realm`.
4. **`packages/mcp-server/src/tools/get-run-state.ts`** — `handleGetRunState` computes
   `deriveDefaultedSteps(run.evidence)` unconditionally (no terminal/seal-outcome guard) and adds
   `defaulted_steps?: string[]` to `RunStateSummary` using the same omit-when-empty convention as its
   siblings (`run_health`, `skip_details`, etc.).
5. **`packages/cli/src/commands/inspect.ts`** — `inspectRun` renders one additional line when
   `deriveDefaultedSteps(run.evidence)` is non-empty: `Defaulted (settled by default): <steps>`,
   grouped right after the Skipped block. Nothing rendered when empty.
6. **`CHANGELOG.md`** — new `[Unreleased] ### Added` entry.
7. **Tests** (3 files): `packages/core/src/engine/defaulted-steps.test.ts` (new, 8 unit tests on the
   pure helper: empty/single/multi/dedup/false/no-diagnostics/gate_response);
   `packages/mcp-server/src/tools/get-run-state-defaulted-steps.test.ts` (new, 6 tests: AC-1
   failure+abort paths, AC-2 exact-match incl. multi-default+dedup, AC-3 negative incl. empty evidence,
   AC-4 complete-run parity); `packages/cli/src/commands/inspect.test.ts` (+5 tests: AC-1 failure+abort,
   multi-default+dedup ordering/line-placement, AC-3 negative ×2).

**Out of scope (per the issue):** `realm run list --stuck` is untouched (AC-1 is satisfied by
`get_run_state` + `inspect` alone); the `execute_step` envelope's complete-only `defaulted_steps` is
unchanged; no `RunStore`/`#188` fidelity-contract change.

## Verification
- `npx tsc --noEmit` (via `npm run build`) → **0 errors**, all 4 packages build clean
- `npm run test` → **8/8 tasks green** — core **1932/1932** (incl. the new 8-test
  `defaulted-steps.test.ts` AND the pre-existing 11-test `validation-exhaustion-default.test.ts`
  passing byte-unchanged — the behavior-identical proof for the `stampDefaultedSteps` refactor),
  mcp-server **271/271** (incl. the new 6-test file), cli **844/844** (incl. `inspect.test.ts` now
  40 tests, +5), realm-testing **81/81**
- `npm run lint` → clean · `npm run format:check` → clean
- Single-derivation grep: `settled_by_default === true` appears in exactly ONE non-test file
  (`defaulted-steps.ts`); `deriveDefaultedSteps(` is called from exactly 3 non-test sites
  (`stampDefaultedSteps`, `handleGetRunState`, `inspectRun`) — no second, parallel derivation anywhere
- `git diff --stat main` → exactly the 9 files above; no `list.ts`/store change

## Rollback
`git revert b4bb4c5`. Additive-only surface (new `defaulted_steps?`/rendered line); no persisted-record
change, no store interface change, no protocol change.

## Related
Report: `/reports/defaulted-steps-read-derive-232.md`. Closes #232.
