### PR TITLE
chore: release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.32.0] — 2026-07-26
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,7 +4529,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.31.2",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4580,7 +4580,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.31.2",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.31.2",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4646,7 +4646,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.31.2",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.31.2');
+program.name('realm').description('Realm workflow engine CLI').version('0.32.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,7 +128,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.31.2';
+export const VERSION = '0.32.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.31.2';
+export const VERSION = '0.32.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.31.2',
+    version: '0.32.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -64,4 +64,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.31.2';
+export const VERSION = '0.32.0';


### PR DESCRIPTION
## Context

**v0.32.0** (minor) — the #279 increment-1 release plus the quick-win cluster. The headline: **the fan-out seal wedge is dead on the migrated paths** — atomic store settlement (`RunStore.settleStep`, dormant-optional for external stores), post-commit finalizer drain with a durable ledger, and the full recovery surface (`realm run drain`/`--void`, purge guard, resume rework). Also ships #219 (stuck-cause attribution), #232 (defaulted-steps visibility), #191 (jittered lock backoff + retryable ELOCKED), and closes #281.

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.32.0] — 2026-07-26`.
- Release bump (via `npm run release`): 4× `package.json` + 5× `VERSION` → `0.32.0`; lockfile.

## Verification

- All payload PRs (#277, #278, #280, #283, #284) were MA-reviewed against primary artifacts with independent forced re-runs + mutation probes; the symptom-death proof (`symptom-death-279.test.ts`) was reproduced independently pre-merge.
- Publish pipeline proven end-to-end since v0.31.2 (setup-node v7 OIDC gate); publish is fail-closed (`--provenance` + id-token pre-flight).

## Rollback

Standard: if publish fails post-tag, re-trigger; if the artifact is broken, patch-release per Part B §8.

## Related

#279 (increment 1 — stays open for increment 2) · #281 (closed) · #219/#232/#191 (closed). Merge-commit (not squash) — the tag rides the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
