### PR TITLE
chore(security): adopt GHSA-frvp-7c67-39w9 upstream fix (SDK 1.30.0) + retire the VEX posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to this project are documented here.
 
 ### Security
 
+- Bumped `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0 (exact-pin manifest bump, realm-mcp + realm-cli): adopts the
+  upstream fix for GHSA-frvp-7c67-39w9 — the SDK's widened range now resolves `@hono/node-server` 2.1.0 (≥2.0.5,
+  the patched line). **Retires the standing `not_affected` posture**: the audit-ci allowlist entry (both tiers) is
+  removed and the OpenVEX document gains a `fixed` statement (v2) — the wait-for-upstream disposition set at
+  v0.31.0 completes.
+- Bumped `hono` 4.12.31 → 4.13.0 (lockfile-only, in-range): GHSA CORS-middleware ReDoS (moderate; realm's serve
+  path uses hono core only — fixed in-range regardless).
+
 - Bumped `fast-uri` 3.1.4 → 3.1.5 (lockfile-only, in-range via `ajv`): GHSA-7p8r-x3mc-p8w7 (HIGH, host confusion
   via backslash authority). Exposure LOW (same class as the v0.31.0 fast-uri triage: `ajv` uses fast-uri only for
   opaque `$ref` parsing and makes no trust decision on the parsed host) — fixed in-range regardless.

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -2,13 +2,5 @@
   "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
   "high": true,
   "skip-dev": true,
-  "allowlist": [
-    {
-      "GHSA-frvp-7c67-39w9": {
-        "active": true,
-        "notes": "not_affected (VEX): @hono/node-server's vulnerable serve-static (CWE-22) handler is never imported or registered — neither by realm's own source nor by the only @hono/node-server code path realm reaches (@modelcontextprotocol/sdk's StreamableHTTPServerTransport -> getRequestListener, used by realm-cli's serve command). So the vulnerable path is unreachable. Windows-only advisory; realm deploys to macOS/Linux. MODERATE<high so inert here; kept as the future re-score-to-HIGH escape hatch. Upstream fix: @modelcontextprotocol/sdk -> @hono/node-server >=2.0.5.",
-        "expiry": "2027-01-31",
-      },
-    },
-  ],
+  "allowlist": [],
 }

--- a/audit-ci.tier2.jsonc
+++ b/audit-ci.tier2.jsonc
@@ -4,13 +4,6 @@
   // skip-dev intentionally OMITTED → defaults false → devDependencies ARE audited (the broader tier-2 net).
   "allowlist": [
     // MUST be identical to audit-ci.jsonc's allowlist (the guard enforces tier-1 ⊆ tier-2).
-    // Copied VERBATIM from audit-ci.jsonc (same notes + expiry).
-    {
-      "GHSA-frvp-7c67-39w9": {
-        "active": true,
-        "notes": "not_affected (VEX): @hono/node-server's vulnerable serve-static (CWE-22) handler is never imported or registered — neither by realm's own source nor by the only @hono/node-server code path realm reaches (@modelcontextprotocol/sdk's StreamableHTTPServerTransport -> getRequestListener, used by realm-cli's serve command). So the vulnerable path is unreachable. Windows-only advisory; realm deploys to macOS/Linux. MODERATE<high so inert here; kept as the future re-score-to-HIGH escape hatch. Upstream fix: @modelcontextprotocol/sdk -> @hono/node-server >=2.0.5.",
-        "expiry": "2027-01-31",
-      },
-    },
+    // (Currently empty — GHSA-frvp-7c67-39w9 retired 2026-07-27: upstream fix adopted, @hono/node-server 2.1.0 via SDK 1.30.0.)
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,12 +241,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -309,68 +309,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1452,16 +1390,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -2376,9 +2314,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3438,9 +3376,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4532,7 +4470,7 @@
       "version": "0.33.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@sensigo/realm": "*",
         "@sensigo/realm-mcp": "*",
         "@sensigo/realm-testing": "*",
@@ -4566,6 +4504,62 @@
         }
       }
     },
+    "packages/cli/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "packages/cli/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "packages/cli/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -4577,6 +4571,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "packages/cli/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/core": {
       "name": "@sensigo/realm",
@@ -4628,7 +4628,7 @@
       "version": "0.33.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@sensigo/realm": "*",
         "zod": "^3.25.7"
       },
@@ -4643,6 +4643,68 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "packages/mcp-server/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "packages/mcp-server/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/mcp-server/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/testing": {
       "name": "@sensigo/realm-testing",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "@sensigo/realm": "*",
     "@sensigo/realm-mcp": "*",
     "@sensigo/realm-testing": "*",
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "chalk": "^5.0.0",
     "commander": "^15.0.0",
     "dotenv": "^17.4.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -45,7 +45,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@sensigo/realm": "*",
     "zod": "^3.25.7"
   },

--- a/security/vex/GHSA-frvp-7c67-39w9.openvex.json
+++ b/security/vex/GHSA-frvp-7c67-39w9.openvex.json
@@ -3,7 +3,7 @@
   "@id": "https://github.com/sensigo-hq/realm/security/vex/GHSA-frvp-7c67-39w9",
   "author": "Mihai Lupu <mihai.lupu@sensigo.ro>",
   "timestamp": "2026-07-24T00:00:00Z",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -13,16 +13,52 @@
       "products": [
         {
           "@id": "pkg:npm/%40sensigo/realm-cli",
-          "subcomponents": [{ "@id": "pkg:npm/%40hono/node-server" }]
+          "subcomponents": [
+            {
+              "@id": "pkg:npm/%40hono/node-server"
+            }
+          ]
         },
         {
           "@id": "pkg:npm/%40sensigo/realm-mcp",
-          "subcomponents": [{ "@id": "pkg:npm/%40hono/node-server" }]
+          "subcomponents": [
+            {
+              "@id": "pkg:npm/%40hono/node-server"
+            }
+          ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "realm-cli reaches @hono/node-server only via @modelcontextprotocol/sdk's StreamableHTTPServerTransport (which uses @hono/node-server's getRequestListener) for the 'realm serve' command's JSON-RPC HTTP transport; the vulnerable serve-static handler is never imported or registered anywhere in that transport or in realm's own source, so the vulnerable path is not reachable. The advisory is additionally Windows-only, while realm deploys to macOS/Linux. @sensigo/realm-mcp declares the same @modelcontextprotocol/sdk version but uses only its stdio transport (StdioServerTransport), never loading the HTTP transport module that references @hono/node-server at all."
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-frvp-7c67-39w9",
+        "description": "@hono/node-server serve-static path traversal (CWE-22), Windows-only"
+      },
+      "products": [
+        {
+          "@id": "pkg:npm/%40sensigo/realm-cli",
+          "subcomponents": [
+            {
+              "@id": "pkg:npm/%40hono/node-server"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:npm/%40sensigo/realm-mcp",
+          "subcomponents": [
+            {
+              "@id": "pkg:npm/%40hono/node-server"
+            }
+          ]
+        }
+      ],
+      "status": "fixed",
+      "timestamp": "2026-07-27T00:00:00Z",
+      "status_notes": "Upstream fix adopted: @modelcontextprotocol/sdk 1.30.0 widened its range to '^1.19.9 || ^2.0.5'; realm now resolves @hono/node-server 2.1.0 (>=2.0.5, the patched line). The prior not_affected statement (v1) remains the historical record for realm-cli/realm-mcp <= the SDK-1.29.0-pinned releases (through v0.33.0). The audit-ci allowlist entry (both tiers) is retired in the same change."
     }
-  ]
+  ],
+  "last_updated": "2026-07-27T00:00:00Z"
 }


### PR DESCRIPTION
## Context
The v0.31.0 triage left GHSA-frvp-7c67-39w9 (@hono/node-server serve-static traversal, Windows-only) as `not_affected` with a wait-for-upstream disposition: "the durable fix is an upstream SDK bump to @hono/node-server >=2.0.5 (NOT released yet)". **That condition has now fired** — SDK 1.30.0 ships the widened range.

## Changes
- `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0 (exact-pin, mcp-server + cli) ⇒ `@hono/node-server` resolves 2.1.0 (patched line).
- audit-ci allowlist entry retired from BOTH tiers (guard green: tier-1 ⊆ tier-2 holds on empty).
- OpenVEX v2: `fixed` statement appended; v1 `not_affected` kept as the historical record for ≤v0.33.0 releases.
- hono 4.13.0 in-range (CORS ReDoS moderate) — supersedes Dependabot #300; dev moderates cleaned (brace-expansion, postcss).

## Verification
Full forced suite green (8/8 tasks); `audit:ci` PASS; tier-2 PASS; allowlist guard PASS; **`npm audit`: 0 vulnerabilities across the entire tree**; VEX JSON validated.

## Rollback
Revert the commit (manifest pins + lockfile + config/docs only).

## Related
v0.31.0 item-#4 disposition (revoke/complete on premise change) · #238 posture · supersedes Dependabot #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
