### PR TITLE
feat(engine): migrate gates/guards/release to atomic settlement (issue #279 increment 2, PR-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,28 @@ All notable changes to this project are documented here.
 - Terminal exports falsely redacted claim nonces and suppressed the pending-finalizer warning.
 - Run-phase derivation now ranks terminal markers (`terminal_state`, `aborted_at`, `abandoned_at`) above an open
   gate — stale `gate_waiting` labels heal on the next write.
+- Fan-out gate-open, gate-resolution, and guard seals can no longer lose an overlap with a concurrent settle —
+  deterministic CAS-loss (a stuck claim, a human decision reported "not recorded", a discarded guard
+  terminalization) is now dead for stores that declare atomic settlement.
+- Gate and guard terminal seals no longer fire their finalizers before the terminal commit — delivery is now
+  ledger-mediated, exactly-once, and recoverable via `realm run drain` if a crash lands between commit and delivery.
+
+### Changed
+
+- Gate-open, gate-resolution, guard, and capability-block/compensating-release write paths migrate to atomic
+  settlement (`RunStore.settleStep`); a non-declaring external store keeps the legacy write path plus an
+  upgrade advisory, matching the increment-1 lockstep-upgrade posture.
+- Refusal envelopes at the gate, guard, and capability-block surfaces are now uniformly typed, including a
+  cancelled-gate disclosure ("your choice was NOT recorded") when a sibling abort cancelled the gate first.
 
 ### Added
 
 - Dormant settlement delta kinds for gates/guards/release (`open_gate`, `settle_gate`, `settle_guard`,
   `release_step`) — engine-inert until the next increment — plus the settlement TCK laws covering them.
+- `submit_human_response` gains an optional `responded_by` attribution pass-through (recorded, not enforced).
+- Three new run-health finding classes for stale/corrupt gate states: a terminal record still carrying a
+  pending gate, a settled gate entry coexisting with a live gate of the same id, and a resolved gate with a
+  guard now awaiting its next drive.
 
 ## [0.32.0] — 2026-07-26
 

--- a/docs/reference/mcp-protocol.md
+++ b/docs/reference/mcp-protocol.md
@@ -121,6 +121,12 @@ When the engine opens a gate:
 | `gate.response_spec.choices` | Valid choice values (e.g. `["approve", "reject"]`).                                                                           |
 | `gate.preview`               | Full step output at gate opening, for reference and debugging.                                                                |
 
+A duplicate `submit_human_response` call with the SAME `gate_id` and the SAME choice (e.g. a
+retried tool call) is an idempotent no-op — it returns the same `ok` outcome the original
+submission committed, not an error. Submitting a DIFFERENT choice against a gate that another
+attempt already resolved is refused (`STATE_BLOCKED`) with the winning choice named, so a racing
+caller learns what was actually recorded rather than silently overwriting it.
+
 ---
 
 ## Error recovery (`agent_action`)

--- a/docs/reference/operating-runs.md
+++ b/docs/reference/operating-runs.md
@@ -42,8 +42,8 @@ that simply has no agent action pending.
 makes the run derive to phase `abandoned` regardless of any `failed_steps` it carries. It:
 
 - is **idempotent** — abandoning an already-abandoned run is a no-op success;
-- **refuses a terminal run** (`completed`/`failed`/`aborted`) with `STATE_RUN_TERMINAL` — it never clobbers a finished run;
-- **refuses a `gate_waiting` run** with `STATE_TRANSITION_DENIED` — resolve the gate first (gate abandonment is intentionally not supported in this version);
+- **refuses a terminal run** (`completed`/`failed`/`aborted`) with `STATE_RUN_TERMINAL` — checked FIRST, keyed on `terminal_state`/the derived phase, never the persisted `run_phase` label (a grandfathered record whose persisted phase still reads `gate_waiting` but is actually terminal is refused HERE, not below) — it never clobbers a finished run;
+- **refuses a run with an OPEN gate** (a genuinely non-terminal run still carrying a live `pending_gate`) with `STATE_TRANSITION_DENIED` — resolve the gate first (gate abandonment is intentionally not supported in this version);
 - is **concurrency-safe** — if a live writer advances the run while abandon is in flight, abandon loses (propagates `STATE_SNAPSHOT_MISMATCH`) rather than corrupting the record.
 
 ### Honesty note
@@ -93,7 +93,9 @@ realm run purge --older-than 30d --force                    # actually deletes t
 | Targets            | Non-terminal, non-`gate_waiting` runs          | **Terminal-only** runs, claim-state permitting (see below) |
 | Exposed to agents? | Yes (`abandon_run` MCP tool)                   | **No** — CLI-only, deliberately never an MCP tool          |
 
-Purge will **never** touch a run that is not terminal or a run that is `gate_waiting`. Beyond that, its
+Purge will **never** touch a run that is not terminal — derived (never the persisted `run_phase`
+label), so a genuinely non-terminal `gate_waiting` run is excluded, while a grandfathered record
+whose stale persisted phase still reads `gate_waiting` but is actually terminal IS eligible. Beyond that, its
 claim-state check is **mode-aware** — the same run can be refused in a batch sweep yet purgeable when
 you name it directly:
 

--- a/packages/cli/src/commands/respond.test.ts
+++ b/packages/cli/src/commands/respond.test.ts
@@ -181,9 +181,15 @@ describe('respondToGate — fires finalizers on gate completion (registry thread
     expect(updated.evidence.some((e) => e.step_id === 'record_outcome')).toBe(true);
   });
 
-  it('records the finalizer as a NON-FATAL failure when the registry lacks its handler (run still completes)', async () => {
-    // Control: a registry without the project handler → handler-not-found is recorded, but the
-    // run outcome is unchanged (finalizer failure never un-completes the run).
+  it('leaves the finalizer PENDING (recoverable on a capable runner) when the registry lacks its handler (run still completes)', async () => {
+    // Control: a registry without the project handler. issue #279 (increment 2, PR-D): gate
+    // resolution now completes via the post-commit drain loop (drainFinalizers) on a declaring
+    // store (JsonFileStore) — its registry pre-check LEAVES an absent-handler entry PENDING and
+    // discloses why, rather than burning it into failed_steps (design record §6: "leasing it,
+    // failing the call, and marking it 'failed' would destroy the 'recoverable on a capable
+    // runner' property a still-pending entry carries" — this is PR-B's own already-shipped drain
+    // semantics, now also reached via gate resolution). The run outcome is unchanged either way
+    // (finalizer non-delivery never un-completes the run).
     const { runId, gateId } = await openGate();
     const { newState } = await respondToGate(
       runId,
@@ -195,7 +201,8 @@ describe('respondToGate — fires finalizers on gate completion (registry thread
 
     expect(newState).toBe('completed');
     const updated = await runStore.get(runId);
-    expect(updated.failed_steps).toContain('record_outcome');
+    expect(updated.failed_steps).not.toContain('record_outcome');
     expect(updated.completed_steps).not.toContain('record_outcome');
+    expect(updated.finalizer_ledger?.['record_outcome']?.status).toBe('pending');
   });
 });

--- a/packages/core/src/engine/dormancy-suite-279.test.ts
+++ b/packages/core/src/engine/dormancy-suite-279.test.ts
@@ -1,17 +1,17 @@
-// dormancy-suite-279.test.ts — verification item 5 (issue #279, increment 1, PR-B). A NAMED
-// representative set (re-parameterizing every pre-existing seal-path test file across a
-// declaring/non-declaring axis is out of proportion for this increment) covering all THREE
-// migrated sites against a non-declaring store double: `store.settleStep === undefined` by
-// construction (own-property masking — never implemented, not merely set to undefined, matching
-// the RunStore.settleStep OPTIONAL contract). Each site is proven byte-identical-SHAPED to legacy
-// behavior (same membership/terminal outcomes the migrated path also produces) PLUS the ONE
-// dormancy advisory (I16) every legacy-path envelope now carries.
+// dormancy-suite-279.test.ts — verification item 5 (issue #279, increment 1 PR-B + increment 2
+// PR-D). A NAMED representative set (re-parameterizing every pre-existing seal-path test file
+// across a declaring/non-declaring axis is out of proportion for this increment) covering ALL
+// EIGHT migrated sites (PR-B's three + PR-D's five) against a non-declaring store double:
+// `store.settleStep === undefined` by construction (own-property masking — never implemented, not
+// merely set to undefined, matching the RunStore.settleStep OPTIONAL contract). Each site is
+// proven byte-identical-SHAPED to legacy behavior (same membership/terminal outcomes the migrated
+// path also produces) PLUS the ONE dormancy advisory (I16) every legacy-path envelope now carries.
 import { describe, it, expect } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { JsonFileStore } from '../store/json-file-store.js';
-import { executeStep } from './execution-loop.js';
+import { executeStep, executeChain, submitHumanResponse } from './execution-loop.js';
 import { ExtensionRegistry } from '../extensions/registry.js';
 import type {
   RunStore,
@@ -20,6 +20,7 @@ import type {
 } from '../store/store-interface.js';
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { TraceBufferStore, BufferedEntry, AppendResult } from '../store/trace-buffer-store.js';
 import type { StepHandler } from '../extensions/step-handler.js';
 
 /**
@@ -187,6 +188,194 @@ describe('dormancy suite — the legacy path is byte-identical-shaped + the ONE 
       // is ever minted on the dormancy path (mintFresh lives exclusively inside applySettlement).
       expect(finalRun.finalizer_ledger).toBeUndefined();
       expect(finalRun.completed_steps).toContain('fin');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // issue #279, increment 2, PR-D — the five NEWLY migrated sites, same discipline.
+  // -------------------------------------------------------------------------
+
+  it('GATE-OPEN site: a non-declaring store settles via the legacy path — opens the gate, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-gate-open-wf',
+        name: 'Dormancy gate open',
+        version: 1,
+        steps: {
+          work: {
+            description: 'w',
+            execution: 'agent',
+            depends_on: [],
+            trust: 'human_confirmed',
+            gate: { choices: ['approve', 'reject'] },
+          },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      expect(result.status).toBe('confirm_required');
+      expect(result.gate?.step_name).toBe('work');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+      const finalRun = await store.get(run.id);
+      expect(finalRun.pending_gate?.step_name).toBe('work');
+    });
+  });
+
+  it('GATE-RESOLUTION site: a non-declaring store settles via the legacy path — resolves the gate, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-gate-resolve-wf',
+        name: 'Dormancy gate resolve',
+        version: 1,
+        steps: {
+          work: {
+            description: 'w',
+            execution: 'agent',
+            depends_on: [],
+            trust: 'human_confirmed',
+            gate: { choices: ['approve', 'reject'] },
+          },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      expect(opened.status).toBe('confirm_required');
+      const result = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: opened.gate!.gate_id,
+        choice: 'approve',
+      });
+      expect(result.status).toBe('ok');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+      const finalRun = await store.get(run.id);
+      expect(finalRun.completed_steps).toContain('work');
+      expect(finalRun.terminal_state).toBe(true);
+    });
+  });
+
+  it('GUARD-CHAIN site: a non-declaring store settles via the legacy path — the guard aborts the run, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-guard-abort-wf',
+        name: 'Dormancy guard abort',
+        version: 1,
+        steps: {
+          step_a: { description: 'a', execution: 'agent', depends_on: [] },
+          guard_b: {
+            description: 'g',
+            execution: 'guard',
+            depends_on: ['step_a'],
+            abort_unless: ["step_a.status == 'open'"],
+          },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      // ONE executeChain call settles step_a (via the same non-declaring dormancy fallback) AND
+      // then drives the guard chain inline — 'closed' ⇒ the guard condition fails ⇒ aborts.
+      const result = await executeChain(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'closed' }),
+      });
+      expect(result.status).toBe('ok');
+      const finalRun = await store.get(run.id);
+      expect(finalRun.terminal_state).toBe(true);
+      expect(finalRun.aborted_at?.step_id).toBe('guard_b');
+      // The guard's own terminal-return envelope (returned directly by executeChainInternal) —
+      // this IS the envelope that reaches the caller.
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+    });
+  });
+
+  it('CAPABILITY-RELEASE site: a non-declaring store settles via the legacy path — records the capability block, and the envelope carries the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-capability-release-wf',
+        name: 'Dormancy capability release',
+        version: 1,
+        steps: {
+          work: {
+            description: 'w',
+            execution: 'auto',
+            depends_on: [],
+            handler: 'not-registered-handler',
+          },
+        },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      // Empty registry — 'not-registered-handler' is never provided, forcing the
+      // ENGINE_HANDLER_NOT_REGISTERED recoverable-incapability leg.
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({}),
+        registry: new ExtensionRegistry(),
+      });
+      expect(result.status).toBe('error');
+      expect(result.error_code).toBe('ENGINE_HANDLER_NOT_REGISTERED');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+      const finalRun = await store.get(run.id);
+      expect(finalRun.capability_blocks?.['work']).toBeDefined();
+      expect(finalRun.in_progress_steps).not.toContain('work');
+      expect(finalRun.terminal_state).toBe(false); // recoverable — never terminal-burned
+    });
+  });
+
+  /** Succeeds on its FIRST `read()` call (the pre-claim enforce-gate read); throws on every
+   *  subsequent call (the post-claim re-read) — simulates the exact race the compensating
+   *  un-claim path exists to recover from (issue #207 PR-2, D3 §5). */
+  class ThrowsOnSecondReadTraceBufferStore implements TraceBufferStore {
+    private readCount = 0;
+    append(): Promise<AppendResult> {
+      throw new Error('append not used by this double');
+    }
+    async read(): Promise<BufferedEntry[]> {
+      this.readCount += 1;
+      if (this.readCount >= 2) throw new Error('simulated post-claim WAL read failure');
+      return [];
+    }
+    async delete(): Promise<void> {}
+    async deleteAllForRun(): Promise<void> {}
+    async readAllForRun(): Promise<Record<string, unknown[]>> {
+      return {};
+    }
+  }
+
+  it('COMPENSATING-UNCLAIM site: a non-declaring store logs-only via the legacy path — the ENGINE_STORE_FAILED envelope is the disclosure, carrying the dormancy advisory', async () => {
+    await withStore(async (store) => {
+      const def: WorkflowDefinition = {
+        id: 'dormancy-unclaim-wf',
+        name: 'Dormancy compensating unclaim',
+        version: 1,
+        steps: { work: { description: 'w', execution: 'agent', depends_on: [] } },
+      };
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({ ok: true }),
+        traceBufferStore: new ThrowsOnSecondReadTraceBufferStore(),
+      });
+      expect(result.status).toBe('error');
+      expect(result.error_code).toBe('ENGINE_STORE_FAILED');
+      expect(result.warnings.some((w) => w.includes(DORMANCY_ADVISORY_SUBSTRING))).toBe(true);
+      // The claim was compensated (released) — log-only, but the step IS eligible again.
+      const finalRun = await store.get(run.id);
+      expect(finalRun.in_progress_steps).not.toContain('work');
+      expect(finalRun.claims?.['work']).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/engine/envelope-pins-279.test.ts
+++ b/packages/core/src/engine/envelope-pins-279.test.ts
@@ -1,0 +1,623 @@
+// envelope-pins-279.test.ts — D-4 typed envelope pins (issue #279, increment 2, PR-D, Deliverable
+// 5): the run_terminal cancelled/zombie discriminator, gate_choice_conflict + winning_choice,
+// already_open's LIVE-gate render, the N1 neutral-wording arm, capability-block refusal
+// degradation, the convergence hint, respondedBy, and evaluatedAtVersion. A mix of real-engine-flow
+// tests (where the scenario is genuinely reachable) and forced-result store doubles (where D-1/N1's
+// own defensive arms are documented as in-contract UNREACHABLE — the ENVELOPE TEXT LOGIC is still
+// unit-testable this way, per the same technique used by guard-chain-consumption-279.test.ts).
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep, executeChain, submitHumanResponse } from './execution-loop.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { RunStore, CreateRunOptions } from '../store/store-interface.js';
+import type { SettlementDelta, SettlementResult } from '../types/settlement.js';
+
+describe('run_terminal envelope — the composed cancelled-predicate (issue #279, increment 2, PR-D, design record D-4)', () => {
+  it('CANCELLED variant: a gate cancelled by a sibling abort discloses "your choice was NOT recorded" + the aborting step', async () => {
+    const def: WorkflowDefinition = {
+      id: 'run-terminal-cancelled-wf',
+      name: 'Run-terminal cancelled variant',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+        aborter: {
+          description: 'aborts',
+          execution: 'auto',
+          depends_on: [],
+          handler: 'abort-handler',
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-cancelled-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      // Pre-claim `aborter` FIRST (before the gate opens) — eligibility.ts's "gate blocks ALL
+      // eligibility" invariant means aborter could never be independently claimed WHILE a gate is
+      // already open; mirroring gate-death-279.test.ts's own fix, both steps' claims must exist
+      // before either commits, matching a realistic fan-out where both were dispatched together.
+      const claimedAborter = await store.claimStep(run.id, 'aborter', def);
+      const aborterToken = claimedAborter.claims?.['aborter']?.token;
+
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      expect(opened.status).toBe('confirm_required');
+      const gateId = opened.gate!.gate_id;
+
+      // aborter's OWN settle_step abort — the REAL applyAbortEdge call executeStep's handler-abort
+      // path would have made, applied directly against the CURRENT fresh state (which shows
+      // gate_step's gate open) — proving the cancel-gate logic fires against a genuinely-open gate.
+      const abortSettle = await store.settleStep!(
+        run.id,
+        {
+          kind: 'settle_step',
+          step: 'aborter',
+          outcome: 'abort',
+          ...(aborterToken !== undefined ? { claimToken: aborterToken } : {}),
+          evidence: [],
+          abort: { stepId: 'aborter', abortMessage: 'aborter says stop' },
+        },
+        def,
+      );
+      expect(abortSettle.applied).toBe(true);
+
+      const finalRunAfterAbort = await store.get(run.id);
+      expect(finalRunAfterAbort.terminal_state).toBe(true);
+      expect(finalRunAfterAbort.skip_details?.['gate_step']?.kind).toBe('gate_cancelled_by_abort');
+
+      const submitAfterCancel = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId,
+        choice: 'approve',
+      });
+      expect(submitAfterCancel.status).toBe('error');
+      expect(submitAfterCancel.error_code).toBe('STATE_RUN_TERMINAL');
+      expect(submitAfterCancel.errors[0]).toContain('NOT recorded');
+      expect(submitAfterCancel.errors[0]).toContain('aborter');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ZOMBIE variant: a grandfathered terminal-with-stale-gate record (no cancel skip-detail) gets the plain terminal text + the resume/purge pointer', async () => {
+    const def: WorkflowDefinition = {
+      id: 'run-terminal-zombie-wf',
+      name: 'Run-terminal zombie variant',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-zombie-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      // Hand-shape a #282-class grandfathered record: terminal AND still carrying a pending_gate,
+      // with NO gate_cancelled_by_abort skip detail (the class this closure legislates over).
+      const zombie = await store.update({
+        ...run,
+        completed_steps: ['gate_step'],
+        terminal_state: true,
+        terminal_reason: 'Workflow completed.',
+        pending_gate: {
+          gate_id: 'zombie-gate',
+          step_name: 'gate_step',
+          preview: {},
+          choices: ['approve', 'reject'],
+          opened_at: new Date().toISOString(),
+        },
+      });
+
+      const result = await submitHumanResponse(store, def, {
+        runId: zombie.id,
+        gateId: 'zombie-gate',
+        choice: 'approve',
+      });
+      expect(result.status).toBe('error');
+      expect(result.error_code).toBe('STATE_RUN_TERMINAL');
+      expect(result.errors[0]).not.toContain('NOT recorded'); // never the cancelled text
+      expect(result.errors[0]).toContain('realm resume');
+      expect(result.errors[0]).toContain('realm run purge');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('gate_choice_conflict envelope (issue #279, increment 2, PR-D)', () => {
+  it('a DIFFERENT choice submitted against an already-resolved gate is refused with the winning choice named', async () => {
+    const def: WorkflowDefinition = {
+      id: 'gate-choice-conflict-wf',
+      name: 'Gate choice conflict',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-conflict-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      const gateId = opened.gate!.gate_id;
+
+      const firstSubmit = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId,
+        choice: 'approve',
+      });
+      expect(firstSubmit.status).toBe('ok');
+
+      const conflictingSubmit = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId,
+        choice: 'reject',
+      });
+      expect(conflictingSubmit.status).toBe('error');
+      expect(conflictingSubmit.error_code).toBe('STATE_BLOCKED');
+      expect(conflictingSubmit.error_details?.['winning_choice']).toBe('approve');
+      expect(conflictingSubmit.errors[0]).toContain('approve');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/** Delegates every method to a real JsonFileStore, except `settleStep`, which — for the FIRST
+ *  call matching `matches` — returns a HAND-CONSTRUCTED SettlementResult instead of delegating.
+ *  Used ONLY for D-1/N1's own documented in-contract-UNREACHABLE defensive arms, where the ENGINE
+ *  cannot honestly reach the scenario, but the ENVELOPE TEXT LOGIC built around it is still real,
+ *  shipped code this repo must pin. */
+class ForcesResultStore implements RunStore {
+  readonly persistsClaims: boolean;
+  private forced = false;
+  constructor(
+    private readonly inner: JsonFileStore,
+    private readonly matches: (delta: SettlementDelta) => boolean,
+    private readonly forcedResult: (fresh: RunRecord) => SettlementResult,
+  ) {
+    this.persistsClaims = inner.persistsClaims;
+  }
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    return this.inner.create(options);
+  }
+  get(runId: string): Promise<RunRecord> {
+    return this.inner.get(runId);
+  }
+  update(record: RunRecord): Promise<RunRecord> {
+    return this.inner.update(record);
+  }
+  list(workflowId?: string): Promise<RunRecord[]> {
+    return this.inner.list(workflowId);
+  }
+  claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord> {
+    return this.inner.claimStep(runId, stepName, definition);
+  }
+  async settleStep(
+    runId: string,
+    delta: SettlementDelta,
+    definition: WorkflowDefinition,
+    options?: { now?: Date },
+  ): Promise<SettlementResult> {
+    if (!this.forced && this.matches(delta)) {
+      this.forced = true;
+      const fresh = await this.inner.get(runId);
+      return this.forcedResult(fresh);
+    }
+    return this.inner.settleStep(runId, delta, definition, options);
+  }
+}
+
+describe('already_open envelope — the LIVE gate wins, rendered verbatim (issue #279, increment 2, PR-D, design record D-1 — in-contract UNREACHABLE, forced for the envelope pin)', () => {
+  it('a forced already_open NOOP renders the LIVE PendingGate, calm, confirm_required, never report_to_user', async () => {
+    const def: WorkflowDefinition = {
+      id: 'already-open-wf',
+      name: 'Already-open fixture',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-already-open-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const liveGate = {
+        gate_id: 'live-gate-id',
+        step_name: 'gate_step',
+        preview: { forced: true },
+        choices: ['approve', 'reject'],
+        opened_at: new Date().toISOString(),
+      };
+      const store = new ForcesResultStore(
+        inner,
+        (d) => d.kind === 'open_gate',
+        (fresh) => ({
+          applied: false,
+          reason: 'already_open',
+          run: { ...fresh, pending_gate: liveGate },
+          gate: liveGate,
+        }),
+      );
+
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+
+      expect(result.status).toBe('confirm_required');
+      expect(result.agent_action).toBeUndefined(); // never report_to_user
+      expect(result.gate?.gate_id).toBe('live-gate-id'); // the LIVE gate, not the rebuilt one
+      expect(result.gate?.preview).toEqual({ forced: true });
+      expect(result.context_hint).toContain('already paused');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('N1 neutral wording — never amplify a "by_other" white lie (issue #279, increment 2, PR-D, design record §2/§11, forced for the envelope pin)', () => {
+  it('open_gate refused already_settled_by_other with a persisted "gate" outcome renders "by a completed gate", never "by a different attempt"', async () => {
+    const def: WorkflowDefinition = {
+      id: 'n1-wording-wf',
+      name: 'N1 wording fixture',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-n1-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const store = new ForcesResultStore(
+        inner,
+        (d) => d.kind === 'open_gate',
+        (fresh) => ({
+          applied: false,
+          reason: 'already_settled_by_other',
+          run: {
+            ...fresh,
+            completed_steps: ['gate_step'],
+            settled: {
+              gate_step: { token: 'some-other-gate-id', outcome: 'gate', choice: 'approve' },
+            },
+          },
+        }),
+      );
+
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.errors[0]).toContain('by a completed gate');
+      expect(result.errors[0]).not.toContain('by a different attempt');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('capability-block refusal degradation (issue #279, increment 2, PR-D, Deliverable 1d)', () => {
+  it('a sibling settles the SAME step FIRST ⇒ the capability-block release is refused, but the SAME block envelope + a typed warning is returned (claim survives for reclaim)', async () => {
+    const def: WorkflowDefinition = {
+      id: 'capability-refusal-wf',
+      name: 'Capability-block refusal fixture',
+      version: 1,
+      steps: {
+        work: { description: 'w', execution: 'auto', depends_on: [], handler: 'not-registered' },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-cap-refusal-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const store = new ForcesResultStore(
+        inner,
+        (d) => d.kind === 'release_step',
+        (fresh) => ({ applied: false, reason: 'claim_lost', run: fresh }),
+      );
+
+      const result = await executeStep(store, def, {
+        runId: run.id,
+        command: 'work',
+        input: {},
+        dispatcher: async () => ({}),
+        registry: new ExtensionRegistry(),
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error_code).toBe('ENGINE_HANDLER_NOT_REGISTERED'); // the SAME block envelope
+      expect(result.warnings.some((w) => w.includes('capability block not persisted'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('claim_lost'))).toBe(true);
+      expect(JSON.stringify(result)).not.toContain('STATE_CLAIM_LOST'); // never that framing
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the convergence hint (issue #279, increment 2, PR-D, design record D-2 N8 narrowing)', () => {
+  it('present: a committed RESOLVE that makes a guard eligible appends "guard <name> now eligible" to the success envelope', async () => {
+    const def: WorkflowDefinition = {
+      id: 'convergence-hint-present-wf',
+      name: 'Convergence hint present',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+        guard_after: {
+          description: 'g',
+          execution: 'guard',
+          depends_on: ['gate_step'],
+          abort_unless: ["gate_step.choice == 'approve'"],
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-hint-present-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      const result = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: opened.gate!.gate_id,
+        choice: 'approve',
+      });
+      expect(result.status).toBe('ok');
+      expect(
+        result.warnings.some(
+          (w) => w.includes("guard 'guard_after' now eligible") && w.includes('converges'),
+        ),
+      ).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('absent: a RESOLVE with no eligible guard carries no convergence hint', async () => {
+    const def: WorkflowDefinition = {
+      id: 'convergence-hint-absent-wf',
+      name: 'Convergence hint absent',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-envelope-hint-absent-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      const result = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: opened.gate!.gate_id,
+        choice: 'approve',
+      });
+      expect(result.status).toBe('ok');
+      expect(result.warnings.some((w) => w.includes('now eligible'))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('respondedBy — recorded, not enforced (issue #279, increment 2, PR-D, design record D-5)', () => {
+  it('supplied: populates BOTH the delta AND the gate_response evidence snapshot', async () => {
+    const def: WorkflowDefinition = {
+      id: 'responded-by-supplied-wf',
+      name: 'RespondedBy supplied',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-responded-by-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      let capturedDelta: SettlementDelta | undefined;
+      const store = new ForcesResultStore(
+        inner,
+        (d) => {
+          if (d.kind === 'settle_gate') capturedDelta = d;
+          return false; // never actually force — just observe, then let the real store handle it
+        },
+        (fresh) => ({ applied: true, run: fresh, transitioned: false, pendingFinalizers: [] }),
+      );
+      const opened = await executeStep(inner, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      const result = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: opened.gate!.gate_id,
+        choice: 'approve',
+        respondedBy: 'operator-42',
+      });
+      expect(result.status).toBe('ok');
+      expect(capturedDelta?.kind).toBe('settle_gate');
+      expect((capturedDelta as { respondedBy?: string }).respondedBy).toBe('operator-42');
+      const finalRun = await inner.get(run.id);
+      const gateEvidence = finalRun.evidence.find((e) => e.kind === 'gate_response');
+      expect(gateEvidence?.responded_by).toBe('operator-42');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('absent: never set on the delta or the snapshot when not supplied', async () => {
+    const def: WorkflowDefinition = {
+      id: 'responded-by-absent-wf',
+      name: 'RespondedBy absent',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-responded-by-absent-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: opened.gate!.gate_id,
+        choice: 'approve',
+      });
+      const finalRun = await store.get(run.id);
+      const gateEvidence = finalRun.evidence.find((e) => e.kind === 'gate_response');
+      expect(gateEvidence?.responded_by).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("evaluatedAtVersion — the chain's own evaluation snapshot (issue #279, increment 2, PR-D, design record §2, lane-B steal 2)", () => {
+  it('populated by the guard chain with the pre-settle run version', async () => {
+    const def: WorkflowDefinition = {
+      id: 'evaluated-at-version-wf',
+      name: 'EvaluatedAtVersion fixture',
+      version: 1,
+      steps: {
+        step_a: { description: 'a', execution: 'agent', depends_on: [] },
+        guard_b: {
+          description: 'g',
+          execution: 'guard',
+          depends_on: ['step_a'],
+          abort_unless: ["step_a.status == 'open'"],
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-evaluated-at-version-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      let capturedDelta: SettlementDelta | undefined;
+      const store = new ForcesResultStore(
+        inner,
+        (d) => {
+          if (d.kind === 'settle_guard') capturedDelta = d;
+          return false; // observe only
+        },
+        (fresh) => ({ applied: true, run: fresh, transitioned: false, pendingFinalizers: [] }),
+      );
+
+      const preGuardRun = await inner.get(run.id); // before step_a settles — just to prove intent
+      expect(preGuardRun.version).toBeDefined();
+
+      await executeChain(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'open' }),
+      });
+
+      expect(capturedDelta?.kind).toBe('settle_guard');
+      const runAfterStepA = await inner.get(run.id).catch(() => undefined);
+      // The captured delta's evaluatedAtVersion is the run version AT THE MOMENT the guard chain
+      // evaluated it — i.e., immediately after step_a's own settle committed (version bumped once),
+      // strictly BEFORE the guard's own settle (which would bump it again).
+      expect((capturedDelta as { evaluatedAtVersion?: number }).evaluatedAtVersion).toBeDefined();
+      if (runAfterStepA !== undefined) {
+        expect(
+          (capturedDelta as { evaluatedAtVersion?: number }).evaluatedAtVersion,
+        ).toBeLessThanOrEqual(runAfterStepA.version);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/execution-loop.test.ts
+++ b/packages/core/src/engine/execution-loop.test.ts
@@ -2748,7 +2748,7 @@ describe('executeStep', () => {
       }
     });
 
-    it('trace_schema warn: gate store.update error envelope retains trace warning', async () => {
+    it('trace_schema warn: gate settleStep error envelope retains trace warning', async () => {
       const def: WorkflowDefinition = {
         ...traceSchemaDefinitionBase,
         steps: {
@@ -2767,8 +2767,10 @@ describe('executeStep', () => {
         params: {},
       });
 
-      // Mock store.update to throw — simulates the gate persistence failure (post-dispatch)
-      vi.spyOn(store, 'update').mockImplementation(async () => {
+      // issue #279 (increment 2, PR-D): gate-open now persists via store.settleStep (not
+      // store.update) on a declaring store — mock THAT to simulate the gate persistence failure
+      // (post-dispatch). Mocking store.update alone no longer reaches the gate-open write path.
+      vi.spyOn(store, 'settleStep').mockImplementation(async () => {
         throw new Error('gate store write failed');
       });
 

--- a/packages/core/src/engine/execution-loop.ts
+++ b/packages/core/src/engine/execution-loop.ts
@@ -9,6 +9,7 @@ import type {
   WorkflowContextSnapshot,
   AgentTraceEntry,
   TraceNormalizationSummary,
+  PendingGate,
 } from '../types/run-record.js';
 import type { ToolCallRecord } from '../types/mcp-types.js';
 import { extensionIdentityDiffers } from '../types/extension-identity.js';
@@ -32,6 +33,10 @@ import type {
   SettleStepDelta,
   SettlementResult,
   MarkFinalizerResult,
+  OpenGateDelta,
+  SettleGateDelta,
+  SettleGuardDelta,
+  ReleaseStepDelta,
 } from '../types/settlement.js';
 import { captureEvidence } from '../evidence/snapshot.js';
 import {
@@ -136,6 +141,13 @@ export interface SubmitGateOptions {
    * gates on workflows with finalizers should thread their run registry here.
    */
   registry?: ExtensionRegistry;
+  /**
+   * Issue #279 (increment 2, PR-D; design record D-5): unenforced attribution passthrough — flows
+   * into the `SettleGateDelta.respondedBy` field AND the gate_response evidence snapshot's own
+   * `responded_by` field when supplied. RECORDED, not enforced (the bearer-gateId-as-sole-
+   * credential model stays authoritative); no arm ever reads it.
+   */
+  respondedBy?: string;
 }
 
 export interface ExecuteChainOptions {
@@ -658,6 +670,26 @@ function stampDefaultedSteps(sealDraft: RunRecord): RunRecord {
 }
 
 /**
+ * The compensating un-claim's own audit-evidence entry (issue #207 PR-2, D3 §5; extracted issue
+ * #279, increment 2, PR-D, Deliverable 1e — the `:679` semantics both the legacy
+ * `buildCompensatingUnclaim` below AND the migrated `release_step` delta's `evidence` field share
+ * verbatim).
+ */
+function buildCompensatingUnclaimEvidence(stepName: string, now: Date): EvidenceSnapshot {
+  return captureEvidence({
+    stepId: stepName,
+    startedAt: now,
+    completedAt: now,
+    input: {},
+    output: {
+      compensating_unclaim: true,
+      reason: 'adoption-read failure after claim',
+      unclaimed_at: now.toISOString(),
+    },
+  });
+}
+
+/**
  * Compensating un-claim (issue #207 PR-2, D3 §5): built from `pendingRun` — the record OUR OWN
  * `claimStep` call returned, never a fresh get — removing the step from `in_progress_steps` AND
  * `claims[step]` in the SAME mutation (the settle-site invariant every other settle path in this
@@ -670,17 +702,7 @@ function stampDefaultedSteps(sealDraft: RunRecord): RunRecord {
  * naturally idempotent) is simply a no-op mutation, not a special case.
  */
 function buildCompensatingUnclaim(pendingRun: RunRecord, stepName: string, now: Date): RunRecord {
-  const auditEvidence = captureEvidence({
-    stepId: stepName,
-    startedAt: now,
-    completedAt: now,
-    input: {},
-    output: {
-      compensating_unclaim: true,
-      reason: 'adoption-read failure after claim',
-      unclaimed_at: now.toISOString(),
-    },
-  });
+  const auditEvidence = buildCompensatingUnclaimEvidence(stepName, now);
   return {
     ...pendingRun,
     in_progress_steps: pendingRun.in_progress_steps.filter((s) => s !== stepName),
@@ -945,13 +967,18 @@ function computeReArmWarnings(
 }
 
 /**
- * Builds the ResponseEnvelope for a `settle_step` REFUSAL (design record §7's result/code table) —
- * shared by all three migrated seal sites (issue #279, increment 1, PR-B). `allEvidence` is
- * attached ONLY for `claim_lost`: the dispatch DID run and produce evidence; it just was not
- * recorded, so the caller should still see what happened. The four other reasons `settle_step` can
- * actually return are enumerated explicitly; the remaining nine `SettlementRefusalReason` members
- * are lease/mark-only and structurally unreachable here (a `default` throws rather than silently
- * mis-rendering one).
+ * Builds the ResponseEnvelope for a `settle_step`/`open_gate` REFUSAL (design record §7's
+ * result/code table) — shared by the three migrated `settle_step` seal sites (issue #279,
+ * increment 1, PR-B) AND the migrated gate-open site (issue #279, increment 2, PR-D; `kind:
+ * 'open_gate'`). `allEvidence` is attached ONLY for `claim_lost`: the dispatch DID run and produce
+ * evidence; it just was not recorded, so the caller should still see what happened. The reasons
+ * both callers can actually return are enumerated explicitly; every OTHER `SettlementRefusalReason`
+ * member is lease/mark/settle_gate/settle_guard/release_step-only and structurally unreachable
+ * here (a `default` throws rather than silently mis-rendering one) — `choice_not_eligible` +
+ * `gate_choice_conflict` + the settle_gate `gate_mismatch`/`run_terminal` variants are consumed at
+ * 1b's own `errorEnvelope` (submitHumanResponse), never here; `gate_open_wait` is chain-consumed
+ * (executeChainInternal's guard loop); `already_released` is site-handled at 1d/1e (never routed
+ * through this shared builder).
  */
 function buildSettlementRefusalEnvelope(
   options: ExecuteStepOptions,
@@ -959,16 +986,21 @@ function buildSettlementRefusalEnvelope(
   result: Extract<SettlementResult, { applied: false }>,
   allEvidence: EvidenceSnapshot[],
   traceWarnings: string[],
+  kind: 'settle_step' | 'open_gate' = 'settle_step',
 ): ResponseEnvelope {
   const extraWarnings = traceWarnings.length > 0 ? traceWarnings : undefined;
   switch (result.reason) {
     case 'already_settled_by_other':
     case 'settled_outcome_divergence': {
       const persisted = result.run.settled?.[options.command]?.outcome;
+      // N1 (design record §2/§11): neutral wording — never amplify a "by_other" white lie. When
+      // the persisted entry's outcome is 'gate', the step was settled by a COMPLETED GATE (a
+      // human decision resolved elsewhere), not literally "a different attempt".
+      const settledByText = persisted === 'gate' ? 'by a completed gate' : 'by a different attempt';
       const err = new WorkflowError(
         `Step '${options.command}' was already settled` +
           (persisted !== undefined ? ` with outcome '${persisted}'` : '') +
-          ` by a different attempt.`,
+          ` ${settledByText}.`,
         {
           code: 'STATE_STEP_ALREADY_SETTLED',
           category: 'STATE',
@@ -1015,25 +1047,33 @@ function buildSettlementRefusalEnvelope(
       return makeErrorEnvelope(options, result.run, err, definition, extraWarnings);
     }
     case 'gate_mismatch': {
-      const err = new WorkflowError(
-        `Step '${options.command}' is the currently open gate; resolve it via ` +
-          `submit_human_response instead of settling it directly.`,
-        {
-          code: 'STATE_BLOCKED',
-          category: 'STATE',
-          agentAction: 'resolve_precondition',
-          retryable: false,
-          details: { runId: options.runId, step: options.command },
-        },
-      );
+      // kind-discriminated (Deliverable 2): open_gate's gate_mismatch means a DIFFERENT step's
+      // gate is open (this step stays claimed — L13); settle_step's means THIS step IS the open
+      // gate and must be resolved via submit_human_response instead.
+      const message =
+        kind === 'open_gate'
+          ? `Step '${options.command}': a gate is open on another step — wait for its resolution; ` +
+            `this step stays claimed.`
+          : `Step '${options.command}' is the currently open gate; resolve it via ` +
+            `submit_human_response instead of settling it directly.`;
+      const err = new WorkflowError(message, {
+        code: 'STATE_BLOCKED',
+        category: 'STATE',
+        agentAction: 'resolve_precondition',
+        retryable: false,
+        details: { runId: options.runId, step: options.command },
+      });
       return makeErrorEnvelope(options, result.run, err, definition, extraWarnings);
     }
     default:
       // run_not_terminal / ledger_not_pending / lease_held / lease_lost / rank_blocked /
-      // not_eligible / already_leased / already_marked are lease_finalizer/mark_finalizer-only —
-      // settle_step never returns them (design record §7).
+      // not_eligible / already_leased / already_marked / already_open / already_released /
+      // gate_choice_conflict / choice_not_eligible / gate_open_wait are all consumed elsewhere
+      // (lease_finalizer/mark_finalizer's own drain loop; open_gate's own NOOP arms at the 1a call
+      // site; 1b's own errorEnvelope; 1d/1e's own site-handling; the guard chain) — settle_step and
+      // open_gate never return them here (design record §7).
       throw new Error(
-        `buildSettlementRefusalEnvelope: unreachable settle_step refusal reason '${result.reason}'`,
+        `buildSettlementRefusalEnvelope: unreachable '${kind}' refusal reason '${result.reason}'`,
       );
   }
 }
@@ -1610,12 +1650,40 @@ export async function executeStep(
           ? await options.traceBufferStore.read(options.runId, options.command)
           : [];
     } catch (err) {
-      try {
-        await store.update(buildCompensatingUnclaim(pendingRun, options.command, new Date()));
-      } catch {
-        // CAS mismatch (someone else already resolved the claim) or any other failure to even
-        // un-claim: stop immediately, leave the claim exactly as it is — never retry here.
+      // issue #279 (increment 2, PR-D, Deliverable 1e): the migrated path — settles this release
+      // atomically against FRESH state via the store's own settleStep, evidence = the SAME
+      // compensating_unclaim audit line (:679 semantics). LOG-ONLY for ALL results (applied / NOOP
+      // / any refusal / a thrown infra error) — no envelope change on any settle outcome; the
+      // ENGINE_STORE_FAILED envelope below is the disclosure regardless. Dormancy: an undeclaring
+      // store falls through to the byte-identical legacy path (I16/#169 fail-closed dormancy).
+      let unclaimDormancyWarning: string | undefined;
+      if (store.settleStep !== undefined) {
+        const unclaimToken = pendingRun.claims?.[options.command]?.token;
+        const delta: ReleaseStepDelta = {
+          kind: 'release_step',
+          step: options.command,
+          ...(unclaimToken !== undefined ? { claimToken: unclaimToken } : {}),
+          evidence: [buildCompensatingUnclaimEvidence(options.command, new Date())],
+        };
+        try {
+          await store.settleStep(options.runId, delta, definition);
+        } catch {
+          // Log-only — see the comment above; never surfaces as its own error.
+        }
+      } else {
+        // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
+        try {
+          await store.update(buildCompensatingUnclaim(pendingRun, options.command, new Date()));
+        } catch {
+          // CAS mismatch (someone else already resolved the claim) or any other failure to even
+          // un-claim: stop immediately, leave the claim exactly as it is — never retry here.
+        }
+        // issue #279 (increment 2, PR-D): + the ONE dormancy advisory (I16) — this IS the legacy
+        // path (store.settleStep undeclared); the ENGINE_STORE_FAILED envelope below is its only
+        // carrier since this release is log-only.
+        unclaimDormancyWarning = DORMANCY_ADVISORY;
       }
+      const unclaimEnvelopeWarnings = mergeWarnings(traceWarnings, unclaimDormancyWarning);
       return makeErrorEnvelope(
         options,
         pendingRun,
@@ -1630,7 +1698,7 @@ export async function executeStep(
           },
         }),
         definition,
-        traceWarnings.length > 0 ? traceWarnings : undefined,
+        unclaimEnvelopeWarnings.length > 0 ? unclaimEnvelopeWarnings : undefined,
       );
     }
 
@@ -2478,12 +2546,60 @@ export async function executeStep(
       // (on the happy path store.update recomputes it identically via deriveRunPhase).
       const blockedRun: RunRecord = { ...blockedDraft, run_phase: deriveRunPhase(blockedDraft) };
 
+      // issue #279 (increment 2, PR-D, Deliverable 1d): the migrated path — settles this release
+      // atomically against FRESH state via the store's own settleStep. This site NEVER calls the
+      // shared buildSettlementRefusalEnvelope: regardless of write outcome (applied / NOOP
+      // already_released / any OTHER refusal / a thrown infra error), the RETURNED envelope is
+      // ALWAYS this SAME capability-block report — only whether the internal capability_blocks
+      // marker got durably persisted varies, disclosed via blockStoreWarning. Dormancy: an
+      // undeclaring store falls through to the byte-identical legacy path below (I16/#169
+      // fail-closed dormancy).
       let persistedBlockedRun: RunRecord | undefined;
       let blockStoreWarning: string | undefined;
-      try {
-        persistedBlockedRun = await store.update(blockedRun);
-      } catch (storeErr) {
-        blockStoreWarning = `Failed to persist capability block: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
+      let dormancyWarning: string | undefined;
+      if (store.settleStep !== undefined) {
+        const releaseClaimToken = pendingRun.claims?.[options.command]?.token;
+        const delta: ReleaseStepDelta = {
+          kind: 'release_step',
+          step: options.command,
+          ...(releaseClaimToken !== undefined ? { claimToken: releaseClaimToken } : {}),
+          capabilityBlock: {
+            requirement:
+              requirement !== undefined
+                ? { kind: requirement.kind, name: requirement.name }
+                : {
+                    kind:
+                      recoverableCode === 'ENGINE_HANDLER_NOT_REGISTERED' ? 'handler' : 'adapter',
+                    name: 'unknown',
+                  },
+            code: recoverableCode,
+          },
+          // The current :2490 append — legacy parity; the compensating un-claim's own :679
+          // audit-line channel belongs to Deliverable 1e ONLY.
+          evidence: allEvidence,
+        };
+        try {
+          const releaseResult = await store.settleStep(options.runId, delta, definition);
+          persistedBlockedRun = releaseResult.run;
+          // applied / NOOP already_released ⇒ the block envelope exactly as today (NOOP merges
+          // silently — no extra warning). ANY OTHER refusal ⇒ the same block envelope + a typed
+          // warning (never STATE_CLAIM_LOST framing) — the claim survives for reclaim either way.
+          if (!releaseResult.applied && releaseResult.reason !== 'already_released') {
+            blockStoreWarning = `capability block not persisted: ${releaseResult.reason}`;
+          }
+        } catch (storeErr) {
+          blockStoreWarning = `Failed to persist capability block: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
+        }
+      } else {
+        // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
+        try {
+          persistedBlockedRun = await store.update(blockedRun);
+        } catch (storeErr) {
+          blockStoreWarning = `Failed to persist capability block: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`;
+        }
+        // issue #279 (increment 2, PR-D): + the ONE dormancy advisory (I16) — this IS the legacy
+        // path (store.settleStep undeclared).
+        dormancyWarning = DORMANCY_ADVISORY;
       }
       // issue #207 PR-2 (D3 §5): NO WAL delete belongs on this capability-block settle path — the
       // prior try/catch here was removed, not just gated. Contract-consistency hygiene, not a
@@ -2519,7 +2635,7 @@ export async function executeStep(
         status: 'error',
         data: {},
         evidence: allEvidence,
-        warnings: mergeWarnings(traceWarnings, blockStoreWarning),
+        warnings: mergeWarnings(traceWarnings, blockStoreWarning, dormancyWarning),
         errors: [dispatchError.message],
         agent_action: blockedAction,
         error_code: recoverableCode,
@@ -2951,24 +3067,200 @@ export async function executeStep(
 
     const gateConfig = stepDef!.gate;
 
+    // The PendingGate object is built EXACTLY as before, regardless of which path commits it below
+    // (issue #279, increment 2, PR-D, Deliverable 1a — the migrated `open_gate` delta carries this
+    // SAME object verbatim; the legacy fallback writes it via `store.update` unchanged).
+    const pendingGate: PendingGate = {
+      gate_id,
+      step_name,
+      preview: output,
+      choices,
+      opened_at: new Date().toISOString(),
+      ...(gateConfig?.owner !== undefined ? { owner: gateConfig.owner } : {}),
+      ...(resolvedGateMessage !== undefined ? { resolved_message: resolvedGateMessage } : {}),
+      ...(gateConfig?.resolution_messages !== undefined
+        ? { resolution_messages: gateConfig.resolution_messages }
+        : {}),
+    };
+
+    // gate.display fallback chain: gate.message resolved → step.prompt resolved → absent
+    const resolvedGateDisplay =
+      resolvedGateMessage !== undefined
+        ? resolvedGateMessage
+        : stepDef!.prompt !== undefined
+          ? renderTemplate(stepDef!.prompt, {
+              evidenceByStep: gateEvidenceCtxEarly,
+              runParams: run.params,
+              ...wfCtxSpreadEarly,
+            })
+          : undefined;
+    const resolvedGateInstructions =
+      stepDef!.instructions !== undefined
+        ? renderTemplate(stepDef!.instructions, {
+            evidenceByStep: gateEvidenceCtxEarly,
+            runParams: run.params,
+            ...wfCtxSpreadEarly,
+          })
+        : undefined;
+
+    function buildGateNextAction(id: string, gateChoices: string[], forStep: string): NextAction {
+      return {
+        instruction: {
+          tool: 'submit_human_response',
+          params: { run_id: options.runId, gate_id: id },
+          call_with: {
+            run_id: options.runId,
+            gate_id: id,
+            choice: `<${gateChoices.join('|')}>`,
+          },
+        },
+        human_readable: `Human review required for step '${forStep}'. Present gate.display to the user, wait for their choice from gate.response_spec.choices, then call submit_human_response.`,
+        orientation: `Run is paused at gate '${id}'. Available choices: ${gateChoices.join(', ')}.`,
+      };
+    }
+
+    // issue #279 (increment 2, PR-D, Deliverable 1a): the migrated path — opens this gate
+    // atomically against FRESH state via the store's own settleStep. Dormancy: an undeclaring
+    // store falls through to the byte-identical legacy path below (I16/#169 fail-closed dormancy).
+    if (store.settleStep !== undefined) {
+      const openClaimToken = pendingRun.claims?.[options.command]?.token;
+      const delta: OpenGateDelta = {
+        kind: 'open_gate',
+        step: options.command,
+        ...(openClaimToken !== undefined ? { claimToken: openClaimToken } : {}),
+        pendingGate,
+        evidence: allEvidence,
+      };
+      let result: SettlementResult;
+      try {
+        result = await store.settleStep(options.runId, delta, definition);
+      } catch (err) {
+        // THROWN infra errors — the same catch shape replicated at every migrated site.
+        if (err instanceof WorkflowError) {
+          return makeErrorEnvelope(
+            options,
+            pendingRun,
+            err,
+            definition,
+            traceWarnings.length > 0 ? traceWarnings : undefined,
+          );
+        }
+        const internal = new WorkflowError('Failed to open gate', {
+          code: 'ENGINE_STORE_FAILED',
+          category: 'ENGINE',
+          agentAction: 'stop',
+          retryable: false,
+        });
+        return makeErrorEnvelope(
+          options,
+          pendingRun,
+          internal,
+          definition,
+          traceWarnings.length > 0 ? traceWarnings : undefined,
+        );
+      }
+
+      if (!result.applied) {
+        if (result.reason === 'already_settled') {
+          // Ok-shaped NOOP — buildAlreadySettledEnvelope's SHAPE but WITHOUT its drain clause:
+          // gate-open NEVER drains (design record §6 row 1 — the crashed-drain recovery paths are
+          // the resolution site's own NOOP drain and the drain verb).
+          const noopRun = result.run;
+          const noopNextActions = noopRun.terminal_state
+            ? []
+            : buildNextActions(definition, noopRun);
+          return {
+            command: options.command,
+            run_id: options.runId,
+            run_version: noopRun.version,
+            status: 'ok',
+            data: {},
+            evidence: [],
+            warnings: [...traceWarnings],
+            errors: [],
+            context_hint: `Step '${options.command}' was already settled (a duplicate/retried attempt) — no action was taken.`,
+            run_phase: noopRun.run_phase,
+            next_actions: noopNextActions,
+          };
+        }
+        if (result.reason === 'already_open') {
+          // D-1: the LIVE gate wins — rendered VERBATIM (this delta's own rebuilt gate is
+          // discarded). Calm, confirm_required (the gate genuinely IS still open) — never
+          // report_to_user (no `agent_action` set, matching the fresh-open confirm_required shape).
+          const liveGate = result.gate!;
+          return {
+            command: options.command,
+            run_id: options.runId,
+            run_version: result.run.version,
+            status: 'confirm_required',
+            data: liveGate.preview,
+            evidence: [],
+            warnings: [...traceWarnings],
+            errors: [],
+            context_hint: `Run is already paused at gate '${liveGate.gate_id}'. Available choices: ${liveGate.choices.join(', ')}.`,
+            run_phase: result.run.run_phase,
+            next_actions: [
+              buildGateNextAction(liveGate.gate_id, liveGate.choices, liveGate.step_name),
+            ],
+            gate: {
+              gate_id: liveGate.gate_id,
+              step_name: liveGate.step_name,
+              preview: liveGate.preview,
+              choices: liveGate.choices,
+              ...(liveGate.resolved_message !== undefined
+                ? { display: liveGate.resolved_message }
+                : {}),
+              response_spec: { choices: liveGate.choices },
+            },
+          };
+        }
+        return buildSettlementRefusalEnvelope(
+          options,
+          definition,
+          result,
+          allEvidence,
+          traceWarnings,
+          'open_gate',
+        );
+      }
+
+      // applied: true — never terminalizes (design record §4.1); build confirm_required off
+      // result.run.
+      const gateRun = result.run;
+      return {
+        command: options.command,
+        run_id: options.runId,
+        run_version: gateRun.version,
+        status: 'confirm_required',
+        data: output,
+        evidence: allEvidence,
+        warnings: [...traceWarnings],
+        errors: [],
+        context_hint: `Run is paused at gate '${gate_id}'. Available choices: ${choices.join(', ')}.`,
+        run_phase: gateRun.run_phase,
+        next_actions: [buildGateNextAction(gate_id, choices, step_name)],
+        gate: {
+          gate_id,
+          step_name,
+          preview: output,
+          choices,
+          ...(resolvedGateDisplay !== undefined ? { display: resolvedGateDisplay } : {}),
+          ...(resolvedGateInstructions !== undefined
+            ? { agent_hint: resolvedGateInstructions }
+            : {}),
+          response_spec: { choices },
+        },
+      };
+    }
+
+    // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
     let gateRun: RunRecord;
     try {
       gateRun = await store.update({
         ...pendingRun,
         // Step stays in in_progress_steps while gate is open — moved to completed on submit.
         evidence: [...pendingRun.evidence, ...allEvidence],
-        pending_gate: {
-          gate_id,
-          step_name,
-          preview: output,
-          choices,
-          opened_at: new Date().toISOString(),
-          ...(gateConfig?.owner !== undefined ? { owner: gateConfig.owner } : {}),
-          ...(resolvedGateMessage !== undefined ? { resolved_message: resolvedGateMessage } : {}),
-          ...(gateConfig?.resolution_messages !== undefined
-            ? { resolution_messages: gateConfig.resolution_messages }
-            : {}),
-        },
+        pending_gate: pendingGate,
       });
     } catch (err) {
       if (err instanceof WorkflowError) {
@@ -2994,40 +3286,6 @@ export async function executeStep(
       );
     }
 
-    // gate.display fallback chain: gate.message resolved → step.prompt resolved → absent
-    const resolvedGateDisplay =
-      resolvedGateMessage !== undefined
-        ? resolvedGateMessage
-        : stepDef!.prompt !== undefined
-          ? renderTemplate(stepDef!.prompt, {
-              evidenceByStep: gateEvidenceCtxEarly,
-              runParams: run.params,
-              ...wfCtxSpreadEarly,
-            })
-          : undefined;
-    const resolvedGateInstructions =
-      stepDef!.instructions !== undefined
-        ? renderTemplate(stepDef!.instructions, {
-            evidenceByStep: gateEvidenceCtxEarly,
-            runParams: run.params,
-            ...wfCtxSpreadEarly,
-          })
-        : undefined;
-
-    const gateNextAction: NextAction = {
-      instruction: {
-        tool: 'submit_human_response',
-        params: { run_id: options.runId, gate_id },
-        call_with: {
-          run_id: options.runId,
-          gate_id,
-          choice: `<${choices.join('|')}>`,
-        },
-      },
-      human_readable: `Human review required for step '${options.command}'. Present gate.display to the user, wait for their choice from gate.response_spec.choices, then call submit_human_response.`,
-      orientation: `Run is paused at gate '${gate_id}'. Available choices: ${choices.join(', ')}.`,
-    };
-
     return {
       command: options.command,
       run_id: options.runId,
@@ -3035,11 +3293,11 @@ export async function executeStep(
       status: 'confirm_required',
       data: output,
       evidence: allEvidence,
-      warnings: [...traceWarnings],
+      warnings: mergeWarnings(traceWarnings, DORMANCY_ADVISORY),
       errors: [],
       context_hint: `Run is paused at gate '${gate_id}'. Available choices: ${choices.join(', ')}.`,
       run_phase: gateRun.run_phase,
-      next_actions: [gateNextAction],
+      next_actions: [buildGateNextAction(gate_id, choices, step_name)],
       gate: {
         gate_id,
         step_name,
@@ -3404,6 +3662,45 @@ export async function executeStep(
  * Submits a human response for a gate-waiting run.
  * Validates the gate_id and choice, then moves the step to completed_steps.
  */
+/** Finds the settled step name for a resolved gate matching `gateId` (issue #279, increment 2,
+ *  PR-D) — a LOCAL mirror of settlement.ts's own `findSettledGateEntry` (not imported: this file
+ *  touches settlement.ts ONLY for Deliverable 3's cancel-trail `gate_id` addition). Used to recover
+ *  a reliable step name off `result.run.settled` for the `already_settled`/`gate_choice_conflict`
+ *  envelopes, since the caller's own pre-read may already be stale by the time either of those
+ *  fires (the gate could have resolved before this call's own Step-1 read). */
+function findGateStepName(run: RunRecord, gateId: string): string | undefined {
+  for (const [step, entry] of Object.entries(run.settled ?? {})) {
+    if (entry.outcome === 'gate' && entry.token === gateId) return step;
+  }
+  return undefined;
+}
+
+/** Builds the gate_response evidence snapshot (issue #279, increment 2, PR-D, Deliverable 1b) —
+ *  the SAME shape submitHumanResponse's legacy path has always built (mirrors execution-loop.ts's
+ *  own pre-PR-D Step 5), extracted so both the migrated and legacy paths construct it identically.
+ *  `respondedBy`, when supplied, populates the snapshot's own `responded_by` field (design record
+ *  D-5) in addition to the delta's own field. */
+function buildGateResponseSnapshot(
+  gate: PendingGate,
+  choice: string,
+  respondedAt: Date,
+  respondedBy: string | undefined,
+): EvidenceSnapshot {
+  const gateEvidence = captureEvidence({
+    stepId: gate.step_name,
+    startedAt: new Date(gate.opened_at),
+    completedAt: respondedAt,
+    input: { choice },
+    output: { ...gate.preview, choice },
+  });
+  return {
+    ...gateEvidence,
+    kind: 'gate_response' as const,
+    ...(gate.resolved_message !== undefined ? { gate_message: gate.resolved_message } : {}),
+    ...(respondedBy !== undefined ? { responded_by: respondedBy } : {}),
+  };
+}
+
 export async function submitHumanResponse(
   store: RunStore,
   definition: WorkflowDefinition,
@@ -3425,6 +3722,319 @@ export async function submitHumanResponse(
           });
     return errorEnvelope('submit_gate', options.runId, 0, e);
   }
+
+  // issue #279 (increment 2, PR-D, Deliverable 1b): the migrated path — the four legacy
+  // verify-arms below (1a-4) become settle_gate's OWN predicate arms; this branch skips them
+  // entirely and settles atomically against FRESH state via the store's own settleStep. Dormancy:
+  // an undeclaring store falls through to the byte-identical legacy path below (I16/#169
+  // fail-closed dormancy).
+  if (store.settleStep !== undefined) {
+    const respondedAt = new Date();
+    // Evidence rule (design record §6 lens-3 S2): built from the PRE-READ `pending_gate` IFF it
+    // matches options.gateId — else `[]` (the arm can never APPLY against a non-matching fresh
+    // read either, so an empty evidence array is inert there; a matching pre-read is guaranteed
+    // fresh enough to be correct on `applied: true`, since gate_id is a per-attempt-minted UUID
+    // that can never "come back" once resolved/absent).
+    const gateResponseEvidence: EvidenceSnapshot[] =
+      run.pending_gate !== undefined && run.pending_gate.gate_id === options.gateId
+        ? [
+            buildGateResponseSnapshot(
+              run.pending_gate,
+              options.choice,
+              respondedAt,
+              options.respondedBy,
+            ),
+          ]
+        : [];
+    const delta: SettleGateDelta = {
+      kind: 'settle_gate',
+      gateId: options.gateId,
+      choice: options.choice,
+      ...(options.respondedBy !== undefined ? { respondedBy: options.respondedBy } : {}),
+      evidence: gateResponseEvidence,
+    };
+
+    let result: SettlementResult;
+    try {
+      result = await store.settleStep(options.runId, delta, definition);
+    } catch (err) {
+      // Thrown infra errors keep the SAME shape as the legacy path's own final-persist catch,
+      // below (design record §6: "thrown infra errors ALSO keep the :3563-3581 shape").
+      const e =
+        err instanceof WorkflowError
+          ? err
+          : new WorkflowError('Failed to persist gate response', {
+              code: 'ENGINE_STORE_FAILED',
+              category: 'ENGINE',
+              agentAction: 'stop',
+              retryable: false,
+            });
+      return errorEnvelope(
+        run.pending_gate?.step_name ?? 'submit_gate',
+        options.runId,
+        run.version,
+        e,
+        `Failed to persist gate response.`,
+        run.run_phase,
+      );
+    }
+
+    if (!result.applied) {
+      switch (result.reason) {
+        case 'already_settled': {
+          // Calm ok envelope stating the resolution already committed (same choice) — never
+          // report_to_user. Drain: on already_settled ∧ pending ledger entries non-empty — hand-
+          // rolled here (buildAlreadySettledEnvelope is ExecuteStepOptions-shaped, not reusable at
+          // this call site) — recovers a crashed-drain RESOLVE on a duplicate submit (design record
+          // §6 row 2, the buildAlreadySettledEnvelope drain-on-NOOP pattern reused verbatim).
+          const stepName = findGateStepName(result.run, options.gateId) ?? 'submit_gate';
+          let noopRun = result.run;
+          let noopDrainWarnings: string[] = [];
+          const hasPending = Object.values(noopRun.finalizer_ledger ?? {}).some(
+            (e) => e.status === 'pending',
+          );
+          if (hasPending) {
+            try {
+              const drainOutcome = await drainFinalizers(
+                store,
+                definition,
+                options.registry,
+                options.runId,
+              );
+              noopRun = drainOutcome.run;
+              noopDrainWarnings = drainOutcome.warnings;
+            } catch (err) {
+              noopDrainWarnings = [
+                `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+              ];
+            }
+          }
+          return {
+            command: stepName,
+            run_id: options.runId,
+            run_version: noopRun.version,
+            status: 'ok',
+            data: {},
+            evidence: [],
+            warnings: mergeWarnings([], ...noopDrainWarnings),
+            errors: [],
+            context_hint: `Gate '${options.gateId}' was already resolved with choice '${options.choice}' — no action was taken.`,
+            run_phase: noopRun.run_phase,
+            next_actions: noopRun.terminal_state ? [] : buildNextActions(definition, noopRun),
+          };
+        }
+        case 'gate_choice_conflict': {
+          const stepName = findGateStepName(result.run, options.gateId);
+          const err = new WorkflowError(
+            `Gate '${options.gateId}' was already resolved with choice '${result.winningChoice}' ` +
+              `— your choice '${options.choice}' was not recorded.`,
+            {
+              code: 'STATE_BLOCKED',
+              category: 'STATE',
+              agentAction: 'report_to_user',
+              retryable: false,
+              details: {
+                runId: options.runId,
+                gateId: options.gateId,
+                winning_choice: result.winningChoice,
+              },
+            },
+          );
+          return errorEnvelope(
+            stepName ?? 'submit_gate',
+            options.runId,
+            result.run.version,
+            err,
+            err.message,
+            result.run.run_phase,
+          );
+        }
+        case 'choice_not_eligible': {
+          // VALIDATION_INPUT_SCHEMA envelope — parity with the legacy path's own step 4 (below).
+          const stepName = result.run.pending_gate!.step_name; // the arm only reaches this check
+          // when fresh.pending_gate.gate_id === gateId, so this is reliably the live gate's step.
+          const expected = (result.choices ?? []).join(', ');
+          const err = new WorkflowError(
+            `Choice '${options.choice}' is not valid. Expected one of: ${expected}`,
+            {
+              code: 'VALIDATION_INPUT_SCHEMA',
+              category: 'VALIDATION',
+              agentAction: 'report_to_user',
+              retryable: false,
+            },
+          );
+          return errorEnvelope(
+            stepName,
+            options.runId,
+            result.run.version,
+            err,
+            `Invalid choice '${options.choice}' for gate '${stepName}'.`,
+            result.run.run_phase,
+          );
+        }
+        case 'gate_mismatch': {
+          const err = new WorkflowError(
+            `Gate '${options.gateId}' is not the open gate and matches no committed resolution.`,
+            {
+              code: 'STATE_BLOCKED',
+              category: 'STATE',
+              agentAction: 'report_to_user',
+              retryable: false,
+              details: { runId: options.runId, gateId: options.gateId },
+            },
+          );
+          return errorEnvelope(
+            'submit_gate',
+            options.runId,
+            result.run.version,
+            err,
+            err.message,
+            result.run.run_phase,
+          );
+        }
+        case 'run_terminal': {
+          // Composed cancelled-predicate (design record §5 D-4/§11 N10): any gate_cancelled_by_abort
+          // skip detail ⇒ the cancelled variant ("your choice was NOT recorded" + cause) — bound by
+          // gate_id equality once that field is populated (PR-D+), else by presence alone (pre-PR-D
+          // records, N10). No match ⇒ the zombie/grandfathered variant + the resume-clears/purge
+          // pointer.
+          const cancelEntry = Object.entries(result.run.skip_details ?? {}).find(
+            ([, d]) => d.kind === 'gate_cancelled_by_abort',
+          );
+          const cancelDetail = cancelEntry?.[1] as
+            { kind: 'gate_cancelled_by_abort'; gate_id?: string } | undefined;
+          const isCancelledMatch =
+            cancelEntry !== undefined &&
+            (cancelDetail!.gate_id === undefined || cancelDetail!.gate_id === options.gateId);
+          if (isCancelledMatch) {
+            const [cancelledStep] = cancelEntry!;
+            const abortedBy = result.run.aborted_at?.step_id;
+            const err = new WorkflowError(
+              `Gate '${options.gateId}' on '${cancelledStep}' was cancelled when ` +
+                `'${abortedBy ?? 'another step'}' aborted the run — your choice was NOT recorded.`,
+              {
+                code: 'STATE_RUN_TERMINAL',
+                category: 'STATE',
+                agentAction: 'report_to_user',
+                retryable: false,
+                details: {
+                  runId: options.runId,
+                  run_phase: result.run.run_phase,
+                  gate_id: options.gateId,
+                  step_name: cancelledStep,
+                  ...(abortedBy !== undefined ? { aborted_by: abortedBy } : {}),
+                },
+              },
+            );
+            return errorEnvelope(
+              cancelledStep,
+              options.runId,
+              result.run.version,
+              err,
+              err.message,
+              result.run.run_phase,
+            );
+          }
+          // Zombie/grandfathered variant — the #282 class: a terminal record may still carry a
+          // stale pending_gate (never cleared), which is the best-effort step label here.
+          const zombieStep = result.run.pending_gate?.step_name ?? 'submit_gate';
+          const err = new WorkflowError(
+            `Run '${options.runId}' is terminal; cannot submit a gate response — 'realm resume' ` +
+              `clears a stale pending gate on a resumable run, or 'realm run purge' removes the ` +
+              `record entirely.`,
+            {
+              code: 'STATE_RUN_TERMINAL',
+              category: 'STATE',
+              agentAction: 'report_to_user',
+              retryable: false,
+              details: { runId: options.runId, run_phase: result.run.run_phase },
+            },
+          );
+          return errorEnvelope(
+            zombieStep,
+            options.runId,
+            result.run.version,
+            err,
+            err.message,
+            result.run.run_phase,
+          );
+        }
+        default:
+          // gate_open_wait/already_open/already_released/choice_not_eligible's siblings and every
+          // other kind's own reason are unreachable here — settle_gate never returns them (design
+          // record §7).
+          throw new Error(
+            `submitHumanResponse: unreachable settle_gate refusal reason '${result.reason}'`,
+          );
+      }
+    }
+
+    // applied: true. Reliable step name: the pre-read's pending_gate.step_name (guaranteed
+    // correct whenever `applied` is true — see the evidence-rule comment above).
+    const resolvedGateStepName = run.pending_gate!.step_name;
+
+    // Drain: on transitioned OR (already_settled ∧ pending ledger entries non-empty) — hand-rolled
+    // (buildAlreadySettledEnvelope is ExecuteStepOptions-shaped, not reusable here). `applied:
+    // true` never reaches the already_settled leg, so only the `transitioned` disjunct applies at
+    // THIS call site (design record §6 row 2).
+    let finalRun = result.run;
+    let drainWarnings: string[] = [];
+    if (result.transitioned) {
+      try {
+        const drainOutcome = await drainFinalizers(
+          store,
+          definition,
+          options.registry,
+          options.runId,
+        );
+        finalRun = drainOutcome.run;
+        drainWarnings = drainOutcome.warnings;
+      } catch (err) {
+        drainWarnings = [
+          `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+        ];
+      }
+    }
+
+    // Convergence hint (design record D-2 N8 narrowing, pedestal steal — must not drop): after a
+    // committed RESOLVE, when a guard is thereby eligible, append one line per eligible guard.
+    // findEligibleGuardSteps self-filters terminal runs (returns [] there), so this is inert on a
+    // gate-completion terminal transition.
+    const convergenceHints = findEligibleGuardSteps(definition, finalRun).map(
+      (name) => `guard '${name}' now eligible — converges at the next drive`,
+    );
+
+    const defaultedStepsDurabilityWarning =
+      finalRun.defaulted_steps !== undefined &&
+      finalRun.defaulted_steps.length > 0 &&
+      !persistsField(store, 'defaulted_steps')
+        ? 'run-level defaultedness marker (defaulted_steps) not durable on this store'
+        : undefined;
+
+    const migratedNextActions = finalRun.terminal_state
+      ? []
+      : buildNextActions(definition, finalRun);
+    const migratedOrientation = finalRun.terminal_state
+      ? `Run completed (phase: '${finalRun.run_phase}'). Call get_run_state with run_id '${options.runId}' to retrieve the full evidence record.`
+      : `Gate '${resolvedGateStepName}' resolved with choice '${options.choice}'. ${migratedNextActions.length} step(s) now available.`;
+
+    return {
+      command: resolvedGateStepName,
+      run_id: options.runId,
+      run_version: finalRun.version,
+      status: 'ok',
+      data: { ...run.pending_gate!.preview, choice: options.choice },
+      evidence: [],
+      warnings: mergeWarnings(convergenceHints, ...drainWarnings, defaultedStepsDurabilityWarning),
+      errors: [],
+      context_hint: migratedOrientation,
+      run_phase: finalRun.run_phase,
+      next_actions: migratedNextActions,
+      ...(finalRun.defaulted_steps?.length ? { defaulted_steps: finalRun.defaulted_steps } : {}),
+    };
+  }
+
+  // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
 
   // 1a. Defensive terminal guard (mirrors #91/#95): a late gate response must never re-drive a
   // run that has already reached a terminal phase.
@@ -3599,7 +4209,9 @@ export async function submitHumanResponse(
     // envelope flag (do NOT add an evidence scan to recompute it). Its disclosure surface is the
     // run-level `defaulted_steps` marker below, plus whatever the gate-open envelope already
     // warned the human with.
-    warnings: mergeWarnings([], defaultedStepsDurabilityWarning),
+    // issue #279 (increment 2, PR-D): + the ONE dormancy advisory (I16) — this IS the legacy path
+    // (store.settleStep undeclared).
+    warnings: mergeWarnings([], defaultedStepsDurabilityWarning, DORMANCY_ADVISORY),
     errors: [],
     context_hint: orientation,
     run_phase: savedRun.run_phase,
@@ -4150,17 +4762,274 @@ async function executeChainInternal(
   // Execute any eligible guard steps inline before looking for the next auto step.
   // Guard steps are synchronous engine decisions — not returned to the agent.
   // Loop to handle cascading guards (guard A passes → guard B becomes eligible).
+  // issue #279 (increment 2, PR-D, Deliverable 1c): non-abort settled_outcome_divergence warnings
+  // ADVANCE the chain but must still surface somewhere — carried here and merged into whichever
+  // envelope eventually returns (the guardsRan rebuild below, or a migrated terminal return).
+  const guardWarnings: string[] = [];
   let guardEligible = findEligibleGuardSteps(definition, run);
   while (guardEligible.length > 0) {
     const guardName = guardEligible[0]!;
     const guardStepDef = definition.steps[guardName]!;
 
-    // Execute inline (pure in-memory; returns updated RunRecord).
+    // Execute inline (pure in-memory; returns updated RunRecord). executeGuardStep stays PURE and
+    // UNTOUCHED (design record §1) — both the migrated and legacy paths below call it identically.
     const guardResult = await executeGuardStep(guardName, guardStepDef, definition, run);
 
     // Capture the guard's OWN evidence (its last entry) BEFORE the finalizer drain appends
     // finalizer evidence — the terminal return below surfaces only the guard's evidence.
     const guardOwnEvidence = guardResult.evidence.slice(-1);
+
+    // issue #279 (increment 2, PR-D, Deliverable 1c): the migrated path — settles this guard's
+    // evaluated outcome atomically against FRESH state via the store's own settleStep. Dormancy:
+    // an undeclaring store falls through to the byte-identical legacy path below (I16/#169
+    // fail-closed dormancy).
+    if (store.settleStep !== undefined) {
+      // Extraction rule (design record §2, normative): reverse-classify guardResult's SEALED
+      // output by MEMBERSHIP — NEVER the terminal_state ternary below (wrong for a non-terminal
+      // pass, which never sets terminal_state at all).
+      const guardSettleOutcome: 'pass' | 'resolution_error' | 'abort' =
+        guardResult.aborted_at !== undefined
+          ? 'abort'
+          : guardResult.failed_steps.includes(guardName)
+            ? 'resolution_error'
+            : 'pass'; // the only remaining membership — completed_steps.includes(guardName)
+
+      let resolutionError: { condition: string; unresolvable_path: string } | undefined;
+      if (guardSettleOutcome === 'resolution_error') {
+        // Rails-compliant re-derivation (normative): normalize abort_unless to string[] (the
+        // executeGuardStep :3632-3635 shape) and re-run evaluateGuardConditions against the SAME
+        // pre-seal `run` passed to executeGuardStep — pure + deterministic, so this reproduces the
+        // discarded internal result byte-for-byte.
+        const conditions = Array.isArray(guardStepDef.abort_unless)
+          ? guardStepDef.abort_unless
+          : [guardStepDef.abort_unless!];
+        const reEvaluated = evaluateGuardConditions(conditions, buildEvidenceByStep(run));
+        if (reEvaluated.kind === 'resolution_error') {
+          resolutionError = {
+            condition: reEvaluated.condition,
+            unresolvable_path: reEvaluated.unresolvable_path,
+          };
+        }
+      }
+
+      const delta: SettleGuardDelta = {
+        kind: 'settle_guard',
+        step: guardName,
+        outcome: guardSettleOutcome,
+        evidence: guardOwnEvidence[0]!,
+        ...(resolutionError !== undefined ? { resolutionError } : {}),
+        ...(guardSettleOutcome === 'abort'
+          ? {
+              abort: {
+                conditions: guardResult.aborted_at!.conditions ?? [],
+                ...(guardResult.aborted_at!.abort_message !== undefined
+                  ? { abort_message: guardResult.aborted_at!.abort_message }
+                  : {}),
+              },
+            }
+          : {}),
+        // evaluatedAtVersion (design record §2, lane-B steal 2): the chain's OWN evaluation
+        // snapshot — this iteration's pre-settle `run.version`.
+        evaluatedAtVersion: run.version,
+      };
+
+      let guardSettleResult: SettlementResult;
+      try {
+        guardSettleResult = await store.settleStep(options.runId, delta, definition);
+      } catch (storeErr) {
+        // Thrown infra errors — the same persist-failure envelope shape the legacy path's own
+        // store.update catch (below) has always returned.
+        const msg = storeErr instanceof Error ? storeErr.message : String(storeErr);
+        return {
+          command: options.command,
+          run_id: options.runId,
+          run_version: run.version,
+          status: 'error',
+          data: {},
+          evidence: [],
+          warnings: [],
+          errors: [`Failed to persist guard step '${guardName}': ${msg}`],
+          agent_action: 'stop' as const,
+          context_hint: `Guard step '${guardName}' could not be persisted. Run state may be inconsistent.`,
+          run_phase: run.run_phase,
+          next_actions: [],
+        };
+      }
+
+      if (!guardSettleResult.applied) {
+        // Chain-consumption table (design record §6, adjudicated):
+        if (
+          guardSettleResult.reason === 'already_settled' ||
+          guardSettleResult.reason === 'gate_open_wait' ||
+          (guardSettleResult.reason === 'settled_outcome_divergence' &&
+            guardSettleOutcome !== 'abort')
+        ) {
+          // already_settled / gate_open_wait ⇒ ADVANCE, threading result.run (findEligibleGuardSteps
+          // self-filters both a now-settled guard and an open gate, so the loop naturally converges).
+          // settled_outcome_divergence on a NON-abort attempt ⇒ ADVANCE + a warning line.
+          if (guardSettleResult.reason === 'settled_outcome_divergence') {
+            guardWarnings.push(
+              `guard '${guardName}' outcome diverged from a concurrent settle` +
+                (guardSettleResult.persisted !== undefined
+                  ? ` (persisted: '${guardSettleResult.persisted}')`
+                  : '') +
+                ' — chain advanced on the persisted outcome.',
+            );
+          }
+          if (guardSettleResult.reason !== 'gate_open_wait') {
+            // "quiet" end-of-pass for gate_open_wait only — nothing was decided, so nothing is
+            // recorded; already_settled/divergence DID decide something (elsewhere), so it is.
+            chainedSteps.push({ step: guardName, run_phase: guardSettleResult.run.run_phase });
+          }
+          run = guardSettleResult.run;
+          // Drain: on already_settled ∧ pending ledger entries non-empty (design record §6, "same
+          // clause" as the transitioned leg below) — recovers a crashed-drain RESOLVE that a
+          // sibling's own settle committed but never drained.
+          if (guardSettleResult.reason === 'already_settled') {
+            const hasPending = Object.values(run.finalizer_ledger ?? {}).some(
+              (e) => e.status === 'pending',
+            );
+            if (hasPending) {
+              try {
+                const drainOutcome = await drainFinalizers(
+                  store,
+                  definition,
+                  options.registry,
+                  options.runId,
+                );
+                run = drainOutcome.run;
+                if (drainOutcome.warnings.length > 0) guardWarnings.push(...drainOutcome.warnings);
+              } catch (err) {
+                guardWarnings.push(
+                  `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
+            }
+          }
+          guardEligible = findEligibleGuardSteps(definition, run);
+          continue;
+        }
+        if (guardSettleResult.reason === 'settled_outcome_divergence') {
+          // ABORT leg only ⇒ report_to_user + chain-RETURN (design record §6/§7) — this attempt's
+          // abort was never recorded.
+          const err = new WorkflowError(
+            `Guard step '${guardName}' was already settled` +
+              (guardSettleResult.persisted !== undefined
+                ? ` (persisted: '${guardSettleResult.persisted}')`
+                : '') +
+              ` by a different attempt — your abort was NOT recorded.`,
+            {
+              code: 'STATE_STEP_ALREADY_SETTLED',
+              category: 'STATE',
+              agentAction: 'report_to_user',
+              retryable: false,
+              details: {
+                runId: options.runId,
+                step: guardName,
+                reason: guardSettleResult.reason,
+                ...(guardSettleResult.persisted !== undefined
+                  ? { persisted: guardSettleResult.persisted }
+                  : {}),
+              },
+            },
+          );
+          return {
+            command: options.command,
+            run_id: options.runId,
+            run_version: guardSettleResult.run.version,
+            status: 'error',
+            data: {},
+            evidence: [],
+            warnings: [],
+            errors: [err.message],
+            error_code: err.code,
+            ...(Object.keys(err.details).length > 0 ? { error_details: err.details } : {}),
+            agent_action: 'report_to_user',
+            context_hint: err.message,
+            run_phase: guardSettleResult.run.run_phase,
+            next_actions: [],
+          };
+        }
+        if (guardSettleResult.reason === 'run_terminal') {
+          // Terminal by OTHER (a sibling settle raced this guard's own evaluation) — INLINE
+          // construction, parity with the entry-terminal envelope (executeChain's own early
+          // return).
+          return {
+            command: options.command,
+            run_id: options.runId,
+            run_version: guardSettleResult.run.version,
+            status: 'ok',
+            data: {},
+            evidence: [],
+            warnings: [],
+            errors: [],
+            agent_action: 'stop' as const,
+            context_hint: `Run '${options.runId}' is already terminal (${guardSettleResult.run.run_phase}); guard '${guardName}' was not evaluated.`,
+            run_phase: guardSettleResult.run.run_phase,
+            next_actions: [],
+          };
+        }
+        // gate_mismatch/choice_not_eligible/already_open/already_released and every other kind's
+        // own reason are unreachable here — settle_guard never returns them (design record §7).
+        throw new Error(
+          `executeChainInternal: unreachable settle_guard refusal reason '${guardSettleResult.reason}'`,
+        );
+      }
+
+      // applied: true.
+      chainedSteps.push({ step: guardName, run_phase: guardSettleResult.run.run_phase });
+
+      if (guardSettleResult.transitioned) {
+        // Drain IMMEDIATELY after a transitioned settle result, BEFORE building the in-loop
+        // terminal envelope (design record §6/R5 — a post-loop drain would be dead code on this
+        // leg: this function RETURNS before ever reaching a post-loop point).
+        let finalGuardRun = guardSettleResult.run;
+        let guardDrainWarnings: string[];
+        try {
+          const drainOutcome = await drainFinalizers(
+            store,
+            definition,
+            options.registry,
+            options.runId,
+          );
+          finalGuardRun = drainOutcome.run;
+          guardDrainWarnings = drainOutcome.warnings;
+        } catch (err) {
+          guardDrainWarnings = [
+            `post-commit finalizer drain failed: ${err instanceof Error ? err.message : String(err)}`,
+          ];
+        }
+        const migratedContextHint =
+          guardSettleOutcome === 'abort'
+            ? `Guard step '${guardName}' aborted the run.`
+            : guardSettleOutcome === 'resolution_error'
+              ? `Guard step '${guardName}' failed with a resolution error. Run is terminated.`
+              : `Guard step '${guardName}' passed and completed the run.`;
+        return {
+          command: options.command,
+          run_id: options.runId,
+          run_version: finalGuardRun.version,
+          status: 'ok',
+          data: {},
+          evidence: guardOwnEvidence,
+          warnings: mergeWarnings(guardWarnings, ...guardDrainWarnings),
+          errors: [],
+          context_hint: migratedContextHint,
+          run_phase: finalGuardRun.run_phase,
+          next_actions: [],
+          ...(finalGuardRun.defaulted_steps?.length
+            ? { defaulted_steps: finalGuardRun.defaulted_steps }
+            : {}),
+        };
+      }
+
+      // Non-terminal pass — continue the chain.
+      run = guardSettleResult.run;
+      guardEligible = findEligibleGuardSteps(definition, run);
+      continue;
+    }
+
+    // --- Legacy path (dormancy fallback — byte-identical to pre-#279 behavior) ---
 
     // Blocking fix #1: classify the terminal outcome by the SEALED record, not aborted_at
     // alone. executeGuardStep sets terminal_state in THREE cases — abort (aborted_at set),
@@ -4237,7 +5106,9 @@ async function executeChainInternal(
         data: {},
         // The guard's own evidence entry, captured before the finalizer drain appended any.
         evidence: guardOwnEvidence,
-        warnings: mergeWarnings([], guardDefaultedStepsDurabilityWarning),
+        // issue #279 (increment 2, PR-D): + the ONE dormancy advisory (I16) — this IS the legacy
+        // path (store.settleStep undeclared).
+        warnings: mergeWarnings([], guardDefaultedStepsDurabilityWarning, DORMANCY_ADVISORY),
         errors: [],
         context_hint: contextHint,
         run_phase: persistedGuardRun.run_phase,
@@ -4263,6 +5134,12 @@ async function executeChainInternal(
       ...result,
       run_version: run.version,
       next_actions: freshNextActions,
+      // issue #279 (increment 2, PR-D): non-abort settled_outcome_divergence warnings accumulated
+      // during the guard loop above (the ADVANCE leg) must reach whichever envelope returns —
+      // this rebuild is the first point after the loop `result` is touched again.
+      ...(guardWarnings.length > 0
+        ? { warnings: mergeWarnings(result.warnings, ...guardWarnings) }
+        : {}),
     };
   }
 

--- a/packages/core/src/engine/gate-death-279.test.ts
+++ b/packages/core/src/engine/gate-death-279.test.ts
@@ -1,0 +1,360 @@
+// gate-death-279.test.ts — R3-death for gates, R5-death (two legs), and the drain-on-NOOP
+// integration case (issue #279, increment 2, PR-D, Deliverable 5). Companion to
+// symptom-death-279.test.ts (R3/R5 for the three PR-B seal sites) — this file proves the SAME two
+// symptoms are dead on the FIVE newly migrated sites' own gate/guard surfaces.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeStep, executeChain, submitHumanResponse } from './execution-loop.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { StepHandler } from '../extensions/step-handler.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { RunStore, CreateRunOptions } from '../store/store-interface.js';
+import type { SettlementDelta, SettlementResult } from '../types/settlement.js';
+
+describe('R3-death for gates (issue #279, increment 2, PR-D) — the PR-B symptom-death-279.test.ts mechanism, applied to gate-open', () => {
+  it('gate-open and an ALREADY-CLAIMED sibling settling CONCURRENTLY both record — the gate OPENS, the sibling commits, zero STATE_SNAPSHOT_MISMATCH', async () => {
+    const def: WorkflowDefinition = {
+      id: 'r3-gate-death-wf',
+      name: 'R3 gate-death fixture',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+        sibling: { description: 'sibling', execution: 'agent', depends_on: [] },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-r3-gate-death-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      // Pre-claim `sibling` FIRST (sequential, deterministic) — eligibility.ts's OWN documented
+      // invariant ("Gate serialization: if a gate is open, no new steps are eligible") means a
+      // genuinely-open gate correctly blocks ALL future ELIGIBILITY checks, globally — unrelated
+      // to PR-D, and not what R3 is about. R3 is about the SETTLE-time race (two concurrent
+      // writers hitting the SAME store), so both steps' CLAIMS must already exist before either
+      // settles — mirroring a realistic fan-out where both steps were already dispatched to
+      // agents before either one's outcome came back.
+      const claimedSibling = await store.claimStep(run.id, 'sibling', def);
+      const siblingToken = claimedSibling.claims?.['sibling']?.token;
+
+      // THE race: gate-open (the full executeStep path, claim included) and the sibling's OWN
+      // settle_step-complete call (the REAL store.settleStep — the exact call executeStep itself
+      // would make post-dispatch) CONCURRENTLY through the real store — no interposition, plain
+      // Promise.all (symptom-death-279's own mechanism).
+      const [resultGate, siblingSettleResult] = await Promise.all([
+        executeStep(store, def, {
+          runId: run.id,
+          command: 'gate_step',
+          input: {},
+          dispatcher: async () => ({ preview: true }),
+        }),
+        store.settleStep!(
+          run.id,
+          {
+            kind: 'settle_step',
+            step: 'sibling',
+            outcome: 'complete',
+            ...(siblingToken !== undefined ? { claimToken: siblingToken } : {}),
+            evidence: [],
+          },
+          def,
+        ),
+      ]);
+
+      expect(resultGate.status).toBe('confirm_required');
+      expect(siblingSettleResult.applied).toBe(true);
+
+      // Zero STATE_SNAPSHOT_MISMATCH anywhere in the gate-open envelope's error surface — the
+      // legacy read-then-update seal (pre-#279) is exactly what would have lost one of these two
+      // writes.
+      expect(JSON.stringify(resultGate)).not.toContain('STATE_SNAPSHOT_MISMATCH');
+
+      const finalRun = await store.get(run.id);
+      expect(finalRun.pending_gate?.step_name).toBe('gate_step');
+      expect(finalRun.completed_steps).toContain('sibling');
+      expect(finalRun.claims?.['gate_step']).toBeDefined(); // gate claim retained (G-1)
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('R5-death (issue #279, increment 2, PR-D) — gate/guard terminal seals no longer fire finalizers before commit', () => {
+  it('settle_gate leg: a gate resolution that COMPLETES the run delivers its finalizer EXACTLY ONCE, strictly POST-COMMIT', async () => {
+    const def: WorkflowDefinition = {
+      id: 'r5-gate-finalizer-wf',
+      name: 'R5 gate finalizer fixture',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+        fin: {
+          description: 'finalizer',
+          execution: 'finalizer',
+          on_outcome: 'complete',
+          handler: 'fin-handler',
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-r5-gate-fin-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      const opened = await executeStep(store, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      expect(opened.status).toBe('confirm_required');
+
+      let handlerCallCount = 0;
+      let snapshotAtHandlerCallTime: { completed: string[]; terminal: boolean } | undefined;
+      const finHandler: StepHandler = {
+        id: 'fin-handler',
+        execute: async () => {
+          handlerCallCount += 1;
+          // Prove POST-COMMIT: by the time the finalizer's handler runs, the gate resolution must
+          // already be durably recorded — read a FRESH copy from disk, not an in-memory draft.
+          const fresh: RunRecord = await store.get(run.id);
+          snapshotAtHandlerCallTime = {
+            completed: [...fresh.completed_steps].sort(),
+            terminal: fresh.terminal_state,
+          };
+          return { data: {} };
+        },
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', finHandler);
+
+      const resolved = await submitHumanResponse(store, def, {
+        runId: run.id,
+        gateId: opened.gate!.gate_id,
+        choice: 'approve',
+        registry,
+      });
+      expect(resolved.status).toBe('ok');
+
+      const finalRun = await store.get(run.id);
+      expect(finalRun.completed_steps.sort()).toEqual(['fin', 'gate_step']);
+      expect(finalRun.terminal_state).toBe(true);
+      expect(handlerCallCount).toBe(1); // exactly once — never zero, never twice
+      expect(snapshotAtHandlerCallTime).toEqual({ completed: ['gate_step'], terminal: true });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('guard-terminal leg (the leg the draft missed): a guard that ABORTS the run delivers its finalizer EXACTLY ONCE, strictly POST-COMMIT', async () => {
+    const def: WorkflowDefinition = {
+      id: 'r5-guard-finalizer-wf',
+      name: 'R5 guard finalizer fixture',
+      version: 1,
+      steps: {
+        step_a: { description: 'a', execution: 'agent', depends_on: [] },
+        guard_b: {
+          description: 'g',
+          execution: 'guard',
+          depends_on: ['step_a'],
+          abort_unless: ["step_a.status == 'open'"],
+        },
+        fin: {
+          description: 'finalizer',
+          execution: 'finalizer',
+          on_outcome: 'abort',
+          handler: 'fin-handler',
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-r5-guard-fin-'));
+    try {
+      const store = new JsonFileStore(dir);
+      const { run } = await store.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+
+      let handlerCallCount = 0;
+      let snapshotAtHandlerCallTime:
+        { skipped: string[]; terminal: boolean; aborted: boolean } | undefined;
+      const finHandler: StepHandler = {
+        id: 'fin-handler',
+        execute: async () => {
+          handlerCallCount += 1;
+          const fresh: RunRecord = await store.get(run.id);
+          snapshotAtHandlerCallTime = {
+            skipped: [...fresh.skipped_steps].sort(),
+            terminal: fresh.terminal_state,
+            aborted: fresh.aborted_at !== undefined,
+          };
+          return { data: {} };
+        },
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', finHandler);
+
+      const result = await executeChain(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'closed' }), // aborts guard_b
+        registry,
+      });
+      expect(result.status).toBe('ok');
+
+      const finalRun = await store.get(run.id);
+      expect(finalRun.skipped_steps).toContain('guard_b');
+      expect(finalRun.completed_steps).toContain('fin');
+      expect(finalRun.terminal_state).toBe(true);
+      expect(finalRun.aborted_at?.step_id).toBe('guard_b');
+      expect(handlerCallCount).toBe(1); // exactly once — never zero, never twice
+      expect(snapshotAtHandlerCallTime).toEqual({
+        skipped: ['guard_b'],
+        terminal: true,
+        aborted: true,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Delegates every method to a real JsonFileStore, EXCEPT `settleStep`: the FIRST `lease_finalizer`
+ * delta is refused (thrown), simulating a crash between the settle_gate commit and the drain loop
+ * actually leasing the first pending finalizer. Every other delta (including every OTHER
+ * `lease_finalizer` call, post-recovery) passes straight through.
+ */
+class RefusesFirstLeaseStore implements RunStore {
+  readonly persistsClaims: boolean;
+  private refused = false;
+  constructor(private readonly inner: JsonFileStore) {
+    this.persistsClaims = inner.persistsClaims;
+  }
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    return this.inner.create(options);
+  }
+  get(runId: string): Promise<RunRecord> {
+    return this.inner.get(runId);
+  }
+  update(record: RunRecord): Promise<RunRecord> {
+    return this.inner.update(record);
+  }
+  list(workflowId?: string): Promise<RunRecord[]> {
+    return this.inner.list(workflowId);
+  }
+  claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord> {
+    return this.inner.claimStep(runId, stepName, definition);
+  }
+  async settleStep(
+    runId: string,
+    delta: SettlementDelta,
+    definition: WorkflowDefinition,
+    options?: { now?: Date },
+  ): Promise<SettlementResult> {
+    if (!this.refused && delta.kind === 'lease_finalizer') {
+      this.refused = true;
+      throw new Error('simulated crash between settle_gate commit and the drain lease');
+    }
+    return this.inner.settleStep(runId, delta, definition, options);
+  }
+}
+
+describe('Drain-on-NOOP integration (issue #279, increment 2, PR-D, design record §6 lens-2 S2)', () => {
+  it('a crashed-drain RESOLVE (finalizer minted PENDING, drain lease failed) self-heals on a duplicate submit — finalizers DELIVERED + the NOOP envelope carries the drain warnings', async () => {
+    const def: WorkflowDefinition = {
+      id: 'drain-on-noop-wf',
+      name: 'Drain-on-NOOP fixture',
+      version: 1,
+      steps: {
+        gate_step: {
+          description: 'gated',
+          execution: 'agent',
+          depends_on: [],
+          trust: 'human_confirmed',
+          gate: { choices: ['approve', 'reject'] },
+        },
+        fin: {
+          description: 'finalizer',
+          execution: 'finalizer',
+          on_outcome: 'complete',
+          handler: 'fin-handler',
+        },
+      },
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'realm-drain-noop-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const crashingStore = new RefusesFirstLeaseStore(inner);
+
+      const opened = await executeStep(crashingStore, def, {
+        runId: run.id,
+        command: 'gate_step',
+        input: {},
+        dispatcher: async () => ({ preview: true }),
+      });
+      expect(opened.status).toBe('confirm_required');
+      const gateId = opened.gate!.gate_id;
+
+      let handlerCallCount = 0;
+      const finHandler: StepHandler = {
+        id: 'fin-handler',
+        execute: async () => {
+          handlerCallCount += 1;
+          return { data: {} };
+        },
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', finHandler);
+
+      // FIRST submit: settle_gate commits (terminal, ledger minted PENDING), but the drain's OWN
+      // lease call is refused (simulated crash) — the finalizer is left PENDING, undelivered.
+      const firstSubmit = await submitHumanResponse(crashingStore, def, {
+        runId: run.id,
+        gateId,
+        choice: 'approve',
+        registry,
+      });
+      expect(firstSubmit.status).toBe('ok');
+      const afterCrash = await inner.get(run.id);
+      expect(afterCrash.terminal_state).toBe(true);
+      expect(afterCrash.finalizer_ledger?.['fin']?.status).toBe('pending');
+      expect(handlerCallCount).toBe(0); // never delivered — the drain's lease call was refused
+
+      // SECOND submit (a duplicate, same gate_id + same choice) against the HONEST store — hits
+      // already_settled, and the design's drain-on-NOOP clause recovers the crashed drain.
+      const duplicateSubmit = await submitHumanResponse(inner, def, {
+        runId: run.id,
+        gateId,
+        choice: 'approve',
+        registry,
+      });
+      expect(duplicateSubmit.status).toBe('ok');
+      expect(handlerCallCount).toBe(1); // NOW delivered, exactly once — the load-bearing proof
+      // A drain warning is not guaranteed on a SUCCESSFUL recovery (the honest store's own drain
+      // just succeeds quietly this time) — delivery itself is what this test proves; the NOOP
+      // envelope's own calm shape (status 'ok', no error) is asserted above.
+      expect(duplicateSubmit.status).toBe('ok');
+
+      const finalRun = await inner.get(run.id);
+      expect(finalRun.completed_steps).toContain('fin');
+      expect(finalRun.finalizer_ledger?.['fin']?.status).toBe('completed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/guard-chain-consumption-279.test.ts
+++ b/packages/core/src/engine/guard-chain-consumption-279.test.ts
@@ -1,0 +1,345 @@
+// guard-chain-consumption-279.test.ts — GUARD_CHAIN_CONSUMPTION (issue #279, increment 2, PR-D,
+// Deliverable 5; design record §6/§8, gate-1 gap-1's forcing test). Four legs through the REAL
+// engine (executeChain) + a REAL JsonFileStore, exercising the chain-consumption table adjudicated
+// for settle_guard's refusal reasons:
+//   (a) a sibling settles the guard FIRST (same outcome) ⇒ our own attempt returns already_settled
+//       ⇒ the chain ADVANCES, threading result.run, with NO error envelope.
+//   (b) a sibling settles the guard FIRST with a DIFFERENT, non-abort outcome ⇒
+//       settled_outcome_divergence ⇒ the chain ADVANCES + a warning line in the final envelope.
+//   (c) same as (b), but OUR OWN attempt is the ABORT leg ⇒ report_to_user + chain-RETURN
+//       (STATE_STEP_ALREADY_SETTLED) — the abort was never recorded.
+//   (d) a gate opens on ANOTHER step between the guard's pre-seal snapshot and its own settle call
+//       ⇒ gate_open_wait ⇒ quiet end-of-pass; the guard re-applies cleanly once the gate resolves.
+//
+// Construction technique: rather than a raw concurrency race (which would non-deterministically
+// decide which of two callers "wins" the guard — unlike symptom-death-279.test.ts's sibling-STEP
+// race, a sibling-GUARD race has no second independent entry point that reaches the SAME guard,
+// since a guard only becomes eligible once ALL its deps land), each leg uses a DETERMINISTIC
+// sibling-injecting store wrapper: on the FIRST `settleStep` call matching a declared predicate,
+// it issues ITS OWN direct call (or a raw open_gate) against a SECOND handle onto the SAME
+// underlying JsonFileStore directory — simulating "a sibling already got there first" — BEFORE
+// delegating to the real call. Every predicate outcome this produces (already_settled/
+// settled_outcome_divergence/gate_open_wait) is computed by the REAL, unmocked
+// settlement.ts/JsonFileStore — only the INTERLEAVING is engineered, not the result. This is a
+// deliberate divergence from the R3-death test's OWN "no interposition hook" instruction — that
+// constraint is stated ONLY for R3-death's specific mechanism (verbatim from symptom-death-279);
+// GUARD_CHAIN_CONSUMPTION's own record language ("an engine-level guard-chain fixture") calls for
+// exactly this kind of deterministic construction.
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonFileStore } from '../store/json-file-store.js';
+import { executeChain, submitHumanResponse } from './execution-loop.js';
+import { captureEvidence } from '../evidence/snapshot.js';
+import type { RunStore, CreateRunOptions } from '../store/store-interface.js';
+import type { RunRecord } from '../types/run-record.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.js';
+import type { SettlementDelta, SettlementResult } from '../types/settlement.js';
+
+/**
+ * Delegates every RunStore method to a real, functional JsonFileStore. `settleStep` is
+ * intercepted: the FIRST call matching `matches(delta)` triggers `inject()` (a raw call against a
+ * SECOND handle on the SAME directory) before delegating to the real settleStep — simulating a
+ * sibling writer that got there first. Every subsequent call passes straight through.
+ */
+class InjectBeforeSettleStore implements RunStore {
+  readonly persistsClaims: boolean;
+  private injected = false;
+
+  constructor(
+    private readonly inner: JsonFileStore,
+    private readonly matches: (delta: SettlementDelta) => boolean,
+    private readonly inject: () => Promise<void>,
+  ) {
+    this.persistsClaims = inner.persistsClaims;
+  }
+  create(options: CreateRunOptions): Promise<{ run: RunRecord; created: boolean }> {
+    return this.inner.create(options);
+  }
+  get(runId: string): Promise<RunRecord> {
+    return this.inner.get(runId);
+  }
+  update(record: RunRecord): Promise<RunRecord> {
+    return this.inner.update(record);
+  }
+  list(workflowId?: string): Promise<RunRecord[]> {
+    return this.inner.list(workflowId);
+  }
+  claimStep(runId: string, stepName: string, definition: WorkflowDefinition): Promise<RunRecord> {
+    return this.inner.claimStep(runId, stepName, definition);
+  }
+  async settleStep(
+    runId: string,
+    delta: SettlementDelta,
+    definition: WorkflowDefinition,
+    options?: { now?: Date },
+  ): Promise<SettlementResult> {
+    if (!this.injected && this.matches(delta)) {
+      this.injected = true;
+      await this.inject();
+    }
+    return this.inner.settleStep(runId, delta, definition, options);
+  }
+}
+
+const def: WorkflowDefinition = {
+  id: 'guard-chain-consumption-wf',
+  name: 'Guard chain consumption fixture',
+  version: 1,
+  steps: {
+    step_a: { description: 'a', execution: 'agent', depends_on: [] },
+    guard_b: {
+      description: 'g',
+      execution: 'guard',
+      depends_on: ['step_a'],
+      abort_unless: ["step_a.status == 'open'"],
+    },
+    gated_step: {
+      description: 'gs',
+      execution: 'agent',
+      depends_on: [],
+      trust: 'human_confirmed',
+      gate: { choices: ['approve', 'reject'] },
+    },
+  },
+};
+
+// Leg (d) ONLY — a SEPARATE definition (not shared with a/b/c, to avoid perturbing their own
+// chain-continuation behavior): adds an independent auto step used to re-drive the chain after the
+// sibling gate resolves. ANY subsequent execute_step/executeChain call naturally re-checks guard
+// eligibility as a side effect (executeChainInternal's own post-executeStep guard-loop check) —
+// `trigger_recheck` realistically stands in for whatever the agent does next.
+const defWithRecheck: WorkflowDefinition = {
+  ...def,
+  id: 'guard-chain-consumption-recheck-wf',
+  steps: {
+    ...def.steps,
+    trigger_recheck: { description: 'tr', execution: 'auto', depends_on: [] },
+  },
+};
+
+function makeGuardEvidence(outcome: 'pass' | 'resolution_error' | 'abort') {
+  return captureEvidence({
+    stepId: 'guard_b',
+    startedAt: new Date(),
+    completedAt: new Date(),
+    input: {},
+    output: { synthetic_sibling_settle: true, outcome },
+  });
+}
+
+describe('GUARD_CHAIN_CONSUMPTION — the chain-consumption table (issue #279, increment 2, PR-D, design record §6)', () => {
+  it('(a) a sibling settles the guard with the SAME outcome FIRST ⇒ already_settled ⇒ the chain ADVANCES, no error envelope', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-gcc-a-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const store = new InjectBeforeSettleStore(
+        inner,
+        (d) => d.kind === 'settle_guard' && d.step === 'guard_b',
+        async () => {
+          await inner.settleStep(
+            run.id,
+            {
+              kind: 'settle_guard',
+              step: 'guard_b',
+              outcome: 'pass',
+              evidence: makeGuardEvidence('pass'),
+            },
+            def,
+          );
+        },
+      );
+
+      const result = await executeChain(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'open' }), // guard_b's own condition would ALSO pass
+      });
+
+      expect(result.status).toBe('ok');
+      expect(result.errors).toEqual([]);
+      expect(result.error_code).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('STATE_STEP_ALREADY_SETTLED');
+      const finalRun = await inner.get(run.id);
+      expect(finalRun.completed_steps).toContain('guard_b'); // settled exactly once, by the sibling
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('(b) a sibling settles the guard with a DIFFERENT, non-abort outcome FIRST ⇒ settled_outcome_divergence ⇒ the chain ADVANCES + a warning line in the final envelope', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-gcc-b-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const store = new InjectBeforeSettleStore(
+        inner,
+        (d) => d.kind === 'settle_guard' && d.step === 'guard_b',
+        async () => {
+          // Sibling settles it as resolution_error — a DIFFERENT membership than our own 'pass'
+          // attempt (step_a.status:'open' makes OUR condition pass).
+          await inner.settleStep(
+            run.id,
+            {
+              kind: 'settle_guard',
+              step: 'guard_b',
+              outcome: 'resolution_error',
+              evidence: makeGuardEvidence('resolution_error'),
+              resolutionError: {
+                condition: "step_a.status == 'open'",
+                unresolvable_path: 'synthetic',
+              },
+            },
+            def,
+          );
+        },
+      );
+
+      const result = await executeChain(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'open' }), // OUR own guard evaluation would PASS
+      });
+
+      expect(result.status).toBe('ok');
+      expect(result.error_code).toBeUndefined();
+      expect(result.warnings.some((w) => w.includes('guard') && w.includes('diverged'))).toBe(true);
+      const finalRun = await inner.get(run.id);
+      // The SIBLING's outcome won (persisted) — resolution_error ⇒ failed_steps + terminal 'failed'.
+      expect(finalRun.failed_steps).toContain('guard_b');
+      expect(finalRun.terminal_state).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('(c) OUR OWN attempt is the ABORT leg, but a sibling already settled it differently ⇒ report_to_user + chain-RETURN (the abort was NOT recorded)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-gcc-c-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({ workflowId: def.id, workflowVersion: 1, params: {} });
+      const store = new InjectBeforeSettleStore(
+        inner,
+        (d) => d.kind === 'settle_guard' && d.step === 'guard_b',
+        async () => {
+          // Sibling settles it as 'pass' — but OUR OWN evaluation (condition fails, step_a.status
+          // 'closed') will attempt 'abort'.
+          await inner.settleStep(
+            run.id,
+            {
+              kind: 'settle_guard',
+              step: 'guard_b',
+              outcome: 'pass',
+              evidence: makeGuardEvidence('pass'),
+            },
+            def,
+          );
+        },
+      );
+
+      const result = await executeChain(store, def, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'closed' }), // OUR OWN guard evaluation aborts
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error_code).toBe('STATE_STEP_ALREADY_SETTLED');
+      expect(result.agent_action).toBe('report_to_user');
+      expect(result.errors[0]).toContain('NOT recorded');
+      const finalRun = await inner.get(run.id);
+      // The SIBLING's 'pass' won — our abort was never recorded.
+      expect(finalRun.completed_steps).toContain('guard_b');
+      expect(finalRun.aborted_at).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("(d) a gate opens on ANOTHER step between the guard's pre-seal snapshot and its own settle ⇒ gate_open_wait ⇒ quiet end-of-pass; the guard re-applies cleanly once the gate resolves", async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-gcc-d-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({
+        workflowId: defWithRecheck.id,
+        workflowVersion: 1,
+        params: {},
+      });
+      const store = new InjectBeforeSettleStore(
+        inner,
+        (d) => d.kind === 'settle_guard' && d.step === 'guard_b',
+        async () => {
+          // Open a gate on the UNRELATED `gated_step` — claim it first, then open_gate.
+          const claimed = await inner.claimStep(run.id, 'gated_step', defWithRecheck);
+          await inner.settleStep(
+            run.id,
+            {
+              kind: 'open_gate',
+              step: 'gated_step',
+              claimToken: claimed.claims?.['gated_step']?.token,
+              pendingGate: {
+                gate_id: 'sibling-gate',
+                step_name: 'gated_step',
+                preview: {},
+                choices: ['approve', 'reject'],
+                opened_at: new Date().toISOString(),
+              },
+              evidence: [],
+            },
+            defWithRecheck,
+          );
+        },
+      );
+
+      // guard_b's OWN condition must be NON-PASS to ever be eligible for gate_open_wait at all
+      // (design record §3: "if fresh.pending_gate !== undefined && delta.outcome !== 'pass'" —
+      // D-2 lets a PASSING guard through even under an open gate; only abort/resolution_error wait).
+      const result = await executeChain(store, defWithRecheck, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'closed' }), // guard_b's OWN condition would ABORT
+      });
+
+      // Quiet end-of-pass: guard_b is neither completed/failed/skipped — the chain simply stops
+      // (the gate now blocks everything), no error.
+      expect(result.status).toBe('ok');
+      expect(result.error_code).toBeUndefined();
+      const midRun = await inner.get(run.id);
+      expect(midRun.completed_steps).not.toContain('guard_b');
+      expect(midRun.failed_steps).not.toContain('guard_b');
+      expect(midRun.skipped_steps).not.toContain('guard_b');
+      expect(midRun.pending_gate?.step_name).toBe('gated_step');
+
+      // Resolve the gate — guard_b becomes eligible again. Drive the independent auto step
+      // (`trigger_recheck`) to re-enter the chain and re-check guard eligibility as a side effect
+      // — the guard re-applies CLEANLY this time (no gate in the way), aborting the run per its
+      // own (unchanged) condition.
+      const resolved = await submitHumanResponse(inner, defWithRecheck, {
+        runId: run.id,
+        gateId: 'sibling-gate',
+        choice: 'approve',
+      });
+      expect(resolved.status).toBe('ok');
+      const finalChain = await executeChain(inner, defWithRecheck, {
+        runId: run.id,
+        command: 'trigger_recheck',
+        input: {},
+        dispatcher: async () => ({}),
+      });
+      expect(finalChain.status).toBe('ok');
+      expect(finalChain.error_code).toBeUndefined();
+      const finalRun = await inner.get(run.id);
+      expect(finalRun.skipped_steps).toContain('guard_b');
+      expect(finalRun.aborted_at?.step_id).toBe('guard_b');
+      expect(finalRun.terminal_state).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/engine/guard-chain-consumption-279.test.ts
+++ b/packages/core/src/engine/guard-chain-consumption-279.test.ts
@@ -1,5 +1,5 @@
 // guard-chain-consumption-279.test.ts — GUARD_CHAIN_CONSUMPTION (issue #279, increment 2, PR-D,
-// Deliverable 5; design record §6/§8, gate-1 gap-1's forcing test). Four legs through the REAL
+// Deliverable 5; design record §6/§8, gate-1 gap-1's forcing test). Five legs through the REAL
 // engine (executeChain) + a REAL JsonFileStore, exercising the chain-consumption table adjudicated
 // for settle_guard's refusal reasons:
 //   (a) a sibling settles the guard FIRST (same outcome) ⇒ our own attempt returns already_settled
@@ -10,6 +10,14 @@
 //       (STATE_STEP_ALREADY_SETTLED) — the abort was never recorded.
 //   (d) a gate opens on ANOTHER step between the guard's pre-seal snapshot and its own settle call
 //       ⇒ gate_open_wait ⇒ quiet end-of-pass; the guard re-applies cleanly once the gate resolves.
+//   (e) [correction, MA review of reports/atomic-settle-279-pr-d.md] a sibling settles the guard
+//       FIRST with the SAME outcome as our own attempt (same shape as leg (a)), but the sibling's
+//       commit is a RAW `store.settleStep` call — it terminalizes the run and mints the finalizer
+//       ledger PENDING, but (being a bare store-layer write, not a full executeChain/
+//       submitHumanResponse call) never drains. Our own attempt then hits already_settled ⇒ the
+//       1c NOOP-leg's own drain-on-already_settled clause must fire and deliver the finalizer,
+//       exactly once, with its warnings (if any) riding `guardWarnings` into the final envelope —
+//       pinning the self-corrected fix Deviation #2 of the PR-D report left unpinned.
 //
 // Construction technique: rather than a raw concurrency race (which would non-deterministically
 // decide which of two callers "wins" the guard — unlike symptom-death-279.test.ts's sibling-STEP
@@ -32,10 +40,12 @@ import { join } from 'node:path';
 import { JsonFileStore } from '../store/json-file-store.js';
 import { executeChain, submitHumanResponse } from './execution-loop.js';
 import { captureEvidence } from '../evidence/snapshot.js';
+import { ExtensionRegistry } from '../extensions/registry.js';
 import type { RunStore, CreateRunOptions } from '../store/store-interface.js';
 import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import type { SettlementDelta, SettlementResult } from '../types/settlement.js';
+import type { StepHandler } from '../extensions/step-handler.js';
 
 /**
  * Delegates every RunStore method to a real, functional JsonFileStore. `settleStep` is
@@ -116,6 +126,23 @@ const defWithRecheck: WorkflowDefinition = {
   steps: {
     ...def.steps,
     trigger_recheck: { description: 'tr', execution: 'auto', depends_on: [] },
+  },
+};
+
+// Leg (e) ONLY — a SEPARATE definition (same reasoning as defWithRecheck): adds a finalizer bound
+// to the run's overall 'abort' outcome (r5-guard-finalizer-wf's own shape, gate-death-279.test.ts),
+// so guard_b's abort terminalizes the run AND mints exactly one finalizer to drain.
+const defWithFinalizer: WorkflowDefinition = {
+  ...def,
+  id: 'guard-chain-consumption-finalizer-wf',
+  steps: {
+    ...def.steps,
+    fin: {
+      description: 'finalizer',
+      execution: 'finalizer',
+      on_outcome: 'abort',
+      handler: 'fin-handler',
+    },
   },
 };
 
@@ -338,6 +365,78 @@ describe('GUARD_CHAIN_CONSUMPTION — the chain-consumption table (issue #279, i
       expect(finalRun.skipped_steps).toContain('guard_b');
       expect(finalRun.aborted_at?.step_id).toBe('guard_b');
       expect(finalRun.terminal_state).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("(e) [correction] a sibling RAW-settles the guard with the SAME (abort) outcome, terminalizing the run and minting a finalizer PENDING with no drain ⇒ our own already_settled leg's NOOP-drain delivers it, exactly once", async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'realm-gcc-e-'));
+    try {
+      const inner = new JsonFileStore(dir);
+      const { run } = await inner.create({
+        workflowId: defWithFinalizer.id,
+        workflowVersion: 1,
+        params: {},
+      });
+
+      let handlerCallCount = 0;
+      const finHandler: StepHandler = {
+        id: 'fin-handler',
+        execute: async () => {
+          handlerCallCount += 1;
+          return { data: {} };
+        },
+      };
+      const registry = new ExtensionRegistry();
+      registry.register('handler', 'fin-handler', finHandler);
+
+      const store = new InjectBeforeSettleStore(
+        inner,
+        (d) => d.kind === 'settle_guard' && d.step === 'guard_b',
+        async () => {
+          // RAW sibling commit — a bare `store.settleStep` call, bypassing executeChain entirely.
+          // applySettleGuard's abort arm mints the finalizer ledger PENDING as part of terminal
+          // postconditions, but ONLY executeChain/submitHumanResponse ever call drainFinalizers —
+          // a raw store-layer write never does, so "no drain runs" arises naturally, without any
+          // separate lease-refusal interception (unlike 1b's own drain-on-NOOP precedent).
+          await inner.settleStep(
+            run.id,
+            {
+              kind: 'settle_guard',
+              step: 'guard_b',
+              outcome: 'abort',
+              evidence: makeGuardEvidence('abort'),
+              abort: {
+                conditions: [
+                  { condition: "step_a.status == 'open'", resolved_value: 'closed', passed: false },
+                ],
+              },
+            },
+            defWithFinalizer,
+          );
+        },
+      );
+
+      const result = await executeChain(store, defWithFinalizer, {
+        runId: run.id,
+        command: 'step_a',
+        input: {},
+        dispatcher: async () => ({ status: 'closed' }), // OUR OWN attempt also aborts — same outcome
+        registry,
+      });
+
+      expect(result.status).toBe('ok');
+      expect(result.errors).toEqual([]);
+      expect(result.error_code).toBeUndefined();
+
+      const finalRun = await inner.get(run.id);
+      // Delivered, not merely settled-terminal: the NOOP-leg's drain-on-already_settled clause
+      // recovered the crashed-drain state left by the raw sibling commit.
+      expect(finalRun.finalizer_ledger?.['fin']?.status).toBe('completed');
+      expect(finalRun.completed_steps).toContain('fin');
+      expect(finalRun.evidence.find((e) => e.step_id === 'fin')).toBeDefined();
+      expect(handlerCallCount).toBe(1); // exactly once — never zero, never twice
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/engine/human-gate.test.ts
+++ b/packages/core/src/engine/human-gate.test.ts
@@ -147,7 +147,13 @@ describe('human gate', () => {
     });
 
     expect(result.status).toBe('error');
-    expect(result.errors[0]).toContain('Gate ID mismatch');
+    // issue #279 (increment 2, PR-D): on the migrated path (JsonFileStore declares settleStep),
+    // an unknown/superseded gateId is settle_gate's own `gate_mismatch` refusal — the design
+    // record's uniform text for "no live gate matches this id", collapsing the legacy path's
+    // separate "no open gate at all" / "gate ID mismatch" texts into one.
+    expect(result.errors[0]).toContain(
+      "Gate 'wrong-gate-id' is not the open gate and matches no committed resolution",
+    );
   });
 
   it('submitHumanResponse with invalid choice returns error', async () => {

--- a/packages/core/src/engine/run-health.test.ts
+++ b/packages/core/src/engine/run-health.test.ts
@@ -384,4 +384,91 @@ describe('classifyRunHealth', () => {
       expect(f.reason.toLowerCase()).not.toContain('stuck');
     }
   });
+
+  // ---------------------------------------------------------------------
+  // issue #279 (increment 2, PR-D, design record §9) — the three NEW finding classes.
+  // ---------------------------------------------------------------------
+
+  it('terminal_with_stale_gate: a terminal record still carrying a pending_gate gets exactly this finding, pointing at purge', () => {
+    const run = makeRun({
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      run_phase: 'gate_waiting', // stale — the #282 class's own persisted-phase symptom
+      pending_gate: {
+        gate_id: 'stale-gate',
+        step_name: 'gated_step',
+        preview: {},
+        choices: ['approve', 'reject'],
+        opened_at: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    const findings = classifyRunHealth(run, { now: NOW });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.kind).toBe('terminal_with_stale_gate');
+    expect(findings[0]?.step).toBe('gated_step');
+    expect(findings[0]?.evidence?.['gate_id']).toBe('stale-gate');
+  });
+
+  it('gate_corruption (G-2): a settled gate entry sharing the SAME gate_id as the live pending_gate is flagged, on BOTH the terminal and non-terminal paths', () => {
+    const corruptGate = {
+      gate_id: 'corrupt-gate',
+      step_name: 'gated_step',
+      preview: {},
+      choices: ['approve', 'reject'],
+      opened_at: '2026-01-01T00:00:00.000Z',
+    };
+    const nonTerminalRun = makeRun({
+      pending_gate: corruptGate,
+      run_phase: 'gate_waiting',
+      settled: { gated_step: { token: 'corrupt-gate', outcome: 'gate', choice: 'approve' } },
+    });
+    const nonTerminalFindings = classifyRunHealth(nonTerminalRun, { now: NOW });
+    expect(nonTerminalFindings.some((f) => f.kind === 'gate_corruption')).toBe(true);
+    const corruptionFinding = nonTerminalFindings.find((f) => f.kind === 'gate_corruption');
+    expect(corruptionFinding?.step).toBe('gated_step');
+    expect(corruptionFinding?.evidence?.['gate_id']).toBe('corrupt-gate');
+
+    const terminalRun = makeRun({
+      terminal_state: true,
+      terminal_reason: 'Workflow completed.',
+      pending_gate: corruptGate,
+      settled: { gated_step: { token: 'corrupt-gate', outcome: 'gate', choice: 'approve' } },
+    });
+    const terminalFindings = classifyRunHealth(terminalRun, { now: NOW });
+    expect(terminalFindings.some((f) => f.kind === 'gate_corruption')).toBe(true);
+  });
+
+  it('resolved_gate_with_eligible_guard: a resolved gate with a NOW-eligible guard names it, ONLY when a definition is supplied', () => {
+    const run = makeRun({
+      completed_steps: ['gated_step'],
+      run_phase: 'running',
+    });
+    const definition: WorkflowDefinition = {
+      id: 'wf',
+      name: 'wf',
+      version: 1,
+      steps: {
+        gated_step: { description: 'g', execution: 'agent', depends_on: [] },
+        guard_after: {
+          description: 'guard',
+          execution: 'guard',
+          depends_on: ['gated_step'],
+          abort_unless: ['gated_step.status == "open"'],
+        },
+      },
+    };
+    const withDefinition = classifyRunHealth(run, { now: NOW, definition });
+    expect(withDefinition.some((f) => f.kind === 'resolved_gate_with_eligible_guard')).toBe(true);
+    const finding = withDefinition.find((f) => f.kind === 'resolved_gate_with_eligible_guard');
+    expect(finding?.step).toBe('guard_after');
+    expect(finding?.reason).toContain('guard_after');
+    expect(finding?.reason).toContain('next drive');
+
+    // Definition-free: the finding never surfaces (findEligibleGuardSteps needs a definition) —
+    // matches list.ts's own disclosed, accepted limitation (design record §9).
+    const withoutDefinition = classifyRunHealth(run, { now: NOW });
+    expect(withoutDefinition.some((f) => f.kind === 'resolved_gate_with_eligible_guard')).toBe(
+      false,
+    );
+  });
 });

--- a/packages/core/src/engine/run-health.ts
+++ b/packages/core/src/engine/run-health.ts
@@ -46,6 +46,22 @@
 //      go find it elsewhere. `opts.definition`, when supplied, additionally adds
 //      `evidence.eligible_steps` (Temporal's list-cheap/describe-rich split); a definition-free
 //      caller still classifies correctly on age alone.
+//   5. issue #279 (increment 2, PR-D, design record §9) — THREE new finding classes surfacing the
+//      #282 class and its adjacent gate-corruption/liveness classes:
+//        - `terminal_with_stale_gate`: `run.terminal_state && run.pending_gate !== undefined` — a
+//          grandfathered #282-class record (checked INSIDE branch 1, above the `pendingFindings`
+//          return, since a terminal run never reaches branches 2-4). Pointer to `realm run purge`.
+//        - `gate_corruption` (G-2): a `settled` entry with `outcome === 'gate'` whose `token`
+//          equals `run.pending_gate.gate_id` — the both-match corruption N9 names (fail-safe
+//          NOOP-not-RESOLVE pinned in settlement.ts, but `pending_gate` then never clears itself).
+//          Checked in BOTH the terminal branch (1) and the non-terminal path — a live pending_gate
+//          can coexist with either. Exits: settle_step abort or purge.
+//        - `resolved_gate_with_eligible_guard` (N8's surface): `opts.definition` supplied AND
+//          `findEligibleGuardSteps(definition, run)` non-empty — that function ALREADY self-filters
+//          both a terminal run and an open gate (eligibility.ts), so this is checked unconditionally
+//          in the non-terminal path with no extra gating needed. Disclosed consequence (list.ts is
+//          frozen and passes no `definition` — this finding never surfaces there; ACCEPTABLE, not a
+//          list.ts defect).
 //
 // Honest-admission rule (Celery-corrected, record §1): `never_claimed_idle`'s reason text NEVER
 // claims rejection — "parked with no claimed step, idle", never "rejected" or "stuck". Rescoped
@@ -59,7 +75,7 @@ import type { RunRecord } from '../types/run-record.js';
 import type { WorkflowDefinition } from '../types/workflow-definition.js';
 import { classifyInProgressClaims } from './claim-liveness.js';
 import { findCapabilityBlockedSteps } from './capability.js';
-import { findEligibleSteps } from './eligibility.js';
+import { findEligibleSteps, findEligibleGuardSteps } from './eligibility.js';
 
 /**
  * Default age threshold for the `never_claimed_idle` finding (issue #221) — 24 hours. Engine-
@@ -80,7 +96,11 @@ export interface RunHealthFinding {
     | 'stale_claim'
     | 'wedged_gate_sibling'
     | 'capability_block'
-    | 'terminal_pending_finalizer';
+    | 'terminal_pending_finalizer'
+    // issue #279 (increment 2, PR-D, design record §9) — the #282 class + its adjacent classes.
+    | 'terminal_with_stale_gate'
+    | 'gate_corruption'
+    | 'resolved_gate_with_eligible_guard';
   /** The affected step, when the finding is step-scoped. Absent for `never_claimed_idle` — a
    *  run-level observation (no step is claimed at all). */
   step?: string;
@@ -102,6 +122,35 @@ export interface RunHealthFinding {
    *  findings carry `{requirement, code}`; `never_claimed_idle` carries `{idle_threshold_ms}` and,
    *  when `opts.definition` was supplied, `{eligible_steps}`. */
   evidence?: Record<string, unknown>;
+}
+
+/**
+ * G-2-corruption detector (issue #279, increment 2, PR-D, design record §9/N9): a `settled` entry
+ * recording a resolved gate (`outcome === 'gate'`) whose `token` equals the run's OWN live
+ * `pending_gate.gate_id` — the both-match corruption `settleGateArms`'s lookup-first ordering
+ * fail-safes against (NOOP, never RESOLVE — settlement.ts), but which then leaves `pending_gate`
+ * permanently unclearable by normal means (exits: `settle_step` abort, or `realm run purge`).
+ * Out-of-contract producer only (a real store honoring `settleStep`'s own atomicity can never
+ * produce this); a run-health finding is the detection surface. Checked from BOTH branches of
+ * {@link classifyRunHealth} (a live pending_gate can coexist with this corruption whether or not
+ * the run has separately gone terminal).
+ */
+function findGateCorruption(run: RunRecord): RunHealthFinding | undefined {
+  if (run.pending_gate === undefined) return undefined;
+  const gateId = run.pending_gate.gate_id;
+  for (const [step, entry] of Object.entries(run.settled ?? {})) {
+    if (entry.outcome === 'gate' && entry.token === gateId) {
+      return {
+        kind: 'gate_corruption',
+        step,
+        reason:
+          'settled gate entry coexists with a live pending_gate bearing the same gate_id — ' +
+          'store history divergent',
+        evidence: { gate_id: gateId },
+      };
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -136,6 +185,22 @@ export function classifyRunHealth(
         },
       });
     }
+    // issue #279 (increment 2, PR-D, design record §9): terminal-with-stale-gate — the #282
+    // class's own surface. A terminal record that STILL carries a pending_gate is a grandfathered
+    // (or mixed-fleet old-binary-written) record; purge is the disposal path.
+    if (run.pending_gate !== undefined) {
+      pendingFindings.push({
+        kind: 'terminal_with_stale_gate',
+        step: run.pending_gate.step_name,
+        reason:
+          'run is terminal but still carries a pending_gate (a grandfathered #282-class record)',
+        evidence: { gate_id: run.pending_gate.gate_id },
+      });
+    }
+    // G-2-corruption: checked here too — a terminal record can carry the same both-match
+    // corruption a live run can (N9).
+    const terminalGateCorruption = findGateCorruption(run);
+    if (terminalGateCorruption !== undefined) pendingFindings.push(terminalGateCorruption);
     if (pendingFindings.length > 0) return pendingFindings;
     return []; // terminal ∧ no pending ledger entries ⇒ [] (byte-identical to pre-#279 behavior)
   }
@@ -165,6 +230,24 @@ export function classifyRunHealth(
       since: b.at,
       evidence: { requirement: b.requirement, code: b.code },
     });
+  }
+
+  // issue #279 (increment 2, PR-D, design record §9): G-2-corruption on the non-terminal path too
+  // — a live pending_gate can coexist with the same both-match corruption a terminal record can.
+  const gateCorruption = findGateCorruption(run);
+  if (gateCorruption !== undefined) findings.push(gateCorruption);
+
+  // issue #279 (increment 2, PR-D, design record §9, N8's surface): resolved-gate-with-eligible-
+  // guard. findEligibleGuardSteps ALREADY self-filters both a terminal run and an open gate
+  // (eligibility.ts), so no extra gating is needed beyond requiring a definition.
+  if (opts?.definition !== undefined) {
+    for (const guardName of findEligibleGuardSteps(opts.definition, run)) {
+      findings.push({
+        kind: 'resolved_gate_with_eligible_guard',
+        step: guardName,
+        reason: `gate resolved; guard '${guardName}' awaits the next drive`,
+      });
+    }
   }
 
   // Branch 4 — never_claimed_idle (the #221 class). since/idle_ms/evidence.idle_threshold_ms are

--- a/packages/core/src/engine/settlement.test.ts
+++ b/packages/core/src/engine/settlement.test.ts
@@ -1,13 +1,20 @@
-// Source-text POSITIVE pin for RunStore.settleStep's migration (issue #279, increment 1, PR-B).
-// PR-A shipped this file's ORIGINAL guard here: a ZERO-invocation-sites assertion proving the
-// engine never called settleStep while the substrate was still dormant. PR-B's whole point is the
-// OPPOSITE — migrating the three seal sites (complete/fail/handler-abort) onto settleStep — so
-// that guard is deleted (as its own header said it would be) and replaced with this positive pin:
-// EXACTLY three `.settleStep(` invocation sites exist, all inside execution-loop.ts (the only
-// migrated file), and packages/mcp-server/src/** stays clean (gate-open/gate-resolution/guard
-// seals are increment-2 territory — untouched this increment, so the MCP surface has nothing new
-// to call). A future accidental FOURTH call site (or a stray call outside execution-loop.ts) fails
-// this test loudly, the same anti-recurrence discipline the deleted guard had, inverted.
+// Source-text POSITIVE pin for RunStore.settleStep's migration (issue #279). PR-A shipped this
+// file's ORIGINAL guard here: a ZERO-invocation-sites assertion proving the engine never called
+// settleStep while the substrate was still dormant. PR-B migrated the three seal sites
+// (complete/fail/handler-abort) onto settleStep — that guard was deleted (as its own header said
+// it would be) and replaced with a positive three-site pin. PR-C added four MORE delta kinds
+// (open_gate/settle_gate/settle_guard/release_step) but stayed engine-inert for them, adding its
+// OWN temporary zero-construction-sites guard. PR-D (increment 2, this file's current state)
+// migrates the five remaining legacy write sites (gate-open, gate-resolution, guard-chain,
+// capability-block release, compensating un-claim) onto settleStep — deleting PR-C's
+// engine-inertness guard (its whole premise is now false) and widening this positive pin to
+// EXACTLY EIGHT `.settleStep(` invocation sites: the three PR-B shipped (complete/fail/
+// handler-abort) plus the five PR-D just migrated (gate-open/gate-resolution/guard-chain/
+// capability-release/compensating-unclaim) — all inside execution-loop.ts (the only migrated
+// file), with packages/mcp-server/src/** staying clean (it constructs no deltas of its own; it
+// only calls into execution-loop.ts's exported functions). A future accidental NINTH call site (or
+// a stray call outside execution-loop.ts) fails this test loudly, the same anti-recurrence
+// discipline the deleted PR-A guard had, inverted.
 //
 // Invocation-scoped (matches `.settleStep(` literally, not a bare `settleStep` name match) so this
 // module's own JSDoc prose can mention the identifier freely without self-tripping the count.
@@ -27,7 +34,9 @@ const SCANNED_ROOTS = [
 ];
 
 const INVOCATION = '.settleStep(';
-const EXPECTED_SITE_COUNT = 3; // complete, fail, handler-abort
+// complete/fail/handler-abort (PR-B) + gate-open/gate-resolution/guard-chain/capability-release/
+// compensating-unclaim (PR-D, increment 2).
+const EXPECTED_SITE_COUNT = 8;
 const MIGRATED_FILE = join(PACKAGES_DIR, 'core', 'src', 'engine', 'execution-loop.ts');
 
 /** Every non-test, non-declaration .ts source file under `root`, recursively. */
@@ -62,7 +71,7 @@ function findInvocationSites(): { file: string; line: number; text: string }[] {
   return sites;
 }
 
-describe('RunStore.settleStep is MIGRATED at exactly three sites (issue #279, increment 1, PR-B)', () => {
+describe('RunStore.settleStep is MIGRATED at exactly eight sites — increment 2, PR-D', () => {
   it('the scan itself is wired correctly (finds at least one .ts source file per root)', () => {
     for (const root of SCANNED_ROOTS) {
       expect(
@@ -72,7 +81,7 @@ describe('RunStore.settleStep is MIGRATED at exactly three sites (issue #279, in
     }
   });
 
-  it(`EXACTLY ${EXPECTED_SITE_COUNT} '.settleStep(' invocation sites exist (complete/fail/handler-abort)`, () => {
+  it(`EXACTLY ${EXPECTED_SITE_COUNT} '.settleStep(' invocation sites exist (complete/fail/handler-abort/gate-open/gate-resolution/guard-chain/capability-release/compensating-unclaim)`, () => {
     const sites = findInvocationSites();
     expect(
       sites.length,
@@ -168,66 +177,5 @@ describe('applySettlement is deterministic — same inputs + fixed now ⇒ deep-
     // Sanity: the fixture actually exercises the applied path (a vacuously-equal pair of
     // refusals would pass this check without proving anything about the transform's output).
     expect(first.applied).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Engine-inert guard for the four increment-2 delta kinds (issue #279, increment 2, PR-C).
-// The whole point of this PR's scope class (EXPAND / Parallel Change) is that open_gate,
-// settle_gate, settle_guard, and release_step are ADDED to the substrate but not yet wired to any
-// call site — the five legacy write sites they'll eventually replace (gate-open, gate-resolution,
-// guard-pass/abort/error, capability-block release) stay on their pre-existing paths until PR-D's
-// migration. This mirrors the ORIGINAL zero-invocation-sites guard PR-A shipped for settle_step
-// itself (since deleted above, replaced by the positive three-site pin, once PR-B migrated it) —
-// same discipline, applied to the four kinds still dormant in THIS increment.
-//
-// Literal-construction-scoped (`kind: 'open_gate'` etc., not a bare identifier match) so this
-// module's own JSDoc/type definitions can mention the kind names freely without self-tripping —
-// settlement.ts (where the delta *types* and `applySettlement`'s dispatcher legitimately name
-// these literals) and any `.test.ts` file (this file's own fixtures, the TCK) are excluded from
-// the scan; every other engine/mcp-server source file must be clean.
-describe('the four increment-2 delta kinds are ENGINE-INERT — no source-text construction site exists yet (issue #279, increment 2, PR-C)', () => {
-  const INCREMENT_2_KINDS = ['open_gate', 'settle_gate', 'settle_guard', 'release_step'];
-  const EXCLUDED_FILES = new Set([join(PACKAGES_DIR, 'core', 'src', 'engine', 'settlement.ts')]);
-
-  function findConstructionSites(): { file: string; line: number; text: string }[] {
-    const sites: { file: string; line: number; text: string }[] = [];
-    for (const root of SCANNED_ROOTS) {
-      for (const file of sourceFiles(root)) {
-        if (EXCLUDED_FILES.has(file)) continue;
-        const lines = readFileSync(file, 'utf8').split('\n');
-        lines.forEach((line, i) => {
-          for (const kind of INCREMENT_2_KINDS) {
-            if (line.includes(`kind: '${kind}'`) || line.includes(`kind:'${kind}'`)) {
-              sites.push({ file, line: i + 1, text: line.trim() });
-            }
-          }
-        });
-      }
-    }
-    return sites;
-  }
-
-  it('no engine or mcp-server source file (excluding settlement.ts) constructs an open_gate/settle_gate/settle_guard/release_step literal', () => {
-    const sites = findConstructionSites();
-    expect(
-      sites,
-      sites.length > 0
-        ? `Found increment-2 delta construction site(s) OUTSIDE settlement.ts — these kinds must ` +
-            `stay engine-inert until PR-D's migration:\n${sites
-              .map((s) => `  ${s.file}:${s.line}: ${s.text}`)
-              .join('\n')}`
-        : '',
-    ).toEqual([]);
-  });
-
-  it('settlement.ts ITSELF does declare all four kinds (sanity check — an empty scan must mean "excluded", not "the kinds do not exist")', () => {
-    const settlementSrc = readFileSync(
-      join(PACKAGES_DIR, 'core', 'src', 'engine', 'settlement.ts'),
-      'utf8',
-    );
-    for (const kind of INCREMENT_2_KINDS) {
-      expect(settlementSrc, `expected settlement.ts to reference kind '${kind}'`).toContain(kind);
-    }
   });
 });

--- a/packages/core/src/engine/settlement.ts
+++ b/packages/core/src/engine/settlement.ts
@@ -333,6 +333,7 @@ function applyAbortEdge(
   // nothing above has touched it.
   if (fresh.pending_gate !== undefined && fresh.pending_gate.step_name !== step) {
     const gateStepName = fresh.pending_gate.step_name;
+    const cancelledGateId = fresh.pending_gate.gate_id;
     const { pending_gate: _droppedGate, ...withoutGate } = aborted;
     aborted = {
       ...withoutGate,
@@ -341,7 +342,9 @@ function applyAbortEdge(
       skipped_steps: [...withoutGate.skipped_steps, gateStepName],
       skip_details: {
         ...withoutGate.skip_details,
-        [gateStepName]: { kind: 'gate_cancelled_by_abort' },
+        // gate_id additive (design record §5 D-4) — the settle_gate run_terminal envelope's
+        // cancelled-variant discriminator binds by this once populated.
+        [gateStepName]: { kind: 'gate_cancelled_by_abort', gate_id: cancelledGateId },
       },
       evidence: [
         ...withoutGate.evidence,
@@ -350,7 +353,7 @@ function applyAbortEdge(
           startedAt: now,
           completedAt: now,
           input: {},
-          output: { gate_cancelled_by_abort: true, aborted_by: step },
+          output: { gate_cancelled_by_abort: true, aborted_by: step, gate_id: cancelledGateId },
         }),
       ],
     };

--- a/packages/core/src/types/run-record.ts
+++ b/packages/core/src/types/run-record.ts
@@ -126,6 +126,14 @@ export interface EvidenceSnapshot {
    * This is an evidence integrity field: it records exactly what the human read.
    */
   gate_message?: string;
+  /**
+   * Issue #279 (increment 2, PR-D; design record D-5): unenforced attribution passthrough for a
+   * gate resolution — the caller-supplied identity of whoever made this gate choice, when
+   * supplied. RECORDED, not enforced (D-5: the bearer-gateId-as-sole-credential model stays the
+   * authority; no arm reads this field). Present only on `gate_response` evidence entries whose
+   * caller supplied `respondedBy`/`responded_by`.
+   */
+  responded_by?: string;
   /** Diagnostic metadata. Present on snapshots captured after Week 7. */
   diagnostics?: StepDiagnostics;
   /** Name of the agent profile active at this step, if any. */
@@ -327,7 +335,16 @@ export type SkipDetail =
    * terminal-with-an-open-gate state #279 exists to close). Dormant until PR-B migrates the seal
    * sites — no engine call site can produce this in PR-A.
    */
-  | { kind: 'gate_cancelled_by_abort' };
+  | {
+      kind: 'gate_cancelled_by_abort';
+      /**
+       * Issue #279 (increment 2, PR-D; design record §5 D-4): the cancelled gate's `gate_id` —
+       * additive, so pre-PR-D cancel records (which lack this field) remain valid; the settle_gate
+       * `run_terminal` envelope's cancelled-variant discriminator binds by skip-detail PRESENCE for
+       * those (N10), and by `gate_id` equality once this field is populated.
+       */
+      gate_id?: string;
+    };
 
 export interface RunRecord {
   id: string;

--- a/packages/mcp-server/src/tools/submit-human-response.test.ts
+++ b/packages/mcp-server/src/tools/submit-human-response.test.ts
@@ -122,9 +122,14 @@ describe('handleSubmitHumanResponse — fires finalizers on gate completion', ()
     expect(updated.completed_steps).toContain('record_outcome');
   });
 
-  it('records the finalizer as a NON-FATAL failure when no registry supplies its handler (run still completes)', async () => {
-    // Control: neither registry nor provider carries the project handler → handler-not-found is
-    // recorded, but the gate still completes the run (finalizer failure is non-fatal).
+  it('leaves the finalizer PENDING (recoverable on a capable runner) when no registry supplies its handler (run still completes)', async () => {
+    // Control: neither registry nor provider carries the project handler. issue #279 (increment 2,
+    // PR-D): gate resolution now completes via the post-commit drain loop (drainFinalizers) on a
+    // declaring store — its registry pre-check LEAVES an absent-handler entry PENDING and
+    // discloses why, rather than burning it into failed_steps (design record §6 — the
+    // "recoverable on a capable runner" property; PR-B's own already-shipped drain semantics, now
+    // also reached via gate resolution). The gate still completes the run either way (finalizer
+    // non-delivery is non-fatal).
     const emptyRegistry = new ExtensionRegistry();
     const { runId, gateId } = await startAndOpenGate({
       runStore,
@@ -138,7 +143,8 @@ describe('handleSubmitHumanResponse — fires finalizers on gate completion', ()
 
     expect(result.run_phase).toBe('completed');
     const updated = await runStore.get(runId);
-    expect(updated.failed_steps).toContain('record_outcome');
+    expect(updated.failed_steps).not.toContain('record_outcome');
     expect(updated.completed_steps).not.toContain('record_outcome');
+    expect(updated.finalizer_ledger?.['record_outcome']?.status).toBe('pending');
   });
 });

--- a/packages/mcp-server/src/tools/submit-human-response.ts
+++ b/packages/mcp-server/src/tools/submit-human-response.ts
@@ -17,7 +17,7 @@ import { sseJsonStringify } from '../sse-json.js';
  * Validates the gate_id and choice, then advances the run past the gate.
  */
 export async function handleSubmitHumanResponse(
-  args: { run_id: string; gate_id: string; choice: string },
+  args: { run_id: string; gate_id: string; choice: string; responded_by?: string | undefined },
   stores?: HandleRunStores,
 ): Promise<ResponseEnvelope> {
   const workflowStore = stores?.workflowStore ?? new JsonWorkflowStore();
@@ -38,6 +38,8 @@ export async function handleSubmitHumanResponse(
     gateId: args.gate_id,
     choice: args.choice,
     ...(registry !== undefined ? { registry } : {}),
+    // issue #279 (increment 2, PR-D; design record D-5): pass-through only, never validated.
+    ...(args.responded_by !== undefined ? { respondedBy: args.responded_by } : {}),
   });
 }
 
@@ -50,6 +52,9 @@ export function registerSubmitHumanResponse(server: McpServer, opts?: HandleRunS
       run_id: z.string(),
       gate_id: z.string(),
       choice: z.string(),
+      // issue #279 (increment 2, PR-D; design record D-5): unenforced attribution passthrough —
+      // pass-through only, never validated.
+      responded_by: z.string().optional(),
     },
     async (args) => {
       try {

--- a/packages/testing/src/mocks/mock-gate.test.ts
+++ b/packages/testing/src/mocks/mock-gate.test.ts
@@ -98,9 +98,13 @@ describe('createGateResponder — registry threading fires finalizers', () => {
     expect(updated.evidence.some((e) => e.step_id === 'record_outcome')).toBe(true);
   });
 
-  it('records the finalizer as a NON-FATAL failure when no registry is passed (run still completes)', async () => {
-    // Control: without the registry the project handler is unresolvable → handler-not-found is
-    // recorded, but the gate still completes the run (finalizer failure is non-fatal).
+  it('leaves the finalizer PENDING (recoverable on a capable runner) when no registry is passed (run still completes)', async () => {
+    // Control: without the registry the project handler is unresolvable. issue #279 (increment 2,
+    // PR-D): gate resolution now completes via the post-commit drain loop (drainFinalizers) on a
+    // declaring store (InMemoryStore) — its registry pre-check LEAVES an absent-handler entry
+    // PENDING and discloses why, rather than burning it into failed_steps (design record §6: the
+    // "recoverable on a capable runner" property; PR-B's own already-shipped drain semantics, now
+    // also reached via gate resolution). The gate still completes the run either way.
     const def = gateFinalizerDef();
     const runId = await openGate(def);
     const result = await createGateResponder(store, def, runId, {});
@@ -108,8 +112,9 @@ describe('createGateResponder — registry threading fires finalizers', () => {
     expect(result.status).toBe('ok');
     const updated = await store.get(runId);
     expect(updated.run_phase).toBe('completed');
-    expect(updated.failed_steps).toContain('record_outcome');
+    expect(updated.failed_steps).not.toContain('record_outcome');
     expect(updated.completed_steps).not.toContain('record_outcome');
+    expect(updated.finalizer_ledger?.['record_outcome']?.status).toBe('pending');
   });
 
   it('backward-compatible: an existing-style call with no registry resolves a gate-only workflow', async () => {


### PR DESCRIPTION
## Summary

Second PR of issue #279's increment 2 (the Parallel-Change migrate step, PR-B's shape). Migrates the five remaining legacy write sites onto atomic settlement (`RunStore.settleStep`):

- **Gate-open** → `open_gate` delta
- **Gate-resolution** (`submitHumanResponse`) → `settle_gate` delta
- **Guard seal chain** → `settle_guard` delta
- **Capability-block release** → `release_step` delta
- **Compensating un-claim** → `release_step` delta

Every migrated site branches on `store.settleStep`'s declaration: a non-declaring store keeps its original write path byte-identical, now carrying a `DORMANCY_ADVISORY`. `settlement.test.ts`'s PR-C engine-inertness pin is replaced by the positive eight-site guard-pin (3 PR-B sites + these 5).

Also ships:
- **D-4 typed refusal envelopes**: `buildSettlementRefusalEnvelope` gains a `kind` discriminator (`settle_step` | `open_gate`) + neutral wording (N1) when a settled entry was closed by a completed gate rather than another attempt.
- **Cancel-trail `gate_id`**: additive field on the abort-cancel `SkipDetail` + evidence snapshot.
- **Three new run-health finding classes**: `terminal_with_stale_gate`, `gate_corruption`, `resolved_gate_with_eligible_guard`.
- **`submit_human_response`** accepts an optional `responded_by` for attribution.
- A docs sweep (`operating-runs.md`, `mcp-protocol.md`) reflecting the new gate-resolution semantics.

Two real production gaps were caught while writing the mandated tests, before ever reaching the verification stage, and fixed: the gate-resolution and guard-chain `already_settled` NOOP legs weren't draining pending finalizers, and the guard-chain's legacy terminal envelope was missing its dormancy advisory. Full rationale, every deviation, and the 6-probe mutation transcript are in the local implementation report (not committed — `/reports/` is local-only per repo convention).

References #279 (stays open for increment 3 / gate-timeout, tracked as #291). Does not close #282 (already closed by PR-C, #288).

## Test plan

- [x] Full forced suite green across all 4 packages: `realm` 2010/2010, `realm-cli` 881/881, `realm-mcp` 281/281, `realm-testing` 151/151 (3323 total)
- [x] `turbo run build lint test --force` clean (build/lint) across all packages; `prettier --check .` clean
- [x] `git diff --stat` matches the anticipated touch-list plus one disclosed addition (`packages/testing/src/mocks/mock-gate.test.ts` — a real fixture-fallout from gate-resolution now draining via the shared finalizer registry, same class already hit in `respond.test.ts`/`submit-human-response.test.ts`)
- [x] All named damage rails verified zero-diff: `eligibility.ts`, `apply-resume.ts`, `purge.ts`, `resume.ts`, `idempotency-policy.ts`, `abandon-run.ts`, `append-trace.ts`, `export.ts`, `list.ts`, `inspect.ts`, `start-run(.batch).ts`, `json-file-store.ts`, `in-memory-store.ts`, `reclaim-step.ts`, `drain.ts`
- [x] `settlement.ts`'s diff confirmed to contain only the Deliverable-3 `gate_id` additions; `executeGuardStep` confirmed byte-untouched
- [x] All 6 named mutation probes run, confirmed red for the specified reason, reverted, confirmed green (drain-drop at settle_gate; divergence-disjunct removal; terminal_state-ternary swap; cancelled-discriminator drop; convergence-hint drop; dormancy-branch inversion)
- [x] New test suites: `guard-chain-consumption-279.test.ts`, `gate-death-279.test.ts`, `envelope-pins-279.test.ts`, plus extensions to `dormancy-suite-279.test.ts` and `run-health.test.ts`

## Design questions surfaced for architect review (no code action taken)

1. **Cloud punch-list additions** (design record §9, restated here so they aren't lost at merge): `SettledEntry`'s `choice` column + `'gate'` outcome value; the four new delta kinds in the `settleStepForTenant` sketch; purge/save derivation notes; the cancelled-gate `gate_id` additive fields; and the restated disposal rule — *"Postgres consumers key on terminal_state, the marker fields, or DERIVED phase — persisted run_phase is render-only, and rendered only after derivation."*
2. The two drain-on-`already_settled` gaps and the guard-chain dormancy-advisory gap (self-corrected mid-implementation, not named in the design record) — flagging for independent re-examination.
3. A narrower, pre-existing, already-accepted residual: a guard at `depth > 0` whose own divergence-ADVANCE warning is immediately followed by a recursive auto-step call would still lose that warning (the `depth0Warnings` mechanism only ever rescues a depth-0 non-auto step's warnings). Not introduced by this PR; no fixture exercises it; flagged only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
