### PR TITLE
chore(security): fix audit gate — fast-uri 3.1.5 + ip-address 10.4.0 (in-range)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
 
 ---
 
+## [Unreleased]
+
+### Security
+
+- Bumped `fast-uri` 3.1.4 → 3.1.5 (lockfile-only, in-range via `ajv`): GHSA-7p8r-x3mc-p8w7 (HIGH, host confusion
+  via backslash authority). Exposure LOW (same class as the v0.31.0 fast-uri triage: `ajv` uses fast-uri only for
+  opaque `$ref` parsing and makes no trust decision on the parsed host) — fixed in-range regardless.
+- Bumped `ip-address` 10.2.0 → 10.4.0 (lockfile-only, in-range via `@modelcontextprotocol/sdk`'s
+  `express-rate-limit`): GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg (HIGH, IPv4/IPv6
+  parsing misclassification). Exposure LOW (used for client-IP classification in the MCP `serve` rate limiter;
+  realm makes no SSRF-relevant address-trust decision) — fixed in-range regardless.
+
 ## [0.33.0] — 2026-07-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,9 +2137,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2447,9 +2447,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Context
`audit:ci` (the #238 PR-blocking gate) went red repo-wide on two newly published transitive HIGH advisories — blocking every open PR (incl. #304, whose diff is unrelated).

## Changes
Lockfile-only, in-range (SECURITY.md rung 1 — fix-in-range, never downgrade): `fast-uri` 3.1.4→3.1.5 (GHSA-7p8r-x3mc-p8w7; exposure LOW, the v0.31.0 triage class) · `ip-address` 10.2.0→10.4.0 (GHSA-mwp4-54f8-5fhr +2; exposure LOW, serve rate-limiter IP classification). CHANGELOG `### Security` entries added.

## Verification
`npm run audit:ci` PASSES locally post-bump; full forced suite green (all packages); no manifest changes (ranges untouched).

## Rollback
Revert the commit (lockfile-only).

## Related
Supersedes Dependabot #299 (same ip-address target — will auto-close at-version). #238 posture working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
