### PR TITLE
chore: release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 ---
 
-## [Unreleased]
+## [0.33.0] — 2026-07-27
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,7 +4529,7 @@
     },
     "packages/cli": {
       "name": "@sensigo/realm-cli",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4580,7 +4580,7 @@
     },
     "packages/core": {
       "name": "@sensigo/realm",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/mcp-server": {
       "name": "@sensigo/realm-mcp",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -4646,7 +4646,7 @@
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sensigo/realm": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-cli",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { workflowCommands, runCommands, topLevelCommands } from './commands-regi
 
 const program = new Command();
 
-program.name('realm').description('Realm workflow engine CLI').version('0.32.0');
+program.name('realm').description('Realm workflow engine CLI').version('0.33.0');
 
 // realm workflow — operations on workflow definitions
 const workflowCmd = new Command('workflow').description('Manage workflow definitions');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,7 +132,7 @@ export {
 } from './engine/precondition.js';
 export type { PreconditionResult } from './engine/precondition.js';
 export type { StepDiagnostics } from './types/run-record.js';
-export const VERSION = '0.32.0';
+export const VERSION = '0.33.0';
 export type { ToolCallRecord, McpServerConfig } from './types/mcp-types.js';
 
 // Extensions

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-mcp",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,4 +6,4 @@ export type { WorkflowProtocol, ProtocolStep } from './protocol/generator.js';
 // issue #107: exported so the operator run-purge CLI command (packages/cli) can construct one
 // and register it as a PerRunArtifactStore alongside JsonFileStore/FailedAttemptStore.
 export { JsonTraceBufferStore } from './json-trace-buffer-store.js';
-export const VERSION = '0.32.0';
+export const VERSION = '0.33.0';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export { createDefaultRegistry };
 export function createRealmMcpServer(options?: RealmMcpServerOptions): McpServer {
   const server = new McpServer({
     name: 'realm',
-    version: '0.32.0',
+    version: '0.33.0',
   });
 
   // When no registry is provided, use the default registry that pre-registers built-in

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensigo/realm-testing",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -64,4 +64,4 @@ export type { TestResult, RunFixtureTestsOptions } from './runner/test-runner.js
 export { startGitHubMockServer } from './servers/github-mock-server.js';
 export type { GitHubMockServerHandle } from './servers/github-mock-server.js';
 
-export const VERSION = '0.32.0';
+export const VERSION = '0.33.0';


### PR DESCRIPTION
## Context
Release v0.33.0 (minor) — the #279 increment-2 release: the complete gates/guards/release migration onto atomic settlement + the #282 stale-phase class closure.

## Changes
- CHANGELOG: `[Unreleased]` → `## [0.33.0] — 2026-07-27` (Fixed: zombie-gate resume, unpurgeable/unresumable grandfathered runs, duplicate-run idempotency flip, append-trace terminal hole, export redaction/warning fixes, phase-derivation reorder, gate/guard CAS-loss dead, fire-before-commit dead · Changed: the five-site migration + typed refusal envelopes · Added: dormant delta kinds + TCK laws, `responded_by`, run-health finding classes).
- `npm run release -- --version 0.33.0`: 4× package.json + VERSION constants bumped; tag `v0.33.0` on the release commit.

## Verification
- Full forced suite green (3324 tests); audit:ci passed; CI green on main pre-branch.

## Rollback
Revert the merge commit; do not push the tag until merged (publish fires on tag push only).

## Related
#279 (closed) · #282 (closed) · #291/#293 (follow-ups)

⚠ **Merge with MERGE COMMIT (not squash/rebase)** — the tag points at the release commit; a rewrite would strand it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
