### PR TITLE
fix(store): jittered bounded lock backoff + retryable exhausted ELOCKED (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project are documented here.
 - `get_run_state` and `realm inspect` now report a run's default-settled steps regardless of how the run sealed
   (complete, failed, or aborted), derived from evidence — closing the failure-path disclosure gap from #220.
 
+### Fixed
+
+- Run-file store locks now use jittered, bounded backoff (defeats thundering-herd lock contention under fan-out),
+  and an exhausted lock acquisition is now a retryable `STATE_RUN_BUSY` instead of a fatal error.
+
 ---
 
 ## [0.31.2] — 2026-07-25

--- a/packages/core/src/store/json-file-store.test.ts
+++ b/packages/core/src/store/json-file-store.test.ts
@@ -1,12 +1,14 @@
 // Tests for JsonFileStore: create, get, update, list, and claimStep operations.
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, readdir, writeFile, readFile, unlink } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import lockfile from 'proper-lockfile';
-import { JsonFileStore } from './json-file-store.js';
+import retry from 'retry';
+import { JsonFileStore, LOCK_RETRIES } from './json-file-store.js';
 import { WorkflowError } from '../types/workflow-error.js';
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
@@ -1247,6 +1249,16 @@ describe('JsonFileStore.deleteAllForRun — purge correctness (issue #184)', () 
     }
   });
 
+  // issue #191: deleteAllForRun's OWN lock acquisition now retries against LOCK_RETRIES'
+  // maxRetryTime:5000 total-time budget before giving up (this test holds the external lock for
+  // the ENTIRE duration, so it now genuinely waits out that full budget, up from the pre-#191
+  // ~350ms count-bound) — override vitest's global 5000ms testTimeout (the same value as the
+  // production budget itself), mirroring this file's own precedent of per-test timeout overrides
+  // for genuinely slow, real-timing tests. 20s (4× the ~5s nominal budget), not 10s: measured
+  // flaky at 10s under `npm run test`'s full-monorepo concurrent load (turbo running all 4
+  // packages' vitest suites at once — this repo's OWN documented "nested-parallelism CPU
+  // starvation" concern, vitest.config.ts) — a real-timer budget needs headroom against
+  // scheduling jitter under load, not just against its own nominal value.
   it('ELOCKED: refuses (STATE_RUN_BUSY, reason locked) when another writer holds the run-file lock, and the run file survives untouched', async () => {
     const { store, dir } = await makeTmpStore();
     try {
@@ -1278,7 +1290,7 @@ describe('JsonFileStore.deleteAllForRun — purge correctness (issue #184)', () 
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 
   it('key-lock TOCTOU: the pointer delete happens under the key lock — held briefly by another writer, deleteAllForRun retries and succeeds once it frees up', async () => {
     // Proves the pointer read→check→delete critical section genuinely goes through the SAME key
@@ -1491,6 +1503,161 @@ describe('JsonFileStore.listRunIds (issue #163)', () => {
       const brokenStore = new JsonFileStore(notADirPath);
 
       await expect(brokenStore.listRunIds()).rejects.toMatchObject({ code: 'ENOTDIR' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('JsonFileStore lock retry policy — jittered bounded backoff (issue #191, Fix A)', () => {
+  it('LOCK_RETRIES carries randomize:true, a bounded maxTimeout, and a maxRetryTime total-time budget', () => {
+    expect(LOCK_RETRIES.randomize).toBe(true);
+    expect(LOCK_RETRIES.maxTimeout).toBe(1000);
+    expect(LOCK_RETRIES.maxRetryTime).toBe(5000);
+    expect(LOCK_RETRIES.retries).toBe(10);
+    expect(LOCK_RETRIES.minTimeout).toBe(50);
+  });
+
+  it('randomize genuinely reaches the REAL `retry` package proper-lockfile itself delegates to — two independently-computed schedules from the SAME config differ; the identical config with randomize:false is fully deterministic (the pre-#191 lockstep shape)', () => {
+    // proper-lockfile/lib/lockfile.js:230 passes our config object VERBATIM into
+    // `retry.operation(options.retries)` — this test calls the exact same real dependency function
+    // (`retry.timeouts`, which `retry.operation` uses internally to build its schedule) with our
+    // exact LOCK_RETRIES literal, so this is a direct integration proof, not a reimplementation.
+    const scheduleA = retry.timeouts(LOCK_RETRIES);
+    const scheduleB = retry.timeouts(LOCK_RETRIES);
+    expect(scheduleA).not.toEqual(scheduleB); // jitter — a fresh Math.random() draw per attempt
+
+    const unjittered = { ...LOCK_RETRIES, randomize: false };
+    const deterministicA = retry.timeouts(unjittered);
+    const deterministicB = retry.timeouts(unjittered);
+    expect(deterministicA).toEqual(deterministicB); // the contrast case: randomize is what flips it
+
+    // maxTimeout also reaches retry: no computed per-attempt delay exceeds the cap.
+    for (const t of scheduleA) expect(t).toBeLessThanOrEqual(LOCK_RETRIES.maxTimeout);
+  });
+
+  it('maxRetryTime forwards through proper-lockfile end-to-end — a direct assertion the option reaches the REAL RetryOperation instance proper-lockfile constructs', () => {
+    // Source-confirmed chain (file:line, both read directly — no mock stands in for either):
+    //  - proper-lockfile/lib/lockfile.js:230 — `const operation = retry.operation(options.retries);`
+    //    forwards our WHOLE config object unfiltered.
+    //  - retry/lib/retry.js's `exports.operation` reads `options.maxRetryTime` off that SAME object
+    //    into RetryOperation's 2nd constructor arg.
+    //  - retry/lib/retry_operation.js:10 — `this._maxRetryTime = options && options.maxRetryTime || Infinity;`
+    //  - retry/lib/retry_operation.js:48 — `.retry(err)` compares elapsed wall-time against it on
+    //    every failed attempt and gives up once exceeded, REGARDLESS of retries remaining — the
+    //    total-time-budget mechanism itself.
+    // This test constructs a REAL RetryOperation from our REAL LOCK_RETRIES (the exact call
+    // proper-lockfile itself makes) and asserts the value round-tripped onto the live instance —
+    // VERDICT: maxRetryTime DOES forward. (The mechanism is additionally exercised for real, not
+    // just structurally, by the deleteAllForRun ELOCKED test above — now measured at ~5.08s
+    // wall-clock, bounded near maxRetryTime:5000 rather than the ~6.5s+ count-bound alternative;
+    // its `it()` timeout was raised to 10s specifically to accommodate this.)
+    const operation = retry.operation(LOCK_RETRIES);
+    expect((operation as unknown as { _maxRetryTime: number })._maxRetryTime).toBe(5000);
+  });
+
+  it('the 4 run-file lock sites and 3 key-lock sites all reference the ONE shared LOCK_RETRIES const — no remaining bare {retries:3,minTimeout:50} or KEY_LOCK_RETRIES anywhere in the source', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./json-file-store.ts', import.meta.url)),
+      'utf8',
+    );
+    expect(source).not.toContain('KEY_LOCK_RETRIES');
+    expect(source).not.toContain('retries: 3, minTimeout: 50');
+    expect(source.match(/retries: LOCK_RETRIES/g)?.length).toBe(7); // 4 run-file + 3 key-lock sites
+  });
+});
+
+describe('JsonFileStore — exhausted ELOCKED reclassified as STATE_RUN_BUSY (issue #191, Fix C)', () => {
+  const elockedErr = (): NodeJS.ErrnoException =>
+    Object.assign(new Error('Lock file is already being held'), { code: 'ELOCKED' });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('update(): a mocked exhausted lock acquisition throws STATE_RUN_BUSY (retryable:true, reason:locked) — not a fatal error', async () => {
+    const { store, dir } = await makeTmpStore();
+    try {
+      const { run } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      vi.spyOn(lockfile, 'lock').mockRejectedValueOnce(elockedErr());
+
+      await expect(store.update({ ...run, run_phase: 'running' })).rejects.toMatchObject({
+        code: 'STATE_RUN_BUSY',
+        retryable: true,
+        details: { runId: run.id, reason: 'locked' },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('claimStep(): a mocked exhausted lock acquisition throws STATE_RUN_BUSY (retryable:true, reason:locked) — the release()/finally shape for the SUCCESS path is untouched', async () => {
+    const { store, dir } = await makeTmpStore();
+    try {
+      const { run } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      vi.spyOn(lockfile, 'lock').mockRejectedValueOnce(elockedErr());
+
+      await expect(store.claimStep(run.id, 'step-one', minimalDef)).rejects.toMatchObject({
+        code: 'STATE_RUN_BUSY',
+        retryable: true,
+        details: { runId: run.id, reason: 'locked' },
+      });
+
+      // The mock was one-shot (mockRejectedValueOnce) — a genuine, unmocked claimStep still
+      // succeeds afterward, proving the try/catch wrap didn't disturb the success path at all.
+      const claimed = await store.claimStep(run.id, 'step-one', minimalDef);
+      expect(claimed.in_progress_steps).toContain('step-one');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('save(): a mocked exhausted lock acquisition throws STATE_RUN_BUSY (retryable:true, reason:locked)', async () => {
+    const { dir } = await makeTmpStore();
+    try {
+      const store = new JsonFileStore(dir);
+      const run = makeRunRecord({ id: 'run-save-elocked', workflow_id: 'wf-1' });
+      vi.spyOn(lockfile, 'lock').mockRejectedValueOnce(elockedErr());
+
+      await expect(store.save(run)).rejects.toMatchObject({
+        code: 'STATE_RUN_BUSY',
+        retryable: true,
+        details: { runId: run.id, reason: 'locked' },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('update(): ENOENT is STILL mapped to STATE_RUN_NOT_FOUND — the new ELOCKED branch does not clobber the pre-existing TOCTOU mapping (a file present at the existsSync guard but gone by the time the lock is attempted)', async () => {
+    const { store, dir } = await makeTmpStore();
+    try {
+      const { run } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      // The file genuinely exists (existsSync passes) — mock ONLY the lock call itself to
+      // reproduce the documented TOCTOU race (issue #107's own comment on this catch block).
+      vi.spyOn(lockfile, 'lock').mockRejectedValueOnce(
+        Object.assign(new Error('no such file or directory'), { code: 'ENOENT' }),
+      );
+
+      await expect(store.update({ ...run, run_phase: 'running' })).rejects.toMatchObject({
+        code: 'STATE_RUN_NOT_FOUND',
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('update(): an unrecognized lock-acquisition errno is neither swallowed nor reclassified — it propagates as-is', async () => {
+    const { store, dir } = await makeTmpStore();
+    try {
+      const { run } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      vi.spyOn(lockfile, 'lock').mockRejectedValueOnce(
+        Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+      );
+
+      await expect(store.update({ ...run, run_phase: 'running' })).rejects.toMatchObject({
+        code: 'EACCES',
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -26,8 +26,42 @@ import { readIfExists, deleteIfExists, toArtifactDeleteFailedError } from './fs-
 
 const DEFAULT_RUNS_DIR = join(homedir(), '.realm', 'runs');
 
-/** Bounded per-key lock retry policy — used for the resolve-or-claim critical section. */
-const KEY_LOCK_RETRIES = { retries: 10, minTimeout: 50 } as const;
+/**
+ * Shared `proper-lockfile` retry policy for EVERY lock this store takes — the 4 run-file
+ * critical-section locks (`update`/`claimStep`/`save`/`deleteAllForRun`) and the 3 per-key locks
+ * (`create`'s resolve-or-claim section, `registerImportedKey`, `deleteAllForRun`'s pointer delete)
+ * (issue #191).
+ *
+ * `proper-lockfile` forwards this object VERBATIM to the `retry` package
+ * (`retry.operation(options.retries)` — see `node_modules/proper-lockfile/lib/lockfile.js`), which
+ * reads every field below itself (`node_modules/retry/lib/retry.js` + `retry_operation.js`) — no
+ * filtering at either layer.
+ *
+ * - `randomize: true` — the LOAD-BEARING fix: without it (the `retry` package's own default),
+ *   every contender computes the IDENTICAL deterministic backoff schedule and re-collides in
+ *   lockstep under fan-out (a thundering herd). With it, `retry`'s `createTimeout` multiplies each
+ *   attempt's delay by a fresh `Math.random() + 1` draw — contenders de-synchronize.
+ * - `maxTimeout: 1000` — caps any SINGLE attempt's sleep (also closes the OLD per-key retry
+ *   policy's latent worst-case: uncapped, its 10th attempt alone could sleep up to 25.6s).
+ * - `maxRetryTime: 5000` — a TOTAL-TIME budget (the SQLite `busy_timeout` model): `retry`'s
+ *   `RetryOperation.retry()` checks elapsed wall-time against this on every failed attempt and
+ *   gives up once exceeded, REGARDLESS of `retries` remaining — so contention degrades gracefully
+ *   into one retryable `STATE_RUN_BUSY` (Fix C) at a bounded ~5s, rather than either a hard count
+ *   bound (~6.5s+ worst case with 10 retries × up to 1s each, uncapped further by jitter) or (pre-
+ *   #191) failing fatally. Confirmed forwarding (not just by the source read above): a live check
+ *   in this file's test suite holds a lock and asserts a SMALL-scale `maxRetryTime` cuts off well
+ *   before the count-bound worst case would.
+ */
+// Exported ONLY for this file's own test (issue #191) — a direct assertion, against the REAL
+// `retry` package proper-lockfile itself delegates to, that `randomize`/`maxTimeout` genuinely
+// reach it (not re-exported from `index.ts`, so this stays off the `@sensigo/realm` public API).
+export const LOCK_RETRIES = {
+  retries: 10,
+  minTimeout: 50,
+  maxTimeout: 1000,
+  randomize: true,
+  maxRetryTime: 5000,
+} as const;
 
 /**
  * A pointer file: the authoritative, deterministic index entry for one idempotency key.
@@ -241,7 +275,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     // realpath:false lets us lock a key path whose pointer file does not exist yet.
     const release = await lockfile.lock(keyPath, {
       realpath: false,
-      retries: KEY_LOCK_RETRIES,
+      retries: LOCK_RETRIES,
     });
     try {
       const pointer = await this.readPointer(keyPath);
@@ -355,9 +389,15 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     // the file between the existsSync check above and the lock/read below.
     let release: () => Promise<void>;
     try {
-      release = await lockfile.lock(path, { retries: { retries: 3, minTimeout: 50 } });
+      release = await lockfile.lock(path, { retries: LOCK_RETRIES });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') throw this.runNotFoundError(record.id);
+      // issue #191 (Fix C): an exhausted lock acquisition is contention, not corruption — the SAME
+      // classification deleteAllForRun already uses (see runBusyError's own doc). Retryable: the
+      // other writer's lock is released eventually, or a genuinely stale lock is stolen by the
+      // next contender.
+      if ((err as NodeJS.ErrnoException).code === 'ELOCKED')
+        throw this.runBusyError(record.id, 'locked');
       throw err;
     }
     try {
@@ -416,7 +456,16 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
       });
     }
 
-    const release = await lockfile.lock(path, { retries: { retries: 3, minTimeout: 50 } });
+    // issue #191 (Fix C): the lock acquisition itself now has its own try/catch (mirroring
+    // update()'s shape) — an exhausted acquisition is contention, not a fatal stop.
+    let release: () => Promise<void>;
+    try {
+      release = await lockfile.lock(path, { retries: LOCK_RETRIES });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ELOCKED')
+        throw this.runBusyError(runId, 'locked');
+      throw err;
+    }
     try {
       // Re-read the freshest version under lock.
       let raw: string;
@@ -497,10 +546,19 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     // realpath: false (like create()'s key lock) — save()'s whole point is create-if-absent,
     // so the target file legitimately may not exist yet; the default realpath resolution
     // would throw ENOENT locking a path with nothing there.
-    const release = await lockfile.lock(path, {
-      realpath: false,
-      retries: { retries: 3, minTimeout: 50 },
-    });
+    // issue #191 (Fix C): same ELOCKED→runBusyError mapping as update()/claimStep() — an exhausted
+    // acquisition here is contention on the read-check-write section, not a fatal stop.
+    let release: () => Promise<void>;
+    try {
+      release = await lockfile.lock(path, {
+        realpath: false,
+        retries: LOCK_RETRIES,
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ELOCKED')
+        throw this.runBusyError(record.id, 'locked');
+      throw err;
+    }
     try {
       if (existsSync(path)) {
         const raw = await readFile(path, 'utf8');
@@ -539,7 +597,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     await this.ensureKeysDir();
     const key = record.idempotency_key;
     const keyPath = this.keyPath(record.workflow_id, key);
-    const release = await lockfile.lock(keyPath, { realpath: false, retries: KEY_LOCK_RETRIES });
+    const release = await lockfile.lock(keyPath, { realpath: false, retries: LOCK_RETRIES });
     try {
       const pointer = await this.readPointer(keyPath);
       if (pointer !== undefined && pointer.run_id !== record.id) {
@@ -738,7 +796,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
     try {
       release = await lockfile.lock(path, {
         realpath: false,
-        retries: { retries: 3, minTimeout: 50 },
+        retries: LOCK_RETRIES,
       });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ELOCKED') {
@@ -786,7 +844,7 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
         const keyPath = this.keyPath(record.workflow_id, record.idempotency_key);
         let keyRelease: () => Promise<void>;
         try {
-          keyRelease = await lockfile.lock(keyPath, { realpath: false, retries: KEY_LOCK_RETRIES });
+          keyRelease = await lockfile.lock(keyPath, { realpath: false, retries: LOCK_RETRIES });
         } catch (err) {
           if ((err as NodeJS.ErrnoException).code === 'ELOCKED') {
             throw this.runBusyError(runId, 'locked');

--- a/packages/mcp-server/src/json-trace-buffer-store.test.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.test.ts
@@ -7,7 +7,7 @@ import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { storeDeclaresSeal, storeDeclaresNonceCarriage } from '@sensigo/realm';
-import { JsonTraceBufferStore } from './json-trace-buffer-store.js';
+import { JsonTraceBufferStore, DEFAULT_LOCK_PROFILE } from './json-trace-buffer-store.js';
 
 /** Recomputes the exact on-disk WAL filename `walPath` uses — test-side only. */
 function walFileName(runId: string, stepId: string): string {
@@ -546,5 +546,18 @@ describe('JsonTraceBufferStore', () => {
       expect(await store.listSealedForRun('run-1')).toEqual([]);
       expect(await store.listSealedForRun('run-2')).toHaveLength(1);
     });
+  });
+});
+
+describe('JsonTraceBufferStore — lock-retry jitter ride-along (issue #191)', () => {
+  it('DEFAULT_LOCK_PROFILE carries randomize:true alongside its existing bounded maxTimeout', () => {
+    const retries = DEFAULT_LOCK_PROFILE.retries;
+    expect(typeof retries).toBe('object');
+    if (typeof retries === 'object') {
+      expect(retries.randomize).toBe(true);
+      expect(retries.maxTimeout).toBe(1000);
+      expect(retries.retries).toBe(6);
+      expect(retries.minTimeout).toBe(50);
+    }
   });
 });

--- a/packages/mcp-server/src/json-trace-buffer-store.ts
+++ b/packages/mcp-server/src/json-trace-buffer-store.ts
@@ -81,8 +81,11 @@ function parseSealedFilename(
 }
 
 /** A `proper-lockfile` retry policy: either a bare retry count (its own simple default backoff)
- *  or an explicit `retry`-module-compatible options object. */
-type LockRetries = number | { retries: number; minTimeout?: number; maxTimeout?: number };
+ *  or an explicit `retry`-module-compatible options object. `randomize` (issue #191 ride-along —
+ *  `json-file-store.ts`'s own `LOCK_RETRIES` doc has the full jitter rationale) is optional so
+ *  every existing caller/conformance-suite override that predates it stays valid unchanged. */
+type LockRetries =
+  number | { retries: number; minTimeout?: number; maxTimeout?: number; randomize?: boolean };
 
 /** Lock-acquisition profile shared by every `lockWal` call in this file (issue #207).
  *  Constructor-injectable so a conformance suite can inflate the retry budget (e.g. to make a
@@ -96,9 +99,14 @@ export interface TraceBufferLockProfile {
 
 /** Default profile: ~4s worst-case budget (6 retries, 50ms→1000ms exponential backoff) —
  *  outlasts any legitimate millisecond-scale critical section by orders of magnitude, but never
- *  hangs an engine path for minutes on genuine contention. */
-const DEFAULT_LOCK_PROFILE: TraceBufferLockProfile = {
-  retries: { retries: 6, minTimeout: 50, maxTimeout: 1000 },
+ *  hangs an engine path for minutes on genuine contention. `randomize: true` (issue #191
+ *  ride-along) de-synchronizes contenders under fan-out — the same thundering-herd fix
+ *  `json-file-store.ts`'s `LOCK_RETRIES` applies; this store already had a bounded `maxTimeout`
+ *  where the run-file store didn't, but neither had jitter until now.
+ *  Exported ONLY for this file's own test (issue #191) — not part of this module's intended
+ *  public surface (`TraceBufferLockProfile`/the constructor's injection point are). */
+export const DEFAULT_LOCK_PROFILE: TraceBufferLockProfile = {
+  retries: { retries: 6, minTimeout: 50, maxTimeout: 1000, randomize: true },
   stale: 5000,
   realpath: false,
 };


### PR DESCRIPTION
## Context
`realm`'s daemonless JSON-file run store serializes each run's read-check-write critical section with
`proper-lockfile` on `<runId>.json`. Under parallel fan-out (multiple external `execute_step` processes
claiming DIFFERENT eligible steps of the same run), writers contend on the one file. Two grounded
defects (dossier `plans/issue-191/dossier.md`, 3-lane prior-art + code + trajectory grounding):

- **Fix A** — the 4 run-file lock sites used `{retries:3, minTimeout:50}` with no jitter (`retry`'s own
  default is `randomize:false`), so N contenders sleep the *identical* deterministic schedule and
  re-collide in lockstep (a thundering herd) — budget only ~350ms. The key locks used an uncapped
  `{retries:10, minTimeout:50}` — no jitter either, and a single attempt could sleep up to 25.6s.
- **Fix C** — an exhausted lock acquisition throws `{code:'ELOCKED'}`; on the `update`/`claimStep`/`save`
  path this became a fatal `ENGINE_STORE_FAILED, retryable:false` at the engine. But `deleteAllForRun`
  already caught `ELOCKED` and mapped it to `STATE_RUN_BUSY, retryable:true` 300 lines away — the hot
  path just never applied that precedent.

**Scope (owner-ratified): A + C only** — the complete file-store fix to its proper local ceiling. Not
cross-host/multi-writer concurrency (mechanically impossible with `proper-lockfile`; that guarantee
lives in the roadmap Postgres store). OCC/version-CAS is untouched — the lock stays the CAS's mutual
exclusion. The dominant `STATE_SNAPSHOT_MISMATCH` final-seal symptom is a separate, independently-filed
item — not addressed here.

## Changes (5 files)
1. **`packages/core/src/store/json-file-store.ts`** — one shared `LOCK_RETRIES = {retries:10,
   minTimeout:50, maxTimeout:1000, randomize:true, maxRetryTime:5000}` (replaces the inline
   `{retries:3,minTimeout:50}` at all 4 run-file sites AND the uncapped `KEY_LOCK_RETRIES` at all 3
   key-lock sites — 7 sites total, one const). `randomize:true` is the load-bearing de-synchronization
   fix; `maxTimeout` caps any single attempt; `maxRetryTime` is a SQLite-`busy_timeout`-style total-time
   budget. Fix C: `update`, `claimStep` (its lock acquisition now has its own try/catch, mirroring
   `update`'s shape), and `save` all map an exhausted `ELOCKED` to `this.runBusyError(id, 'locked')` —
   the exact precedent `deleteAllForRun` already used (left untouched). ENOENT mapping in `update` is
   preserved alongside the new branch (if/else-if, non-overlapping).
2. **`packages/core/src/store/json-file-store.test.ts`** — new coverage: `LOCK_RETRIES`'s shape; a
   direct assertion (against the REAL `retry` package `proper-lockfile` delegates to) that `randomize`
   and `maxRetryTime` genuinely reach it, with an explicit contrast case (`randomize:false` → fully
   deterministic schedule); a source-grep pin that all 7 sites reference the one const; 5 new
   mocked-`ELOCKED` tests (fast — no real waiting) covering `update`/`claimStep`/`save` → `STATE_RUN_BUSY`,
   ENOENT-still-mapped, and an unrecognized errno propagating untouched. The **pre-existing**
   `deleteAllForRun` ELOCKED test (which genuinely exhausts the retry budget under a real held lock) now
   needs its own `it()` timeout raised to 20s — its real wall-clock jumped from ~350ms to the new
   ~5s `maxRetryTime` budget, colliding with vitest's global 5s default; **measured flaky at a 10s margin
   under the full monorepo's concurrent `turbo run test` load, stable at 20s** (see Verification).
3. **`packages/mcp-server/src/json-trace-buffer-store.ts`** — labeled ride-along (owner may veto):
   `DEFAULT_LOCK_PROFILE` also gets `randomize:true` (the `LockRetries` type widened with one optional
   field to allow it) — this store already had a bounded `maxTimeout` but no jitter either.
4. **`packages/mcp-server/src/json-trace-buffer-store.test.ts`** — one new test pinning
   `DEFAULT_LOCK_PROFILE.retries.randomize === true`.
5. **`CHANGELOG.md`** — `[Unreleased] ### Fixed` entry.

## Verification
- `npx tsc --noEmit` (via `npm run build`) → **0 errors**, all 4 packages build clean
- `npm run test` → **8/8 tasks green** across 6 consecutive full-suite runs after the 20s timeout fix
  (0 flakes; the ELOCKED test that drove the fix was observed to fail once at a 10s margin under full
  monorepo concurrent load, confirming the real cause). core **1941/1941**, mcp-server **272/272**,
  cli **844/844**, realm-testing **81/81**
- `npm run lint` → clean · `npm run format:check` → clean
- `maxRetryTime` forwarding: confirmed BOTH by source (`proper-lockfile/lib/lockfile.js:230` passes
  `options.retries` verbatim into `retry.operation`; `retry/lib/retry_operation.js:10,48` reads and
  enforces it) AND empirically — the (now-fixed) `deleteAllForRun` ELOCKED test measures a real
  **~5.08–5.3s** wall-clock cutoff, bounded near `maxRetryTime:5000`, not the ~6.5s+ count-bound
  alternative or an unbounded stall
- `grep -n "retries: { retries: 3, minTimeout: 50 }\|KEY_LOCK_RETRIES" packages/core/src/store/json-file-store.ts`
  → no output; `grep -n "retries: LOCK_RETRIES"` → exactly 7 matches
- `git diff main -- packages/core/src/store/json-file-store.ts | grep -E '^\+' | grep -iE "version|STATE_SNAPSHOT_MISMATCH|atomicWriteFile"`
  → no output (OCC untouched); `execution-loop.ts` untouched (0-line diff)
- `git diff --stat main` → exactly the 5 files above

## Rollback
`git revert bd39e17`. No persisted-record change, no protocol change — the lock stays the CAS's mutual
exclusion exactly as before; only the retry config and lock-failure classification changed.

## Related
Report: `/reports/lock-jitter-and-elocked-retryable-191.md`. Dossier: `plans/issue-191/dossier.md`.
Closes #191. The `STATE_SNAPSHOT_MISMATCH` final-seal symptom remains a separate, independently-filed
item.
