### PR TITLE
feat(engine): migrate seal sites to atomic settlement + finalizer drain (issue #279 PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,47 @@ All notable changes to this project are documented here.
   (complete, failed, or aborted), derived from evidence — closing the failure-path disclosure gap from #220.
 - `RunStore.settleStep` (optional): atomic intent-based step settlement applied to fresh state under the store's
   own serialization, with the `applySettlement` pure transform, per-claim fencing tokens, the finalizer ledger, and
-  a forcing conformance TCK — dormant in this release; the engine adopts it in the next PR (#279).
+  a forcing conformance TCK.
+- `realm run drain <id> [--force]` / `--all [--force]` / `--void <finalizer>`: recovers finalizers left undelivered
+  by a crash between a settle's commit and its post-commit drain — dry-run by default (draining executes extension
+  code), rank-pass rendering (actionable / lease-held / rank-blocked-behind-held-lease / no-pendings), and an
+  operator void with lease-discriminated disclosure and full evidence provenance.
+- `realm run purge` refuses (`STATE_RUN_BUSY`, reason `drain_pending`) to delete a terminal run with an undrained
+  finalizer, in every mode including single-id `--force` — the escape is `realm run drain` / `--void`, never
+  force-bypassing purge.
+- `get_run_state` / `realm run list --stuck` / `realm inspect` gain a new run-health finding,
+  `terminal_pending_finalizer`, for a terminal run carrying an undelivered finalizer — pointing at `realm run drain`.
+- `start_run` (idempotent reuse) and `realm run export` now disclose undelivered finalizers on a terminal run
+  ("N finalizer(s) not yet delivered — realm run drain `<id>`"); `realm agent --run-id` on a terminal run with
+  pendings appends the same pointer to its refusal message.
+- `get_workflow_protocol` gains one appended rule: a concurrent settlement of the same step by a sibling attempt
+  resolves automatically — on `STATE_STEP_ALREADY_SETTLED`, call `get_run_state` and continue.
+- Two new `WorkflowError` codes: `STATE_STEP_ALREADY_SETTLED` and `STATE_CLAIM_LOST` (the migrated seal sites'
+  typed settle_step refusal envelopes).
 
 ### Fixed
 
 - Run-file store locks now use jittered, bounded backoff (defeats thundering-herd lock contention under fan-out),
   and an exhausted lock acquisition is now a retryable `STATE_RUN_BUSY` instead of a fatal error.
+- The fan-out seal wedge (issue #279): two sibling steps settling concurrently on the migrated paths now both
+  record cleanly — no `STATE_SNAPSHOT_MISMATCH`, no lost outcome. Finalizers now fire strictly AFTER their
+  triggering settle commits durably (post-commit drain), closing the latent fire-before-commit window the legacy
+  read-then-update seal carried (a settle that lost a race could still have already fired its finalizers).
+- `realm resume` now strips a stale `abandoned_at` marker in the same write that clears `terminal_state` (issue
+  #281) — previously a resumed-and-re-terminalized run could still read as "abandoned" to a reader that treats
+  `abandoned_at`'s presence as authoritative.
+
+### Changed
+
+- The engine's three seal sites (complete, fail, handler-abort) now settle via `RunStore.settleStep` when the
+  store declares it — the legacy read-then-update path remains the fallback for a store that does not (fail-closed
+  dormancy; this dual branch persists until a major version). **Upgrade all binaries sharing a `runsDir` together**
+  — pending-finalizer guards (the purge refusal, the drain verb, the run-health finding) exist only from this
+  version onward; an older binary sharing the same `runsDir` neither recognizes nor respects them.
+- `realm resume` gained four refusals before its write: an aborted run is never resumable; a finalizer named via
+  `--from` is refused (drain/void it instead); an unexpired drain lease refuses (bounded wait, never
+  force-bypassable); and an in-progress claim now blocks resume unless it is provably stale (`--force` overrides
+  only the unknown-age case, never a healthy claim).
 
 ---
 

--- a/packages/cli/src/agent/run-agent.ts
+++ b/packages/cli/src/agent/run-agent.ts
@@ -234,8 +234,17 @@ export async function runAgent(deps: AgentDeps, options: AgentRunOptions): Promi
     // --run-id path: attach to existing run
     currentRun = await deps.store.get(options.existingRunId);
     if (currentRun.terminal_state) {
+      // issue #279 (increment 1, PR-B), design record §6: point at the recovery verb when the
+      // terminal run this attach targeted still carries an undelivered finalizer.
+      const pendingFinalizerCount = Object.values(currentRun.finalizer_ledger ?? {}).filter(
+        (e) => e.status === 'pending',
+      ).length;
+      const drainHint =
+        pendingFinalizerCount > 0
+          ? ` ${pendingFinalizerCount} finalizer(s) not yet delivered — realm run drain ${options.existingRunId}.`
+          : '';
       throw new Error(
-        `Run ${options.existingRunId} is already in terminal state: ${currentRun.terminal_reason ?? currentRun.run_phase}`,
+        `Run ${options.existingRunId} is already in terminal state: ${currentRun.terminal_reason ?? currentRun.run_phase}.${drainHint}`,
       );
     }
     runId = options.existingRunId;

--- a/packages/cli/src/agent/run-attach.test.ts
+++ b/packages/cli/src/agent/run-attach.test.ts
@@ -141,6 +141,25 @@ describe('resolveRunAttach', () => {
     expect(untouched.terminal_reason).toBe('spawn_failed');
   });
 
+  // issue #279 (increment 1, PR-B), design record §6.
+  it('a terminal run with a pending finalizer gets the drain-verb pointer appended to the refusal message', async () => {
+    const store = new InMemoryStore();
+    const runId = await createRun(store);
+    const run = await store.get(runId);
+    run.terminal_state = true;
+    run.terminal_reason = 'Workflow completed.';
+    run.finalizer_ledger = { fin: { status: 'pending', rank: 0 } };
+    await store.update(run);
+
+    await expect(
+      resolveRunAttach(runId, {
+        store,
+        workflowStore: makeWorkflowStore(),
+        loadExtensions: okLoader(),
+      }),
+    ).rejects.toThrow(`1 finalizer(s) not yet delivered — realm run drain ${runId}`);
+  });
+
   it('a completed run is refused, not re-attached', async () => {
     const store = new InMemoryStore();
     const runId = await createRun(store);

--- a/packages/cli/src/agent/run-attach.ts
+++ b/packages/cli/src/agent/run-attach.ts
@@ -50,8 +50,18 @@ export async function resolveRunAttach(
     } else {
       // Same refusal (and message) the agent loop raises today — thrown BEFORE any
       // extension code loads.
+      //
+      // issue #279 (increment 1, PR-B), design record §6: point at the recovery verb when the
+      // terminal run this attach targeted still carries an undelivered finalizer.
+      const pendingFinalizerCount = Object.values(run.finalizer_ledger ?? {}).filter(
+        (e) => e.status === 'pending',
+      ).length;
+      const drainHint =
+        pendingFinalizerCount > 0
+          ? ` ${pendingFinalizerCount} finalizer(s) not yet delivered — realm run drain ${runId}.`
+          : '';
       throw new Error(
-        `Run ${runId} is already in terminal state: ${run.terminal_reason ?? run.run_phase}`,
+        `Run ${runId} is already in terminal state: ${run.terminal_reason ?? run.run_phase}.${drainHint}`,
       );
     }
   }

--- a/packages/cli/src/commands-registry.ts
+++ b/packages/cli/src/commands-registry.ts
@@ -13,6 +13,7 @@ import { gcCommand } from './commands/gc.js';
 import { exportCommand } from './commands/export.js';
 import { reconcileCommand } from './commands/reconcile.js';
 import { attemptsCommand } from './commands/attempts.js';
+import { drainCommand } from './commands/drain.js';
 import { respondCommand } from './commands/respond.js';
 import { inspectCommand } from './commands/inspect.js';
 import { replayCommand } from './commands/replay.js';
@@ -55,6 +56,7 @@ export const runCommands = [
   exportCommand,
   reconcileCommand,
   attemptsCommand,
+  drainCommand,
 ];
 
 /** Top-level commands not nested under a subgroup. */

--- a/packages/cli/src/commands/drain-purge-integration.test.ts
+++ b/packages/cli/src/commands/drain-purge-integration.test.ts
@@ -1,0 +1,85 @@
+// drain-purge-integration.test.ts — verification item 3 (issue #279, increment 1, PR-B): the
+// full recovery-closure loop — purge refuses `drain_pending` on a terminal run with an undrained
+// finalizer (every mode, including single-id --force), and after an operator `--void` (via
+// `runDrainAction`, the real drain-command logic), purge proceeds normally.
+//
+// `purgeRuns` (unlike `purgeCommand`) and `runDrainAction` (unlike driving `drainCommand` via
+// `.parseAsync`) both take EXPLICIT store parameters — the established purge.test.ts precedent,
+// now matched by drain.ts (see drain.ts's file-header note and drain.test.ts's header note for the
+// full account of why a `$HOME`-override + `drainCommand.parseAsync(...)` test is unreliable here:
+// `drain.ts` statically imports `loadProjectExtensions`, which itself has a top-level VALUE import
+// of `@sensigo/realm` — eagerly capturing JsonFileStore's `DEFAULT_RUNS_DIR` at module-load time,
+// before any `beforeEach` can override `$HOME`. Confirmed empirically: an earlier, $HOME-override
+// draft of this test silently read/wrote the REAL `~/.realm/runs` instead of a temp dir). Neither
+// function here relies on `$HOME` or any default at all — both take an explicit store — so a
+// static top-level import is safe.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  drainFinalizers,
+  captureEvidence,
+  DRAIN_LEASE_MAX,
+} from '@sensigo/realm';
+import { runDrainAction, type DrainRuntimeDeps } from './drain.js';
+import { purgeRuns } from './purge.js';
+
+const DEPS: DrainRuntimeDeps = { drainFinalizers, captureEvidence, drainLeaseMax: DRAIN_LEASE_MAX };
+
+describe('purge ⟷ drain recovery closure (issue #279, increment 1, PR-B, verification item 3)', () => {
+  let dir: string;
+  let runsDir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-drain-purge-'));
+    runsDir = join(dir, 'runs');
+    await mkdir(runsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('purge refuses drain_pending (single-id --force included) → --void (via runDrainAction) → purge proceeds', async () => {
+    const anchorStore = new JsonFileStore(runsDir);
+    const workflowStore = new JsonWorkflowStore(join(dir, 'workflows'));
+    const { run } = await anchorStore.create({
+      workflowId: 'drain-purge-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await anchorStore.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    // 1. purge (dry-run) reports it, but does not delete.
+    const dryRunResult = await purgeRuns({ runId: run.id, dryRun: true }, anchorStore, []);
+    expect(dryRunResult.selected.length + dryRunResult.skipped.length).toBeGreaterThan(0);
+    expect(existsSync(join(runsDir, `${run.id}.json`))).toBe(true);
+
+    // 2. purge --force (dryRun:false) STILL refuses — drain_pending is not force-bypassable.
+    const forcedResult = await purgeRuns({ runId: run.id, dryRun: false }, anchorStore, []);
+    expect(forcedResult.blocked).toHaveLength(1);
+    expect(forcedResult.blocked[0]?.reason).toContain('drain_pending');
+    expect(existsSync(join(runsDir, `${run.id}.json`))).toBe(true); // survives intact
+
+    // 3. Operator voids the finalizer via `runDrainAction` (the same logic `realm run drain
+    // --void` wires, driven directly against the explicit anchorStore — no $HOME involved).
+    await runDrainAction(run.id, { void: 'fin' }, anchorStore, workflowStore, DEPS);
+    const afterVoid = await anchorStore.get(run.id);
+    expect(afterVoid.finalizer_ledger?.['fin']?.status).toBe('voided');
+
+    // 4. purge --force now proceeds — no pending entries left.
+    const finalResult = await purgeRuns({ runId: run.id, dryRun: false }, anchorStore, []);
+    expect(finalResult.purged).toContain(run.id);
+    expect(existsSync(join(runsDir, `${run.id}.json`))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/drain.test.ts
+++ b/packages/cli/src/commands/drain.test.ts
@@ -1,0 +1,368 @@
+// Tests for `realm run drain` (issue #279, increment 1, PR-B) — the classifier's four rank-pass
+// classes (pure unit tests), plus the full command behavior (--void / --all / per-run dry-run and
+// --force) driven directly through `runDrainAction` against an EXPLICITLY-constructed store.
+//
+// issue #279 (increment 1, PR-B) — CORRECTED test-isolation approach: an earlier draft of this
+// file drove `drainCommand.parseAsync(...)` under a `$HOME` override (mirroring abandon.test.ts).
+// That is UNRELIABLE for `drain.ts` specifically: `drain.ts` statically imports
+// `loadProjectExtensions`, which itself has a top-level VALUE import of `@sensigo/realm` — so
+// merely importing anything from `drain.js` (even dynamically, even mid-test) eagerly evaluates
+// `@sensigo/realm`'s module graph, including JsonFileStore's module-load-time
+// `DEFAULT_RUNS_DIR = join(homedir(), ...)` capture. Confirmed empirically: an isolated run of the
+// (now-replaced) $HOME-override version of these tests silently wrote real run files into the
+// ACTUAL `~/.realm/runs` (verified via file timestamps/content, then cleaned up) — the seeding
+// store and `drainCommand`'s internal store both resolved to the same frozen-wrong default, so the
+// tests still "passed" while polluting real user data. `runDrainAction` (drain.ts) now takes
+// `runStore`/`workflowStore`/its three `@sensigo/realm` runtime values as EXPLICIT parameters —
+// tests below construct `new JsonFileStore(tmpDir)` with an EXPLICIT directory and inject
+// `drainFinalizers`/`captureEvidence`/`DRAIN_LEASE_MAX` directly, never relying on `$HOME` or any
+// default at all. A static top-level import of `@sensigo/realm` is therefore safe here (no
+// `$HOME`-timing dependency exists to defeat).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  JsonFileStore,
+  JsonWorkflowStore,
+  drainFinalizers,
+  captureEvidence,
+  DRAIN_LEASE_MAX,
+  ExtensionRegistry,
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+} from '@sensigo/realm';
+import type { RunRecord, WorkflowDefinition } from '@sensigo/realm';
+import {
+  classifyDrainRankPass,
+  isBatchActionable,
+  runDrainAction,
+  type DrainRuntimeDeps,
+} from './drain.js';
+
+const NOW = new Date('2026-07-08T12:00:00.000Z');
+const past = new Date(NOW.getTime() - 60_000).toISOString();
+const future = new Date(NOW.getTime() + 60_000).toISOString();
+// The CLI-level describe block below drives the REAL action function, which reads the REAL system
+// clock (`new Date()`), not the fixed NOW above — its fixtures must be relative to Date.now().
+const realFuture = new Date(Date.now() + 60_000).toISOString();
+
+const DEPS: DrainRuntimeDeps = { drainFinalizers, captureEvidence, drainLeaseMax: DRAIN_LEASE_MAX };
+
+function makeRun(over: Partial<RunRecord>): RunRecord {
+  return {
+    id: 'r1',
+    workflow_id: 'wf',
+    workflow_version: 1,
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: [],
+    skipped_steps: [],
+    run_phase: 'completed',
+    version: 1,
+    params: {},
+    evidence: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    terminal_state: true,
+    ...over,
+  };
+}
+
+describe('classifyDrainRankPass — the four rank-pass classes (issue #279, increment 1, PR-B)', () => {
+  it('empty ledger ⇒ zero entries (caller renders no_pendings)', () => {
+    expect(classifyDrainRankPass(undefined, NOW)).toEqual([]);
+    expect(classifyDrainRankPass({}, NOW)).toEqual([]);
+  });
+
+  it('a single never-leased pending entry ⇒ actionable', () => {
+    const entries = classifyDrainRankPass({ fin: { status: 'pending', rank: 0 } }, NOW);
+    expect(entries).toEqual([{ name: 'fin', rank: 0, class: 'actionable' }]);
+  });
+
+  it('a single EXPIRED-lease pending entry ⇒ actionable (not lease_held)', () => {
+    const entries = classifyDrainRankPass(
+      { fin: { status: 'pending', rank: 0, lease_token: 'dead', lease_deadline: past } },
+      NOW,
+    );
+    expect(entries).toEqual([{ name: 'fin', rank: 0, class: 'actionable' }]);
+  });
+
+  it('a single UNEXPIRED-lease pending entry ⇒ lease_held', () => {
+    const entries = classifyDrainRankPass(
+      { fin: { status: 'pending', rank: 0, lease_token: 'live', lease_deadline: future } },
+      NOW,
+    );
+    expect(entries).toEqual([
+      { name: 'fin', rank: 0, class: 'lease_held', lease_deadline: future },
+    ]);
+  });
+
+  it('a held lease at rank 0 blocks EVERY higher-ranked pending entry (rank_blocked_behind_held_lease) — R11', () => {
+    const entries = classifyDrainRankPass(
+      {
+        first: { status: 'pending', rank: 0, lease_token: 'live', lease_deadline: future },
+        second: { status: 'pending', rank: 1 },
+        third: { status: 'pending', rank: 2 },
+      },
+      NOW,
+    );
+    expect(entries.map((e) => e.class)).toEqual([
+      'lease_held',
+      'rank_blocked_behind_held_lease',
+      'rank_blocked_behind_held_lease',
+    ]);
+  });
+
+  it('multiple actionable entries before any held lease are ALL actionable', () => {
+    const entries = classifyDrainRankPass(
+      {
+        first: { status: 'pending', rank: 0 },
+        second: { status: 'pending', rank: 1 },
+      },
+      NOW,
+    );
+    expect(entries.map((e) => e.class)).toEqual(['actionable', 'actionable']);
+  });
+
+  it('non-pending entries (completed/failed/voided) are excluded entirely', () => {
+    const entries = classifyDrainRankPass(
+      {
+        done: { status: 'completed', rank: 0 },
+        gone: { status: 'voided', rank: 1 },
+        actionable: { status: 'pending', rank: 2 },
+      },
+      NOW,
+    );
+    expect(entries).toEqual([{ name: 'actionable', rank: 2, class: 'actionable' }]);
+  });
+});
+
+describe('isBatchActionable', () => {
+  it('true when at least one pending entry is actionable', () => {
+    expect(
+      isBatchActionable(
+        makeRun({ finalizer_ledger: { fin: { status: 'pending', rank: 0 } } }),
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it('false when the only pending entry is lease_held', () => {
+    const run = makeRun({
+      finalizer_ledger: {
+        fin: { status: 'pending', rank: 0, lease_token: 'live', lease_deadline: future },
+      },
+    });
+    expect(isBatchActionable(run, NOW)).toBe(false);
+  });
+
+  it('false when there is no ledger at all', () => {
+    expect(isBatchActionable(makeRun({}), NOW)).toBe(false);
+  });
+});
+
+describe('runDrainAction (issue #279, increment 1, PR-B) — explicit store injection, no $HOME reliance', () => {
+  let dir: string;
+  let store: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'realm-drain-cli-'));
+    store = new JsonFileStore(dir);
+    workflowStore = new JsonWorkflowStore(join(dir, 'workflows'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const wf: WorkflowDefinition = {
+    id: 'drain-wf',
+    name: 'Drain WF',
+    version: 1,
+    steps: { work: { description: 'w', execution: 'agent', depends_on: [] } },
+  };
+
+  it('dry-run (default, no --force) renders the rank-pass classes and mutates nothing', async () => {
+    await workflowStore.register(wf);
+    const { run } = await store.create({ workflowId: 'drain-wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    await runDrainAction(run.id, {}, store, workflowStore, DEPS);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.some((c) => String(c[0]).includes('actionable'))).toBe(true);
+    const reloaded = await store.get(run.id);
+    expect(reloaded.finalizer_ledger?.['fin']?.status).toBe('pending'); // untouched
+  });
+
+  it('a non-terminal run reports "nothing to drain" and mutates nothing', async () => {
+    await workflowStore.register(wf);
+    const { run } = await store.create({ workflowId: 'drain-wf', workflowVersion: 1, params: {} });
+
+    await runDrainAction(run.id, {}, store, workflowStore, DEPS);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.some((c) => String(c[0]).includes('not terminal'))).toBe(true);
+  });
+
+  it('--void voids a pending finalizer with operator-provenance evidence and the never-leased disclosure', async () => {
+    await workflowStore.register(wf);
+    const { run } = await store.create({ workflowId: 'drain-wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    await runDrainAction(run.id, { void: 'fin' }, store, workflowStore, DEPS);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.some((c) => String(c[0]).includes('never executed'))).toBe(true);
+    const reloaded = await store.get(run.id);
+    expect(reloaded.finalizer_ledger?.['fin']?.status).toBe('voided');
+    const voidEvidence = reloaded.evidence.find((e) => e.step_id === 'fin');
+    expect(voidEvidence).toBeDefined();
+    expect(voidEvidence?.output_summary?.['provenance']).toBe('operator');
+  });
+
+  it('--void refuses on an unexpired lease — not force-bypassable', async () => {
+    await workflowStore.register(wf);
+    const { run } = await store.create({ workflowId: 'drain-wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: {
+        fin: { status: 'pending', rank: 0, lease_token: 'live', lease_deadline: realFuture },
+      },
+    });
+
+    await expect(
+      runDrainAction(run.id, { void: 'fin' }, store, workflowStore, DEPS),
+    ).rejects.toThrow('process.exit');
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes('active drain lease'))).toBe(true);
+    const reloaded = await store.get(run.id);
+    expect(reloaded.finalizer_ledger?.['fin']?.status).toBe('pending');
+  });
+
+  it('--force actually drains a terminal run with an actionable finalizer', async () => {
+    await workflowStore.register({
+      id: 'drain-wf',
+      name: 'Drain WF',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      steps: {
+        work: { description: 'w', execution: 'agent', depends_on: [] },
+        fin: {
+          description: 'f',
+          execution: 'finalizer',
+          on_outcome: 'always',
+          handler: 'fin-handler',
+        },
+      },
+    });
+    const { run } = await store.create({ workflowId: 'drain-wf', workflowVersion: 1, params: {} });
+    await store.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    const registry = new ExtensionRegistry();
+    registry.register('handler', 'fin-handler', {
+      id: 'fin-handler',
+      execute: async () => ({ data: {} }),
+    });
+    await runDrainAction(run.id, { force: true }, store, workflowStore, {
+      ...DEPS,
+      resolveRegistry: async () => registry,
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.some((c) => String(c[0]).includes('Drained run'))).toBe(true);
+    const reloaded = await store.get(run.id);
+    expect(reloaded.finalizer_ledger?.['fin']?.status).toBe('completed');
+  });
+
+  it('--all batch mode drains every actionable run and reports the tally', async () => {
+    await workflowStore.register({
+      id: 'drain-wf',
+      name: 'Drain WF',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      steps: {
+        work: { description: 'w', execution: 'agent', depends_on: [] },
+        fin: {
+          description: 'f',
+          execution: 'finalizer',
+          on_outcome: 'always',
+          handler: 'fin-handler',
+        },
+      },
+    });
+    const { run: run1 } = await store.create({
+      workflowId: 'drain-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await store.update({
+      ...run1,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+    const { run: run2 } = await store.create({
+      workflowId: 'drain-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+    await store.update({
+      ...run2,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    const registry = new ExtensionRegistry();
+    registry.register('handler', 'fin-handler', {
+      id: 'fin-handler',
+      execute: async () => ({ data: {} }),
+    });
+    await runDrainAction(undefined, { all: true, force: true }, store, workflowStore, {
+      ...DEPS,
+      resolveRegistry: async () => registry,
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.some((c) => String(c[0]).includes('Drained 2/2'))).toBe(true);
+    const reloaded1 = await store.get(run1.id);
+    const reloaded2 = await store.get(run2.id);
+    expect(reloaded1.finalizer_ledger?.['fin']?.status).toBe('completed');
+    expect(reloaded2.finalizer_ledger?.['fin']?.status).toBe('completed');
+  });
+});

--- a/packages/cli/src/commands/drain.ts
+++ b/packages/cli/src/commands/drain.ts
@@ -1,0 +1,345 @@
+// drain command — post-commit finalizer recovery + operator void (issue #279, increment 1, PR-B).
+//
+// `realm run drain <run-id> [--force]` / `--all [--force]` / `--void <finalizer>`: dry-run is the
+// DEFAULT (draining executes extension/handler code — the same reclaim posture as `realm run
+// reclaim`'s own per-step/--force split). Loads project extensions (the respond.ts precedent) so
+// a real drain fires REAL handlers, not the built-in default registry alone.
+import { Command } from 'commander';
+import type {
+  RunRecord,
+  RunStore,
+  WorkflowRegistrar,
+  WorkflowDefinition,
+  ExtensionRegistry,
+  EvidenceSnapshot,
+  CaptureEvidenceParams,
+} from '@sensigo/realm';
+import { loadProjectExtensions } from '../extensions/load-project-extensions.js';
+
+// issue #279 (increment 1, PR-B): NO top-level VALUE import from `@sensigo/realm` in THIS file —
+// but that alone is NOT sufficient, and this comment corrects an earlier (wrong) assumption to
+// that effect. `loadProjectExtensions` (above) itself has a top-level VALUE import of
+// `@sensigo/realm` (adapters, createDefaultRegistry, etc.) — so merely *statically* importing
+// anything from this module (e.g. a test file's `import { drainCommand } from './drain.js'`)
+// ALREADY evaluates `@sensigo/realm`'s module graph, including JsonFileStore's module-load-time
+// `DEFAULT_RUNS_DIR = join(homedir(), ...)` capture — BEFORE any test's `beforeEach` can override
+// `$HOME`. Confirmed by direct observation: an isolated `vitest run` of a $HOME-override test
+// exercising `drainCommand.parseAsync(...)` silently read/wrote the REAL `~/.realm/runs`, not the
+// test's temp dir (both the seeding store and drainCommand's internal store resolved to the same
+// frozen-wrong default — internally consistent, so the test still "passed" while polluting real
+// user data). The FIX is architectural, not import-ordering: `runDrainAction` below takes
+// `runStore`/`workflowStore`/the three `@sensigo/realm` runtime values it needs as EXPLICIT
+// parameters (mirrors resume.ts's `resumeRun`) — tests call it directly with an explicitly-dired
+// store, never through `drainCommand.parseAsync`'s default-store construction. Only
+// `drainCommand`'s own `.action()` (real CLI use) still does the dynamic `@sensigo/realm` import
+// and constructs the real defaults.
+
+/** One pending finalizer's classification at the RANK-PASS level (design record §6) — what the
+ *  NEXT real drain pass would do with it, in rank order. `no_pendings` is a whole-run summary
+ *  (never a per-entry class) emitted only when the ledger has zero pending entries. */
+export type DrainRankPassClass =
+  'actionable' | 'lease_held' | 'rank_blocked_behind_held_lease' | 'no_pendings';
+
+export interface DrainRankPassEntry {
+  name: string;
+  rank: number;
+  class: Exclude<DrainRankPassClass, 'no_pendings'>;
+  lease_deadline?: string;
+}
+
+/**
+ * Classifies every PENDING finalizer_ledger entry, in rank order, mirroring exactly what a real
+ * `drainFinalizers` pass would encounter: the first entry whose lease is absent-or-expired is
+ * `actionable`; the first entry with an UNEXPIRED lease is `lease_held` and HALTS the simulated
+ * pass — every pending entry ranked after it is `rank_blocked_behind_held_lease` (R11:
+ * rank-monotonic HALT withholds every higher-ranked deliverable finalizer behind it). Returns `[]`
+ * when there are no pending entries (the caller renders `no_pendings`).
+ */
+export function classifyDrainRankPass(
+  ledger: RunRecord['finalizer_ledger'],
+  now: Date,
+): DrainRankPassEntry[] {
+  const pending = Object.entries(ledger ?? {})
+    .filter(([, e]) => e.status === 'pending')
+    .sort(([, a], [, b]) => a.rank - b.rank);
+
+  const result: DrainRankPassEntry[] = [];
+  let halted = false;
+  for (const [name, entry] of pending) {
+    if (halted) {
+      result.push({ name, rank: entry.rank, class: 'rank_blocked_behind_held_lease' });
+      continue;
+    }
+    const isHeld =
+      entry.lease_token !== undefined &&
+      entry.lease_deadline !== undefined &&
+      new Date(entry.lease_deadline).getTime() > now.getTime();
+    if (isHeld) {
+      result.push({
+        name,
+        rank: entry.rank,
+        class: 'lease_held',
+        ...(entry.lease_deadline !== undefined ? { lease_deadline: entry.lease_deadline } : {}),
+      });
+      halted = true;
+    } else {
+      result.push({ name, rank: entry.rank, class: 'actionable' });
+    }
+  }
+  return result;
+}
+
+/** Batch actionability (design record §6): `status 'pending' ∧ (lease absent ∨ expired)` — a
+ *  never-leased pending entry is IN (it has never been attempted), matching `classifyDrainRankPass`
+ *  labeling it `actionable` rather than excluding it for lacking a lease at all. */
+export function isBatchActionable(run: RunRecord, now: Date): boolean {
+  return classifyDrainRankPass(run.finalizer_ledger, now).some((e) => e.class === 'actionable');
+}
+
+function renderDryRun(runId: string, run: RunRecord, now: Date): void {
+  if (!run.terminal_state) {
+    console.log(`Run '${runId}' is not terminal (phase: '${run.run_phase}') — nothing to drain.`);
+    return;
+  }
+  const entries = classifyDrainRankPass(run.finalizer_ledger, now);
+  if (entries.length === 0) {
+    console.log(`Run '${runId}' has no pending finalizers. Nothing to drain.`);
+    return;
+  }
+  console.log(`Run '${runId}' (${run.run_phase}) — pending finalizers, rank order:`);
+  for (const e of entries) {
+    const label =
+      e.class === 'actionable'
+        ? 'actionable — would lease, execute, and mark on --force'
+        : e.class === 'lease_held'
+          ? `lease held (expires ${e.lease_deadline}) — a drainer is executing NOW`
+          : 'rank-blocked — a lower rank holds an active lease, withholding this one';
+    console.log(`  • [${e.rank}] ${e.name}: ${label}`);
+  }
+  console.log(
+    `\nRe-run with --force to actually drain. Use --void <finalizer> to void one instead.`,
+  );
+}
+
+async function resolveRegistry(
+  workflowStore: WorkflowRegistrar,
+  run: RunRecord,
+  opts: { project?: string; extensionsModule?: string },
+): Promise<ExtensionRegistry> {
+  const workflow = await workflowStore.get(run.workflow_id);
+  const { registry } = await loadProjectExtensions(workflow, {
+    ...(opts.extensionsModule !== undefined ? { overrideModule: opts.extensionsModule } : {}),
+    projectDir: opts.project ?? process.cwd(),
+  });
+  return registry;
+}
+
+export interface DrainCommandOptions {
+  force?: boolean;
+  all?: boolean;
+  void?: string;
+  project?: string;
+  extensionsModule?: string;
+}
+
+/** The three `@sensigo/realm` runtime values `runDrainAction` needs, injected explicitly (never
+ *  re-imported internally) — this is what makes the function testable without a `$HOME` override:
+ *  see the file-header note on why `$HOME`-override alone is unreliable for this command. */
+export interface DrainRuntimeDeps {
+  drainFinalizers: (
+    store: RunStore,
+    definition: WorkflowDefinition,
+    registry: ExtensionRegistry,
+    runId: string,
+  ) => Promise<{ run: RunRecord; warnings: string[] }>;
+  captureEvidence: (params: CaptureEvidenceParams) => EvidenceSnapshot;
+  drainLeaseMax: number;
+  /** Test-only injection point — when absent (the real CLI path), `resolveRegistry` below (the
+   *  project-extensions loader) is used. Lets tests supply a hand-built `ExtensionRegistry` with a
+   *  real handler registered, without needing an on-disk extensions-module fixture. */
+  resolveRegistry?: (
+    workflowStore: WorkflowRegistrar,
+    run: RunRecord,
+    opts: { project?: string; extensionsModule?: string },
+  ) => Promise<ExtensionRegistry>;
+}
+
+/**
+ * The full `realm run drain` behaviour (--void / --all / per-run dry-run/--force), factored out of
+ * the Commander `.action()` so tests can drive it directly against an explicitly-constructed store
+ * (bypassing JsonFileStore's `$HOME`-derived default entirely) rather than through
+ * `drainCommand.parseAsync(...)`, whose own default-store construction cannot be relied on to
+ * respect a test's `$HOME` override (see the file-header note).
+ */
+export async function runDrainAction(
+  runId: string | undefined,
+  opts: DrainCommandOptions,
+  runStore: RunStore,
+  workflowStore: WorkflowRegistrar,
+  deps: DrainRuntimeDeps,
+): Promise<void> {
+  const now = new Date();
+
+  // ============================ --void <finalizer> ============================
+  if (opts.void !== undefined) {
+    if (runId === undefined) {
+      console.error('Provide a <run-id> when using --void.');
+      process.exit(1);
+    }
+    if (opts.all === true) {
+      console.error('Cannot combine --void with --all.');
+      process.exit(1);
+    }
+    try {
+      const run = await runStore.get(runId);
+      const entry = run.finalizer_ledger?.[opts.void];
+      if (entry === undefined) {
+        console.error(`No finalizer ledger entry named '${opts.void}' on run '${runId}'.`);
+        process.exit(1);
+      }
+      if (entry.status !== 'pending') {
+        console.error(
+          `Finalizer '${opts.void}' is '${entry.status}', not 'pending' — nothing to void.`,
+        );
+        process.exit(1);
+      }
+      const isHeld =
+        entry.lease_token !== undefined &&
+        entry.lease_deadline !== undefined &&
+        new Date(entry.lease_deadline).getTime() > now.getTime();
+      if (isHeld) {
+        console.error(
+          `Finalizer '${opts.void}' has an active drain lease (expires ` +
+            `${entry.lease_deadline}) — a drainer is executing NOW. Wait for the lease to ` +
+            `expire (bounded — leases are clamped to ${deps.drainLeaseMax}s) and retry. Not ` +
+            `force-bypassable.`,
+        );
+        process.exit(1);
+      }
+      const neverLeased = entry.lease_token === undefined;
+      const disclosure = neverLeased
+        ? `finalizer '${opts.void}' voided by operator — never executed`
+        : `finalizer '${opts.void}' voided by operator — may have executed without a ` +
+          `recorded mark (its lease had already expired)`;
+      const voidEvidence = deps.captureEvidence({
+        stepId: opts.void,
+        startedAt: now,
+        completedAt: now,
+        input: {},
+        output: { voided: true, provenance: 'operator', never_leased: neverLeased },
+      });
+      await runStore.update({
+        ...run,
+        finalizer_ledger: {
+          ...run.finalizer_ledger,
+          [opts.void]: { status: 'voided', rank: entry.rank },
+        },
+        evidence: [...run.evidence, voidEvidence],
+      });
+      console.log(disclosure);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    return;
+  }
+
+  // ============================ Batch mode (--all) ============================
+  if (opts.all === true) {
+    if (runId !== undefined) {
+      console.error('Cannot combine a <run-id> with --all. Use one or the other.');
+      process.exit(1);
+    }
+    const runs = await runStore.list();
+    const actionable = runs.filter((r) => r.terminal_state && isBatchActionable(r, now));
+
+    if (actionable.length === 0) {
+      console.log('No runs with an actionable pending finalizer.');
+      return;
+    }
+
+    if (opts.force !== true) {
+      console.log(`${actionable.length} run(s) WOULD be drained:`);
+      for (const r of actionable) {
+        console.log(`  • ${r.id}`);
+      }
+      console.log(`\nRe-run with --force to actually drain them.`);
+      return;
+    }
+
+    let drained = 0;
+    for (const r of actionable) {
+      try {
+        const registry = await (deps.resolveRegistry ?? resolveRegistry)(workflowStore, r, opts);
+        const workflow = await workflowStore.get(r.workflow_id);
+        const outcome = await deps.drainFinalizers(runStore, workflow, registry, r.id);
+        drained += 1;
+        for (const w of outcome.warnings) console.log(`  ⚠ ${r.id}: ${w}`);
+        console.log(`  ✓ ${r.id}: drained`);
+      } catch (err) {
+        console.error(`  ✗ ${r.id}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    console.log(`Drained ${drained}/${actionable.length} run(s).`);
+    return;
+  }
+
+  // ============================ Per-run mode ============================
+  if (runId === undefined) {
+    console.error('Provide a <run-id>, or use --all for batch mode.');
+    process.exit(1);
+  }
+
+  try {
+    const run = await runStore.get(runId);
+
+    if (opts.force !== true) {
+      renderDryRun(runId, run, now);
+      return;
+    }
+
+    if (!run.terminal_state) {
+      console.error(
+        `Run '${runId}' is not terminal (phase: '${run.run_phase}') — nothing to drain.`,
+      );
+      process.exit(1);
+    }
+
+    const registry = await (deps.resolveRegistry ?? resolveRegistry)(workflowStore, run, opts);
+    const workflow = await workflowStore.get(run.workflow_id);
+    const outcome = await deps.drainFinalizers(runStore, workflow, registry, runId);
+    for (const w of outcome.warnings) console.log(`  ⚠ ${w}`);
+    console.log(`Drained run '${runId}'.`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+export const drainCommand = new Command('drain')
+  .description(
+    'Drain post-commit finalizers for a terminal run (recovery for issue #279 crash windows)',
+  )
+  .argument('[run-id]', 'ID of the run to drain; omit when using --all')
+  .option('--force', 'Actually drain (without this, drain only reports what WOULD run)')
+  .option('--all', 'Batch mode: drain every run with an actionable pending finalizer')
+  .option('--void <finalizer>', 'Void a specific pending finalizer instead of draining it')
+  .option(
+    '--project <dir>',
+    'CONFIG anchor: deployment root whose realm.yaml applies to definitions without a stored trust_root (default: current directory)',
+  )
+  .option(
+    '--extensions-module <path>',
+    "CODE override: module that REPLACES the workflow's declared 'extensions' modules (repair tool)",
+  )
+  .action(async (runId: string | undefined, opts: DrainCommandOptions) => {
+    const { JsonFileStore, JsonWorkflowStore, drainFinalizers, captureEvidence, DRAIN_LEASE_MAX } =
+      await import('@sensigo/realm');
+    const runStore = new JsonFileStore();
+    const workflowStore = new JsonWorkflowStore();
+    await runDrainAction(runId, opts, runStore, workflowStore, {
+      drainFinalizers,
+      captureEvidence,
+      drainLeaseMax: DRAIN_LEASE_MAX,
+    });
+  });

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -121,6 +121,56 @@ describe('buildExportBundle', () => {
     }
   });
 
+  // issue #279 (increment 1, PR-B), design record §6.
+  it('a terminal run with a pending finalizer gets the pending-drain warning (mutually exclusive with the non-terminal warning)', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({
+        run_phase: 'completed',
+        terminal_state: true,
+        finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+      });
+      await injectRun(dir, run);
+
+      const { bundle, warning } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      expect(warning).toBeDefined();
+      expect(warning).toContain('1 finalizer(s) not yet delivered');
+      expect(warning).toContain(`realm run drain ${run.id}`);
+      // No bundle-version bump — run rides the export verbatim either way.
+      expect(bundle.realm_export_version).toBe(3);
+      expect(bundle.run.finalizer_ledger).toEqual(run.finalizer_ledger);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a terminal run with NO pending finalizers gets no pending-drain warning', async () => {
+    const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
+    try {
+      const run = makeRun({
+        run_phase: 'completed',
+        terminal_state: true,
+        finalizer_ledger: { fin: { status: 'completed', rank: 0 } },
+      });
+      await injectRun(dir, run);
+
+      const { warning } = await buildExportBundle(run.id, {
+        runStore,
+        failedAttemptStore,
+        traceBufferStore,
+      });
+
+      expect(warning).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('clean run (no attempts, no WAL): attempts: [], attempts_capped: false, wal: {} — not an error (issue #186: complete: true, absence is not a failure)', async () => {
     const { dir, runStore, failedAttemptStore, traceBufferStore } = await makeStores();
     try {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -280,10 +280,19 @@ export async function buildExportBundle(
     artifact_errors: artifactErrors,
   };
 
+  // issue #279 (increment 1, PR-B), design record §6: a pending-drain warning mirroring the
+  // non-terminal warning's TONE — mutually exclusive with it (pendings imply terminal: the
+  // finalizer ledger is only ever minted on a terminal edge). `warning` stays SINGULAR (no
+  // bundle-version bump) — `run` (carrying finalizer_ledger) rides the export verbatim either way.
+  const pendingFinalizerCount = Object.values(run.finalizer_ledger ?? {}).filter(
+    (e) => e.status === 'pending',
+  ).length;
   const warning = nonTerminal
     ? `best-effort snapshot: run '${runId}' is still ${run.run_phase}; its artifacts are read at ` +
       `slightly different instants and may be mid-flight`
-    : undefined;
+    : pendingFinalizerCount > 0
+      ? `${pendingFinalizerCount} finalizer(s) not yet delivered — realm run drain ${runId}`
+      : undefined;
 
   return { bundle, warning };
 }

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -449,6 +449,20 @@ describe("--stuck label format: TWO-GROUP join (issue #221 correction — restor
     expect(result).toContain("sibling=claim_stale  enrich: needs adapter 'shopify'");
     expect(result).not.toContain('sibling=claim_stale, enrich:');
   });
+
+  // issue #279 (increment 1, PR-B): a THIRD kind-filter group for terminal_pending_finalizer,
+  // appended-segment style after capabilityLabels — same S4 "line format otherwise unchanged" rail.
+  it('a TERMINAL run with a pending finalizer renders the drain-verb-pointing label and shows up under --stuck', async () => {
+    const run = makeRun({
+      id: 'run-pending-finalizer',
+      run_phase: 'completed',
+      terminal_state: true,
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+    const result = await listRuns(undefined, makeStore([run]), undefined, true);
+    expect(result).toContain('run-pending-finalizer');
+    expect(result).toContain('fin=never_leased (realm run drain)');
+  });
 });
 
 describe('--stuck age-gating (issue #221 — classifyRunHealth-backed)', () => {

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -71,6 +71,11 @@ function renderFindingLabel(f: RunHealthFinding): string | undefined {
     }
     case 'never_claimed_idle':
       return undefined;
+    // issue #279 (increment 1, PR-B): a terminal run with an undrained finalizer — points at the
+    // recovery verb directly in the label (appended-segment style; see the dedicated kind-filter
+    // group below for the group header this label's segment rides in).
+    case 'terminal_pending_finalizer':
+      return `${f.step}=${f.reason} (realm run drain)`;
   }
 }
 
@@ -202,6 +207,17 @@ export async function listRuns(
         .filter((l): l is string => l !== undefined);
       if (capabilityLabels.length > 0) {
         line += `  ${capabilityLabels.join(', ')}`;
+      }
+      // issue #279 (increment 1, PR-B): a THIRD kind-filter group, appended-segment style — same
+      // pattern as claimLabels/capabilityLabels above, NOT routed through #219's
+      // renderCauseSegment (that one is FailedAttemptStore-sourced — a different mechanism; this
+      // is classifyRunHealth-sourced, like the two groups above it).
+      const pendingFinalizerLabels = findings
+        .filter((f) => f.kind === 'terminal_pending_finalizer')
+        .map(renderFindingLabel)
+        .filter((l): l is string => l !== undefined);
+      if (pendingFinalizerLabels.length > 0) {
+        line += `  ${pendingFinalizerLabels.join(', ')}`;
       }
       // issue #219: cause attribution, appended LAST — best-effort, per-run (one run's sidecar
       // I/O failure never aborts the rest of the list). `records.length === 0` (no throw) means

--- a/packages/cli/src/commands/resume-wedge-e2e.test.ts
+++ b/packages/cli/src/commands/resume-wedge-e2e.test.ts
@@ -1,0 +1,104 @@
+// resume-wedge-e2e.test.ts — verification item 4 (issue #279, increment 1, PR-B): ONE end-to-end
+// R1-wedge reproduction through the REAL CLI — settle-fail → resume (via the real resumeCommand)
+// → re-claim → settle applies. JsonFileStore's default dir is computed at module-load time, so
+// $HOME must be set BEFORE the first `@sensigo/realm` import (mirrors abandon.test.ts/drain.test.ts).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resumeCommand } from './resume.js';
+
+describe('resume wedge e2e (issue #279, increment 1, PR-B, verification item 4)', () => {
+  let home: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'realm-resume-wedge-e2e-'));
+    await mkdir(join(home, '.realm', 'runs'), { recursive: true });
+    await mkdir(join(home, '.realm', 'workflows'), { recursive: true });
+    originalHome = process.env['HOME'];
+    process.env['HOME'] = home;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = originalHome;
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('settle-fail → resume (real CLI) → re-claim → settle APPLIES (the R1 wedge is gone on the migrated path)', async () => {
+    const { JsonFileStore, JsonWorkflowStore, executeStep, CURRENT_WORKFLOW_SCHEMA_VERSION } =
+      await import('@sensigo/realm');
+    const runStore = new JsonFileStore();
+    const workflowStore = new JsonWorkflowStore();
+
+    const def = {
+      id: 'resume-wedge-wf',
+      name: 'Resume Wedge WF',
+      version: 1,
+      schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      steps: {
+        work: { description: 'w', execution: 'agent' as const },
+      },
+    };
+    await workflowStore.register(def);
+
+    const { run } = await runStore.create({
+      workflowId: 'resume-wedge-wf',
+      workflowVersion: 1,
+      params: {},
+    });
+
+    // 1. Settle-fail 'work' through the REAL migrated engine path.
+    const failResult = await executeStep(runStore, def, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => {
+        throw new Error('handler boom');
+      },
+    });
+    expect(failResult.status).toBe('error');
+    const afterFail = await runStore.get(run.id);
+    expect(afterFail.failed_steps).toContain('work');
+    expect(afterFail.terminal_state).toBe(true);
+    expect(afterFail.run_phase).toBe('failed');
+
+    // 2. Resume through the REAL CLI command (not a hand-called function — the literal Command
+    // object `realm resume` wires).
+    await resumeCommand.parseAsync([run.id, '--from', 'work'], { from: 'user' });
+    expect(exitSpy).not.toHaveBeenCalled();
+    const afterResume = await runStore.get(run.id);
+    expect(afterResume.terminal_state).toBe(false);
+    expect(afterResume.failed_steps).not.toContain('work');
+    expect(afterResume.claims?.['work']).toBeUndefined(); // claim released
+
+    // 3. Re-claim + settle again — this time succeeding. Under the LEGACY (pre-#279) mechanism,
+    // this re-settle raced the read-then-update draft against whatever state existed at read
+    // time; on the migrated path it settles atomically against fresh state and simply APPLIES.
+    const completeResult = await executeStep(runStore, def, {
+      runId: run.id,
+      command: 'work',
+      input: {},
+      dispatcher: async () => ({ result: 'ok' }),
+    });
+
+    expect(completeResult.status).toBe('ok');
+    expect(completeResult.errors).toEqual([]);
+    const finalRun = await runStore.get(run.id);
+    expect(finalRun.completed_steps).toContain('work');
+    expect(finalRun.terminal_state).toBe(true);
+    expect(finalRun.run_phase).toBe('completed');
+  });
+});

--- a/packages/cli/src/commands/resume.test.ts
+++ b/packages/cli/src/commands/resume.test.ts
@@ -181,4 +181,186 @@ describe('resumeRun', () => {
     expect(resumed.skip_details?.['step-b']).toBeUndefined();
     expect(resumed.skipped_steps).not.toContain('step-b');
   });
+
+  // ---------------------------------------------------------------------------
+  // issue #279 (increment 1, PR-B) — the four CLI refusals (design record §5).
+  // ---------------------------------------------------------------------------
+
+  describe('CLI refusals (issue #279, increment 1, PR-B)', () => {
+    it('RESUME_REFUSES_ABORTED — a run with aborted_at set is never resumable, regardless of run_phase', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'resume-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      // A structurally-inconsistent-but-defensive fixture: run_phase says 'failed' (which
+      // RESUMABLE_PHASES would normally admit), but aborted_at is ALSO set — proving this refusal
+      // is genuinely independent of the phase check, not merely redundant with it.
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['step-one'],
+        terminal_state: true,
+        aborted_at: { step_id: 'step-one', abort_message: 'handler aborted' },
+      });
+
+      await expect(resumeRun(run.id, 'step-one', runStore, workflowStore)).rejects.toThrow(
+        /aborted runs are never resumable/,
+      );
+    });
+
+    it('refuses a finalizer --from target — points at the drain verb instead', async () => {
+      const finalizerWorkflow: WorkflowDefinition = {
+        id: 'resume-finalizer-wf',
+        name: 'Resume Finalizer Workflow',
+        version: 1,
+        schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+        steps: {
+          work: { description: 'w', execution: 'agent' },
+          fin: { description: 'f', execution: 'finalizer', on_outcome: 'always' },
+        },
+      };
+      await workflowStore.register(finalizerWorkflow);
+      const { run } = await runStore.create({
+        workflowId: 'resume-finalizer-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['fin'],
+        terminal_state: true,
+      });
+
+      await expect(resumeRun(run.id, 'fin', runStore, workflowStore)).rejects.toThrow(
+        /finalizer — finalizers cannot be resumed via --from/,
+      );
+    });
+
+    it('refuses on an unexpired drain lease — bounded wait, never force-bypassable', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'resume-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const farFuture = new Date(Date.now() + 60_000).toISOString();
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['step-one'],
+        terminal_state: true,
+        finalizer_ledger: {
+          fin: {
+            status: 'pending',
+            rank: 0,
+            lease_token: 'active-drainer',
+            lease_deadline: farFuture,
+          },
+        },
+      });
+
+      await expect(resumeRun(run.id, 'step-one', runStore, workflowStore)).rejects.toThrow(
+        /active drain lease/,
+      );
+      // Not force-bypassable — even --force must still refuse.
+      await expect(
+        resumeRun(run.id, 'step-one', runStore, workflowStore, { force: true }),
+      ).rejects.toThrow(/active drain lease/);
+    });
+
+    it('an EXPIRED drain lease does NOT refuse — the finalizer is voided normally', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'resume-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const past = new Date(Date.now() - 60_000).toISOString();
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['step-one'],
+        terminal_state: true,
+        finalizer_ledger: {
+          fin: { status: 'pending', rank: 0, lease_token: 'dead-drainer', lease_deadline: past },
+        },
+      });
+
+      const { voided } = await resumeRun(run.id, 'step-one', runStore, workflowStore);
+      expect(voided).toHaveLength(1);
+      const resumed = await runStore.get(run.id);
+      expect(resumed.finalizer_ledger?.['fin']?.status).toBe('voided');
+    });
+
+    it('a HEALTHY claim on another in-progress step refuses resume — never force-bypassable', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'resume-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const farFuture = new Date(Date.now() + 60_000).toISOString();
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['step-one'],
+        terminal_state: true,
+        in_progress_steps: ['other-step'],
+        claims: { 'other-step': { deadline: farFuture, token: 'live-token' } },
+      });
+
+      await expect(resumeRun(run.id, 'step-one', runStore, workflowStore)).rejects.toThrow(
+        /HEALTHY claim/,
+      );
+      await expect(
+        resumeRun(run.id, 'step-one', runStore, workflowStore, { force: true }),
+      ).rejects.toThrow(/HEALTHY claim/);
+    });
+
+    it('a claim_unknown_age claim refuses WITHOUT --force, but --force overrides it', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'resume-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['step-one'],
+        terminal_state: true,
+        in_progress_steps: ['other-step'],
+        claims: { 'other-step': { deadline: null, token: 'unknown-age-token' } },
+      });
+
+      await expect(resumeRun(run.id, 'step-one', runStore, workflowStore)).rejects.toThrow(
+        /unknown-age claim/,
+      );
+      // --force overrides — the claim is released inside applyResume.
+      await resumeRun(run.id, 'step-one', runStore, workflowStore, { force: true });
+      const resumed = await runStore.get(run.id);
+      expect(resumed.in_progress_steps).toEqual([]);
+      expect(resumed.claims).toEqual({});
+    });
+
+    it('a STALE (concrete, past-deadline) claim is released WITHOUT needing --force', async () => {
+      const { run } = await runStore.create({
+        workflowId: 'resume-test-wf',
+        workflowVersion: 1,
+        params: {},
+      });
+      const past = new Date(Date.now() - 60_000).toISOString();
+      await runStore.update({
+        ...run,
+        run_phase: 'failed',
+        failed_steps: ['step-one'],
+        terminal_state: true,
+        in_progress_steps: ['other-step'],
+        claims: { 'other-step': { deadline: past, token: 'stale-token' } },
+      });
+
+      await resumeRun(run.id, 'step-one', runStore, workflowStore);
+      const resumed = await runStore.get(run.id);
+      expect(resumed.in_progress_steps).toEqual([]);
+      expect(resumed.claims).toEqual({});
+    });
+  });
 });

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,26 +1,69 @@
 // resume command — removes a step from failed_steps so it can be re-executed.
+//
+// issue #279 (increment 1, PR-B): the write itself is now the core-owned pure `applyResume`
+// transform (design record §5) — this file's job narrows to the FOUR CLI refusals that must run
+// BEFORE it (structural aborted_at guard, a finalizer `--from` target, an unexpired drain lease,
+// and the three-way claim classification), then a single atomic `store.update()` of whatever
+// `applyResume` computed (its own version-CAS is the whole atomicity story — see that module's
+// doc). issue #281 rides here too: applyResume strips `abandoned_at` alongside `terminal_reason`.
 import { Command } from 'commander';
-import type { RunStore } from '@sensigo/realm';
-import type { WorkflowRegistrar } from '@sensigo/realm';
-import { WorkflowError } from '@sensigo/realm';
-import { RESUMABLE_PHASES, propagateSkips } from '@sensigo/realm';
+import type { RunStore, WorkflowRegistrar, ApplyResumeVoidedFinalizer } from '@sensigo/realm';
+
+// issue #279 (increment 1, PR-B): NO top-level VALUE import from `@sensigo/realm` — JsonFileStore's
+// default runsDir is computed at module-load time (`homedir()`), so a top-level value import here
+// would freeze it before any test/caller can override `$HOME` (the abandon.ts precedent). Every
+// value this file needs is loaded dynamically inside `resumeRun` itself (cached after the first
+// call — cheap on every subsequent one).
+
+export interface ResumeOptions {
+  /** Overrides the claim_unknown_age refusal (§5.4) — the ONLY refusal `--force` can bypass. A
+   *  healthy claim and an unexpired drain lease are NEVER force-bypassable. */
+  force?: boolean;
+}
 
 /**
- * Removes `stepName` from `failed_steps` so the DAG engine can re-evaluate its
- * eligibility on the next execute-step call.
+ * Removes `stepName` from `failed_steps` so the DAG engine can re-evaluate its eligibility on the
+ * next execute-step call — via the core `applyResume` transform (design record §5), after the
+ * four CLI refusals below all clear.
  *
  * @param runId         The run to resume.
  * @param stepName      The failed step to re-enable.
  * @param runStore      Store holding run records.
  * @param workflowStore Registrar for workflow definitions.
+ * @param opts          `force` overrides ONLY the claim_unknown_age refusal.
+ * @returns             The finalizers this resume voided (empty on the common no-pendings case).
  */
 export async function resumeRun(
   runId: string,
   stepName: string,
   runStore: RunStore,
   workflowStore: WorkflowRegistrar,
-): Promise<void> {
+  opts: ResumeOptions = {},
+): Promise<{ voided: ApplyResumeVoidedFinalizer[] }> {
+  const { WorkflowError, applyResume, RESUMABLE_PHASES, classifyClaim, DRAIN_LEASE_MAX } =
+    await import('@sensigo/realm');
   const run = await runStore.get(runId);
+
+  // §5.1 — structural, phase-independent (RESUME_REFUSES_ABORTED pin): an aborted run is never
+  // resumable, checked directly against aborted_at rather than relying on RESUMABLE_PHASES
+  // excluding 'aborted' as a side effect. Checked FIRST and independently of the phase check below
+  // — deriveRunPhase(:34-42) always derives phase 'aborted' whenever aborted_at is set (the two
+  // can never diverge through any real store write today), so this ordering is what makes the
+  // explicit, by-name business rule ("abort ⇒ never resumable") the one that actually fires,
+  // rather than silently riding on RESUMABLE_PHASES's exclusion as an unstated implementation
+  // detail a future phase-set change could break.
+  if (run.aborted_at !== undefined) {
+    throw new WorkflowError(
+      `Run ${runId} was aborted (step '${run.aborted_at.step_id}') — aborted runs are never ` +
+        `resumable.`,
+      {
+        code: 'STATE_TRANSITION_DENIED',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      },
+    );
+  }
 
   if (!RESUMABLE_PHASES.has(run.run_phase)) {
     throw new WorkflowError(
@@ -36,13 +79,29 @@ export async function resumeRun(
 
   const workflow = await workflowStore.get(run.workflow_id);
 
-  if (workflow.steps[stepName] === undefined) {
+  const targetStep = workflow.steps[stepName];
+  if (targetStep === undefined) {
     throw new WorkflowError(`Step '${stepName}' not found in workflow '${run.workflow_id}'.`, {
       code: 'STEP_NOT_FOUND',
       category: 'ENGINE',
       agentAction: 'report_to_user',
       retryable: false,
     });
+  }
+
+  // §5.2 — a finalizer `--from` target is refused (finalizers settle via the drain verb, not
+  // resume — resuming one would bypass the ledger's own lease/mark discipline entirely).
+  if (targetStep.execution === 'finalizer') {
+    throw new WorkflowError(
+      `Step '${stepName}' is a finalizer — finalizers cannot be resumed via --from. Use ` +
+        `'realm run drain ${runId}' or '--void ${stepName}' instead.`,
+      {
+        code: 'STATE_TRANSITION_DENIED',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: false,
+      },
+    );
   }
 
   if (!run.failed_steps.includes(stepName)) {
@@ -54,49 +113,93 @@ export async function resumeRun(
     });
   }
 
-  // Re-enable the failed step AND make the run runnable again. Filtering failed_steps alone leaves
-  // the run terminal (terminal_state:true), so `realm agent --run-id` throws on it and the
-  // `while (!terminal_state)` drivers skip it. Mirror the test-harness reference: strip
-  // terminal_reason (destructure-and-omit to honour exactOptionalPropertyTypes), re-derive
-  // skipped_steps from scratch so steps skipped only because of this failure become eligible again,
-  // and reset terminal_state to false. update() recomputes run_phase → 'running'.
-  //
-  // #111 clean slate: `...rest` still carries the run's stale `skip_details` — it MUST be reset
-  // to `{}` alongside `skipped_steps: []`, or an orphaned detail would survive for a step that is
-  // now re-eligible (violating `Object.keys(skip_details) ⊆ skipped_steps` isn't the risk here —
-  // the risk is a STALE-but-still-valid-looking reason for a step that no longer has one).
-  // No handler/guard-abort detail is re-mintable by this propagateSkips-only recompute — that is
-  // fine and unreachable: resume is gated to failed/abandoned phases (RESUMABLE_PHASES), never
-  // the aborted phase a handler/guard abort produces.
-  const { terminal_reason: _terminalReason, ...rest } = run;
-  const failedSteps = rest.failed_steps.filter((s) => s !== stepName);
-  const { skipped: skippedSteps, details: skipDetails } = propagateSkips(
-    { ...rest, failed_steps: failedSteps, skipped_steps: [] as string[], skip_details: {} },
-    workflow,
-  );
-  await runStore.update({
-    ...rest,
-    failed_steps: failedSteps,
-    skipped_steps: skippedSteps,
-    skip_details: skipDetails,
-    terminal_state: false,
-  });
+  const now = new Date();
+
+  // §5.3 — any pending finalizer ledger entry with an UNEXPIRED lease refuses: a drainer is
+  // executing RIGHT NOW. Bounded by the §3 clamp (DRAIN_LEASE_MAX) — the wait is short by
+  // construction, so there is deliberately NO --force bypass (final-gate F10a).
+  for (const [name, entry] of Object.entries(run.finalizer_ledger ?? {})) {
+    if (entry.status !== 'pending') continue;
+    if (entry.lease_token === undefined || entry.lease_deadline === undefined) continue;
+    if (new Date(entry.lease_deadline).getTime() <= now.getTime()) continue; // expired — not held
+    throw new WorkflowError(
+      `Run ${runId} has an active drain lease on finalizer '${name}' (expires ` +
+        `${entry.lease_deadline}) — a drainer is executing NOW. Wait for the lease to expire ` +
+        `(bounded — leases are clamped to ${DRAIN_LEASE_MAX}s) and retry. Not force-bypassable.`,
+      {
+        code: 'STATE_TRANSITION_DENIED',
+        category: 'STATE',
+        agentAction: 'report_to_user',
+        retryable: true,
+        details: { runId, finalizer: name, lease_deadline: entry.lease_deadline },
+      },
+    );
+  }
+
+  // §5.4 — claims: classifyClaim three-way. healthy ⇒ refuse (no override); claim_unknown_age ⇒
+  // refuse UNLESS --force; stale/absent ⇒ released inside applyResume, no refusal here.
+  for (const step of run.in_progress_steps) {
+    const claim = run.claims?.[step];
+    if (claim === undefined) continue; // absent — released inside applyResume
+    const state = classifyClaim(claim, now);
+    if (state === 'healthy') {
+      throw new WorkflowError(
+        `Step '${step}' has a HEALTHY claim (deadline ${claim.deadline}) — a live runner is ` +
+          `presumed on it. Resume refuses to disturb live work.`,
+        {
+          code: 'STATE_TRANSITION_DENIED',
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: true,
+          details: { runId, step },
+        },
+      );
+    }
+    if (state === 'claim_unknown_age' && opts.force !== true) {
+      throw new WorkflowError(
+        `Step '${step}' has an unknown-age claim (no reliable deadline) — its liveness cannot ` +
+          `be verified. Re-run with --force to override (only after confirming the runner is ` +
+          `actually dead).`,
+        {
+          code: 'STATE_TRANSITION_DENIED',
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: false,
+          details: { runId, step },
+        },
+      );
+    }
+    // claim_stale, or claim_unknown_age with --force: falls through — applyResume releases it.
+  }
+
+  const { run: resumedRun, voided } = applyResume(run, stepName, workflow);
+  await runStore.update(resumedRun);
+  return { voided };
 }
 
 export const resumeCommand = new Command('resume')
   .description('Remove a step from failed_steps so it can be re-executed')
   .argument('<run-id>', 'ID of the run to resume')
   .requiredOption('--from <step>', 'Name of the failed step to re-enable')
-  .action(async (runId: string, opts: { from: string }) => {
+  .option(
+    '--force',
+    'Override the claim_unknown_age refusal ONLY (never a healthy claim or an unexpired drain lease)',
+  )
+  .action(async (runId: string, opts: { from: string; force?: boolean }) => {
     const { JsonFileStore, JsonWorkflowStore } = await import('@sensigo/realm');
     const runStore = new JsonFileStore();
     const workflowStore = new JsonWorkflowStore();
     try {
-      await resumeRun(runId, opts.from, runStore, workflowStore);
+      const { voided } = await resumeRun(runId, opts.from, runStore, workflowStore, {
+        ...(opts.force !== undefined ? { force: opts.force } : {}),
+      });
       console.log(
         `Resumed run '${runId}': step '${opts.from}' re-enabled and run reset to 'running'.\n` +
           `Drive it with: realm agent --run-id ${runId}`,
       );
+      for (const { disclosure } of voided) {
+        console.log(`  ⚠ ${disclosure}`);
+      }
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/cli/src/commands/store-fs-guard.test.ts
+++ b/packages/cli/src/commands/store-fs-guard.test.ts
@@ -296,15 +296,21 @@ const RAW_TRACE_BUFFER_STORE_DELETE = /\btraceBufferStore\??\.(delete|deleteAllF
  *  contract-clause justification issue #207 PR-2 requires. */
 const RAW_DELETE_ALLOW_LIST: Record<string, { count: number; reason: string }> = {
   'core/src/engine/execution-loop.ts': {
-    count: 2,
+    count: 4,
     reason:
-      'the failure-settle delete (persist-gated on store.update succeeding — #186 posture) and ' +
-      'the success-settle delete (clause (a) of the unified deletion contract: the settlement ' +
-      'already committed and is durably visible, so this delete never races an unsettled step) ' +
-      '— both intentionally UNFENCED: neither can race a concurrent append_trace once the run ' +
-      "is claimed (appends are refused once in_progress/settled, per append_trace.ts's own " +
-      'eligibility check). The capability-block delete (formerly a third site here) was REMOVED ' +
-      "entirely, not fenced — see execution-loop.ts's own comment at that call site.",
+      'the LEGACY failure-settle delete (persist-gated on store.update succeeding — #186 posture) ' +
+      'and the LEGACY success-settle delete (clause (a) of the unified deletion contract: the ' +
+      'settlement already committed and is durably visible, so this delete never races an ' +
+      'unsettled step), PLUS their two MIGRATED-path twins (issue #279 increment 1, PR-B): the ' +
+      "fail site's migrated delete (gated on result.applied — BU-12, the settleStep equivalent " +
+      "of the same persist-gate) and the complete site's migrated delete (same clause-(a) " +
+      'reasoning, now gated on settleStep having committed instead of store.update). All FOUR are ' +
+      'intentionally UNFENCED for the identical reason: none can race a concurrent append_trace ' +
+      'once the run is claimed (appends are refused once in_progress/settled, per ' +
+      "append_trace.ts's own eligibility check) — the migration changes WHICH store method " +
+      'commits the settlement, not this invariant. The capability-block delete (formerly a fifth ' +
+      "site here) was REMOVED entirely, not fenced — see execution-loop.ts's own comment at that " +
+      'call site.',
   },
   'core/src/engine/reclaim-step.ts': {
     count: 1,

--- a/packages/core/src/engine/apply-resume.test.ts
+++ b/packages/core/src/engine/apply-resume.test.ts
@@ -1,0 +1,165 @@
+// apply-resume.test.ts — RESUME_CLEARS_SETTLED (projection + abandoned_at strip + void step, all
+// on the single returned payload) for the core-owned pure resume transform (issue #279, increment
+// 1, PR-B). Normative spec: plans/issue-279/design-d4-increment1.md §5.
+import { describe, it, expect } from 'vitest';
+import { applyResume } from './apply-resume.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+
+const def: WorkflowDefinition = {
+  id: 'resume-wf',
+  name: 'Resume TCK fixture',
+  version: 1,
+  steps: {
+    a: { description: 'a', execution: 'agent', depends_on: [] },
+    b: { description: 'b', execution: 'agent', depends_on: [] },
+    fin: { description: 'f', execution: 'finalizer', on_outcome: 'always' },
+  },
+};
+
+function baseRun(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: 'resume-run',
+    workflow_id: def.id,
+    workflow_version: 1,
+    completed_steps: [],
+    in_progress_steps: [],
+    failed_steps: ['a'],
+    skipped_steps: [],
+    run_phase: 'failed',
+    version: 5,
+    params: {},
+    evidence: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    terminal_state: true,
+    terminal_reason: `Step 'a' failed: boom`,
+    ...overrides,
+  };
+}
+
+describe('applyResume — RESUME_CLEARS_SETTLED (issue #279, increment 1, PR-B)', () => {
+  it('projects settled down to live membership, strips terminal_reason AND abandoned_at, resets terminal_state, and VOIDS every pending finalizer — all on the single returned payload', () => {
+    const snapshot = baseRun({
+      abandoned_at: '2026-01-01T00:00:00.000Z',
+      settled: {
+        a: { token: 'tok-a', outcome: 'fail' },
+        // an ORPHAN entry — 'ghost' is not in any membership array (simulates a stale/foreign
+        // entry from a hand-authored or divergent history) — the projection must drop it too,
+        // since it is not in completed′∪failed′∪skipped′ either.
+        ghost: { token: null, outcome: 'complete' },
+      },
+      finalizer_ledger: {
+        fin: { status: 'pending', rank: 0 },
+      },
+    });
+
+    const { run, voided } = applyResume(snapshot, 'a', def);
+
+    // terminal_reason + abandoned_at BOTH stripped (issue #281).
+    expect(run.terminal_reason).toBeUndefined();
+    expect(run.abandoned_at).toBeUndefined();
+    expect(run.terminal_state).toBe(false);
+
+    // 'a' removed from failed_steps (resumed).
+    expect(run.failed_steps).not.toContain('a');
+
+    // settled L17 projection: 'a' is gone from every membership array now (removed from
+    // failed_steps, never in completed/skipped) ⇒ dropped. 'ghost' was never in any membership
+    // array ⇒ dropped too (orphan).
+    expect(run.settled?.['a']).toBeUndefined();
+    expect(run.settled?.['ghost']).toBeUndefined();
+
+    // The pending finalizer is VOIDED, loudly disclosed as never-executed (no lease_token).
+    expect(run.finalizer_ledger?.['fin']?.status).toBe('voided');
+    expect(voided).toHaveLength(1);
+    expect(voided[0]!.name).toBe('fin');
+    expect(voided[0]!.disclosure).toMatch(/never executed, superseded by resume/);
+
+    // Claims released unconditionally.
+    expect(run.in_progress_steps).toEqual([]);
+    expect(run.claims).toEqual({});
+  });
+
+  it('a leased-but-unmarked pending finalizer gets the OTHER disclosure wording (may have executed without a recorded mark)', () => {
+    const snapshot = baseRun({
+      finalizer_ledger: {
+        fin: {
+          status: 'pending',
+          rank: 0,
+          lease_token: 'some-drainer-token',
+          lease_deadline: '2020-01-01T00:00:00.000Z', // expired — otherwise the CLI would refuse
+        },
+      },
+    });
+
+    const { voided } = applyResume(snapshot, 'a', def);
+
+    expect(voided).toHaveLength(1);
+    expect(voided[0]!.disclosure).toMatch(
+      /may have executed without a recorded mark; may re-execute at the next terminal edge/,
+    );
+  });
+
+  it('never-downgrades an already-completed or already-failed finalizer ledger entry (only PENDING entries are voided)', () => {
+    const snapshot = baseRun({
+      finalizer_ledger: {
+        completedFin: { status: 'completed', rank: 0 },
+        failedFin: { status: 'failed', rank: 1 },
+      },
+    });
+
+    const { run, voided } = applyResume(snapshot, 'a', def);
+
+    expect(run.finalizer_ledger?.['completedFin']?.status).toBe('completed');
+    expect(run.finalizer_ledger?.['failedFin']?.status).toBe('failed');
+    expect(voided).toHaveLength(0);
+  });
+
+  it('a run with no finalizer_ledger at all resumes cleanly (undefined stays undefined, no crash)', () => {
+    const snapshot = baseRun();
+    const { run, voided } = applyResume(snapshot, 'a', def);
+    expect(run.finalizer_ledger).toBeUndefined();
+    expect(voided).toEqual([]);
+  });
+
+  it('re-derives skipped_steps/skip_details from scratch (a step skipped only because of the now-resumed failure becomes eligible again)', () => {
+    const snapshot = baseRun({
+      skipped_steps: ['b'],
+      skip_details: { b: { kind: 'trigger_rule_unsatisfiable' } },
+    });
+    const { run } = applyResume(snapshot, 'a', def);
+    // 'b' has no dependency on 'a' in this fixture, so propagateSkips should NOT re-skip it —
+    // proving the skip state is genuinely RE-DERIVED, not merely carried forward stale.
+    expect(run.skipped_steps).not.toContain('b');
+    expect(run.skip_details['b']).toBeUndefined();
+  });
+
+  it('releases a genuinely DANGLING claim (non-empty in_progress_steps/claims — the actual R1-wedge shape, a crash mid-execution with no settle ever reached), not merely a fixture that is already empty', () => {
+    const snapshot = baseRun({
+      // The resumed step itself was left claimed (crashed before any settle) AND a sibling step
+      // also has a stale claim outstanding — both must be released unconditionally.
+      in_progress_steps: ['a', 'b'],
+      claims: {
+        a: { deadline: '2020-01-01T00:00:00.000Z', token: 'dead-token-a' },
+        b: { deadline: '2020-01-01T00:00:00.000Z', token: 'dead-token-b' },
+      },
+    });
+    const { run } = applyResume(snapshot, 'a', def);
+    expect(run.in_progress_steps).toEqual([]);
+    expect(run.claims).toEqual({});
+  });
+
+  it('a settled entry still in live membership (e.g. a genuinely completed sibling step) SURVIVES the projection', () => {
+    const snapshot = baseRun({
+      completed_steps: ['b'],
+      settled: {
+        a: { token: 'tok-a', outcome: 'fail' },
+        b: { token: 'tok-b', outcome: 'complete' },
+      },
+    });
+    const { run } = applyResume(snapshot, 'a', def);
+    expect(run.settled?.['a']).toBeUndefined(); // 'a' is being resumed — no longer settled
+    expect(run.settled?.['b']).toEqual({ token: 'tok-b', outcome: 'complete' }); // survives
+  });
+});

--- a/packages/core/src/engine/apply-resume.ts
+++ b/packages/core/src/engine/apply-resume.ts
@@ -1,0 +1,111 @@
+// apply-resume.ts — the core-owned pure resume transform (issue #279, increment 1, PR-B).
+// Normative spec: plans/issue-279/design-d4-increment1.md §5. "snapshot" naming is deliberate: this
+// function's own atomicity claim is ZERO — the caller's single `store.update()` version-CAS on the
+// RETURNED record is what makes the whole resume atomic; `snapshot` is read pre-lock, the payload
+// simply carries the version it was read at (lens-1 F14).
+//
+// The CLI's OWN refusals (packages/cli/src/commands/resume.ts) — aborted_at / a finalizer `--from`
+// target / an unexpired pending-ledger lease / a healthy-or-unknown-age claim — ALL run BEFORE this
+// is ever called. By the time control reaches here, every remaining in-progress claim is provably
+// stale-or-absent (no live work is being interrupted), so this function releases ALL of them
+// unconditionally — do NOT widen this signature with claim-classification inputs; that would
+// re-litigate a decision the CLI refusals already made.
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import { propagateSkips } from './eligibility.js';
+
+/** One finalizer voided by a resume, with its lease-discriminated disclosure message (design
+ *  record §5: "never executed, superseded by resume" vs "may have executed without a recorded
+ *  mark — may re-execute at the next terminal edge"). */
+export interface ApplyResumeVoidedFinalizer {
+  name: string;
+  disclosure: string;
+}
+
+export interface ApplyResumeResult {
+  /** The fully-mutated record — pass directly to `store.update()` for the atomic write. */
+  run: RunRecord;
+  /** Every pending finalizer ledger entry this resume voided, in `Object.entries` order. Empty
+   *  when the run carried no pending finalizers (the common case). */
+  voided: ApplyResumeVoidedFinalizer[];
+}
+
+/**
+ * Resumes `stepName` (design record §5) — filters it out of `failed_steps`, wipes and re-derives
+ * `skipped_steps`/`skip_details` from scratch (NOTE — final-gate F9 cross-reference: this
+ * wipe+re-derive relies on the premise that handler/guard-abort runs are never resumable; the
+ * CLI's own `aborted_at` refusal, run BEFORE this function, is what makes that premise
+ * STRUCTURALLY true rather than merely conventional), resets `terminal_state:false`, strips
+ * `terminal_reason` AND `abandoned_at` (issue #281 — the load-bearing fix for the `aborted_at`
+ * mask: leaving a stale `abandoned_at` on a resumed-and-re-terminalized run would let a future
+ * PR-A-vintage `isTerminal` reader mis-read it as abandoned again), projects `settled` down to
+ * still-live membership (L17: `settled′ = {s ∈ settled | s ∈ completed′∪failed′∪skipped′}`), VOIDS
+ * every pending finalizer ledger entry (leases dropped, each disclosed), and releases every
+ * remaining claim unconditionally.
+ *
+ * Pure — no I/O, no `Date.now()`/randomness. Returns the mutated record; the caller performs the
+ * single atomic `store.update()`.
+ */
+export function applyResume(
+  snapshot: RunRecord,
+  stepName: string,
+  definition: WorkflowDefinition,
+): ApplyResumeResult {
+  const failedSteps = snapshot.failed_steps.filter((s) => s !== stepName);
+  const { skipped: skippedSteps, details: skipDetails } = propagateSkips(
+    {
+      ...snapshot,
+      failed_steps: failedSteps,
+      skipped_steps: [] as string[],
+      skip_details: {},
+    },
+    definition,
+  );
+
+  // settled L17 PROJECTION.
+  const liveMembership = new Set([...snapshot.completed_steps, ...failedSteps, ...skippedSteps]);
+  const settled: RunRecord['settled'] =
+    snapshot.settled !== undefined
+      ? Object.fromEntries(Object.entries(snapshot.settled).filter(([s]) => liveMembership.has(s)))
+      : undefined;
+
+  // VOID every pending finalizer ledger entry, loudly, with lease discrimination.
+  const voided: ApplyResumeVoidedFinalizer[] = [];
+  let finalizerLedger: RunRecord['finalizer_ledger'] = snapshot.finalizer_ledger;
+  if (finalizerLedger !== undefined) {
+    const nextLedger: NonNullable<RunRecord['finalizer_ledger']> = {};
+    for (const [name, entry] of Object.entries(finalizerLedger)) {
+      if (entry.status !== 'pending') {
+        nextLedger[name] = entry;
+        continue;
+      }
+      const neverLeased = entry.lease_token === undefined;
+      nextLedger[name] = { status: 'voided', rank: entry.rank };
+      voided.push({
+        name,
+        disclosure: neverLeased
+          ? `finalizer '${name}' voided by resume — never executed, superseded by resume`
+          : `finalizer '${name}' voided by resume — may have executed without a recorded mark; ` +
+            `may re-execute at the next terminal edge`,
+      });
+    }
+    finalizerLedger = nextLedger;
+  }
+
+  // Strip terminal_reason + abandoned_at (issue #281); release ALL remaining claims
+  // unconditionally (the CLI refusals guarantee none are healthy by the time this runs).
+  const { terminal_reason: _tr, abandoned_at: _aa, ...rest } = snapshot;
+  const run: RunRecord = {
+    ...rest,
+    failed_steps: failedSteps,
+    skipped_steps: skippedSteps,
+    skip_details: skipDetails,
+    terminal_state: false,
+    in_progress_steps: [],
+    claims: {},
+    ...(settled !== undefined ? { settled } : {}),
+    ...(finalizerLedger !== undefined ? { finalizer_ledger: finalizerLedger } : {}),
+  };
+
+  return { run, voided };
+}

--- a/packages/core/src/engine/dormancy-suite-279.test.ts
+++ b/packages/core/src/engine/dormancy-suite-279.test.ts
@@ -1,0 +1,192 @@
+// dormancy-suite-279.test.ts — verification item 5 (issue #279, increment 1, PR-B). A NAMED
+// representative set (re-parameterizing every pre-existing seal-path test file across a
+// declaring/non-declaring axis is out of proportion for this increment) covering all THREE
+// migrated sites against a non-declaring store double: `store.settleStep === undefined` by
+// construction (own-property masking — never implemented, not merely set to undefined, matching
+// the RunStore.settleStep OPTIONAL contract). Each site is proven byte-identical-SHAPED to legacy
+// behavior (same membership/terminal outcomes the migrated path also produces) PLUS the ONE
+// dormancy advisory (I16) every legacy-path envelope now carries.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep } from './execution-loop.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type {
+  RunStore,
+  CreateRunOptions,
+  LoadBearingRunRecordField,
+} from '../store/store-interface.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { StepHandler } from '../extensions/step-handler.js';
+
+/**
+ * Delegates every RunStore method to a real, functional JsonFileStore — EXCEPT `settleStep`,
+ * which is never implemented at all (not set to `undefined`; simply absent), so
+ * `store.settleStep === undefined` holds by construction and every migrated seal site takes its
+ * dormancy-fallback branch. Mirrors execution-loop-fidelity-gate.test.ts's own
+ * `DeclaredFieldsOverrideStore` precedent (issue #188), narrowed to this PR's one concern.
+ */
+class NonDeclaringStoreDouble implements RunStore {
+  readonly persistsClaims: boolean;
+  readonly persistedRunRecordFields?: ReadonlySet<LoadBearingRunRecordField>;
+
+  constructor(private readonly inner: JsonFileStore) {
+    this.persistsClaims = inner.persistsClaims;
+    this.persistedRunRecordFields = inner.persistedRunRecordFields;
+  }
+
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    return this.inner.create(options);
+  }
+  get(runId: string): Promise<RunRecord> {
+    return this.inner.get(runId);
+  }
+  update(record: RunRecord): Promise<RunRecord> {
+    return this.inner.update(record);
+  }
+  list(workflowId?: string): Promise<RunRecord[]> {
+    return this.inner.list(workflowId);
+  }
+  claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord> {
+    return this.inner.claimStep(runId, stepName, definition);
+  }
+  // settleStep intentionally OMITTED.
+}
+
+const DORMANCY_ADVISORY_SUBSTRING = 'settled via the legacy compatibility path';
+
+async function withStore<T>(fn: (store: NonDeclaringStoreDouble) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'realm-dormancy-'));
+  try {
+    return await fn(new NonDeclaringStoreDouble(new JsonFileStore(dir)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('dormancy suite — the legacy path is byte-identical-shaped + the ONE advisory (issue #279, increment 1, PR-B, verification item 5)', () => {
+  it('COMPLETE site: a non-declaring store settles via the legacy path — completes the run, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-complete-wf',
+        name: 'Dormancy complete',
+        version: 1,
+        steps: { work: { description: 'w', execution: 'agent', depends_on: [] } },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({ ok: true }),
+      });
+      expect(result.status).toBe('ok');
+      expect(result.errors).toEqual([]);
+      const finalRun = await store.get(run.id);
+      expect(finalRun.completed_steps).toContain('work');
+      expect(finalRun.terminal_state).toBe(true);
+      expect(finalRun.run_phase).toBe('completed');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+    });
+  });
+
+  it('FAIL site: a non-declaring store settles via the legacy path — fails the run, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-fail-wf',
+        name: 'Dormancy fail',
+        version: 1,
+        steps: { work: { description: 'w', execution: 'agent', depends_on: [] } },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => {
+          throw new Error('boom');
+        },
+      });
+      expect(result.status).toBe('error');
+      const finalRun = await store.get(run.id);
+      expect(finalRun.failed_steps).toContain('work');
+      expect(finalRun.terminal_state).toBe(true);
+      expect(finalRun.run_phase).toBe('failed');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+    });
+  });
+
+  it('HANDLER-ABORT site: a non-declaring store settles via the legacy path — aborts the run, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-abort-wf',
+        name: 'Dormancy abort',
+        version: 1,
+        steps: {
+          work: { description: 'w', execution: 'auto', depends_on: [], handler: 'abort-handler' },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const abortHandler: StepHandler = {
+        id: 'abort-handler',
+        execute: async () => ({ abort: { message: 'graceful stop' } }),
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'abort-handler', abortHandler);
+
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({}),
+        registry,
+      });
+      expect(result.status).toBe('ok'); // handler-abort is a recorded 'ok' outcome, not an error
+      const finalRun = await store.get(run.id);
+      expect(finalRun.terminal_state).toBe(true);
+      expect(finalRun.aborted_at?.step_id).toBe('work');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+    });
+  });
+
+  it('the claim-time drain advisory: a non-declaring store never mints a finalizer_ledger at all (mintFresh only runs inside applySettlement), so the claim-refusal path has nothing to disclose', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-claim-advisory-wf',
+        name: 'Dormancy claim advisory',
+        version: 1,
+        steps: {
+          work: { description: 'w', execution: 'agent', depends_on: [] },
+          fin: {
+            description: 'f',
+            execution: 'finalizer',
+            on_outcome: 'always',
+            handler: 'fin-handler',
+          },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', {
+        id: 'fin-handler',
+        execute: async () => ({ data: {} }),
+      });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({}),
+        registry,
+      });
+      expect(result.status).toBe('ok');
+      const finalRun = await store.get(run.id);
+      // The LEGACY buildFinalizedSeal path drains the finalizer pre-commit, in-band — no ledger
+      // is ever minted on the dormancy path (mintFresh lives exclusively inside applySettlement).
+      expect(finalRun.finalizer_ledger).toBeUndefined();
+      expect(finalRun.completed_steps).toContain('fin');
+    });
+  });
+});

--- a/packages/core/src/engine/drain-rereads-ledger.test.ts
+++ b/packages/core/src/engine/drain-rereads-ledger.test.ts
@@ -1,0 +1,154 @@
+// drain-rereads-ledger.test.ts — verification item 6, mutation probe (b) (issue #279, increment 1,
+// PR-B): pins the DRAIN_REREADS_LEDGER property — `drainFinalizers` must select the NEXT
+// lowest-ranked finalizer to attempt from a FRESH re-derivation (`pendingByRank(run)` against the
+// latest known record) on every loop iteration, never from a list of names captured once at pass
+// start.
+//
+// Why this needs its own test (this property was previously UNPINNED — discovered while running
+// verification 6's mutation probe (b), which the existing suite did not catch): membership and
+// rank are fixed at mint time (all applicable finalizers mint together, synchronously, at the
+// single terminal transition, before any drain pass begins) and a store's `settleStep` gracefully
+// no-ops (`applied:false, reason:'ledger_not_pending'`) on a stale lease attempt — so a pass-start
+// snapshot converges to the SAME final ledger state as a fresh-derivation implementation in every
+// scenario this increment's design permits. The only OBSERVABLE difference is in the number of
+// `settleStep` calls made for an entry that a concurrent actor (here: the fin0 handler itself,
+// standing in for a concurrent operator `--void`) resolves out from under a still-in-flight drain
+// pass: fresh re-derivation sees the resolution immediately (via the SAME store's latest state) and
+// never attempts to lease it; a pass-start snapshot still tries — a wasted (harmless, but real)
+// round-trip a snapshot implementation would make that a re-reading one would not.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep } from './execution-loop.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type { RunStore, CreateRunOptions } from '../store/store-interface.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { SettlementDelta, SettlementResult } from '../types/settlement.js';
+import type { StepHandler } from '../extensions/step-handler.js';
+
+/** Delegates everything to a real JsonFileStore, counting `settleStep` calls per finalizer name
+ *  (lease + mark both count) — the observable proxy for "did drainFinalizers even ATTEMPT this
+ *  entry", independent of its outcome. */
+class CountingStore implements RunStore {
+  readonly settleStepCallsByFinalizer = new Map<string, number>();
+  readonly persistsClaims: boolean;
+
+  constructor(private readonly inner: JsonFileStore) {
+    this.persistsClaims = inner.persistsClaims;
+  }
+
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    return this.inner.create(options);
+  }
+  get(runId: string): Promise<RunRecord> {
+    return this.inner.get(runId);
+  }
+  update(record: RunRecord): Promise<RunRecord> {
+    return this.inner.update(record);
+  }
+  list(workflowId?: string): Promise<RunRecord[]> {
+    return this.inner.list(workflowId);
+  }
+  claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord> {
+    return this.inner.claimStep(runId, stepName, definition);
+  }
+  settleStep(
+    runId: string,
+    delta: SettlementDelta,
+    definition: WorkflowDefinition,
+    options?: { now?: Date },
+  ): Promise<SettlementResult> {
+    if (delta.kind === 'lease_finalizer' || delta.kind === 'mark_finalizer') {
+      this.settleStepCallsByFinalizer.set(
+        delta.finalizer,
+        (this.settleStepCallsByFinalizer.get(delta.finalizer) ?? 0) + 1,
+      );
+    }
+    return this.inner.settleStep(runId, delta, definition, options);
+  }
+}
+
+describe('drainFinalizers re-derives pending-by-rank from fresh state every iteration (issue #279, increment 1, PR-B, verification item 6, probe b — DRAIN_REREADS_LEDGER)', () => {
+  it('a finalizer resolved by a concurrent actor DURING the pass is never leased — zero settleStep calls for it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-drain-reread-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const store = new CountingStore(inner);
+
+      const def: WorkflowDefinition = {
+        id: 'drain-reread-wf',
+        name: 'Drain reread WF',
+        version: 1,
+        steps: {
+          work: { description: 'w', execution: 'agent', depends_on: [] },
+          // Declaration order fixes mint rank: fin0 → rank 0, fin1 → rank 1.
+          fin0: {
+            description: 'f0',
+            execution: 'finalizer',
+            on_outcome: 'always',
+            handler: 'fin0-handler',
+          },
+          fin1: {
+            description: 'f1',
+            execution: 'finalizer',
+            on_outcome: 'always',
+            handler: 'fin1-handler',
+          },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const registry = new ExtensionRegistry();
+      // fin0's handler stands in for a CONCURRENT operator: while fin0 is executing (after this
+      // drain pass has already leased it, but before fin1 has been looked at), it directly voids
+      // fin1 on the SAME store — exactly what an external `--void fin1` would do mid-pass.
+      const fin0Handler: StepHandler = {
+        id: 'fin0-handler',
+        execute: async () => {
+          const mid = await inner.get(run.id);
+          await inner.update({
+            ...mid,
+            finalizer_ledger: {
+              ...mid.finalizer_ledger,
+              fin1: { status: 'voided', rank: mid.finalizer_ledger?.['fin1']?.rank ?? 1 },
+            },
+          });
+          return { data: {} };
+        },
+      };
+      const fin1Handler: StepHandler = {
+        id: 'fin1-handler',
+        execute: async () => ({ data: {} }),
+      };
+      registry.register('handler', 'fin0-handler', fin0Handler);
+      registry.register('handler', 'fin1-handler', fin1Handler);
+
+      // Settle 'work' — mints BOTH fin0 (rank 0) and fin1 (rank 1) as pending, transitions the run
+      // terminal, and (per D1) auto-drains post-commit.
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({}),
+        registry,
+      });
+      expect(result.status).toBe('ok');
+
+      const finalRun = await inner.get(run.id);
+      // fin0 genuinely ran (leased + marked): exactly one lease + one mark = 2 calls.
+      expect(store.settleStepCallsByFinalizer.get('fin0')).toBe(2);
+      // fin1 was voided DURING fin0's execution — a fresh-derivation drain never attempts to
+      // lease it at all (pendingByRank, re-read after fin0's mark, no longer lists it as pending).
+      // Under a pass-start-snapshot mutation this would instead be >=1 (a wasted lease attempt
+      // refused as `ledger_not_pending`).
+      expect(store.settleStepCallsByFinalizer.get('fin1')).toBeUndefined();
+      expect(finalRun.finalizer_ledger?.['fin1']?.status).toBe('voided'); // never overwritten back
+      expect(finalRun.finalizer_ledger?.['fin0']?.status).toBe('completed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/execution-loop-attributed-adoption.test.ts
+++ b/packages/core/src/engine/execution-loop-attributed-adoption.test.ts
@@ -315,7 +315,7 @@ describe('execution-loop.ts — settle-time seal decision (issue #197 PR-2, deli
     await rm(dir, { recursive: true, force: true });
   });
 
-  it('sealed:true ⇒ the live WAL is retired to a sealed artifact (not deleted), warns "preserved (sealed)", and the seal happens AFTER store.update (ordering)', async () => {
+  it('sealed:true ⇒ the live WAL is retired to a sealed artifact (not deleted), warns "preserved (sealed)", and the seal happens AFTER the settling commit (ordering)', async () => {
     const { run } = await store.create({
       workflowId: 'attributed-adoption-agent-wf',
       workflowVersion: 1,
@@ -326,12 +326,17 @@ describe('execution-loop.ts — settle-time seal decision (issue #197 PR-2, deli
       writerNonce: 'other-writer',
     });
 
+    // issue #279 (increment 1, PR-B): JsonFileStore declares settleStep — the complete site's
+    // MIGRATED path commits via settleStep, not store.update. Track that instead; the ordering
+    // invariant under test (seal strictly AFTER the settling commit) is unchanged by the migration.
     const calls: string[] = [];
-    const originalUpdate = store.update.bind(store);
-    vi.spyOn(store, 'update').mockImplementation(async (rec) => {
-      calls.push('update');
-      return originalUpdate(rec);
-    });
+    const originalSettleStep = store.settleStep!.bind(store);
+    vi.spyOn(store, 'settleStep' as never).mockImplementation((async (...args: unknown[]) => {
+      calls.push('settleStep');
+      return (
+        originalSettleStep as (...a: unknown[]) => ReturnType<NonNullable<typeof store.settleStep>>
+      )(...args);
+    }) as never);
     const originalSeal = traceBufferStore.sealFenced.bind(traceBufferStore);
     vi.spyOn(traceBufferStore, 'sealFenced').mockImplementation(async (...args) => {
       calls.push('sealFenced');
@@ -348,7 +353,7 @@ describe('execution-loop.ts — settle-time seal decision (issue #197 PR-2, deli
     });
 
     expect(envelope.status).toBe('ok');
-    expect(calls).toEqual(['update', 'sealFenced']); // seal strictly AFTER the settling update
+    expect(calls).toEqual(['settleStep', 'sealFenced']); // seal strictly AFTER the settling commit
     expect(
       envelope.warnings.some(
         (w) => w.includes('foreign line(s) preserved (sealed)') && w.includes('realm run export'),

--- a/packages/core/src/engine/execution-loop-fenced-trio-adoption.test.ts
+++ b/packages/core/src/engine/execution-loop-fenced-trio-adoption.test.ts
@@ -95,7 +95,7 @@ describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)
   });
 
   // ── :1566-equivalent — failure-settle persist-gate ──────────────────────────────────────────
-  it('failure-settle: WAL delete never fires when the preceding store.update itself fails (persist-gate)', async () => {
+  it('failure-settle: WAL delete never fires when the migrated settleStep itself fails (persist-gate)', async () => {
     const { run } = await store.create({
       workflowId: 'fenced-adoption-agent-wf',
       workflowVersion: 1,
@@ -105,9 +105,14 @@ describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)
     await traceBufferStore.append(run.id, 'step-agent', [{ event: 'pre_failure_line' }]);
     const deleteSpy = vi.spyOn(traceBufferStore, 'delete');
 
-    const updateSpy = vi
-      .spyOn(store, 'update')
-      .mockRejectedValue(new Error('simulated persist failure'));
+    // issue #279 (increment 1, PR-B): JsonFileStore declares settleStep — the fail site's
+    // MIGRATED path settles via settleStep, not store.update. A settleStep throw returns an
+    // error envelope BEFORE the WAL-cleanup section is ever reached (it lives inside the
+    // applied:true branch only), so the same persist-gate invariant holds under the new
+    // mechanism: WAL cleanup never fires when the settle itself never committed.
+    const settleStepSpy = vi
+      .spyOn(store, 'settleStep' as never)
+      .mockRejectedValue(new Error('simulated persist failure') as never);
 
     try {
       const envelope = await executeStep(store, agentDef, {
@@ -121,11 +126,12 @@ describe('execution-loop.ts — fenced-trio call-site adoption (issue #207 PR-2)
       });
 
       expect(envelope.status).toBe('error');
+      expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
       expect(deleteSpy).not.toHaveBeenCalled();
       // The WAL survives — it is the sole remaining evidence copy until reclaim (#186 posture).
       expect(await traceBufferStore.read(run.id, 'step-agent')).toHaveLength(1);
     } finally {
-      updateSpy.mockRestore();
+      settleStepSpy.mockRestore();
     }
   });
 

--- a/packages/core/src/engine/execution-loop-fidelity-gate.test.ts
+++ b/packages/core/src/engine/execution-loop-fidelity-gate.test.ts
@@ -186,7 +186,14 @@ describe('execution-loop — extension_identity field-fidelity gate (issue #188)
       // no registry passed at all
     });
 
-    expect(envelope.warnings).toEqual([]);
+    // issue #279 (increment 1, PR-B): `DeclaredFieldsOverrideStore` declares no settleStep either
+    // (it predates PR-A/PR-B) — the legacy dormancy path now carries its own ONE advisory (I16),
+    // unrelated to the #188 extension-identity gate this test is actually about. No #188-specific
+    // warning fires (no registry identity was ever set) — only the dormancy advisory.
+    expect(envelope.warnings).toEqual([
+      'settled via the legacy compatibility path — this store does not declare atomic settlement ' +
+        '(RunStore.settleStep); upgrade the store to close the fan-out seal race (issue #279)',
+    ]);
   });
 });
 

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -1702,21 +1702,23 @@ describe('executeStep', () => {
   });
 
   describe('cleanup failure warning', () => {
-    it('surfaces cleanup failure as warning when the failed-state store.update throws', async () => {
+    // issue #279 (increment 1, PR-B): JsonFileStore now declares settleStep, so the fail site's
+    // MIGRATED path (not the legacy store.update path) handles this run — a genuine settleStep
+    // throw surfaces as a hard ENGINE_STORE_FAILED error envelope (the complete-site's own
+    // pre-existing catch pattern, replicated at all three migrated sites — design record §1/D1),
+    // never a warning-degraded 'error' envelope that still preserves the ORIGINAL dispatch
+    // failure's message. Mocking store.update (the old target) would no longer even intercept
+    // this path, since the migrated fail site never calls it.
+    it('surfaces a hard ENGINE_STORE_FAILED error envelope when the migrated settleStep throws', async () => {
       const { run: run } = await store.create({
         workflowId: 'test-wf',
         workflowVersion: 1,
         params: {},
       });
 
-      // Step claiming is now done via store.claimStep (not store.update), so the first
-      // store.update call is the cleanup write that marks the run as failed.
-      // Throw on every store.update call to simulate cleanup failure.
-      const originalUpdate = store.update.bind(store);
-      vi.spyOn(store, 'update').mockImplementation(async (_record) => {
+      vi.spyOn(store, 'settleStep' as never).mockImplementation((async () => {
         throw new Error('store write failed');
-        return originalUpdate(_record);
-      });
+      }) as never);
 
       try {
         const envelope = await executeStep(store, definition, {
@@ -1727,9 +1729,9 @@ describe('executeStep', () => {
         });
 
         expect(envelope.status).toBe('error');
-        expect(envelope.errors[0]).toContain('step failed');
-        expect(envelope.warnings).toHaveLength(1);
-        expect(envelope.warnings[0]).toMatch(/Failed to persist step failure/);
+        expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
+        expect(envelope.errors[0]).toMatch(/Failed to persist run update/);
+        expect(envelope.agent_action).toBe('stop');
       } finally {
         vi.restoreAllMocks();
       }
@@ -2698,7 +2700,7 @@ describe('executeStep', () => {
       expect(envelope.warnings[0]).toContain('step-one');
     });
 
-    it('trace_schema warn: both trace warning and cleanup warning appear when dispatch fails and store.update throws', async () => {
+    it('trace_schema warn: the trace warning survives a migrated settleStep throw (issue #279 PR-B)', async () => {
       const def: WorkflowDefinition = {
         ...traceSchemaDefinitionBase,
         steps: {
@@ -2716,10 +2718,12 @@ describe('executeStep', () => {
         params: {},
       });
 
-      // Mock store.update to throw — simulates cleanup write failure
-      vi.spyOn(store, 'update').mockImplementation(async () => {
+      // JsonFileStore declares settleStep — the fail site's MIGRATED path handles this run, so
+      // simulating a persist failure now means mocking settleStep, not store.update (the fail
+      // site's legacy-only call, unreachable once the store declares the capability).
+      vi.spyOn(store, 'settleStep' as never).mockImplementation((async () => {
         throw new Error('store write failed');
-      });
+      }) as never);
 
       try {
         const envelope = await executeStep(store, def, {
@@ -2731,10 +2735,14 @@ describe('executeStep', () => {
         });
 
         expect(envelope.status).toBe('error');
-        expect(envelope.warnings).toHaveLength(2);
-        // Trace warning first (deterministic order), cleanup warning second
+        expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
+        // The trace warning survives (threaded through makeErrorEnvelope's extraWarnings) even
+        // though the settle itself hard-failed — the persist-failure detail now lives in
+        // errors[0]/error_code instead of a second warning entry (design record §1/D1: a genuine
+        // throw must never become a false-ok/warning-degraded envelope).
+        expect(envelope.warnings).toHaveLength(1);
         expect(envelope.warnings[0]).toContain('step-one');
-        expect(envelope.warnings[1]).toMatch(/Failed to persist step failure/);
+        expect(envelope.errors[0]).toMatch(/Failed to persist run update/);
       } finally {
         vi.restoreAllMocks();
       }
@@ -3519,16 +3527,20 @@ describe('Step 5 dispatch-failure envelope', () => {
     ).toBe(true);
   });
 
-  it('store.update failure suppresses next_actions', async () => {
+  it('a migrated settleStep failure suppresses next_actions and hard-stops (issue #279 PR-B)', async () => {
     const { run: run } = await store.create({
       workflowId: 'two-step-wf',
       workflowVersion: 1,
       params: {},
     });
 
-    // claimStep uses its own atomic file-lock write and does not call store.update,
-    // so spying on store.update only intercepts the Step 5 store.update(failedRun) call.
-    vi.spyOn(store, 'update').mockRejectedValue(new Error('disk full'));
+    // JsonFileStore declares settleStep — the fail site's MIGRATED path handles this run;
+    // store.update is never called there, so simulating a persist failure means mocking
+    // settleStep. A genuine throw now hard-stops (agent_action: 'stop') REGARDLESS of the
+    // original dispatch error's own agentAction — design record §1/D1's replicated
+    // complete-site catch pattern overrides it, rather than degrading to a warning that
+    // preserves the original semantics.
+    vi.spyOn(store, 'settleStep' as never).mockRejectedValue(new Error('disk full') as never);
 
     const envelope = await executeStep(store, twoStepDef, {
       runId: run.id,
@@ -3545,9 +3557,10 @@ describe('Step 5 dispatch-failure envelope', () => {
     });
 
     expect(envelope.status).toBe('error');
-    expect(envelope.agent_action).toBe('wait_for_human');
+    expect(envelope.error_code).toBe('ENGINE_STORE_FAILED');
+    expect(envelope.agent_action).toBe('stop');
     expect(envelope.next_actions).toHaveLength(0);
-    expect(envelope.warnings.some((w) => w.toLowerCase().includes('persist'))).toBe(true);
+    expect(envelope.errors.some((w) => w.toLowerCase().includes('persist'))).toBe(true);
   });
 
   it('run_version reflects persisted version not stale pre-persist version', async () => {
@@ -3557,14 +3570,17 @@ describe('Step 5 dispatch-failure envelope', () => {
       params: {},
     });
 
-    // Track the version returned by store.update in Step 5.
-    const originalUpdate = store.update.bind(store);
+    // issue #279 (increment 1, PR-B): JsonFileStore declares settleStep — the fail site's
+    // MIGRATED path settles via settleStep, not store.update. Track the version it returns.
+    const originalSettleStep = store.settleStep!.bind(store);
     let persistedVersion: number | undefined;
-    vi.spyOn(store, 'update').mockImplementation(async (record) => {
-      const result = await originalUpdate(record);
-      persistedVersion = result.version;
+    vi.spyOn(store, 'settleStep' as never).mockImplementation((async (...args: unknown[]) => {
+      const result = await (
+        originalSettleStep as (...a: unknown[]) => ReturnType<NonNullable<typeof store.settleStep>>
+      )(...args);
+      if (result.applied) persistedVersion = result.run.version;
       return result;
-    });
+    }) as never);
 
     const singleStepDef: WorkflowDefinition = {
       id: 'single-step-wf',

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -28,6 +28,11 @@ import { storeDeclaresSeal, storeDeclaresNonceCarriage } from '../store/trace-bu
 import { partitionBufferedEntries, type BufferedEntryPartition } from './trace-adoption.js';
 import { deriveDefaultedSteps } from './defaulted-steps.js';
 import { selectFinalizers } from './settlement.js';
+import type {
+  SettleStepDelta,
+  SettlementResult,
+  MarkFinalizerResult,
+} from '../types/settlement.js';
 import { captureEvidence } from '../evidence/snapshot.js';
 import {
   validateInputSchema,
@@ -904,6 +909,195 @@ function makeErrorEnvelope(
 }
 
 /**
+ * Design record §6: a claim-time refusal envelope's advisory line when the fresh run carries
+ * finalizer_ledger pendings — points the caller at the recovery verb. `undefined` when there is
+ * nothing pending (the common case — never emits an empty/placeholder advisory).
+ */
+function finalizerDrainAdvisory(run: RunRecord): string | undefined {
+  const pendingCount = Object.values(run.finalizer_ledger ?? {}).filter(
+    (e) => e.status === 'pending',
+  ).length;
+  if (pendingCount === 0) return undefined;
+  return `${pendingCount} finalizer(s) not yet delivered — realm run drain ${run.id}`;
+}
+
+/**
+ * Re-arm disclosure (final-gate F10b, design record §6) — the settling caller's own comparison,
+ * NEVER inside the frozen `applySettlement` transform: any finalizer that was `'voided'` (an
+ * operator `--void`) in `before.finalizer_ledger` and is `'pending'` again in
+ * `after.finalizer_ledger` was just RE-ARMED by mintFresh on THIS terminal edge (a later
+ * fail-then-complete-differently — or any outcome that newly selects it — re-mints a clean pending
+ * entry per §4's mint rule; mintFresh has no memory of a prior void, by design). Called only when
+ * `result.transitioned === true` (mintFresh only ever runs on the terminal false→true edge).
+ */
+function computeReArmWarnings(
+  before: RunRecord['finalizer_ledger'],
+  after: RunRecord['finalizer_ledger'],
+): string[] {
+  const warnings: string[] = [];
+  for (const [name, afterEntry] of Object.entries(after ?? {})) {
+    const beforeEntry = before?.[name];
+    if (beforeEntry?.status === 'voided' && afterEntry.status === 'pending') {
+      warnings.push(`finalizer '${name}' was operator-voided; re-armed by this terminal edge`);
+    }
+  }
+  return warnings;
+}
+
+/**
+ * Builds the ResponseEnvelope for a `settle_step` REFUSAL (design record §7's result/code table) —
+ * shared by all three migrated seal sites (issue #279, increment 1, PR-B). `allEvidence` is
+ * attached ONLY for `claim_lost`: the dispatch DID run and produce evidence; it just was not
+ * recorded, so the caller should still see what happened. The four other reasons `settle_step` can
+ * actually return are enumerated explicitly; the remaining nine `SettlementRefusalReason` members
+ * are lease/mark-only and structurally unreachable here (a `default` throws rather than silently
+ * mis-rendering one).
+ */
+function buildSettlementRefusalEnvelope(
+  options: ExecuteStepOptions,
+  definition: WorkflowDefinition,
+  result: Extract<SettlementResult, { applied: false }>,
+  allEvidence: EvidenceSnapshot[],
+  traceWarnings: string[],
+): ResponseEnvelope {
+  const extraWarnings = traceWarnings.length > 0 ? traceWarnings : undefined;
+  switch (result.reason) {
+    case 'already_settled_by_other':
+    case 'settled_outcome_divergence': {
+      const persisted = result.run.settled?.[options.command]?.outcome;
+      const err = new WorkflowError(
+        `Step '${options.command}' was already settled` +
+          (persisted !== undefined ? ` with outcome '${persisted}'` : '') +
+          ` by a different attempt.`,
+        {
+          code: 'STATE_STEP_ALREADY_SETTLED',
+          category: 'STATE',
+          agentAction: 'resolve_precondition',
+          retryable: false,
+          details: {
+            runId: options.runId,
+            step: options.command,
+            reason: result.reason,
+            ...(persisted !== undefined ? { persisted_outcome: persisted } : {}),
+          },
+        },
+      );
+      return makeErrorEnvelope(options, result.run, err, definition, extraWarnings);
+    }
+    case 'claim_lost': {
+      const err = new WorkflowError(
+        `Step '${options.command}': this attempt's outcome was NOT recorded — the claim was lost ` +
+          `(settled by another writer, or the run advanced).`,
+        {
+          code: 'STATE_CLAIM_LOST',
+          category: 'STATE',
+          agentAction: 'resolve_precondition',
+          retryable: false,
+          details: { runId: options.runId, step: options.command },
+        },
+      );
+      return {
+        ...makeErrorEnvelope(options, result.run, err, definition, extraWarnings),
+        evidence: allEvidence,
+      };
+    }
+    case 'run_terminal': {
+      const err = new WorkflowError(
+        `Run '${options.runId}' is terminal; cannot settle step '${options.command}'.`,
+        {
+          code: 'STATE_RUN_TERMINAL',
+          category: 'STATE',
+          agentAction: 'report_to_user',
+          retryable: false,
+          details: { runId: options.runId, run_phase: result.run.run_phase },
+        },
+      );
+      return makeErrorEnvelope(options, result.run, err, definition, extraWarnings);
+    }
+    case 'gate_mismatch': {
+      const err = new WorkflowError(
+        `Step '${options.command}' is the currently open gate; resolve it via ` +
+          `submit_human_response instead of settling it directly.`,
+        {
+          code: 'STATE_BLOCKED',
+          category: 'STATE',
+          agentAction: 'resolve_precondition',
+          retryable: false,
+          details: { runId: options.runId, step: options.command },
+        },
+      );
+      return makeErrorEnvelope(options, result.run, err, definition, extraWarnings);
+    }
+    default:
+      // run_not_terminal / ledger_not_pending / lease_held / lease_lost / rank_blocked /
+      // not_eligible / already_leased / already_marked are lease_finalizer/mark_finalizer-only —
+      // settle_step never returns them (design record §7).
+      throw new Error(
+        `buildSettlementRefusalEnvelope: unreachable settle_step refusal reason '${result.reason}'`,
+      );
+  }
+}
+
+/**
+ * Ok-shaped envelope for a `settle_step` NOOP (`already_settled`) — the idempotent-retry case
+ * (design record §7: ok-shaped, calm context_hint, never `report_to_user`). Drain-aware: when the
+ * fresh run still carries pending finalizers, this retry attempts the SAME post-commit drain a
+ * fresh apply would have run — recovering an ambiguous-retry crash window (§6). A drain failure
+ * degrades to a warning (never an error status) — the settle itself is not in question here.
+ */
+async function buildAlreadySettledEnvelope(
+  store: RunStore,
+  definition: WorkflowDefinition,
+  options: ExecuteStepOptions,
+  result: Extract<SettlementResult, { applied: false }> & { reason: 'already_settled' },
+  traceWarnings: string[],
+): Promise<ResponseEnvelope> {
+  let run = result.run;
+  let drainWarnings: string[] = [];
+  const hasPending = Object.values(run.finalizer_ledger ?? {}).some((e) => e.status === 'pending');
+  if (hasPending) {
+    try {
+      const drainOutcome = await drainFinalizers(
+        store,
+        definition,
+        options.registry,
+        options.runId,
+      );
+      run = drainOutcome.run;
+      drainWarnings = drainOutcome.warnings;
+    } catch (err) {
+      drainWarnings = [
+        `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+      ];
+    }
+  }
+  const nextActions = run.terminal_state ? [] : buildNextActions(definition, run);
+  return {
+    command: options.command,
+    run_id: options.runId,
+    run_version: run.version,
+    status: 'ok',
+    data: {},
+    evidence: [],
+    warnings: mergeWarnings(traceWarnings, ...drainWarnings),
+    errors: [],
+    context_hint: `Step '${options.command}' was already settled (a duplicate/retried attempt) — no action was taken.`,
+    run_phase: run.run_phase,
+    next_actions: nextActions,
+  };
+}
+
+/**
+ * Design record §10 (I16, fail-closed dormancy): the ONE advisory warning every legacy
+ * (dormancy-fallback) seal-site envelope carries when `store.settleStep` is undeclared — never a
+ * hard requirement; the legacy read-then-update path remains fully functional. This dual branch
+ * persists until a major version (final-gate F4/R13).
+ */
+const DORMANCY_ADVISORY =
+  'settled via the legacy compatibility path — this store does not declare atomic settlement ' +
+  '(RunStore.settleStep); upgrade the store to close the fan-out seal race (issue #279)';
+
+/**
  * Validates eligibility, claims the step, executes it through the dispatcher with retry
  * and timeout support, captures evidence, persists the updated run record, and returns
  * a ResponseEnvelope containing the outcome and the next eligible actions.
@@ -1333,6 +1527,8 @@ export async function executeStep(
     if (err instanceof WorkflowError) {
       if (err.code === 'STATE_STEP_ALREADY_CLAIMED') {
         const freshRun = await store.get(options.runId).catch(() => run);
+        // Design record §6: append the drain advisory when the fresh run carries pendings.
+        const claimedAdvisory = finalizerDrainAdvisory(freshRun);
         return {
           command: options.command,
           run_id: options.runId,
@@ -1340,7 +1536,7 @@ export async function executeStep(
           status: 'blocked',
           data: {},
           evidence: [],
-          warnings: [],
+          warnings: claimedAdvisory !== undefined ? [claimedAdvisory] : [],
           errors: [],
           agent_action: 'resolve_precondition' as const,
           context_hint: `Step '${options.command}' was already claimed by another process.`,
@@ -1351,6 +1547,20 @@ export async function executeStep(
             suggestion: `Step is already in progress. Wait for it to complete.`,
           },
         };
+      }
+      // Design record §6: STATE_STEP_NOT_ELIGIBLE (a claim-time eligibility re-check race) also
+      // gets the drain advisory when the fresh run carries pendings — a fresh re-read since `run`
+      // (Step 1's load) may be stale by the time claimStep's own re-check inside its lock raced.
+      if (err.code === 'STATE_STEP_NOT_ELIGIBLE') {
+        const freshRun = await store.get(options.runId).catch(() => run);
+        const notEligibleAdvisory = finalizerDrainAdvisory(freshRun);
+        const extraWarnings =
+          notEligibleAdvisory !== undefined
+            ? [...traceWarnings, notEligibleAdvisory]
+            : traceWarnings.length > 0
+              ? traceWarnings
+              : undefined;
+        return makeErrorEnvelope(options, freshRun, err, definition, extraWarnings);
       }
       return makeErrorEnvelope(
         options,
@@ -1781,6 +1991,107 @@ export async function executeStep(
             }),
             status: 'skipped',
           };
+
+          // issue #279 (increment 1, PR-B): the migrated path — a store declaring settleStep
+          // settles this abort atomically against FRESH state (not `pendingRun`, which may be
+          // stale relative to a concurrent sibling settle). Dormancy: an undeclaring store falls
+          // through to the byte-identical legacy path below (I16/#169 fail-closed dormancy).
+          if (store.settleStep !== undefined) {
+            const abortClaimToken = pendingRun.claims?.[options.command]?.token;
+            const delta: SettleStepDelta = {
+              kind: 'settle_step',
+              step: options.command,
+              outcome: 'abort',
+              ...(abortClaimToken !== undefined ? { claimToken: abortClaimToken } : {}),
+              evidence: [abortEvidence],
+              abort: { stepId: options.command, abortMessage },
+            };
+            let result: SettlementResult;
+            try {
+              result = await store.settleStep(options.runId, delta, definition);
+            } catch (err) {
+              // THROWN infra errors (lock exhaustion, run-not-found, I/O) — the complete-site's
+              // existing catch shape, replicated at all three migrated sites.
+              if (err instanceof WorkflowError) {
+                return makeErrorEnvelope(
+                  options,
+                  pendingRun,
+                  err,
+                  definition,
+                  traceWarnings.length > 0 ? traceWarnings : undefined,
+                );
+              }
+              const internal = new WorkflowError('Failed to persist run update', {
+                code: 'ENGINE_STORE_FAILED',
+                category: 'ENGINE',
+                agentAction: 'stop',
+                retryable: false,
+              });
+              return makeErrorEnvelope(
+                options,
+                pendingRun,
+                internal,
+                definition,
+                traceWarnings.length > 0 ? traceWarnings : undefined,
+              );
+            }
+            if (!result.applied) {
+              if (result.reason === 'already_settled') {
+                return buildAlreadySettledEnvelope(
+                  store,
+                  definition,
+                  options,
+                  { ...result, reason: 'already_settled' },
+                  traceWarnings,
+                );
+              }
+              return buildSettlementRefusalEnvelope(
+                options,
+                definition,
+                result,
+                [abortEvidence],
+                traceWarnings,
+              );
+            }
+            // applied: true — abort is UNCONDITIONALLY terminal (transitioned is always true here;
+            // isTerminal(fresh) was already refused above inside applySettlement).
+            let finalRun = result.run;
+            let drainWarnings: string[] = [];
+            const reArmWarnings = computeReArmWarnings(
+              pendingRun.finalizer_ledger,
+              result.run.finalizer_ledger,
+            );
+            try {
+              const drainOutcome = await drainFinalizers(
+                store,
+                definition,
+                options.registry,
+                options.runId,
+              );
+              finalRun = drainOutcome.run;
+              drainWarnings = drainOutcome.warnings;
+            } catch (err) {
+              // A drain failure is NEVER the step's own failure — the abort already committed.
+              drainWarnings = [
+                `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+              ];
+            }
+            return {
+              command: options.command,
+              run_id: options.runId,
+              run_version: finalRun.version,
+              status: 'ok',
+              data: {},
+              evidence: [abortEvidence],
+              warnings: mergeWarnings(traceWarnings, ...reArmWarnings, ...drainWarnings),
+              errors: [],
+              context_hint: `Handler step '${options.command}' aborted the run: ${abortMessage}`,
+              run_phase: finalRun.run_phase,
+              next_actions: [],
+            };
+          }
+
+          // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
           const withHandlerSkipped: RunRecord = {
             ...pendingRun,
             in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
@@ -1832,7 +2143,9 @@ export async function executeStep(
             evidence: [abortEvidence],
             // Issue #140: was hardcoded `[]` — now threads traceWarnings (e.g. the programmatic
             // on_timeout/idempotent gate advisory above) so it survives this settle path too.
-            warnings: mergeWarnings(traceWarnings),
+            // Issue #279 (increment 1, PR-B): + the ONE dormancy advisory (I16) — this IS the
+            // legacy path (store.settleStep undeclared).
+            warnings: mergeWarnings(traceWarnings, DORMANCY_ADVISORY),
             errors: [],
             context_hint: `Handler step '${options.command}' aborted the run: ${abortMessage}`,
             run_phase: (persistedAbortRun ?? abortedRun).run_phase,
@@ -2216,6 +2529,183 @@ export async function executeStep(
       };
     }
 
+    // issue #279 (increment 1, PR-B): the migrated path — settles this failure atomically against
+    // FRESH state via the store's own settleStep. Dormancy: an undeclaring store falls through to
+    // the byte-identical legacy path below (I16/#169 fail-closed dormancy).
+    if (store.settleStep !== undefined) {
+      const failClaimToken = pendingRun.claims?.[options.command]?.token;
+      const delta: SettleStepDelta = {
+        kind: 'settle_step',
+        step: options.command,
+        outcome: 'fail',
+        ...(failClaimToken !== undefined ? { claimToken: failClaimToken } : {}),
+        evidence: allEvidence,
+        failureMessage: dispatchError.message,
+      };
+      let result: SettlementResult;
+      try {
+        result = await store.settleStep(options.runId, delta, definition);
+      } catch (err) {
+        // THROWN infra errors — the same catch shape replicated at all three migrated sites.
+        if (err instanceof WorkflowError) {
+          return makeErrorEnvelope(
+            options,
+            pendingRun,
+            err,
+            definition,
+            traceWarnings.length > 0 ? traceWarnings : undefined,
+          );
+        }
+        const internal = new WorkflowError('Failed to persist run update', {
+          code: 'ENGINE_STORE_FAILED',
+          category: 'ENGINE',
+          agentAction: 'stop',
+          retryable: false,
+        });
+        return makeErrorEnvelope(
+          options,
+          pendingRun,
+          internal,
+          definition,
+          traceWarnings.length > 0 ? traceWarnings : undefined,
+        );
+      }
+      if (!result.applied) {
+        if (result.reason === 'already_settled') {
+          return buildAlreadySettledEnvelope(
+            store,
+            definition,
+            options,
+            { ...result, reason: 'already_settled' },
+            traceWarnings,
+          );
+        }
+        // WAL/sealFenced gates become result.applied (BU-12): claim_lost ⇒ the WAL SURVIVES
+        // (reclaim's drain owns it) — no WAL cleanup attempted on ANY refusal.
+        return buildSettlementRefusalEnvelope(
+          options,
+          definition,
+          result,
+          allEvidence,
+          traceWarnings,
+        );
+      }
+
+      let finalRun = result.run;
+      let drainWarnings: string[] = [];
+      const reArmWarnings = result.transitioned
+        ? computeReArmWarnings(pendingRun.finalizer_ledger, result.run.finalizer_ledger)
+        : [];
+      if (result.transitioned) {
+        try {
+          const drainOutcome = await drainFinalizers(
+            store,
+            definition,
+            options.registry,
+            options.runId,
+          );
+          finalRun = drainOutcome.run;
+          drainWarnings = drainOutcome.warnings;
+        } catch (err) {
+          drainWarnings = [
+            `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+          ];
+        }
+      }
+
+      // WAL cleanup — placement stays post-commit (unchanged), now gated on result.applied
+      // (BU-12) rather than a separate persistedRun-defined check (the settle already committed
+      // by the time we reach here, so there is no "did the persist succeed" ambiguity to gate on).
+      let migratedWalCleanupWarning: string | undefined;
+      {
+        let performPlainDelete = true;
+        if (
+          adoptionPartition !== undefined &&
+          adoptionPartition.preserved_foreign > 0 &&
+          options.traceBufferStore !== undefined &&
+          storeDeclaresSeal(options.traceBufferStore)
+        ) {
+          try {
+            const sealResult = await options.traceBufferStore.sealFenced!(
+              options.runId,
+              options.command,
+              buildSettleSealGuard(store, options.runId, options.command),
+            );
+            if (sealResult.sealed) {
+              performPlainDelete = false;
+              migratedWalCleanupWarning =
+                `${adoptionPartition.preserved_foreign} foreign line(s) preserved (sealed) — ` +
+                'retrieve via `realm run export`';
+            } else if (sealResult.reason === 'capped') {
+              migratedWalCleanupWarning =
+                'preservation cap reached — foreign lines destroyed, not preserved';
+            } else {
+              performPlainDelete = false;
+            }
+          } catch (err) {
+            performPlainDelete = false;
+            migratedWalCleanupWarning = `Failed to seal trace buffer after step failure: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+        if (performPlainDelete) {
+          try {
+            await options.traceBufferStore?.delete(options.runId, options.command);
+          } catch (walErr) {
+            migratedWalCleanupWarning = `Failed to clean up trace buffer after step failure: ${walErr instanceof Error ? walErr.message : String(walErr)}`;
+          }
+        }
+      }
+
+      const migratedEffectiveAction = resolvePostDispatchAgentAction(
+        dispatchError,
+        finalRun.terminal_state,
+      );
+      let migratedNextActions: NextAction[] = [];
+      if (migratedEffectiveAction !== 'stop') {
+        try {
+          migratedNextActions = buildNextActions(definition, finalRun);
+        } catch {
+          // buildNextActions can throw for unresolvable template references; fall back to [].
+        }
+      }
+      const migratedContextHint =
+        migratedEffectiveAction === 'stop'
+          ? `Step '${options.command}' failed. Run is terminated.`
+          : migratedEffectiveAction === 'wait_and_proceed'
+            ? `Step '${options.command}' was rate-limited. Wait ${dispatchError.retry_after !== undefined ? `${dispatchError.retry_after} second(s)` : 'a moment'} then follow next_actions — no human intervention required.`
+            : migratedEffectiveAction === 'wait_for_human'
+              ? `Step '${options.command}' failed due to external service unavailability. Wait for service recovery, then proceed with the steps in next_actions.`
+              : `Step '${options.command}' failed. ${result.transitioned ? 'Run is terminated.' : 'Recovery steps are available in next_actions.'}`;
+
+      return {
+        command: options.command,
+        run_id: options.runId,
+        run_version: finalRun.version,
+        status: 'error',
+        data: {},
+        evidence: allEvidence,
+        warnings: mergeWarnings(
+          traceWarnings,
+          migratedWalCleanupWarning,
+          ...reArmWarnings,
+          ...drainWarnings,
+        ),
+        errors: [dispatchError.message],
+        agent_action: migratedEffectiveAction,
+        error_code: dispatchError.code,
+        ...(Object.keys(dispatchError.details).length > 0
+          ? { error_details: dispatchError.details }
+          : {}),
+        ...(dispatchError.retry_after !== undefined
+          ? { retry_after: dispatchError.retry_after }
+          : {}),
+        context_hint: migratedContextHint,
+        run_phase: finalRun.run_phase,
+        next_actions: migratedNextActions,
+      };
+    }
+
+    // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
     // Pure in-memory derivations — no I/O, no try required.
     const afterFail: RunRecord = {
       ...pendingRun,
@@ -2361,7 +2851,13 @@ export async function executeStep(
       status: 'error',
       data: {},
       evidence: allEvidence,
-      warnings: mergeWarnings(traceWarnings, storeCleanupWarning ?? walCleanupWarning),
+      // Issue #279 (increment 1, PR-B): + the ONE dormancy advisory (I16) — this IS the legacy
+      // path (store.settleStep undeclared).
+      warnings: mergeWarnings(
+        traceWarnings,
+        storeCleanupWarning ?? walCleanupWarning,
+        DORMANCY_ADVISORY,
+      ),
       errors: [dispatchError.message],
       agent_action: effectiveAction,
       // issue #140 (D3 §2, discriminator OBSERVABLE): additive-optional — lets a caller
@@ -2557,6 +3053,177 @@ export async function executeStep(
   }
 
   // Step 6: Move step from in_progress to completed, compute terminal state.
+  // issue #279 (increment 1, PR-B): the migrated path — settles this completion atomically
+  // against FRESH state via the store's own settleStep. Dormancy: an undeclaring store falls
+  // through to the byte-identical legacy path below (I16/#169 fail-closed dormancy).
+  if (store.settleStep !== undefined) {
+    const completeClaimToken = pendingRun.claims?.[options.command]?.token;
+    const delta: SettleStepDelta = {
+      kind: 'settle_step',
+      step: options.command,
+      outcome: 'complete',
+      ...(completeClaimToken !== undefined ? { claimToken: completeClaimToken } : {}),
+      evidence: allEvidence,
+    };
+    let result: SettlementResult;
+    try {
+      result = await store.settleStep(options.runId, delta, definition);
+    } catch (err) {
+      // THROWN infra errors — the same catch shape replicated at all three migrated sites.
+      if (err instanceof WorkflowError) {
+        return makeErrorEnvelope(
+          options,
+          pendingRun,
+          err,
+          definition,
+          traceWarnings.length > 0 ? traceWarnings : undefined,
+        );
+      }
+      const internal = new WorkflowError('Failed to persist run update', {
+        code: 'ENGINE_STORE_FAILED',
+        category: 'ENGINE',
+        agentAction: 'stop',
+        retryable: false,
+      });
+      return makeErrorEnvelope(
+        options,
+        pendingRun,
+        internal,
+        definition,
+        traceWarnings.length > 0 ? traceWarnings : undefined,
+      );
+    }
+    if (!result.applied) {
+      if (result.reason === 'already_settled') {
+        return buildAlreadySettledEnvelope(
+          store,
+          definition,
+          options,
+          { ...result, reason: 'already_settled' },
+          traceWarnings,
+        );
+      }
+      // WAL/sealFenced gates become result.applied (BU-12): claim_lost ⇒ the WAL SURVIVES.
+      return buildSettlementRefusalEnvelope(
+        options,
+        definition,
+        result,
+        allEvidence,
+        traceWarnings,
+      );
+    }
+
+    let finalRun = result.run;
+    let drainWarnings: string[] = [];
+    const reArmWarnings = result.transitioned
+      ? computeReArmWarnings(pendingRun.finalizer_ledger, result.run.finalizer_ledger)
+      : [];
+    if (result.transitioned) {
+      try {
+        const drainOutcome = await drainFinalizers(
+          store,
+          definition,
+          options.registry,
+          options.runId,
+        );
+        finalRun = drainOutcome.run;
+        drainWarnings = drainOutcome.warnings;
+      } catch (err) {
+        drainWarnings = [
+          `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+        ];
+      }
+    }
+
+    // WAL cleanup — placement stays post-commit (unchanged), gated on result.applied (BU-12).
+    let migratedSuccessWalCleanupWarning: string | undefined;
+    {
+      let performPlainDelete = true;
+      if (
+        adoptionPartition !== undefined &&
+        adoptionPartition.preserved_foreign > 0 &&
+        options.traceBufferStore !== undefined &&
+        storeDeclaresSeal(options.traceBufferStore)
+      ) {
+        try {
+          const sealResult = await options.traceBufferStore.sealFenced!(
+            options.runId,
+            options.command,
+            buildSettleSealGuard(store, options.runId, options.command),
+          );
+          if (sealResult.sealed) {
+            performPlainDelete = false;
+            migratedSuccessWalCleanupWarning =
+              `${adoptionPartition.preserved_foreign} foreign line(s) preserved (sealed) — ` +
+              'retrieve via `realm run export`';
+          } else if (sealResult.reason === 'capped') {
+            migratedSuccessWalCleanupWarning =
+              'preservation cap reached — foreign lines destroyed, not preserved';
+          } else {
+            performPlainDelete = false;
+          }
+        } catch (err) {
+          performPlainDelete = false;
+          migratedSuccessWalCleanupWarning = `Failed to seal trace buffer after step completion: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      }
+      if (performPlainDelete) {
+        try {
+          await options.traceBufferStore?.delete(options.runId, options.command);
+        } catch (err) {
+          migratedSuccessWalCleanupWarning = `Failed to clean up trace buffer after step completion: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      }
+    }
+
+    const migratedDefaultedStepsDurabilityWarning =
+      finalRun.defaulted_steps !== undefined &&
+      finalRun.defaulted_steps.length > 0 &&
+      !persistsField(store, 'defaulted_steps')
+        ? 'run-level defaultedness marker (defaulted_steps) not durable on this store'
+        : undefined;
+
+    const migratedNextActions = finalRun.terminal_state
+      ? []
+      : buildNextActions(definition, finalRun);
+    const migratedOrientation = finalRun.terminal_state
+      ? `Run completed (phase: '${finalRun.run_phase}'). Call get_run_state with run_id '${options.runId}' to retrieve the full evidence record.`
+      : migratedNextActions.length > 0
+        ? `Step '${options.command}' completed. ${migratedNextActions.length} step(s) now available.`
+        : `Step '${options.command}' completed. Waiting for other steps to complete.`;
+
+    return {
+      command: options.command,
+      run_id: options.runId,
+      run_version: finalRun.version,
+      status: 'ok',
+      data: output,
+      evidence: allEvidence,
+      warnings: mergeWarnings(
+        traceWarnings,
+        currentWarn,
+        migratedSuccessWalCleanupWarning,
+        migratedDefaultedStepsDurabilityWarning,
+        ...reArmWarnings,
+        ...drainWarnings,
+      ),
+      errors: [],
+      context_hint: migratedOrientation,
+      run_phase: finalRun.run_phase,
+      next_actions: migratedNextActions,
+      ...(carriageActive && adoptionPartition !== undefined
+        ? {
+            adopted_own: adoptionPartition.adopted_own,
+            adopted_anonymous: adoptionPartition.adopted_anonymous,
+            preserved_foreign: adoptionPartition.preserved_foreign,
+          }
+        : {}),
+      ...(settledByDefault ? { settled_by_default: true } : {}),
+      ...(finalRun.defaulted_steps?.length ? { defaulted_steps: finalRun.defaulted_steps } : {}),
+    };
+  }
+
+  // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
   const afterComplete: RunRecord = {
     ...pendingRun,
     in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== options.command),
@@ -2699,11 +3366,14 @@ export async function executeStep(
     status: 'ok',
     data: output,
     evidence: allEvidence,
+    // Issue #279 (increment 1, PR-B): + the ONE dormancy advisory (I16) — this IS the legacy
+    // path (store.settleStep undeclared).
     warnings: mergeWarnings(
       traceWarnings,
       currentWarn,
       successWalCleanupWarning,
       defaultedStepsDurabilityWarning,
+      DORMANCY_ADVISORY,
     ),
     errors: [],
     context_hint: orientation,
@@ -3192,6 +3862,219 @@ async function buildFinalizedSeal(
   }
 
   return { ...record, terminal_state: true };
+}
+
+/** Every currently-`'pending'` finalizer in `run`'s ledger, ascending by rank — the order the
+ *  drain loop below consumes (design record §6). */
+function pendingByRank(run: RunRecord): string[] {
+  return Object.entries(run.finalizer_ledger ?? {})
+    .filter(([, e]) => e.status === 'pending')
+    .sort(([, a], [, b]) => a.rank - b.rank)
+    .map(([name]) => name);
+}
+
+/** Bounded retry count for `mark_finalizer` on a thrown `STATE_RUN_BUSY` (design record §6: "bounded
+ *  retry on thrown STATE_RUN_BUSY"). Small and fixed — lock contention self-heals quickly; this is
+ *  not a backoff schedule, just enough attempts to ride out a transient contender. */
+const DRAIN_MARK_BUSY_RETRIES = 3;
+
+/**
+ * Post-commit finalizer drain (design record §6, D2, issue #279 increment 1 PR-B). Drains the
+ * LOWEST-ranked pending finalizer, re-reading the record returned by the LAST settle/lease/mark at
+ * every step — NEVER a pass-start snapshot (the DRAIN_REREADS_LEDGER pin: a snapshot taken once at
+ * the top of this function would go stale the instant the first lease/mark commits, silently
+ * reintroducing exactly the kind of pre-commit assumption #279 exists to eliminate).
+ *
+ * Lives here (not in settlement.ts) so the module-private `withTimeout`/`callHandler` — already
+ * proven by `buildFinalizedSeal` above — are reused without exporting them; `settlement.ts` stays
+ * pure/no-I/O (design record §7 CS-purity).
+ *
+ * Registry pre-check: an absent handler leaves the entry pending and discloses why, rather than
+ * burning it (leasing it, failing the call, and marking it 'failed' would destroy the "recoverable
+ * on a capable runner" property a still-pending entry carries). Rank-monotonic: a pass HALTS at the
+ * first entry it cannot lease/execute, so a lower-ranked absent-handler or held-lease entry
+ * withholds every higher-ranked (later) finalizer behind it (R11) — this is deliberate: rank order
+ * is a DELIVERY order guarantee, not just a preference.
+ *
+ * `not_eligible` at lease OR mark time is a contract violation (an unknown finalizer id — mintFresh
+ * only ever mints real workflow finalizer names) and aborts the pass LOUD (throws), distinct from
+ * `ledger_not_pending` at lease time, which ADVANCES (someone else already resolved it). A
+ * non-BUSY infra throw from `mark_finalizer` also aborts loud, with the remaining-pending list in
+ * the message. The executed-but-not-recorded warning (three reasons: `lease_lost`,
+ * `ledger_not_pending`-AFTER-execution, `run_not_terminal`) halts the pass rather than continuing —
+ * each of those three reasons refuses the mark WITHOUT mutating the ledger entry's `'pending'`
+ * status, so continuing would re-select the SAME entry next iteration (an infinite loop); halting
+ * is the only forward-progress-safe response until an operator or a later terminal edge resolves it.
+ */
+export async function drainFinalizers(
+  store: RunStore,
+  definition: WorkflowDefinition,
+  registry: ExtensionRegistry | undefined,
+  runId: string,
+): Promise<{ run: RunRecord; warnings: string[] }> {
+  // .bind(store): a bare `store.settleStep` reference loses its `this` binding — the store's own
+  // method body (e.g. JsonFileStore's `this.ensureDir()`/`this.filePath()`) would throw on
+  // `this === undefined` once called through the detached reference below.
+  const settleStep = store.settleStep?.bind(store);
+  if (settleStep === undefined) {
+    // Defensive — every caller only invokes this once it has already confirmed the store
+    // declares settleStep. A fresh read is still the correct degenerate response.
+    return { run: await store.get(runId), warnings: [] };
+  }
+  const warnings: string[] = [];
+  let run = await store.get(runId);
+
+  for (;;) {
+    const pending = pendingByRank(run);
+    if (pending.length === 0) break;
+    const finalizerName = pending[0]!;
+    const stepDef = definition.steps[finalizerName];
+    const handlerName = stepDef?.handler;
+    const handler = handlerName !== undefined ? registry?.getHandler(handlerName) : undefined;
+
+    // Registry pre-check — never burn an absent handler; rank-monotonic HALT (R11).
+    if (stepDef === undefined || handlerName === undefined || handler === undefined) {
+      warnings.push(
+        `finalizer '${finalizerName}' left pending — handler not available on this surface`,
+      );
+      break;
+    }
+
+    const leaseToken = crypto.randomUUID();
+    const leaseSeconds = stepDef.timeout_seconds ?? DRAIN_CEILING_SECONDS;
+    const leaseResult: SettlementResult = await settleStep(
+      runId,
+      { kind: 'lease_finalizer', finalizer: finalizerName, leaseToken, leaseSeconds },
+      definition,
+    );
+    if (!leaseResult.applied) {
+      if (leaseResult.reason === 'lease_held' || leaseResult.reason === 'rank_blocked') {
+        run = leaseResult.run;
+        break; // HALT the pass — a peer holds this lease, or a lower rank is still pending.
+      }
+      if (leaseResult.reason === 'ledger_not_pending') {
+        run = leaseResult.run;
+        continue; // ADVANCE — a peer already resolved this entry.
+      }
+      // not_eligible — unknown finalizer id; a contract violation (mintFresh never mints one).
+      throw new Error(
+        `drainFinalizers: lease refused '${leaseResult.reason}' for finalizer '${finalizerName}' ` +
+          `on run '${runId}' — remaining pending: ${pendingByRank(leaseResult.run).join(', ')}`,
+      );
+    }
+    run = leaseResult.run;
+
+    // callHandler under withTimeout, OUTSIDE any critical section (the store's CS ends the
+    // instant the lease-apply write above returned).
+    const startedAt = new Date();
+    const evidenceByStep = buildEvidenceByStep(run);
+    const callOptions: ExecuteStepOptions = {
+      runId,
+      command: finalizerName,
+      input: {},
+      dispatcher: async () => ({}),
+      ...(registry !== undefined ? { registry } : {}),
+    };
+    let markResult: MarkFinalizerResult;
+    let evidenceSnapshot: EvidenceSnapshot;
+    try {
+      const callResult = await withTimeout(
+        (signal) => callHandler(stepDef, callOptions, run, evidenceByStep, signal),
+        leaseSeconds * 1000,
+        finalizerName,
+      );
+      if (callResult.kind === 'abort') {
+        markResult = 'failed';
+        evidenceSnapshot = captureEvidence({
+          stepId: finalizerName,
+          startedAt,
+          completedAt: new Date(),
+          input: {},
+          output: { aborted: true, abort_message: callResult.message },
+          error: `Finalizer '${finalizerName}' returned abort: ${callResult.message}`,
+        });
+      } else {
+        markResult = 'completed';
+        evidenceSnapshot = captureEvidence({
+          stepId: finalizerName,
+          startedAt,
+          completedAt: new Date(),
+          input: {},
+          output: callResult.output,
+          ...(callResult.kind === 'warn' ? { warn: callResult.message } : {}),
+        });
+      }
+    } catch (err) {
+      markResult = 'failed';
+      const message = err instanceof Error ? err.message : String(err);
+      evidenceSnapshot = captureEvidence({
+        stepId: finalizerName,
+        startedAt,
+        completedAt: new Date(),
+        input: {},
+        output: {},
+        error: `Finalizer '${finalizerName}' failed: ${message}`,
+      });
+    }
+
+    // mark_finalizer — same lease token; bounded retry on a THROWN STATE_RUN_BUSY only.
+    let markOutcome: SettlementResult | undefined;
+    for (let attempt = 1; attempt <= DRAIN_MARK_BUSY_RETRIES; attempt++) {
+      try {
+        markOutcome = await settleStep(
+          runId,
+          {
+            kind: 'mark_finalizer',
+            finalizer: finalizerName,
+            leaseToken,
+            result: markResult,
+            evidence: evidenceSnapshot,
+          },
+          definition,
+        );
+        break;
+      } catch (err) {
+        const isBusy = err instanceof WorkflowError && err.code === 'STATE_RUN_BUSY';
+        if (isBusy && attempt < DRAIN_MARK_BUSY_RETRIES) continue;
+        // Non-BUSY infra throw (or BUSY exhausted) ⇒ abort the pass loud, remaining-pending named.
+        throw new Error(
+          `drainFinalizers: mark_finalizer failed for '${finalizerName}' on run '${runId}' — ` +
+            `remaining pending: ${pendingByRank(run).join(', ')}: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
+    }
+    /* istanbul ignore next -- the for-loop above always either assigns markOutcome or throws */
+    if (markOutcome === undefined) {
+      throw new Error(
+        `drainFinalizers: mark_finalizer produced no outcome for '${finalizerName}' on run '${runId}'`,
+      );
+    }
+    if (!markOutcome.applied) {
+      if (markOutcome.reason === 'not_eligible') {
+        throw new Error(
+          `drainFinalizers: mark refused 'not_eligible' for finalizer '${finalizerName}' on run ` +
+            `'${runId}' — contract violation (mintFresh never mints an unknown id)`,
+        );
+      }
+      // lease_lost / ledger_not_pending(-after-execution) / run_not_terminal: the handler DID
+      // execute, but the outcome could not be durably recorded — the three-reason
+      // executed-but-not-recorded warning (design record §6). Halt: none of these three mutate
+      // the entry's 'pending' status, so continuing would re-select the SAME entry forever.
+      run = markOutcome.run;
+      warnings.push(
+        `finalizer '${finalizerName}' executed but its outcome may not have been recorded ` +
+          `(${markOutcome.reason}) — it may re-execute at the next terminal edge`,
+      );
+      break;
+    }
+    run = markOutcome.run;
+    // result:'failed' is settled too (a recorded terminal outcome for this finalizer) — the loop
+    // continues to the next rank regardless of markResult.
+  }
+
+  return { run, warnings };
 }
 
 async function executeChainInternal(

--- a/packages/core/src/engine/latent-bug-claim-lost-no-fire.test.ts
+++ b/packages/core/src/engine/latent-bug-claim-lost-no-fire.test.ts
@@ -1,0 +1,82 @@
+// latent-bug-claim-lost-no-fire.test.ts — verification item 2 (issue #279, increment 1, PR-B): a
+// seal whose settle REFUSES (claim_lost, via a forced token mismatch) fires NO finalizers. Today's
+// (pre-migration) legacy path computes its in-memory draft and drains finalizers BEFORE the
+// persist even attempts — a losing concurrent writer's draft could already have fired finalizers
+// before discovering (via a CAS failure) that it lost the race. On the migrated path, the fresh
+// read + refusal happen INSIDE applySettlement, atomically, before any finalizer selection ever
+// runs — a claim_lost refusal can never reach mintFresh/drainFinalizers at all.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep } from './execution-loop.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { StepHandler } from '../extensions/step-handler.js';
+
+const def: WorkflowDefinition = {
+  id: 'claim-lost-no-fire-wf',
+  name: 'claim_lost no-fire fixture',
+  version: 1,
+  steps: {
+    a: { description: 'a', execution: 'agent', depends_on: [] },
+    fin: {
+      description: 'finalizer',
+      execution: 'finalizer',
+      on_outcome: 'always',
+      handler: 'fin-handler',
+    },
+  },
+};
+
+describe('a claim_lost refusal fires ZERO finalizers (issue #279, increment 1, PR-B, verification item 2)', () => {
+  it('a settle that refuses claim_lost never reaches mintFresh/drainFinalizers', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-claim-lost-no-fire-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      let handlerCallCount = 0;
+      const finHandler: StepHandler = {
+        id: 'fin-handler',
+        execute: async () => {
+          handlerCallCount += 1;
+          return { data: {} };
+        },
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', finHandler);
+
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'a',
+        input: {},
+        // The dispatcher fires WHILE this call holds its own claim — simulate a concurrent
+        // writer stealing the claim (a DIFFERENT token) mid-dispatch, forcing claim_lost the
+        // instant this call's own settle attempt reads fresh state.
+        dispatcher: async () => {
+          const mid = await store.get(run.id);
+          await store.update({
+            ...mid,
+            claims: { ...mid.claims, a: { deadline: null, token: 'a-different-writers-token' } },
+          });
+          return {};
+        },
+        registry,
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error_code).toBe('STATE_CLAIM_LOST');
+      // ZERO finalizer calls — the refusal never reached mintFresh/drainFinalizers.
+      expect(handlerCallCount).toBe(0);
+
+      const finalRun = await store.get(run.id);
+      expect(finalRun.completed_steps).not.toContain('fin');
+      expect(finalRun.finalizer_ledger).toBeUndefined(); // never minted
+      expect(finalRun.terminal_state).toBe(false); // the run never terminalized either
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/re-arm-disclosure.test.ts
+++ b/packages/core/src/engine/re-arm-disclosure.test.ts
@@ -1,0 +1,102 @@
+// re-arm-disclosure.test.ts — final-gate F10b (design record §6, issue #279 increment 1 PR-B):
+// the settling caller (NOT the frozen applySettlement transform) compares
+// pendingRun.finalizer_ledger against result.run.finalizer_ledger post-commit; any entry
+// voided-before/pending-after (an operator-voided finalizer that mintFresh just re-armed on a
+// LATER terminal edge) emits "finalizer '<F>' was operator-voided; re-armed by this terminal edge".
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep } from './execution-loop.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+
+const def: WorkflowDefinition = {
+  id: 're-arm-wf',
+  name: 'Re-arm disclosure fixture',
+  version: 1,
+  steps: {
+    work: { description: 'w', execution: 'agent', depends_on: [] },
+    fin: { description: 'f', execution: 'finalizer', on_outcome: 'always' },
+  },
+};
+
+describe('re-arm disclosure (issue #279, increment 1, PR-B, final-gate F10b)', () => {
+  it('an operator-voided finalizer re-armed by a later terminal edge emits the re-arm warning', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-re-arm-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      // 1. Fail 'work' — terminalizes (single step), mints 'fin' pending (on_outcome: 'always').
+      // executeStep claims the step itself (Step 3) — no manual pre-claim needed/allowed.
+      const firstFail = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => {
+          throw new Error('boom');
+        },
+      });
+      expect(firstFail.status).toBe('error');
+      const afterFirstFail = await store.get(run.id);
+      expect(afterFirstFail.finalizer_ledger?.['fin']?.status).toBe('pending');
+
+      // 2. Operator --void's it directly (mirrors drain.ts's --void action).
+      await store.update({
+        ...afterFirstFail,
+        finalizer_ledger: { fin: { status: 'voided', rank: 0 } },
+      });
+
+      // 3. Resume 'work' (applyResume never touches an already-voided entry — it stays voided).
+      const { applyResume } = await import('./apply-resume.js');
+      const beforeResume = await store.get(run.id);
+      const { run: resumed } = applyResume(beforeResume, 'work', def);
+      await store.update(resumed);
+      const afterResume = await store.get(run.id);
+      expect(afterResume.finalizer_ledger?.['fin']?.status).toBe('voided'); // untouched by resume
+
+      // 4. Re-fail 'work' — a NEW terminal false→true edge. selectFinalizers re-selects 'fin'
+      // (on_outcome 'always'); mintFresh's never-downgrade guard only skips 'completed'/'failed',
+      // NOT 'voided' — so 'fin' is re-armed to a clean pending entry. THIS is the re-arm moment.
+      const secondFail = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => {
+          throw new Error('boom again');
+        },
+      });
+
+      expect(secondFail.status).toBe('error');
+      expect(
+        secondFail.warnings.some(
+          (w) => w.includes("finalizer 'fin' was operator-voided") && w.includes('re-armed'),
+        ),
+      ).toBe(true);
+      const finalRun = await store.get(run.id);
+      expect(finalRun.finalizer_ledger?.['fin']?.status).toBe('pending');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a finalizer that was NEVER voided produces no re-arm warning on a normal terminal edge', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-re-arm-clean-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => {
+          throw new Error('boom');
+        },
+      });
+      expect(result.warnings.some((w) => w.includes('re-armed'))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/run-health.test.ts
+++ b/packages/core/src/engine/run-health.test.ts
@@ -28,13 +28,27 @@ function makeRun(over: Partial<RunRecord> = {}): RunRecord {
 
 describe('classifyRunHealth', () => {
   // ---------------------------------------------------------------------
-  // Branch 1 — terminal guard (unconditional first).
+  // Branch 1 — terminal guard, NARROWED by issue #279 (increment 1, PR-B, design record §6):
+  // `terminal ∧ no pending finalizer_ledger entries ⇒ []` — no longer literally unconditional on
+  // terminal_state alone (pendings are checked first; see the finding tests further below).
   // ---------------------------------------------------------------------
-  it('terminal_state ⇒ [] unconditionally', () => {
+  it('terminal_state with NO pending finalizer_ledger entries ⇒ [] (byte-identical to pre-#279 behavior)', () => {
     const run = makeRun({
       terminal_state: true,
       run_phase: 'completed',
       updated_at: new Date(NOW.getTime() - 100 * 86_400_000).toISOString(),
+    });
+    expect(classifyRunHealth(run, { now: NOW })).toEqual([]);
+  });
+
+  it('terminal_state with a finalizer_ledger that has ZERO pending entries (all completed/failed/voided) ⇒ []', () => {
+    const run = makeRun({
+      terminal_state: true,
+      run_phase: 'completed',
+      finalizer_ledger: {
+        done: { status: 'completed', rank: 0 },
+        gone: { status: 'voided', rank: 1 },
+      },
     });
     expect(classifyRunHealth(run, { now: NOW })).toEqual([]);
   });
@@ -48,6 +62,96 @@ describe('classifyRunHealth', () => {
       aborted_at: { step_id: 'guard_check' },
     });
     expect(classifyRunHealth(run, { now: NOW })).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------
+  // Branch 1 (narrowed) — the NEW terminal_pending_finalizer finding (issue #279, increment 1,
+  // PR-B). POSITIVE pin: terminal + pending ⇒ EXACTLY the new finding and ONLY it — no
+  // claim/capability/idle finding may leak through (the narrowed guard must still suppress them).
+  // ---------------------------------------------------------------------
+  it('terminal + a never-leased pending finalizer ⇒ exactly ONE terminal_pending_finalizer finding, reason never_leased', () => {
+    const run = makeRun({
+      terminal_state: true,
+      run_phase: 'completed',
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+    expect(classifyRunHealth(run, { now: NOW })).toEqual([
+      {
+        kind: 'terminal_pending_finalizer',
+        step: 'fin',
+        reason: 'never_leased',
+        evidence: { rank: 0 },
+      },
+    ]);
+  });
+
+  it('terminal + a pending finalizer with an EXPIRED lease ⇒ reason lease_expired', () => {
+    const run = makeRun({
+      terminal_state: true,
+      run_phase: 'completed',
+      finalizer_ledger: {
+        fin: {
+          status: 'pending',
+          rank: 0,
+          lease_token: 'dead-drainer',
+          lease_deadline: new Date(NOW.getTime() - 60_000).toISOString(),
+        },
+      },
+    });
+    const findings = classifyRunHealth(run, { now: NOW });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toBe('lease_expired');
+  });
+
+  it('terminal + a pending finalizer with an UNEXPIRED (active) lease ⇒ reason lease_held', () => {
+    const run = makeRun({
+      terminal_state: true,
+      run_phase: 'completed',
+      finalizer_ledger: {
+        fin: {
+          status: 'pending',
+          rank: 0,
+          lease_token: 'live-drainer',
+          lease_deadline: new Date(NOW.getTime() + 60_000).toISOString(),
+        },
+      },
+    });
+    const findings = classifyRunHealth(run, { now: NOW });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toBe('lease_held');
+  });
+
+  it('POSITIVE PIN: a terminal run with BOTH a pending finalizer AND a stale in-progress claim shows ONLY the finalizer finding (no claim finding leaks through)', () => {
+    const run = makeRun({
+      terminal_state: true,
+      run_phase: 'failed',
+      in_progress_steps: ['work'],
+      claims: { work: { deadline: new Date(NOW.getTime() - 60_000).toISOString() } },
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+    const findings = classifyRunHealth(run, { now: NOW });
+    expect(findings).toEqual([
+      {
+        kind: 'terminal_pending_finalizer',
+        step: 'fin',
+        reason: 'never_leased',
+        evidence: { rank: 0 },
+      },
+    ]);
+    expect(findings.some((f) => f.kind === 'stale_claim')).toBe(false);
+  });
+
+  it('multiple pending finalizers each produce their own finding, in ledger order', () => {
+    const run = makeRun({
+      terminal_state: true,
+      run_phase: 'completed',
+      finalizer_ledger: {
+        first: { status: 'pending', rank: 0 },
+        second: { status: 'pending', rank: 1 },
+      },
+    });
+    const findings = classifyRunHealth(run, { now: NOW });
+    expect(findings.map((f) => f.step)).toEqual(['first', 'second']);
   });
 
   // ---------------------------------------------------------------------

--- a/packages/core/src/engine/run-health.ts
+++ b/packages/core/src/engine/run-health.ts
@@ -15,9 +15,15 @@
 //
 // Branch-conditioning table (design record §1, fold B1 — the detectors are CALL-SITE-conditioned,
 // not internal to any one detector):
-//   1. `run.terminal_state === true` ⇒ [] — unconditional FIRST guard. A terminal run (including a
-//      terminal+claimed guard-abort record — a claim can still be `in_progress_steps` at the
-//      instant a guard aborts the run) has nothing further to report.
+//   1. issue #279 (increment 1, PR-B), design record §6 — this guard is NARROWED (explicitly
+//      authorized): `terminal ∧ no pending finalizer_ledger entries ⇒ []`. Pendings are checked
+//      BEFORE the terminal short-circuit — a terminal run with an undrained finalizer gets EXACTLY
+//      the new `terminal_pending_finalizer` finding(s) and NOTHING else (no claim/capability/idle
+//      finding may leak through on a terminal run; the narrowed guard still suppresses them once
+//      the pending check clears). A terminal run with a fully-drained (or finalizer-free) ledger
+//      still returns [] exactly as before — including a terminal+claimed guard-abort record (a
+//      claim can still be `in_progress_steps` at the instant a guard aborts the run) — nothing
+//      further to report.
 //   2. Claim findings: `classifyInProgressClaims(run, now)` entries with `state !== 'healthy' &&
 //      step !== run.pending_gate?.step_name`. The open-gate claim is always `{deadline: null}` ⇒
 //      `claim_unknown_age` — excluding it is what keeps a healthy gate_waiting run at ZERO
@@ -69,7 +75,12 @@ export const DEFAULT_IDLE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
  * renders from.
  */
 export interface RunHealthFinding {
-  kind: 'never_claimed_idle' | 'stale_claim' | 'wedged_gate_sibling' | 'capability_block';
+  kind:
+    | 'never_claimed_idle'
+    | 'stale_claim'
+    | 'wedged_gate_sibling'
+    | 'capability_block'
+    | 'terminal_pending_finalizer';
   /** The affected step, when the finding is step-scoped. Absent for `never_claimed_idle` — a
    *  run-level observation (no step is claimed at all). */
   step?: string;
@@ -102,10 +113,33 @@ export function classifyRunHealth(
   run: RunRecord,
   opts?: { now?: Date; idleThresholdMs?: number; definition?: WorkflowDefinition },
 ): RunHealthFinding[] {
-  // Branch 1 — unconditional first guard (record §1, B1).
-  if (run.terminal_state) return [];
-
   const now = opts?.now ?? new Date();
+
+  // Branch 1 — NARROWED first guard (issue #279, increment 1, PR-B, design record §6, explicitly
+  // authorized): checked BEFORE the terminal short-circuit. A terminal run with a still-'pending'
+  // finalizer_ledger entry gets EXACTLY these findings and returns immediately — no claim,
+  // capability, or idle finding may leak through on a terminal run.
+  if (run.terminal_state) {
+    const pendingFindings: RunHealthFinding[] = [];
+    for (const [name, entry] of Object.entries(run.finalizer_ledger ?? {})) {
+      if (entry.status !== 'pending') continue;
+      const isLeased = entry.lease_token !== undefined && entry.lease_deadline !== undefined;
+      const leaseExpired = isLeased && new Date(entry.lease_deadline!).getTime() <= now.getTime();
+      const reason = !isLeased ? 'never_leased' : leaseExpired ? 'lease_expired' : 'lease_held';
+      pendingFindings.push({
+        kind: 'terminal_pending_finalizer',
+        step: name,
+        reason,
+        evidence: {
+          rank: entry.rank,
+          ...(entry.lease_deadline !== undefined ? { lease_deadline: entry.lease_deadline } : {}),
+        },
+      });
+    }
+    if (pendingFindings.length > 0) return pendingFindings;
+    return []; // terminal ∧ no pending ledger entries ⇒ [] (byte-identical to pre-#279 behavior)
+  }
+
   const idleThresholdMs = opts?.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
   const findings: RunHealthFinding[] = [];
 

--- a/packages/core/src/engine/settlement.test.ts
+++ b/packages/core/src/engine/settlement.test.ts
@@ -1,20 +1,18 @@
-// Source-text anti-recurrence guard for RunStore.settleStep's dormancy (issue #279, increment 1,
-// PR-A). PR-A's whole point is ZERO engine behavior change: `applySettlement`/`settleStep` exist,
-// are exported, and are conformance-tested (see @sensigo/realm-testing's settlement-contract.ts),
-// but nothing in the engine or the MCP server calls them yet — the engine still seals steps via
-// the legacy read-then-update path. This guard fails loudly if that invariant is ever violated by
-// accident (a future engine-file edit that starts calling `store.settleStep(...)` without going
-// through the deliberate PR-B migration).
+// Source-text POSITIVE pin for RunStore.settleStep's migration (issue #279, increment 1, PR-B).
+// PR-A shipped this file's ORIGINAL guard here: a ZERO-invocation-sites assertion proving the
+// engine never called settleStep while the substrate was still dormant. PR-B's whole point is the
+// OPPOSITE — migrating the three seal sites (complete/fail/handler-abort) onto settleStep — so
+// that guard is deleted (as its own header said it would be) and replaced with this positive pin:
+// EXACTLY three `.settleStep(` invocation sites exist, all inside execution-loop.ts (the only
+// migrated file), and packages/mcp-server/src/** stays clean (gate-open/gate-resolution/guard
+// seals are increment-2 territory — untouched this increment, so the MCP surface has nothing new
+// to call). A future accidental FOURTH call site (or a stray call outside execution-loop.ts) fails
+// this test loudly, the same anti-recurrence discipline the deleted guard had, inverted.
 //
-// Invocation-scoped (matches `.settleStep(` literally), NOT a bare `settleStep` name match — this
-// module's own JSDoc prose (RunStore.settleStep, the interface declaration, this very comment)
-// mentions the identifier freely without ever writing the CALL syntax, so the invocation-scoped
-// pattern cannot self-trip. Mechanically executable path-prefix globs, mirroring the #107
-// deleteAllForRun declarer-scan precedent (packages/cli/src/commands/purge-guard.test.ts) rather
-// than a hand-maintained list of "files that must not call it".
-//
-// PR-B (the settleStep migration) DELETES this guard test entirely — its whole job there is to
-// start calling settleStep from the engine's seal sites, which is exactly what this test forbids.
+// Invocation-scoped (matches `.settleStep(` literally, not a bare `settleStep` name match) so this
+// module's own JSDoc prose can mention the identifier freely without self-tripping the count.
+// Mechanically executable path-prefix globs, mirroring the #107 deleteAllForRun declarer-scan
+// precedent (packages/cli/src/commands/purge-guard.test.ts).
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -29,6 +27,8 @@ const SCANNED_ROOTS = [
 ];
 
 const INVOCATION = '.settleStep(';
+const EXPECTED_SITE_COUNT = 3; // complete, fail, handler-abort
+const MIGRATED_FILE = join(PACKAGES_DIR, 'core', 'src', 'engine', 'execution-loop.ts');
 
 /** Every non-test, non-declaration .ts source file under `root`, recursively. */
 function sourceFiles(root: string): string[] {
@@ -47,30 +47,22 @@ function sourceFiles(root: string): string[] {
   return out;
 }
 
-describe('RunStore.settleStep is DORMANT in the engine and MCP server (issue #279, increment 1, PR-A)', () => {
-  it('ZERO `.settleStep(` invocation sites under packages/core/src/engine/** or packages/mcp-server/src/**', () => {
-    const offenders: { file: string; line: number; text: string }[] = [];
-    for (const root of SCANNED_ROOTS) {
-      for (const file of sourceFiles(root)) {
-        const lines = readFileSync(file, 'utf8').split('\n');
-        lines.forEach((line, i) => {
-          if (line.includes(INVOCATION)) {
-            offenders.push({ file, line: i + 1, text: line.trim() });
-          }
-        });
-      }
+function findInvocationSites(): { file: string; line: number; text: string }[] {
+  const sites: { file: string; line: number; text: string }[] = [];
+  for (const root of SCANNED_ROOTS) {
+    for (const file of sourceFiles(root)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (line.includes(INVOCATION)) {
+          sites.push({ file, line: i + 1, text: line.trim() });
+        }
+      });
     }
-    expect(
-      offenders,
-      offenders.length > 0
-        ? `Found ${offenders.length} '.settleStep(' invocation site(s) in the engine/MCP server ` +
-            `— PR-A requires ZERO engine behavior change. If this is the deliberate PR-B ` +
-            `migration, DELETE this guard test as part of that PR (see this file's own header):\n` +
-            offenders.map((o) => `  ${o.file}:${o.line}: ${o.text}`).join('\n')
-        : '',
-    ).toEqual([]);
-  });
+  }
+  return sites;
+}
 
+describe('RunStore.settleStep is MIGRATED at exactly three sites (issue #279, increment 1, PR-B)', () => {
   it('the scan itself is wired correctly (finds at least one .ts source file per root)', () => {
     for (const root of SCANNED_ROOTS) {
       expect(
@@ -80,7 +72,31 @@ describe('RunStore.settleStep is DORMANT in the engine and MCP server (issue #27
     }
   });
 
-  it('settlement.ts declares applySettlement and selectFinalizers as its exported surface (sanity check on the module this guard is about)', () => {
+  it(`EXACTLY ${EXPECTED_SITE_COUNT} '.settleStep(' invocation sites exist (complete/fail/handler-abort)`, () => {
+    const sites = findInvocationSites();
+    expect(
+      sites.length,
+      sites.length !== EXPECTED_SITE_COUNT
+        ? `Expected exactly ${EXPECTED_SITE_COUNT} '.settleStep(' invocation site(s), found ` +
+            `${sites.length}:\n${sites.map((s) => `  ${s.file}:${s.line}: ${s.text}`).join('\n')}`
+        : '',
+    ).toBe(EXPECTED_SITE_COUNT);
+  });
+
+  it('every invocation site lives in execution-loop.ts — none anywhere else (mcp-server stays clean)', () => {
+    const sites = findInvocationSites();
+    const elsewhere = sites.filter((s) => s.file !== MIGRATED_FILE);
+    expect(
+      elsewhere,
+      elsewhere.length > 0
+        ? `Found '.settleStep(' invocation site(s) OUTSIDE execution-loop.ts (increment 2 ` +
+            `territory — gate-open/gate-resolution/guard seals must stay on the legacy path this ` +
+            `increment):\n${elsewhere.map((s) => `  ${s.file}:${s.line}: ${s.text}`).join('\n')}`
+        : '',
+    ).toEqual([]);
+  });
+
+  it('settlement.ts declares applySettlement and selectFinalizers as its exported surface (sanity check on the module this pin is about)', () => {
     const settlementSrc = readFileSync(
       join(PACKAGES_DIR, 'core', 'src', 'engine', 'settlement.ts'),
       'utf8',

--- a/packages/core/src/engine/symptom-death-279.test.ts
+++ b/packages/core/src/engine/symptom-death-279.test.ts
@@ -1,0 +1,121 @@
+// symptom-death-279.test.ts — verification item 1, "THE POINT" (issue #279, increment 1, PR-B).
+// Two concurrent executeStep calls settling different SIBLING steps of one run, through the REAL
+// engine and a REAL JsonFileStore: BOTH outcomes are recorded, ZERO STATE_SNAPSHOT_MISMATCH,
+// exactly one terminal transition + one finalizer mint, and the finalizer fires EXACTLY ONCE,
+// strictly POST-COMMIT (both siblings already durably completed by the time the handler runs).
+//
+// The pre-#279 legacy read-then-update seal is THE bug this proves is dead on the migrated path:
+// two concurrent settles racing a stale in-memory draft would silently lose one outcome (or throw
+// STATE_SNAPSHOT_MISMATCH on the loser). No pre/post contrast is required — this test passing AT
+// ALL against the real, unmocked engine + store is the proof (per the hand-off prompt's own
+// instruction).
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep } from './execution-loop.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { StepHandler } from '../extensions/step-handler.js';
+import type { RunRecord } from '../types/run-record.js';
+
+const def: WorkflowDefinition = {
+  id: 'symptom-death-279-wf',
+  name: 'Symptom-death fan-out fixture',
+  version: 1,
+  steps: {
+    a: { description: 'sibling a', execution: 'agent', depends_on: [] },
+    b: { description: 'sibling b', execution: 'agent', depends_on: [] },
+    fin: {
+      description: 'finalizer',
+      execution: 'finalizer',
+      on_outcome: 'always',
+      handler: 'fin-handler',
+    },
+  },
+};
+
+describe('THE symptom dies end-to-end (issue #279, increment 1, PR-B, verification item 1)', () => {
+  it('two sibling steps settling CONCURRENTLY both record, zero STATE_SNAPSHOT_MISMATCH, exactly one terminal transition + one mint, and the finalizer fires exactly once, post-commit', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-symptom-death-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({
+        workflowId: def.id,
+        workflowVersion: 1,
+        params: {},
+      });
+
+      // executeStep claims each step itself (Step 3) — no manual pre-claim (claimStep's own
+      // single-owner guarantee is a separate, already-proven property; this test is about the
+      // SETTLE race specifically, which fires once each call's OWN internal claim succeeds).
+      let handlerCallCount = 0;
+      let membershipAtHandlerCallTime: { completed: string[] } | undefined;
+      const finHandler: StepHandler = {
+        id: 'fin-handler',
+        execute: async () => {
+          handlerCallCount += 1;
+          // Prove POST-COMMIT: by the time the finalizer's handler runs, BOTH siblings must
+          // already be durably recorded — read a FRESH copy from disk, not an in-memory draft.
+          const fresh: RunRecord = await store.get(run.id);
+          membershipAtHandlerCallTime = { completed: [...fresh.completed_steps].sort() };
+          return { data: {} };
+        },
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', finHandler);
+
+      // THE race: both siblings settle CONCURRENTLY through the real engine + real store.
+      const [resultA, resultB] = await Promise.all([
+        executeStep(store, def, {
+          runId: run.id,
+          command: 'a',
+          input: {},
+          dispatcher: async () => ({}),
+          registry,
+        }),
+        executeStep(store, def, {
+          runId: run.id,
+          command: 'b',
+          input: {},
+          dispatcher: async () => ({}),
+          registry,
+        }),
+      ]);
+
+      // BOTH outcomes recorded — zero STATE_SNAPSHOT_MISMATCH, zero lost settlement.
+      expect(resultA.status).toBe('ok');
+      expect(resultB.status).toBe('ok');
+      expect(resultA.errors).toEqual([]);
+      expect(resultB.errors).toEqual([]);
+
+      const finalRun = await store.get(run.id);
+      expect(finalRun.completed_steps.sort()).toEqual(['a', 'b', 'fin']);
+      expect(finalRun.terminal_state).toBe(true);
+      expect(finalRun.run_phase).toBe('completed');
+
+      // Exactly one terminal transition + one mint: the finalizer ran EXACTLY once (not zero,
+      // not twice — a lost race under the legacy mechanism could plausibly double-fire or
+      // never-fire depending on which draft won).
+      expect(handlerCallCount).toBe(1);
+
+      // POST-COMMIT proof: at the instant the handler ran, BOTH siblings were ALREADY durably
+      // completed (read fresh from disk) — the finalizer never fired off a stale pre-commit draft.
+      expect(membershipAtHandlerCallTime).toEqual({ completed: ['a', 'b'] });
+
+      // Zero STATE_SNAPSHOT_MISMATCH anywhere in either envelope's error surface.
+      expect(JSON.stringify(resultA)).not.toContain('STATE_SNAPSHOT_MISMATCH');
+      expect(JSON.stringify(resultB)).not.toContain('STATE_SNAPSHOT_MISMATCH');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  // NOTE: the "no-await single-owner path" (InMemoryStore) is proven separately by
+  // @sensigo/realm-testing's own settlement TCK (L1 FRESH_APPLICATION, run against InMemoryStore)
+  // and by that package's dedicated no-await behavioral-overlap pin — packages/core cannot import
+  // @sensigo/realm-testing itself (it would be a circular package dependency: testing already
+  // depends on core), so this file's own proof is JsonFileStore-only, per the constraint the #183/
+  // #188 precedent already established for this exact situation.
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,9 @@ export { deriveDefaultedSteps } from './engine/defaulted-steps.js';
 // DORMANT: no engine/mcp call site constructs a SettlementDelta or calls settleStep in this
 // release (enforced by an in-repo source-text guard — see its own test for the exact scope).
 export { applySettlement, selectFinalizers } from './engine/settlement.js';
+export { applyResume } from './engine/apply-resume.js';
+export type { ApplyResumeResult, ApplyResumeVoidedFinalizer } from './engine/apply-resume.js';
+export { drainFinalizers } from './engine/execution-loop.js';
 export type {
   SettlementDelta,
   SettleStepDelta,

--- a/packages/core/src/store/json-file-store.test.ts
+++ b/packages/core/src/store/json-file-store.test.ts
@@ -1249,6 +1249,57 @@ describe('JsonFileStore.deleteAllForRun — purge correctness (issue #184)', () 
     }
   });
 
+  // issue #279 (increment 1, PR-B), R11: drain_pending — a terminal run with an undrained
+  // finalizer must never be deleted, since that would destroy the record a later `realm run
+  // drain`/`--void` needs. Unconditional — no store-level force bypass exists (purge.ts's
+  // single-id --force path inherits this same under-lock throw automatically).
+  it('drain_pending: refuses (STATE_RUN_BUSY, reason drain_pending) when a finalizer ledger entry is still pending, and the run file survives intact', async () => {
+    const { store, dir } = await makeTmpStore();
+    try {
+      const { run } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      await store.update({
+        ...run,
+        run_phase: 'completed',
+        terminal_state: true,
+        terminal_reason: 'Workflow completed.',
+        finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+      });
+
+      await expect(store.deleteAllForRun(run.id)).rejects.toMatchObject({
+        code: 'STATE_RUN_BUSY',
+        details: { runId: run.id, reason: 'drain_pending' },
+      });
+
+      expect(existsSync(join(dir, `${run.id}.json`))).toBe(true);
+      const survivor = await store.get(run.id);
+      expect(survivor.finalizer_ledger?.['fin']?.status).toBe('pending');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('drain_pending: a run whose finalizer ledger has NO pending entries (completed/failed/voided only) deletes normally', async () => {
+    const { store, dir } = await makeTmpStore();
+    try {
+      const { run } = await store.create({ workflowId: 'wf-1', workflowVersion: 1, params: {} });
+      await store.update({
+        ...run,
+        run_phase: 'completed',
+        terminal_state: true,
+        terminal_reason: 'Workflow completed.',
+        finalizer_ledger: {
+          done: { status: 'completed', rank: 0 },
+          gone: { status: 'voided', rank: 1 },
+        },
+      });
+
+      await expect(store.deleteAllForRun(run.id)).resolves.toBeUndefined();
+      expect(existsSync(join(dir, `${run.id}.json`))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   // issue #191: deleteAllForRun's OWN lock acquisition now retries against LOCK_RETRIES'
   // maxRetryTime:5000 total-time budget before giving up (this test holds the external lock for
   // the ENTIRE duration, so it now genuinely waits out that full budget, up from the pre-#191

--- a/packages/core/src/store/json-file-store.ts
+++ b/packages/core/src/store/json-file-store.ts
@@ -824,15 +824,25 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
 
   /**
    * Builds the `STATE_RUN_BUSY` error thrown when `deleteAllForRun` cannot proceed because
-   * another writer holds the run-file (or key) lock, or because the run is no longer terminal
-   * (issue #184). Retryable: a live writer self-heals (the lock is released), and a genuinely
-   * stale lock is eventually stolen by the next contender.
+   * another writer holds the run-file (or key) lock, because the run is no longer terminal
+   * (issue #184), or because a finalizer ledger entry is still `'pending'` (issue #279, increment
+   * 1, PR-B: `drain_pending` — R11). Retryable: a live writer self-heals (the lock is released), a
+   * genuinely stale lock is eventually stolen by the next contender, and a pending finalizer is
+   * eventually drained or voided by an operator — but `drain_pending` is deliberately NOT
+   * force-bypassable at the CLI layer (residual R11, owner-ratified): the escape is `realm run
+   * drain` or `--void`, never `purge --force`.
    */
-  private runBusyError(runId: string, reason: 'locked' | 'no_longer_terminal'): WorkflowError {
+  private runBusyError(
+    runId: string,
+    reason: 'locked' | 'no_longer_terminal' | 'drain_pending',
+  ): WorkflowError {
     const message =
       reason === 'locked'
         ? `Run '${runId}' is locked by another writer`
-        : `Run '${runId}' is no longer terminal — refusing to delete (it may have been resumed)`;
+        : reason === 'no_longer_terminal'
+          ? `Run '${runId}' is no longer terminal — refusing to delete (it may have been resumed)`
+          : `Run '${runId}' has a pending finalizer — refusing to delete until it is drained or ` +
+            `voided (realm run drain ${runId} / --void <finalizer>)`;
     return new WorkflowError(message, {
       code: 'STATE_RUN_BUSY',
       category: 'STATE',
@@ -894,6 +904,18 @@ export class JsonFileStore implements RunStore, PerRunArtifactStore {
       // `deleteAllForRun` never deletes a non-terminal run, full stop.
       if (!TERMINAL_PHASES.has(record.run_phase) || record.terminal_state !== true) {
         throw this.runBusyError(runId, 'no_longer_terminal');
+      }
+
+      // issue #279 (increment 1, PR-B), R11: any finalizer ledger entry still 'pending' refuses
+      // deletion — deleting the run out from under an undrained finalizer would silently destroy
+      // the record a later `realm run drain`/`--void` needs to act on. Unconditional (no --force
+      // bypass at this layer — purge.ts's single-id --force path routes through this SAME
+      // under-lock throw, so it inherits the refusal automatically); the escape is the drain verb.
+      const pendingFinalizer = Object.entries(record.finalizer_ledger ?? {}).find(
+        ([, entry]) => entry.status === 'pending',
+      );
+      if (pendingFinalizer !== undefined) {
+        throw this.runBusyError(runId, 'drain_pending');
       }
 
       const deleted: string[] = [];

--- a/packages/core/src/types/workflow-error.ts
+++ b/packages/core/src/types/workflow-error.ts
@@ -47,6 +47,14 @@ export type ErrorCode =
   | 'STATE_LEGACY_FORMAT'
   | 'STATE_STEP_ALREADY_CLAIMED'
   | 'STATE_STEP_NOT_ELIGIBLE'
+  // issue #279 (increment 1, PR-B): a settle_step delta refused because the step's settled entry
+  // already carries a DIFFERENT token (already_settled_by_other) or a DIFFERENT outcome
+  // (settled_outcome_divergence) — the persisted outcome is disclosed in `details`. Never thrown
+  // for the SAME-token/SAME-outcome retry, which is an ok-shaped no-op (design record §7).
+  | 'STATE_STEP_ALREADY_SETTLED'
+  // issue #279 (increment 1, PR-B): a settle_step delta refused `claim_lost` — this attempt's
+  // outcome was NOT recorded (the claim was lost to a concurrent settle, or the run advanced).
+  | 'STATE_CLAIM_LOST'
   | 'STATE_RUN_DIVERGED'
   | 'STATE_RUN_ALREADY_ACTIVE'
   | 'STATE_IDEMPOTENCY_KEY_USED'

--- a/packages/mcp-server/src/tools/get-workflow-protocol.ts
+++ b/packages/mcp-server/src/tools/get-workflow-protocol.ts
@@ -20,6 +20,19 @@ const WRITER_NONCE_PROTOCOL_RULE =
   'of the honest-but-unattributed floor.';
 
 /**
+ * Issue #279 (increment 1, PR-B), design record §6: ONE appended TOOL-layer rule (the
+ * WRITER_NONCE_PROTOCOL_RULE precedent above) — a concurrent settlement of the SAME step by a
+ * sibling attempt resolves automatically (no operator action needed); on the specific
+ * STATE_STEP_ALREADY_SETTLED error, the agent should call get_run_state and continue from the
+ * run's actual state rather than treating it as a genuine failure. The generator itself is
+ * untouched — same rationale as the writer_nonce rule above.
+ */
+const CONCURRENT_SETTLEMENT_PROTOCOL_RULE =
+  'A concurrent completion of the same step by a sibling attempt resolves automatically — on a ' +
+  "STATE_STEP_ALREADY_SETTLED error, call get_run_state and continue from the run's actual " +
+  'state rather than treating it as a failure.';
+
+/**
  * Business logic for the get_workflow_protocol tool.
  * Returns the full agent protocol for the specified workflow.
  */
@@ -30,7 +43,10 @@ export async function handleGetWorkflowProtocol(
   const store = stores?.workflowStore ?? new JsonWorkflowStore();
   const definition = await store.get(args.workflow_id);
   const protocol = generateProtocol(definition);
-  return { ...protocol, rules: [...protocol.rules, WRITER_NONCE_PROTOCOL_RULE] };
+  return {
+    ...protocol,
+    rules: [...protocol.rules, WRITER_NONCE_PROTOCOL_RULE, CONCURRENT_SETTLEMENT_PROTOCOL_RULE],
+  };
 }
 
 /** Registers the get_workflow_protocol MCP tool on the server. */

--- a/packages/mcp-server/src/tools/mcp-tools.test.ts
+++ b/packages/mcp-server/src/tools/mcp-tools.test.ts
@@ -105,6 +105,20 @@ describe('mcp tool handlers', () => {
     expect(result.steps.length).toBe(1);
   });
 
+  // issue #279 (increment 1, PR-B): the appended concurrent-settlement protocol rule.
+  it('handleGetWorkflowProtocol appends the concurrent-settlement rule (STATE_STEP_ALREADY_SETTLED guidance)', async () => {
+    const workflowStore = new JsonWorkflowStore(workflowDir);
+    await workflowStore.register(makeSimpleDef());
+
+    const result = await handleGetWorkflowProtocol({ workflow_id: 'simple-wf' }, { workflowStore });
+
+    expect(
+      result.rules.some(
+        (r) => r.includes('STATE_STEP_ALREADY_SETTLED') && r.includes('get_run_state'),
+      ),
+    ).toBe(true);
+  });
+
   it('handleStartRun creates a run and chains auto steps', async () => {
     const workflowStore = new JsonWorkflowStore(workflowDir);
     await workflowStore.register(makeSimpleDef());

--- a/packages/mcp-server/src/tools/start-run-pending-drain-advisory.test.ts
+++ b/packages/mcp-server/src/tools/start-run-pending-drain-advisory.test.ts
@@ -1,0 +1,109 @@
+// issue #279 (increment 1, PR-B), design record §6: an idempotent 'reuse' match on a TERMINAL run
+// carrying undelivered (pending) finalizers gets ONE extra advisory warning pointing at the
+// recovery verb — disclosure only, never a policy input (decideIdempotencyPolicy's own domain is
+// unchanged; this warning is added by the CALLER after the policy already decided 'reuse').
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore, JsonWorkflowStore, CURRENT_WORKFLOW_SCHEMA_VERSION } from '@sensigo/realm';
+import type { WorkflowDefinition } from '@sensigo/realm';
+import { handleStartRun } from './start-run.js';
+
+const workflow: WorkflowDefinition = {
+  id: 'pending-drain-advisory-wf',
+  name: 'Pending Drain Advisory WF',
+  version: 1,
+  schema_version: CURRENT_WORKFLOW_SCHEMA_VERSION,
+  steps: {
+    work: { description: 'w', execution: 'agent', depends_on: [] },
+  },
+};
+
+const IDEMPOTENCY_KEY = 'pending-drain-advisory-key';
+
+describe('start_run — pending-drain advisory on idempotent reuse (issue #279, increment 1, PR-B)', () => {
+  let runStore: JsonFileStore;
+  let workflowStore: JsonWorkflowStore;
+
+  beforeEach(async () => {
+    const runDir = await mkdtemp(join(tmpdir(), 'pending-drain-run-'));
+    const wfDir = await mkdtemp(join(tmpdir(), 'pending-drain-wf-'));
+    runStore = new JsonFileStore(runDir);
+    workflowStore = new JsonWorkflowStore(wfDir);
+    await workflowStore.register(workflow);
+  });
+
+  it('a terminal run with a pending finalizer gets the "completion recorded; N finalizer(s) not yet delivered" advisory on reuse', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'pending-drain-advisory-wf',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    await runStore.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      completed_steps: ['work'],
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    const result = await handleStartRun(
+      { workflow_id: 'pending-drain-advisory-wf', idempotency_key: IDEMPOTENCY_KEY },
+      { runStore, workflowStore },
+    );
+
+    expect(result.deduped).toBe(true);
+    expect(
+      result.warnings.some(
+        (w) => w.includes('completion recorded') && w.includes(`realm run drain ${run.id}`),
+      ),
+    ).toBe(true);
+  });
+
+  it('a terminal run with NO pending finalizers gets no such advisory', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'pending-drain-advisory-wf',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    await runStore.update({
+      ...run,
+      run_phase: 'completed',
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      completed_steps: ['work'],
+    });
+
+    const result = await handleStartRun(
+      { workflow_id: 'pending-drain-advisory-wf', idempotency_key: IDEMPOTENCY_KEY },
+      { runStore, workflowStore },
+    );
+
+    expect(result.deduped).toBe(true);
+    expect(result.warnings.some((w) => w.includes('completion recorded'))).toBe(false);
+  });
+
+  it('a NON-terminal run with a pending finalizer (defensive fixture) gets no advisory — pendings imply terminal in-contract', async () => {
+    const { run } = await runStore.create({
+      workflowId: 'pending-drain-advisory-wf',
+      workflowVersion: 1,
+      params: {},
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    await runStore.update({
+      ...run,
+      finalizer_ledger: { fin: { status: 'pending', rank: 0 } },
+    });
+
+    const result = await handleStartRun(
+      { workflow_id: 'pending-drain-advisory-wf', idempotency_key: IDEMPOTENCY_KEY },
+      { runStore, workflowStore },
+    );
+
+    expect(result.warnings.some((w) => w.includes('completion recorded'))).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/tools/start-run.ts
+++ b/packages/mcp-server/src/tools/start-run.ts
@@ -117,6 +117,18 @@ export async function handleStartRun(
         `Idempotency key matched an existing run created with different params; the original run is returned unchanged (params not updated).`,
       );
     }
+    // issue #279 (increment 1, PR-B), design record §6: pending-drain is DISCLOSURE ONLY here —
+    // it never feeds decideIdempotencyPolicy's own decision (that pure function's domain is
+    // unchanged); a 'reuse' match on a terminal run with undelivered finalizers just gets one
+    // extra advisory line pointing at the recovery verb.
+    const pendingFinalizerCount = Object.values(run.finalizer_ledger ?? {}).filter(
+      (e) => e.status === 'pending',
+    ).length;
+    if (run.terminal_state && pendingFinalizerCount > 0) {
+      warnings.push(
+        `completion recorded; ${pendingFinalizerCount} finalizer(s) not yet delivered — realm run drain ${run.id}`,
+      );
+    }
     logDedup({
       tool: 'start_run',
       workflow_id: definition.id,


### PR DESCRIPTION
## Summary

PR-B (the "migrate phase") of issue #279's increment-1 program — the second and final PR. Where PR-A (#283) shipped the dormant substrate, this PR makes the engine actually use it:

- Migrates the three seal sites (complete / fail / handler-abort) in `execution-loop.ts` to `RunStore.settleStep`, behind a fail-closed dormancy branch (an undeclaring store keeps the byte-identical legacy path + one advisory warning).
- Adds post-commit finalizer drain (`drainFinalizers`): a rank-ordered lease → execute → mark loop that re-reads the ledger fresh at every step.
- Ships every recovery surface in the same PR (the design record's binding recovery-closure invariant): `realm run drain <run-id> [--force] / --all / --void <finalizer>`, a purge `drain_pending` guard (single-id `--force` still refuses — the escape is drain/void, never force), and `applyResume` + resume's four new CLI refusals.
- `applyResume` also strips `abandoned_at` alongside `terminal_reason` — **closes #281**.
- Disclosure sweep: `run-health.ts` (new `terminal_pending_finalizer` finding), `list --stuck` rendering, `export.ts` pending-drain warning, `get_workflow_protocol` rule, the MCP `start_run` dedup advisory, and the re-arm disclosure (an operator-voided finalizer that re-arms at the next terminal edge).

**The symptom dies**: two sibling steps settling concurrently both record, zero `STATE_SNAPSHOT_MISMATCH`, and finalizers fire exactly once post-commit off the durable ledger instead of pre-commit off hope (verified end-to-end — see Verification below).

Design record: `plans/issue-279/design-d4-increment1.md` (§10 covers this PR's scope).

## A test-isolation defect found and fixed along the way

While building Verification 3 (the drain CLI + purge integration test), I discovered that `drain.ts`'s test suite was silently writing real run files into the **actual `~/.realm/runs`** on every run, not a temp directory. Root cause: `drain.ts` statically imports `loadProjectExtensions` (a real, necessary dependency for resolving project extensions), and that module itself has a top-level *value* import of `@sensigo/realm` — so merely importing anything from `drain.js` eagerly evaluates `JsonFileStore`'s module-load-time `DEFAULT_RUNS_DIR = join(homedir(), ...)` capture, before any test's `beforeEach` can override `$HOME`. The established `$HOME`-override idiom (`abandon.ts`/`resume.ts`) only works when the command file's own import chain is completely inert w.r.t. `@sensigo/realm` — `drain.ts`'s was not.

Fix: `drain.ts` was restructured so `runDrainAction` takes `runStore`/`workflowStore`/its three `@sensigo/realm` runtime values as **explicit parameters** (mirrors `resume.ts`'s `resumeRun`), with `drainCommand`'s `.action()` reduced to a thin wrapper that constructs the real defaults. Tests now drive `runDrainAction` directly against an explicitly-dired store — no `$HOME` involved at all. `drain.test.ts` and the new `drain-purge-integration.test.ts` were rewritten accordingly. 31 leaked test-artifact run files (`workflow_id` exactly matching test fixtures, all dated today) were identified and removed from the real `~/.realm/runs`; a full monorepo test run afterward confirmed zero further leakage.

`purge.ts` has the identical latent defect (a pre-existing top-level value import, predating this PR) but was **not** touched — converting `isPurgeEligible`'s synchronous call graph to support lazy loading is a larger, riskier, tangential refactor. `drain-purge-integration.test.ts` instead drives `purgeRuns` directly with an explicit `anchorStore` (matching `purge.test.ts`'s own established precedent). Flagging this for awareness — the same class of hazard is proven live in `purge.ts`, currently silent for lack of test files that touch it under `$HOME` override.

## Verification

1. **Symptom-death e2e** (`symptom-death-279.test.ts`): two sibling steps settle concurrently via a real `JsonFileStore`; both record, zero `STATE_SNAPSHOT_MISMATCH`, exactly one terminal transition + one finalizer call, and a fresh `store.get()` taken at the instant the finalizer handler runs shows BOTH siblings already in `completed_steps` — proving post-commit ordering.
2. **Latent-bug fix** (`latent-bug-claim-lost-no-fire.test.ts`): a settle refused via `claim_lost` fires zero finalizer calls; `finalizer_ledger`/`terminal_state` are never touched.
3. **Recovery closure, live** (`drain.test.ts` + `drain-purge-integration.test.ts`): dry-run renders the four rank-pass classes; `--force` drains a real finalizer; `--all` batch-drains; `--void` voids with operator-provenance evidence and refuses on an unexpired lease; purge refuses `drain_pending` (dry-run and `--force` alike) until an operator voids the finalizer, then proceeds.
4. **Resume e2e wedge repro** (`resume-wedge-e2e.test.ts`): settle-fail → resume via the real `resumeCommand.parseAsync` → re-claim → re-settle succeeds — the R1 wedge is gone on the migrated path.
5. **Dormancy suite** (`dormancy-suite-279.test.ts`): a non-declaring store double proves all three migrated sites take the byte-identical-shaped legacy path, each carrying the one dormancy advisory.
6. **Mutation probes** (all 5 confirmed red-under-mutation, green-after-revert):
   - (a) delete the dormancy branch ⇒ the dormancy suite reds.
   - (b) make drain iterate a pass-start snapshot instead of re-reading the ledger ⇒ **previously unpinned** — closed with a new test (`drain-rereads-ledger.test.ts`) proving a concurrently-voided finalizer is never leased under fresh re-derivation.
   - (c) drop `applyResume`'s settled-clear / terminal_state reset / claim-release ⇒ the payload-level unit tests red; a genuinely-dangling-claim scenario (the actual R1-wedge shape) was **previously unpinned** by any fixture — closed with a new test in `apply-resume.test.ts`.
   - (d) drop the purge `drain_pending` guard ⇒ its dedicated test reds.
   - (e) fire the finalizer drain before the settle commit instead of after ⇒ the symptom-death test's exactly-once/post-commit assertion reds.
7. **Full suite green, forced**: core 85/1969, cli 73/873, mcp-server 28/276, testing (incl. the 47-case settlement TCK across both store implementations) 6/129 — all passing. Lint clean across all packages. Format clean (`prettier --check .`).
8. `git diff --stat` matches the prompt's touch list (plus disclosed additions below). Three migrated sites carry `.settleStep(` (positive pin in `settlement.test.ts`). `reclaim-step.ts` and both `abandon-run.ts` files have **zero diff**. `execution-loop.ts`'s hunks do not intersect gate-open (`pending_gate`/`gate_id`/`gateConfig`), gate-resolution (`submitHumanResponse`), or guard-seal (`executeGuardStep`, `buildSettleSealGuard`'s own definition) — confirmed by direct grep against the diff, zero matches.

## Deviations from the prompt (disclosed, not scope creep)

- `packages/cli/src/agent/run-attach.ts` (+ its test) received the same drain-hint treatment as `run-agent.ts`'s attach path — it's the actually-user-visible implementation `commands/agent.ts` calls into, carrying duplicate terminal-state-throw logic. Same disclosure item, two call sites.
- `packages/cli/src/commands/store-fs-guard.test.ts`: the exact-count allow-list for raw WAL-delete call sites needed bumping from 2 to 4 (the migrated fail/complete sites duplicate the legacy WAL-cleanup logic) — a mechanical consequence of the migration, not a new behavior.
- Everything else new/modified is exactly the touch list.

## Next steps for the architect

- Post the increment-1 status to **#279** (do not close — increment 2, gates/guards, remains).
- **#281 auto-closes** via this PR's `Closes #281`.
- Fold the design record §10/§11 cloud-punch-list items into the realm-cloud punch-list.
- Consider whether `purge.ts`'s pre-existing test-isolation defect (see above) warrants its own tracked follow-up now that its sibling class has a proven fix pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
